### PR TITLE
Only throw obsolete MongoDB error when actually using the bulk import API.

### DIFF
--- a/packages/reaction-core/server/import.js
+++ b/packages/reaction-core/server/import.js
@@ -3,10 +3,6 @@
  * @author Tom De Caluwé
  */
 
-if (!MongoInternals.NpmModule.Collection.prototype.initializeUnorderedBulkOp) {
-  throw Error("Couldn't detect the MongoDB bulk API, are you using MongoDB 2.6 or above?");
-}
-
 ReactionImport = class {};
 
 ReactionFixture = Object.create(ReactionImport);
@@ -196,6 +192,10 @@ ReactionImport.context = function (collection) {
  */
 ReactionImport.buffer = function (collection) {
   check(collection, Mongo.Collection);
+
+  if (!MongoInternals.NpmModule.Collection.prototype.initializeUnorderedBulkOp) {
+    throw Error("Couldn't detect the MongoDB bulk API, are you using MongoDB 2.6 or above?");
+  }
 
   // Construct a buffer identifier.
   let name = this._name(collection);


### PR DESCRIPTION
Older versions can be used when not using the `ReactionImport` functionality.