### PR TITLE
Avoid Flow Router Error : route's path must start with '/'

### DIFF
--- a/packages/reaction-router/common/init.js
+++ b/packages/reaction-router/common/init.js
@@ -86,6 +86,10 @@ ReactionRouter.initPackageRoutes = (userId) => {
           let options = {};
           let routeName;
 
+          // If route doesn't start with "/" we add it to avoid the flow-router error
+          route = (route.substring(0, 1) != '/') ? '/' + route : route;
+
+
           routeName = ReactionRouter.getRouteName(pkg.name, registryItem);
           // check route permissions
           if (ReactionCore.hasPermission(routeName, userId) || ReactionCore.hasPermission(route, userId)) {


### PR DESCRIPTION
Flow Router generate some errors if you didn't add '/' before the route name. And when i registered my custom dashboard item using register.js for the first time i forgot to attach '/' in the route which generated this error. 