### PR TITLE
Fix for accounts to be compatible with the meteor-1.3

### DIFF
--- a/packages/reaction-accounts/client/helpers/util.js
+++ b/packages/reaction-accounts/client/helpers/util.js
@@ -45,10 +45,10 @@ ReactionServiceHelper = class ReactionServiceHelper {
   }
 
   services(extendEach) {
-    let services = this.availableServices();
+    let availableServices = this.availableServices();
     let configurations = ServiceConfiguration.configurations.find().fetch();
 
-    return _.map(services, (name) => {
+    return _.map(availableServices, (name) => {
       let matchingConfigurations = _.where(configurations, {service: name});
       let service = {
         name: name,


### PR DESCRIPTION
Hello, we can't call method and variables by the same name