### PR TITLE
Added name field to shipping fixture data.

### DIFF
--- a/packages/reaction-shipping/private/data/Shipping.json
+++ b/packages/reaction-shipping/private/data/Shipping.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Default shipping provider",
     "methods": [
       {
         "name": "Free",


### PR DESCRIPTION
There was a bug with default shipping provider.
On every start of app it tries to upsert shipping collection with such key:
```javascript
{ name: undefined }
```
It happens due to absence of name field in fixture data json.

https://github.com/reactioncommerce/reaction/blob/development/packages/reaction-shipping/server/fixtures.js#L10
https://github.com/reactioncommerce/reaction/blob/development/packages/reaction-core/server/import.js#L385-L399