### PR TITLE
Add reaction-sample-data package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -64,6 +64,10 @@ reactioncommerce:reaction-stripe
 #reactioncommerce:reaction-auth-net
 #reactioncommerce:reaction-braintree
 
+# Reaction Commerce Data
+
+reactioncommerce:reaction-sample-data
+
 # Testing packages
 # velocity:html-reporter
 # sanjo:jasmine


### PR DESCRIPTION
This PR adds a separate package which contains the sample data for a running reaction shop, as described in #508. 

To be functional, additional PR's in `reaction-core` and `reaction-shipping` need to be accepted:
* reactioncommerce/reaction-core#209
* reactioncommerce/reaction-shipping#4

The `reaction-sample-data` should also be transferred to `reactioncommerce`.