### PR TITLE
Add note about MongoDB requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ cd reaction && git checkout master # default branch is development
 
 Additional installation options are in the [developer documentation](https://github.com/reactioncommerce/reaction/blob/development/docs/developer/installation.md).
 
+_Note: When using a standalone MongoDB server, make sure you are using version 2.6 or later._
+
 _Note: for windows installation you also need:_
 - OpenSSL x86 ([windows installer](https://slproweb.com/products/Win32OpenSSL.html))
 - Visual Studio 2008 redistributables

--- a/packages/reaction-core/server/import.js
+++ b/packages/reaction-core/server/import.js
@@ -3,6 +3,10 @@
  * @author Tom De Caluwé
  */
 
+if (!MongoInternals.NpmModule.Collection.prototype.initializeUnorderedBulkOp) {
+  throw Error("Couldn't detect the MongoDB bulk API, are you using MongoDB 2.6 or above?");
+}
+
 ReactionImport = class {};
 
 ReactionFixture = Object.create(ReactionImport);


### PR DESCRIPTION
Reaction needs the MongoDB 2.6 bulk operations API. This PR adds a note in the docs about this requirement and will throw an `Error` on startup if the API couldn't be found.