### PR TITLE
inventory/register refactoring

### DIFF
--- a/packages/reaction-inventory/server/methods.js
+++ b/packages/reaction-inventory/server/methods.js
@@ -37,21 +37,24 @@ Meteor.methods({
           `inserting ${newQty - inventoryVariantCount} new inventory items for ${variant._id}`
         );
 
+        let items = [];
         while (i <= newQty) {
-          let inventoryItem = ReactionCore.Collections.Inventory.insert({
+          items.push({
             shopId: product.shopId,
             variantId: variant._id,
             productId: product._id
           });
-
-          if (!inventoryItem) {
-            // throw new Meteor.Error("Inventory Anomaly Detected. Abort! Abort!");
-            return totalNewInventory;
-          }
-          ReactionInventory.Log.debug(`registered ${inventoryItem}`);
-          totalNewInventory++;
           i++;
         }
+
+        let inventoryItem = ReactionCore.Collections.Inventory.batchInsert(items);
+
+        if (!inventoryItem) { // or maybe `inventory.length === 0`?
+          // throw new Meteor.Error("Inventory Anomaly Detected. Abort! Abort!");
+          return totalNewInventory;
+        }
+        ReactionInventory.Log.debug(`registered ${inventoryItem}`);
+        totalNewInventory += inventoryItem.length;
       }
     }
     // returns the total amount of new inventory created

--- a/packages/reaction-schemas/package.js
+++ b/packages/reaction-schemas/package.js
@@ -15,6 +15,7 @@ Package.onUse(function (api) {
   api.use("aldeed:collection2@2.5.0");
   api.use("aldeed:simple-schema@1.3.3");
   api.use("matb33:collection-hooks@0.8.1");
+  api.use("mikowals:batch-insert@1.1.13");
 
 
   // ReactionCore declaration


### PR DESCRIPTION
Hello,

I was trying to find a way to make this method faster and reading of [this](http://info.meteor.com/blog/inserting-50000-documents-into-a-collection-slow-fast-and-fastest) great article gives me a solution. I did some tests with previous version of method with adding `childVariant` with 1000 items. For me average time of this operations was around 24 seconds. With [`batchInsert`](https://atmospherejs.com/mikowals/batch-insert) the same operation was taken around 0.1 seconds which is very cool)