### PR TITLE
Potentially call setPaymentAddress also if cart.billing is present (but

### DIFF
--- a/packages/reaction-accounts/client/templates/addressBook/grid/grid.js
+++ b/packages/reaction-accounts/client/templates/addressBook/grid/grid.js
@@ -8,11 +8,9 @@ Template.addressBookGrid.helpers({
     });
 
     if (cart) {
-      if (cart.billing) {
-        if (cart.billing[0].address) {
-          if (this._id === cart.billing[0].address._id) {
-            return "active";
-          }
+      if (cart.billing && cart.billing[0].address) {
+        if (this._id === cart.billing[0].address._id) {
+          return "active";
         }
       } else { // if this is a first checkout review, we need to push default
         // billing address to cart
@@ -30,11 +28,9 @@ Template.addressBookGrid.helpers({
     });
 
     if (cart) {
-      if (cart.shipping) {
-        if (cart.shipping[0].address) {
-          if (this._id === cart.shipping[0].address._id) {
-            return "active";
-          }
+      if (cart.shipping && cart.shipping[0].address) {
+        if (this._id === cart.shipping[0].address._id) {
+          return "active";
         }
       } else { // if this is a first checkout review, we need to push default
         // shipping address to cart


### PR DESCRIPTION
no billing address is specified yet).

Before this fix setPaymentAdress was not called if cart.billing
was there (even if no address was specified)

Analogous to cart.billing the same applies to cart.shipping.


NOTICE: This FIX is more targeting a "developer annoyance". There's no problem when using the shop as intended. The problem does occur when going through the checkout process until the shipment page and then PURGING the whole cart object in mongo db.  After creating the cart again and starting the checkout process again, the shipment is not clickable any more.

![screen_shot_2016-01-13_at_17_54_06](https://cloud.githubusercontent.com/assets/1733229/12301424/46444046-ba20-11e5-8a38-c024f96e9362.jpg)
