### PR TITLE
Allow overriding less variables from reactioncommerce:core-theme more easily.

### DIFF
--- a/docs/developer/themes.md
+++ b/docs/developer/themes.md
@@ -64,9 +64,9 @@ reactioncommerce:default-theme
 #my:custom-theme
 ```
 
-Uncomment (remove the #) on the line with `my:custom-theme` to enable the theme. The name `my:custom-theme` represents the name of your theme package in the `package.js` file in `packages/my-custom-theme/package.js`. If you modified the name, be sure to change it here to match as well.
+Comment the line with `reactioncommerce:default-theme` (add # at the beginning) and uncomment (remove the #) on the line with `my:custom-theme` to enable the theme. The name `my:custom-theme` represents the name of your theme package in the `package.js` file in `packages/my-custom-theme/package.js`. If you modified the name, be sure to change it here to match as well.
 
-If your custom theme is complete enough to replace `reactioncommerce:default-theme` feel free to remove or comment it out.
+If your custom theme is complete enough to replace the standard core-theme altogether, feel free to remove the lines with `@import "{reactioncommerce:core-theme}...` from main.less.
 
 ### Step 4
 open `main.less` add css and/or imports here.

--- a/packages/my-custom-theme-template/main.less
+++ b/packages/my-custom-theme-template/main.less
@@ -14,6 +14,55 @@
 
 */
 
+// Import Bootstrap 3 Styles
+@import "{reactioncommerce:core-theme}/lib/bootstrap/less/bootstrap.less";
+
+// Import Reaction Core Theme Styles
+@import "{reactioncommerce:core-theme}/default/alerts.less";
+
+// Disabled: Reaction-UI can handle RTL
+// @import "{reactioncommerce:core-theme}/default/bootstrap.rtl.less";
+@import "{reactioncommerce:core-theme}/default/dropdowns.less";
+@import "{reactioncommerce:core-theme}/default/forms.less";
+@import "{reactioncommerce:core-theme}/default/grid.less";
+@import "{reactioncommerce:core-theme}/default/mixins.less";
+@import "{reactioncommerce:core-theme}/default/navs.less";
+@import "{reactioncommerce:core-theme}/default/panels.less";
+@import "{reactioncommerce:core-theme}/default/popovers.less";
+@import "{reactioncommerce:core-theme}/default/variables.less";
+@import "{reactioncommerce:core-theme}/default/base.less";
+@import "{reactioncommerce:core-theme}/theme/accounts/accounts.less";
+@import "{reactioncommerce:core-theme}/theme/accounts/inline/inline.less";
+@import "{reactioncommerce:core-theme}/theme/cart/cartDrawer/cartDrawer.less";
+@import "{reactioncommerce:core-theme}/theme/cart/cartDrawer/cartItems/cartItems.less";
+@import "{reactioncommerce:core-theme}/theme/cart/cartDrawer/cartSubTotals/cartSubTotals.less";
+@import "{reactioncommerce:core-theme}/theme/cart/cartIcon/cartIcon.less";
+@import "{reactioncommerce:core-theme}/theme/cart/checkout/addressBook/addressBook.less";
+@import "{reactioncommerce:core-theme}/theme/cart/checkout/checkout.less";
+@import "{reactioncommerce:core-theme}/theme/cart/checkout/progressBar/progressBar.less";
+@import "{reactioncommerce:core-theme}/theme/dashboard/console/console.less";
+@import "{reactioncommerce:core-theme}/theme/dashboard/dashboard.less";
+@import "{reactioncommerce:core-theme}/theme/dashboard/orders/orders.less";
+@import "{reactioncommerce:core-theme}/theme/dashboard/packages/grid/package/package.less";
+@import "{reactioncommerce:core-theme}/theme/dashboard/shop/accounts.less";
+@import "{reactioncommerce:core-theme}/theme/dashboard/shop/settings.less";
+@import "{reactioncommerce:core-theme}/theme/dashboard/widget/widget.less";
+@import "{reactioncommerce:core-theme}/theme/layout/footer/footer.less";
+@import "{reactioncommerce:core-theme}/theme/layout/header/header.less";
+@import "{reactioncommerce:core-theme}/theme/layout/header/tags/tags.less";
+@import "{reactioncommerce:core-theme}/theme/layout/layout.less";
+@import "{reactioncommerce:core-theme}/theme/products/productDetail/attributes/attributes.less";
+@import "{reactioncommerce:core-theme}/theme/products/productDetail/images/productImageGallery.less";
+@import "{reactioncommerce:core-theme}/theme/products/productDetail/productDetail.less";
+@import "{reactioncommerce:core-theme}/theme/products/productDetail/tags/tags.less";
+@import "{reactioncommerce:core-theme}/theme/products/productDetail/variants/variant.less";
+@import "{reactioncommerce:core-theme}/theme/products/productDetail/variants/variantForm/childVariant/childVariant.less";
+@import "{reactioncommerce:core-theme}/theme/products/productDetail/variants/variantForm/variantForm.less";
+@import "{reactioncommerce:core-theme}/theme/products/productDetail/variants/variantList/variantList.less";
+@import "{reactioncommerce:core-theme}/theme/products/productGrid/productGrid.less";
+@import "{reactioncommerce:core-theme}/theme/products/productList/productList.less";
+@import "{reactioncommerce:core-theme}/theme/products/products.less";
+
 // Get bootstrap variables
 @import "{reactioncommerce:core-theme}/lib/bootstrap/less/variables.less";
 

--- a/packages/my-custom-theme-template/styles/base.less
+++ b/packages/my-custom-theme-template/styles/base.less
@@ -1,4 +1,7 @@
-// Styles
+// Custom theme styles
+
+// Example: Override less variables from reactioncommerce:core-theme
+@navbar-default-bg: #61462F;
 
 /*
   Example importing mixins, If you change the language to a RTL language,
@@ -11,3 +14,4 @@ body {
   .margin-left(50px);
   background-color: #ff00ff;
 }
+


### PR DESCRIPTION
The docs were not clear how one could easily override less variables for
custom colors. With this proposed change it is doable with much less
work for the unexperienced developer.