### PR TITLE
Look for settings files in the reaction base directory

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -3,7 +3,7 @@
 set -u
 set -e
 
-DIRNAME="$(dirname "$(pwd)")"
+DIRNAME=$(pwd)
 CONFIG=$DIRNAME/settings/settings.json
 DEVCONFIG=$DIRNAME/settings/dev.settings.json
 


### PR DESCRIPTION
As `bin/run` is called from the reaction installation base directory (where `reaction` script is located), calling `dirname` on `pwd` results in the parent directory of the reaction install. Just by removing the `dirname`, reaction finds my settings files again.