### PR TITLE
Do not reload shop if it's already in the database

### DIFF
--- a/packages/reaction-sample-data/server/load.js
+++ b/packages/reaction-sample-data/server/load.js
@@ -3,7 +3,7 @@
  */
 
 ReactionImport.startup = function () {
-  ReactionImport.process(Assets.getText("private/data/Shops.json"), ["name"], ReactionImport.shop);
+  ReactionImport.fixture().process(Assets.getText("private/data/Shops.json"), ["name"], ReactionImport.shop);
   ReactionImport.fixture().process(Assets.getText("private/data/Products.json"), ["title"], ReactionImport.load);
   ReactionImport.fixture().process(Assets.getText("private/data/Tags.json"), ["name"], ReactionImport.load);
   ReactionImport.flush();


### PR DESCRIPTION
Fixture data should always be loaded using the `ReactionImport.fixture()` modifier. Fixes #548.