### PR TITLE
Allow adding an entire package to the index revisited.

### DIFF
--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,8 +1,27 @@
 *
 !.gitignore
 
+!my-custom-theme-template
 !my-custom-theme-template/*
 
+!reaction-accounts
+!reaction-analytics
+!reaction-analytics-libs
+!reaction-collections
+!reaction-core
+!reaction-core-theme
+!reaction-default-theme
+!reaction-inventory
+!reaction-product-simple
+!reaction-sample-data
+!reaction-schemas
+!reaction-shipping
+!reaction-social
+!reaction-ui
+!reaction-email-templates
+
+# For some reason the above inverse ignore rules don't play well with some
+# editors, so we also add inverse ignore rules for their subdirectories.
 !reaction-accounts/*
 !reaction-analytics/*
 !reaction-analytics-libs/*


### PR DESCRIPTION
This PR fixes the problems associated with #668. I checked with Atom's Fuzzy Finder, however since I don't have a windows or mac install, not with Github Desktop. Since the old inverse `.gitignore` rules are a subset of the new ones, it seems to me everything should work fine with this setup.