### PR TITLE
Set the default shop email before creating the admin user.

### DIFF
--- a/packages/reaction-core/server/registry.js
+++ b/packages/reaction-core/server/registry.js
@@ -125,6 +125,16 @@ ReactionRegistry.createDefaultAdminUser = function () {
     }
   }
 
+  // set the default shop email to the default admin email
+  ReactionCore.Collections.Shops.update(shopId, {
+    $addToSet: {
+      emails: {
+        address: options.email,
+        verified: true
+      },
+      domains: Meteor.settings.ROOT_URL
+    }
+  });
   // create the new admin user
   // we're checking again to see if this user was created but not specifically for this shop.
   if (Meteor.users.find({
@@ -173,16 +183,6 @@ ReactionRegistry.createDefaultAdminUser = function () {
       }
     });
   }
-  // set the defaut shop email to the default admin email
-  ReactionCore.Collections.Shops.update(shopId, {
-    $addToSet: {
-      emails: {
-        address: options.email,
-        verified: true
-      },
-      domains: Meteor.settings.ROOT_URL
-    }
-  });
   // populate roles with all the packages and their permissions
   // this way the default user has all permissions
   const packages = ReactionCore.Collections.Packages.find().fetch();


### PR DESCRIPTION
When running Reaction on a fresh environment, in spite of the store email setting (`REACTION_EMAIL`) on *.settings.json, it would send welcome email to the default address `${shop.name}@localhost`, refer https://github.com/reactioncommerce/reaction/blob/3e58c86194d1bc9b0980f55692941a7a43cffb95/packages/reaction-accounts/server/methods/accounts.js#L413-L414

By moving the below code of setting the default shop email

```
// set the default shop email to the default admin email
  ReactionCore.Collections.Shops.update(shopId, {
    $addToSet: {
      emails: {
        address: options.email,
        verified: true
      },
      domains: Meteor.settings.ROOT_URL
    }
  });
```
to the place before the line of creating user `accountId = Accounts.createUser(options);` that eventually triggers sending welcome email, we could ensure that the welcome email is sent to the shop email address which is preset on *.settings.json.
