### PR TITLE
Introduce a bash script to reduce redundant configuration values

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Set environment variables if needed
+# MONGO_URL=mongodb://localhost:27017/myapp
+# PORT=3000
+
+if [ -n "$1" ]; then
+  METEOR_SETTINGS="$(cat $1)"
+fi
+


### PR DESCRIPTION
Hi Aaron,

I propose a new shell script to reduce clutter when dealing with debug & deploy environments.

My suggestion is to have a canonical way of starting the reactioncommerce app, regardless of the environment.

With the new file it would be for development:

    $ source env.sh settings/dev.sample.json
    $ meteor


And for production it could be something along the lines.. 

    $ source env.sh settings/production.sample.json
    $ forever start my/bundle/main.js



Inspired by: https://www.eventedmind.com/feed/meteor-organizing-environment-variables-and-settings

Please let me know if you're interested and I would modify the source and docs. Thank you!