### PR TITLE
Fixing #665 and #666

### DIFF
--- a/packages/reaction-core-theme/theme/layout/header/tags/tags.less
+++ b/packages/reaction-core-theme/theme/layout/header/tags/tags.less
@@ -51,12 +51,15 @@
     border-color: @input-border-focus;
     box-shadow: 0 0 10px @input-border-focus;
   }
-  .tag-input-group-remove {
+  .tag-input-group-controls {
     position: absolute;
     .right(6px);
     top: 4px;
     color: @input-color-placeholder;
     .padding-right(4px);
+  }
+  .tag-input-group-remove .tag-input-group-hide {
+    float: right;
   }
   .tags-submit-new {
     padding-left: 5px;

--- a/packages/reaction-core/client/templates/layout/header/tags/tags.html
+++ b/packages/reaction-core/client/templates/layout/header/tags/tags.html
@@ -31,8 +31,9 @@
       <span class="tag-input">
         <input type="text" class="tags-input-select" value="{{name}}" placeholder="Edit tags"/>
       </span>
-      <span class="tag-input-group-remove">
-         <i class="fa fa-times-circle fa-lg"></i>
+      <span class="tag-input-group-controls">
+        <i class="tag-input-group-hide fa fa-minus-circle fa-lg"></i>
+        <i class="tag-input-group-remove fa fa-times-circle fa-lg"></i>
       </span>
     </div>
   </li>

--- a/packages/reaction-core/client/templates/layout/header/tags/tags.js
+++ b/packages/reaction-core/client/templates/layout/header/tags/tags.js
@@ -141,6 +141,19 @@ Template.tagInputForm.events({
         return template.$(".tags-submit-new").focus();
       });
   },
+  "click .tag-input-group-hide": function (event, template) {
+    return Meteor.call("shop/hideHeaderTag", this._id,
+      function (error) {
+        if (error) {
+          return Alerts.add(
+            "An error occurred, the tag couldn't be hidden.",
+            "warning", {
+              autoHide: true
+            });
+        }
+        return template.$(".tags-submit-new").focus();
+      });
+  },
   "focusin .tags-input-select": function (tagEvent) {
     return $(tagEvent.currentTarget).autocomplete({
       delay: 0,

--- a/packages/reaction-core/client/templates/layout/header/tags/tags.js
+++ b/packages/reaction-core/client/templates/layout/header/tags/tags.js
@@ -186,6 +186,14 @@ Template.tagInputForm.events({
       }
     });
   },
+  "keypress .tags-input-select": function (event, template) {
+    if (event.keyCode === 13) {
+      event.target.blur();
+    } else if (event.keyCode === 27) {
+      event.target.value = this.name;
+      event.target.blur();
+    }
+  },
   "focusout .tags-input-select": function (event, template) {
     let val;
     val = $(event.currentTarget).val();

--- a/packages/reaction-core/server/methods/shop.js
+++ b/packages/reaction-core/server/methods/shop.js
@@ -482,6 +482,26 @@ Meteor.methods({
   },
 
   /**
+   * shop/hideHeaderTag
+   * @param {String} tagId - method to remove tag navigation tags
+   * @param {String} currentTagId - currentTagId
+   * @return {String} returns remove result
+   */
+  "shop/hideHeaderTag": function (tagId) {
+    check(tagId, String);
+    // must have core permissions
+    if (!ReactionCore.hasPermission("core")) {
+      throw new Meteor.Error(403, "Access Denied");
+    }
+    this.unblock();
+    // hide it
+    console.log({ _id: tagId });
+    return ReactionCore.Collections.Tags.update({ _id: tagId }, {
+      $set: { isTopLevel: false }
+    });
+  },
+
+  /**
    * flushTranslations
    * @summary Helper method to remove all translations, and reload from jsonFiles
    * @return {undefined}


### PR DESCRIPTION
* Allows using enter and escape to submit or cancel a `updateHeaderTags` call.
* Add a button to mark a tag as non `isTopLevel`.