### PR TITLE
Install script updates

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -51,9 +51,8 @@ if [ "$UNAME" != "Linux" -a "$UNAME" != "Darwin" ] ; then
 fi
 
 #
-# check if node + npm is already installed otherwise warn.
+# check if node + npm is installed.  if not, try to install them.
 #
-
 if npm -v >/dev/null 2>&1; then
   echo "Node install verified. Checking Meteor installation."
 else
@@ -61,23 +60,38 @@ else
   echo "* Installing Node.js & Npm http://nodejs.org      *"
   echo "***************************************************"
   #
-  # Check if Homebrew is installed
+  # OSX Node Installer
   #
-  which -s brew
-  if [[ $? != 0 ]] ; then
-    PREFIX=$(brew --prefix)
-    brew install node
+  if [ "$UNAME" = "Darwin" ] ; then
+      # use Homebrew if installed
+    if which brew >/dev/null 2>&1; then
+      brew install node
+    else
+      # else use official installer package
+      curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/"
+    fi
   else
-    # distribution install, should work on linux, osx
-    echo 'export PATH=$HOME/node-latest-install:$PATH' >> ~/.bashrc
-    . ~/.bashrc
-    mkdir ~/local
-    mkdir ~/node-latest-install
-    cd ~/node-latest-install
-    curl http://nodejs.org/dist/node-latest.tar.gz | tar xz --strip-components=1
-    ./configure --prefix=~/local
-    make install # ok, fine, this step probably takes more than 30 seconds...
-    curl https://www.npmjs.org/install.sh | sh
+  #
+  # Linux Node Installer
+  #
+    # Ubuntu/Debian
+    if which apt-get >/dev/null 2>&1; then
+      curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+      sudo apt-get install -y nodejs build-essential git
+
+    # CentOS/Red Hat/Fedora
+    elif which yum >/dev/null 2>&1; then
+      curl --silent --location https://rpm.nodesource.com/setup | sudo bash -
+      sudo yum -y install nodejs gcc-c++ make git
+
+    # TODO: find a solution for reliably building from source on all other Linux distros
+    else
+      echo "Sorry, this install script doesn't support installing Node on your OS."
+      echo "Please see the official docs for installation instructions:"
+      echo "  https://nodejs.org/en/download/package-manager/"
+      echo "Once Node is installed, try running this script again."
+      exit 1
+    fi
   fi
 fi
 

--- a/bin/install
+++ b/bin/install
@@ -17,17 +17,37 @@
 #
 set -eu
 exec 1>&2
+
 #
-#  check that this is osx or linux
+#  check if we're on a supported OS
 #
 UNAME=$(uname)
+
+# Windows?
+if [ "$UNAME" ">" "MINGW" -a "$UNAME" "<" "MINGX" ] ; then
+  echo "Sorry, this install script doesn't support Windows at this time."
+  echo "You will have to manually install Node, NPM, and Meteor."
+  echo "To install Node/NPM, download the installer from:"
+  echo " https://nodejs.org/en/download/package-manager/#windows"
+  echo "To install Meteor, download the installer from:"
+  echo " https://install.meteor.com/windows"
+  echo "Then you can run Reaction with: "
+  echo "  git clone https://github.com/reactioncommerce/reaction "
+  echo "  cd reaction"
+  echo "  meteor"
+  exit 1
+fi
+
+# If not OSX or Linux, exit
 if [ "$UNAME" != "Linux" -a "$UNAME" != "Darwin" ] ; then
-    echo "Sorry, this install script doesn't support your OS."
-    echo "Install Meteor from https://www.meteor.com/install "
-    echo "git clone https://github.com/reactioncommerce/reaction "
-    echo "cd reaction"
-    echo "meteor"
-    exit 1
+  echo "Sorry, this install script doesn't support your OS."
+  echo "Reaction Commerce requires Meteor to be installed."
+  echo "For more details on supported platforms, see https://www.meteor.com/install"
+  echo "Then you can: "
+  echo "  git clone https://github.com/reactioncommerce/reaction "
+  echo "  cd reaction"
+  echo "  meteor"
+  exit 1
 fi
 
 #


### PR DESCRIPTION
Improves the initial OS handling of the install script (adds a helpful message for Windows users with dependency install steps that are needed).  Adds custom Node installs for OSX and apt/yum package managers.  

Tested on fresh installs of OSX 10.11.1, Ubuntu 14.04, and CentOS 7.

As noted in the source, we still need a reliable method of building Node from source that will work on all other Linux distros (the code that was there didn't work on OSX or Ubuntu, so I removed it completely)

This also fixes #375.  Since there isn't a bug anymore, we can probably close that one.  However, it's probably worth starting a new issue to track improvements with misc Linux install handling.  For now, this script will work on OSX or for Linux users with either apt or yum package managers.  All other Linux users will be shown a message with a link to Node's manual install instructions (which I'd argue shouldn't be asking a lot if you're already comfortable using a less popular Linux distro). 