### PR TITLE
cart updates, paymentMethods without using sessionId

### DIFF
--- a/packages/reaction-core/common/methods/cart.js
+++ b/packages/reaction-core/common/methods/cart.js
@@ -4,10 +4,8 @@
 //
 if (Meteor.isClient) {
   Meteor.methods({
-    "cart/submitPayment": function (paymentMethod, sessionId) {
+    "cart/submitPayment": function (paymentMethod) {
       check(paymentMethod, ReactionCore.Schemas.PaymentMethod);
-      check(sessionId, String);
-
       let checkoutCart = ReactionCore.Collections.Cart.findOne({
         userId: Meteor.userId()
       });

--- a/packages/reaction-core/server/methods/cart.js
+++ b/packages/reaction-core/server/methods/cart.js
@@ -468,16 +468,15 @@ Meteor.methods({
    * create new cart within `cart/createCart` method
    * @return {String} returns orderId
    */
-  "cart/copyCartToOrder": function (cartId, sessionId) {
+  "cart/copyCartToOrder": function (cartId) {
     check(cartId, String);
-    check(sessionId, String);
-
     const cart = ReactionCore.Collections.Cart.findOne(cartId);
     // security check
     if (cart.userId !== this.userId) {
       throw new Meteor.Error(403, "Access Denied");
     }
     const order = Object.assign({}, cart);
+    const sessionId = cart.sessionId;
 
     ReactionCore.Log.info("cart/copyCartToOrder", cartId);
     // reassign the id, we'll get a new orderId
@@ -848,14 +847,11 @@ Meteor.methods({
    * and adds "paymentSubmitted" to cart workflow
    * Note: this method also has a client stub, that forwards to cartCompleted
    * @param {Object} paymentMethod - paymentMethod object
-   * @param {String} sessionId - current client session id. We don't use it
    * directly within this method, just throw down though hooks
    * @return {String} returns update result
    */
-  "cart/submitPayment": function (paymentMethod, sessionId) {
+  "cart/submitPayment": function (paymentMethod,) {
     check(paymentMethod, ReactionCore.Schemas.PaymentMethod);
-    check(sessionId, String);
-
     let checkoutCart = ReactionCore.Collections.Cart.findOne({
       userId: Meteor.userId()
     });

--- a/packages/reaction-core/server/methods/cart.js
+++ b/packages/reaction-core/server/methods/cart.js
@@ -850,7 +850,7 @@ Meteor.methods({
    * directly within this method, just throw down though hooks
    * @return {String} returns update result
    */
-  "cart/submitPayment": function (paymentMethod,) {
+  "cart/submitPayment": function (paymentMethod) {
     check(paymentMethod, ReactionCore.Schemas.PaymentMethod);
     let checkoutCart = ReactionCore.Collections.Cart.findOne({
       userId: Meteor.userId()

--- a/packages/reaction-core/server/methods/hooks/cart.js
+++ b/packages/reaction-core/server/methods/hooks/cart.js
@@ -17,9 +17,7 @@ ReactionCore.MethodHooks.after("cart/submitPayment", function (options) {
     if (cart) {
       if (cart.items && cart.billing[0].paymentMethod) {
         // we need to throw an the session below the `cart/createCart` method
-        const sessionId = options.arguments[1];
-        const orderId = Meteor.call("cart/copyCartToOrder",
-          cart._id, sessionId);
+        const orderId = Meteor.call("cart/copyCartToOrder", cart._id);
         // Return orderId as result from this after hook call.
         // This is done by extending the existing result.
         result.orderId = orderId;


### PR DESCRIPTION
Removes breaking changes from copyCartToOrder and cart/submitPayment 

Negates need for:

- https://github.com/reactioncommerce/reaction-paypal/pull/23
- https://github.com/reactioncommerce/reaction-stripe/pull/11