### PR TITLE
fix issue #693

### DIFF
--- a/packages/reaction-core/client/helpers/layout.js
+++ b/packages/reaction-core/client/helpers/layout.js
@@ -65,7 +65,8 @@ Template.registerHelper("reactionTemplate", function (options) {
   let Packages = ReactionCore.Collections.Packages.find({
     layout: {
       $elemMatch: options.hash
-    }
+    },
+    shopId: shopId
   });
   //  we can have multiple packages contributing to the layout / workflow
   Packages.forEach(function (reactionPackage) {


### PR DESCRIPTION
When multiple shops are added in the DB and the same layout name is found in multiple shops too many entries are returned, we should only take into consideration the main shop's layout definition I think.