### PR TITLE
Partially fix of `addressBook` checkbox behavior

### DIFF
--- a/packages/reaction-accounts/client/templates/addressBook/form/form.js
+++ b/packages/reaction-accounts/client/templates/addressBook/form/form.js
@@ -42,17 +42,11 @@ Template.addressBookForm.helpers({
   /*
    *  Defaults billing/shipping when 1st new address.
    */
-  isBillingDefault: function() {
-    var ref;
-    if (!(((ref = this.profile) != null ? ref.addressBook : void 0) && !addressBookEditId.get())) {
-      return true;
-    }
+  isBillingDefault: function () {
+    return typeof this.address === "object" ? this.address.isBillingDefault : true;
   },
-  isShippingDefault: function() {
-    var ref;
-    if (!(((ref = this.profile) != null ? ref.addressBook : void 0) && !addressBookEditId.get())) {
-      return true;
-    }
+  isShippingDefault: function () {
+    return typeof this.address === "object" ? this.address.isShippingDefault : true;
   }
 });
 


### PR DESCRIPTION
Hi, there was a bug when editing an address - checkboxes was always enabled. This partially fix this situation, but one bug still missed. It happens then you remove address just after editing. After it you will see "add new address" form with old checkboxes state. If you put breakpoint inside those methods - you will see that `this` object still contain removed object with address. I have not idea why Blaze doing this:)