### PR TITLE
don't send welcome email to default admin

### DIFF
--- a/packages/reaction-accounts/server/methods/accounts.js
+++ b/packages/reaction-accounts/server/methods/accounts.js
@@ -68,8 +68,14 @@ Accounts.onCreateUser(function (options, user) {
     let account = _.clone(user);
     account.userId = user._id;
     ReactionCore.Collections.Accounts.insert(account);
-    // send welcome email to new users
-    Meteor.call("accounts/sendWelcomeEmail", shopId, user._id);
+
+    // send a welcome email to new users,
+    // but skip the first default admin user
+    // (default admins already get a verification email)
+    if (!Meteor.users.find().count() === 0) {
+      Meteor.call("accounts/sendWelcomeEmail", shopId, user._id);
+    }
+
     // assign default user roles
     user.roles = roles;
     return user;


### PR DESCRIPTION
The default admin gets a verification email with essentially the same content (with the addition of a email verification url), so this is only removing the redundant second email for that user.