### PR TITLE
i18n labels fix

### DIFF
--- a/packages/reaction-core/client/helpers/apps.js
+++ b/packages/reaction-core/client/helpers/apps.js
@@ -165,8 +165,19 @@ function getReactionApps(optionHash) {
                 if (!registry.packageName) registry.packageName = app.name;
                 if (registry.enabled !== false) {
                   // TODO move this to a function and reuse with Template.dashboardHeader.helpers
-                  const registryLabel = registry.label ? registry.label.toCamelCase() : "";
-                  const i18nKey = `admin.${registry.provides}.${registryLabel}`;
+                  let registryLabel = "";
+                  let i18nKey;
+                  // first we check the default place for a label
+                  if (registry.label) {
+                    registryLabel = registry.label.toCamelCase();
+                    i18nKey = `admin.${registry.provides}.${registryLabel}`;
+                    // and if we don't find it, we are trying to look at first
+                    // registry entry
+                  } else if (app.registry && app.registry.length &&
+                    app.registry[0].label) {
+                    registryLabel = app.registry[0].label.toCamelCase();
+                    i18nKey = `admin.${app.registry[0].provides}.${registryLabel}`;
+                  }
                   registry.i18nKeyLabel = `${i18nKey}Label`;
                   registry.i18nKeyDescription = `${i18nKey}Description`;
                   registry.enabled = registry.enabled || app.enabled;

--- a/packages/reaction-core/client/helpers/apps.js
+++ b/packages/reaction-core/client/helpers/apps.js
@@ -164,22 +164,7 @@ function getReactionApps(optionHash) {
               if (match === Object.keys(registryFilter).length) {
                 if (!registry.packageName) registry.packageName = app.name;
                 if (registry.enabled !== false) {
-                  // TODO move this to a function and reuse with Template.dashboardHeader.helpers
-                  let registryLabel = "";
-                  let i18nKey;
-                  // first we check the default place for a label
-                  if (registry.label) {
-                    registryLabel = registry.label.toCamelCase();
-                    i18nKey = `admin.${registry.provides}.${registryLabel}`;
-                    // and if we don't find it, we are trying to look at first
-                    // registry entry
-                  } else if (app.registry && app.registry.length &&
-                    app.registry[0].label) {
-                    registryLabel = app.registry[0].label.toCamelCase();
-                    i18nKey = `admin.${app.registry[0].provides}.${registryLabel}`;
-                  }
-                  registry.i18nKeyLabel = `${i18nKey}Label`;
-                  registry.i18nKeyDescription = `${i18nKey}Description`;
+                  registry = ReactionCore.translateRegistry(registry, app);
                   registry.enabled = registry.enabled || app.enabled;
                   registry.packageId = app._id;
                   // check permissions before pushing so that templates aren't required.

--- a/packages/reaction-dashboard/client/templates/dashboard/dashboard.js
+++ b/packages/reaction-dashboard/client/templates/dashboard/dashboard.js
@@ -7,11 +7,7 @@ Template.dashboardHeader.helpers({
     let route = ReactionRouter.current().route.name;
     let registry = ReactionCore.getRegistryForCurrentRoute() || {};
     if (registry && route) {
-      // TODO move this to a function and reuse with reactionApps in apps.js
-      const registryLabel = registry.label ? registry.label.toCamelCase() : "";
-      const i18nKey = `admin.${registry.provides}.${registryLabel}`;
-      registry.i18nKeyLabel = `${i18nKey}Title`;
-      return registry;
+      return ReactionCore.translateRegistry(registry);
     }
   }
 });

--- a/packages/reaction-dashboard/client/templates/dashboard/settings/settings.html
+++ b/packages/reaction-dashboard/client/templates/dashboard/settings/settings.html
@@ -12,7 +12,7 @@
     <div class="nav-settings-heading">
       <h3 class="nav-settings-title">
         <span>
-          {{i18n registry.i18nKey registry.i18nLabel}}
+          {{i18n registry.i18nKeyLabel ""}}
         </span>
         {{> Template.dynamic template=settingsHeaderControls}}
       </h3>

--- a/packages/reaction-dashboard/client/templates/dashboard/settings/settings.js
+++ b/packages/reaction-dashboard/client/templates/dashboard/settings/settings.js
@@ -8,12 +8,7 @@ Template.settingsHeader.helpers({
    * @return {Object} Registry entry for item
    */
   registry: function () {
-    // just some handle little helpers for default package i18nKey/i18nLabel
-    let registry = ReactionCore.getActionView() || {};
-    registry.nameSpace = registry.name || registry.template || "app";
-    registry.i18nLabel = registry.label || registry.provides || "Settings";
-    registry.i18nKey = registry.nameSpace.toCamelCase() + "." + registry.i18nLabel.toCamelCase();
-    return registry;
+    return ReactionCore.getActionView() || {};
   },
 
   /**

--- a/packages/reaction-dashboard/client/templates/dashboard/shop/settings/settings.js
+++ b/packages/reaction-dashboard/client/templates/dashboard/shop/settings/settings.js
@@ -50,14 +50,14 @@ Template.shopSettings.helpers({
   paymentMethodOptions() {
     const paymentMethods = ReactionCore.Apps({provides: "paymentMethod"});
     const options = [{
-      label: "Auto",
+      label: i18n.t("app.auto"),
       value: "none"
     }];
 
     if (paymentMethods && _.isArray(paymentMethods)) {
       for (let method of paymentMethods) {
         options.push({
-          label: method.packageName,
+          label: i18n.t(method.i18nKeyLabel),
           value: method.packageName
         });
       }

--- a/packages/reaction-i18n/client/helpers/i18n.js
+++ b/packages/reaction-i18n/client/helpers/i18n.js
@@ -270,3 +270,34 @@ pos, len) {
   return (price === 0 ? currentPrice.replace(originalPrice, formattedPrice) :
     price.replace(originalPrice, formattedPrice));
 }
+
+Object.assign(ReactionCore, {
+  /**
+   * translateRegistry
+   * @summary added i18n strings to registry
+   * @param {Object} registry  registry object
+   * @param {Object} [app] app object. It contains registries
+   * @return {Object} with updated registry
+   */
+  translateRegistry(registry, app) {
+    let registryLabel = "";
+    let i18nKey = "";
+    // first we check the default place for a label
+    if (registry.label) {
+      registryLabel = registry.label.toCamelCase();
+      i18nKey = `admin.${registry.provides}.${registryLabel}`;
+      // and if we don't find it, we are trying to look at first
+      // registry entry
+    } else if (app && app.registry && app.registry.length &&
+      app.registry[0].label) {
+      registryLabel = app.registry[0].label.toCamelCase();
+      i18nKey = `admin.${app.registry[0].provides}.${registryLabel}`;
+    }
+    registry.i18nKeyLabel = `${i18nKey}Label`;
+    registry.i18nKeyDescription = `${i18nKey}Description`;
+    registry.i18nKeyPlaceholder = `${i18nKey}Placeholder`;
+    registry.i18nKeyTooltip = `${i18nKey}Tooltip`;
+
+    return registry;
+  }
+});


### PR DESCRIPTION
Looks like logic in registry become more complex, so:
- fixed bug with creation of label for i18n;
- fixed a bug with translation payment **providers** (new term for methods;) );

before:
![translation_fix](https://cloud.githubusercontent.com/assets/11130487/13143686/7b5ebf82-d667-11e5-913e-04c49ec67fb5.png)

after:
![translation_fix1](https://cloud.githubusercontent.com/assets/11130487/13143695/84a7b63e-d667-11e5-9482-dd5d43230dd7.png)

P.S. Translation for these and for `app.auto` will be provided later.