### PR TITLE
Fixes issue loading custom layouts for routes via the registry.

### DIFF
--- a/packages/reaction-router/common/init.js
+++ b/packages/reaction-router/common/init.js
@@ -79,6 +79,7 @@ ReactionRouter.initPackageRoutes = (userId) => {
           let {
             route,
             template,
+            layout,
             workflow,
             triggersEnter,
             triggersExit
@@ -91,10 +92,12 @@ ReactionRouter.initPackageRoutes = (userId) => {
           if (ReactionCore.hasPermission(routeName, userId) || ReactionCore.hasPermission(route, userId)) {
             options.template = template;
             options.workflow = workflow;
+            options.layout = layout;
           } else {
             // WIP - known issue with auth/login/reload
             options.template = "unauthorized";
             options.workflow = workflow;
+            options.layout = layout;
           }
 
           // define new route
@@ -104,6 +107,7 @@ ReactionRouter.initPackageRoutes = (userId) => {
             options: {
               name: routeName,
               template: options.template,
+              layout: options.layout,
               triggersEnter: triggersEnter,
               triggersExit: triggersExit,
               action: () => {

--- a/packages/reaction-schemas/common/schemas/registry.js
+++ b/packages/reaction-schemas/common/schemas/registry.js
@@ -38,6 +38,10 @@ ReactionCore.Schemas.Registry = new SimpleSchema({
     type: String,
     optional: true
   },
+  layout: {
+    type: String,
+    optional: true
+  },
   triggersEnter: {
     label: "Trigger on Entry",
     type: [String],


### PR DESCRIPTION
Fixes issue where defining a layout in a route in the registry wouldn't get picked up.

e.g.
```
  registry: [{
    // Provides Dashboard Card
    // Route from card renders template specified in the dashboard when clicking
    // the card or the arrow on the card
    // Links to main rentalProducts list
    route: '/dashboard/rentalProducts',
    provides: 'dashboard',
    name: 'rentalProducts',
    label: 'Rental Products',
    description: 'Enables rental products for your shop',
    icon: 'fa fa-calendar',
    container: 'getoutfitted',
    template: 'dashboardRentalProducts',
    workflow: 'coreRentalWorkflow',
    layout: 'coreRentalLayout',
    priority: 1
```

The `layout: 'coreRentalLayout'` section here would get excluded from the package registry because the `layout` was not in the schema.

Adding `options.layout` to `reaction-router/common/init.js` allows us to pass the layout in as an option on the route.