### PR TITLE
Add "paymentmethod" to core

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -66,6 +66,7 @@ reactioncommerce:reaction-paypal
 reactioncommerce:reaction-stripe
 #reactioncommerce:reaction-auth-net
 #reactioncommerce:reaction-braintree
+reactioncommerce:reaction-paymentmethod
 
 # Reaction Commerce Data
 
@@ -84,3 +85,4 @@ reactioncommerce:default-theme
 # Forced updates on packages
 jparker:gravatar@0.4.1
 cosmos:browserify@0.9.2
+


### PR DESCRIPTION
I think this would be valuable to have for people who are just trying out RC to have a payment method that requires no configuration and is turned on by default. Then they can run stuff through the cart before they dig in too deep.

Also updated README to reflect that this has tests now and uses the "Advanced Boilerplate".

Closes https://github.com/reactioncommerce/reaction/issues/616