### PR TITLE
[Meteor-1.3 compat] New dep to reaction-accounts

### DIFF
--- a/packages/reaction-accounts/package.js
+++ b/packages/reaction-accounts/package.js
@@ -33,6 +33,7 @@ Package.onUse(function (api) {
   api.use("oauth-encryption");
   api.use("accounts-base@1.2.2");
   api.use("accounts-password@1.1.4");
+  api.use("service-configuration");
   api.use("jparker:gravatar@0.4.1");
   api.use("reactioncommerce:core@0.12.0");
 

--- a/packages/reaction-core/server/registry/loadSettings.js
+++ b/packages/reaction-core/server/registry/loadSettings.js
@@ -41,7 +41,7 @@ ReactionRegistry.loadSettings = function (json) {
       //
       // insert into the Packages collection
       if (exists) {
-        result = ReactionCore.Collections.Packages.upsert({
+        ReactionCore.Collections.Packages.upsert({
           name: item.name
         }, {
           $set: {


### PR DESCRIPTION
Hello, added new dep `service-configuration` to `reaction-accounts`. W/o this service configuration not creates collection.
+ removed unused global var;
