### PR TITLE
fixed back button for 'createPage' button from 'Flat Pages' package

### DIFF
--- a/packages/reaction-core/client/templates/layout/admin/admin.html
+++ b/packages/reaction-core/client/templates/layout/admin/admin.html
@@ -1,5 +1,6 @@
 <template name="coreAdminLayout">
   <span class="layout-alerts-global">{{>bootstrapAlerts}}</span>
+
   <div class="page {{adminControlsClassname}}" id="reactionAppContainer">
     <nav class="reaction-navigation-header">{{> yield region="layoutHeader"}}</nav>
     <nav class="reaction-cart-drawer">{{>cartDrawer}}</nav>
@@ -11,23 +12,20 @@
     <footer class="reaction-navigation-footer footer-default">{{>yield region="layoutFooter"}}</footer>
   </div>
 
-
   <div class="admin-controls {{adminControlsClassname}}">
-      <div class="admin-controls-detail">
-        <div class="admin-controls-heading">
-          {{> settingsHeader}}
-        </div>
-        <div class="admin-controls-content action-view-body">
-          {{> Template.dynamic template=template.template data=template.data}}
-        </div>
-        <div class="admin-controls-footer">
-          <div class="admin-controls-container">
-            {{>yield region="adminControlsFooter"}}
-          </div>
+    <div class="admin-controls-detail">
+      <div class="admin-controls-heading">
+        {{> settingsHeader}}
+      </div>
+      <div class="admin-controls-content action-view-body">
+        {{> Template.dynamic template=template.template data=template.data}}
+      </div>
+      <div class="admin-controls-footer">
+        <div class="admin-controls-container">
+          {{>yield region="adminControlsFooter"}}
         </div>
       </div>
-
-
+    </div>
   </div>
 
   <div class="admin-controls-menu">
@@ -57,7 +55,6 @@
     </nav>
     <nav>
       {{> yield "dashboardControls"}}
-
       {{#if settings}}
         {{#with settings}}
           <button id="{{route}}" title="{{label}}" data-event-action="showPackageSettings">

--- a/packages/reaction-core/client/templates/layout/admin/admin.js
+++ b/packages/reaction-core/client/templates/layout/admin/admin.js
@@ -96,7 +96,7 @@ Template.coreAdminLayout.events({
   },
 
   /**
-   * Submit sign up form
+   * Create a new object with 'back' button working
    * @param  {Event} event - jQuery Event
    * @param  {Template} template - Blaze Template
    * @return {void}
@@ -105,11 +105,9 @@ Template.coreAdminLayout.events({
     if (this.route === "createProduct") {
       event.preventDefault();
       event.stopPropagation();
-
       Meteor.call("products/createProduct", (error, productId) => {
         let currentTag;
         let currentTagId;
-
         if (error) {
           throw new Meteor.Error("createProduct error", error);
         } else if (productId) {
@@ -120,6 +118,18 @@ Template.coreAdminLayout.events({
           }
           Router.go("product", {
             _id: productId
+          });
+        }
+      });
+    } else if (this.route === "createPage") {
+      event.preventDefault();
+      event.stopPropagation();
+      Meteor.call("pages/createPage", (error, pageId) => {
+        if (error) {
+          throw new Meteor.Error("createPage error", error);
+        } else if (pageId) {
+          Router.go("page", {
+            _id: pageId
           });
         }
       });


### PR DESCRIPTION
I don't want this PR to be merged, but I want to have it to show how solve issue https://github.com/ramusus/reaction-flat-pages/issues/5 with back button while creating new Page from admin sidebar and user menu.

The problem: back button from new page form - undesirably creates another page, so it's necessary to hook event. Unfortunately I didn't find how hook this event from flat pages package. This PR solve this issue, but it's not clean way, while code of creating page is located here, not there

