### PR TITLE
Add forever and phantomjs to production dockerfiles

### DIFF
--- a/bin/docker/build-bundle.sh
+++ b/bin/docker/build-bundle.sh
@@ -18,6 +18,9 @@ cp -r --parents include/ /usr
 # install npm
 curl https://www.npmjs.com/install.sh | sh
 
+# install forever
+npm install -g forever
+
 # build the meteor application
 cd /var/src
 /usr/bin/build-meteor.sh

--- a/bin/docker/build-bundle.sh
+++ b/bin/docker/build-bundle.sh
@@ -18,8 +18,8 @@ cp -r --parents include/ /usr
 # install npm
 curl https://www.npmjs.com/install.sh | sh
 
-# install forever
-npm install -g forever
+# install forever and phantomjs
+npm install -g forever phantomjs
 
 # build the meteor application
 cd /var/src

--- a/docker/reaction.minimal.docker
+++ b/docker/reaction.minimal.docker
@@ -14,6 +14,7 @@ RUN /usr/bin/install-graphicsmagick.sh
 ENV PORT 3000
 ENV ROOT_URL http://localhost
 ENV MONGO_URL mongodb://127.0.0.1:27017/meteor
+ENV NODE forever
 
 RUN mkdir -p "/var/src" "/var/www"
 WORKDIR /var/www/bundle

--- a/docker/reaction.mongo.docker
+++ b/docker/reaction.mongo.docker
@@ -14,6 +14,7 @@ RUN /usr/bin/install-graphicsmagick.sh
 ENV PORT 3000
 ENV ROOT_URL http://localhost
 ENV MONGO_URL mongodb://127.0.0.1:27017/meteor
+ENV NODE forever
 
 RUN mkdir -p "/var/src" "/var/www"
 WORKDIR /var/www/bundle


### PR DESCRIPTION
Forever support adds about 10mb, phantomjs (which is needed for spiderable) around 40mb. ~~The docker build currently fails because of a bug in npm 3.4.1 but will complete again with npm 3.5.0.~~