### PR TITLE
Don't allow guest checkout when it is disabled

### DIFF
--- a/packages/reaction-accounts/client/templates/inline/inline.html
+++ b/packages/reaction-accounts/client/templates/inline/inline.html
@@ -1,6 +1,6 @@
 <template name="loginInline">
   <div class="accounts-dialog accounts-inline">
-    {{#unless currentUser}}
+    {{#if guestLoginOk}}
       <div class="col-md-6 pull-left checkout-guest">
         <div class="guest-checkout">
           <p class="text-justify" data-i18n="checkoutLogin.guestMessage">Continue as a guest, and you can create an account later.
@@ -17,6 +17,6 @@
       <div class="checkout-login">
         {{> loginForm startView='loginFormSignUpView'}}
       </div>
-    {{/unless}}
+    {{/if}}
   </div>
 </template>

--- a/packages/reaction-collections/server/publications/packages.js
+++ b/packages/reaction-collections/server/publications/packages.js
@@ -6,9 +6,6 @@
  */
 Meteor.publish("Packages", function (shopCursor) {
   check(shopCursor, Match.Optional(Object));
-  if (this.userId === null) {
-    return this.ready();
-  }
   const shop = shopCursor || ReactionCore.getCurrentShop();
   const {
     Packages

--- a/packages/reaction-core/client/helpers/utilities.js
+++ b/packages/reaction-core/client/helpers/utilities.js
@@ -10,7 +10,7 @@
  * @summary overrides Meteor Package.blaze currentUser method
  * @return {[Boolean]} returns true/null if user has registered
  */
-currentUser = function () {
+_currentUser = function () {
   if (typeof ReactionCore === "object") {
     const shopId = ReactionCore.getShopId();
     const user = Accounts.user();
@@ -28,7 +28,7 @@ currentUser = function () {
  */
 if (Package.blaze) {
   Package.blaze.Blaze.Template.registerHelper("currentUser", function () {
-    return this.currentUser;
+    return _currentUser();
   });
 }
 
@@ -39,7 +39,7 @@ if (Package.blaze) {
  */
 if (Package.blaze) {
   Package.blaze.Blaze.Template.registerHelper("guestLoginOk", function () {
-    let currentUser = this.currentUser;
+    let currentUser = _currentUser();
     let guestLoginOk = !currentUser && ReactionCore.allowGuestCheckout();
     return guestLoginOk;
   });

--- a/packages/reaction-core/client/helpers/utilities.js
+++ b/packages/reaction-core/client/helpers/utilities.js
@@ -10,21 +10,41 @@
  * @summary overrides Meteor Package.blaze currentUser method
  * @return {[Boolean]} returns true/null if user has registered
  */
+currentUser = function () {
+  if (typeof ReactionCore === "object") {
+    const shopId = ReactionCore.getShopId();
+    const user = Accounts.user();
+    if (!shopId || typeof user !== "object") return null;
+    // shoppers should always be guests
+    const isGuest = Roles.userIsInRole(user, "guest", shopId);
+    // but if a user has never logged in then they are anonymous
+    const isAnonymous = Roles.userIsInRole(user, "anonymous", shopId);
+    return isGuest && !isAnonymous ? user : null;
+  }
+};
+
+/**
+ * register currentUser as a template helper
+ */
 if (Package.blaze) {
   Package.blaze.Blaze.Template.registerHelper("currentUser", function () {
-    if (typeof ReactionCore === "object") {
-      const shopId = ReactionCore.getShopId();
-      const user = Accounts.user();
-      if (!shopId || typeof user !== "object") return null;
-      // shoppers should always be guests
-      const isGuest = Roles.userIsInRole(user, "guest", shopId);
-      // but if a user has never logged in then they are anonymous
-      const isAnonymous = Roles.userIsInRole(user, "anonymous", shopId);
-
-      return isGuest && !isAnonymous ? user : null;
-    }
+    return this.currentUser;
   });
 }
+
+/**
+ * registerHelper guestLoginOk
+ * @summary Determines whether whether guest login is both applicable and allowed
+ * @return {Boolean} If no current user and allowGuestCheckout is not disabled
+ */
+if (Package.blaze) {
+  Package.blaze.Blaze.Template.registerHelper("guestLoginOk", function () {
+    let currentUser = this.currentUser;
+    let guestLoginOk = !currentUser && ReactionCore.allowGuestCheckout();
+    return guestLoginOk;
+  });
+}
+
 
 /**
  * registerHelper monthOptions

--- a/packages/reaction-core/client/main.js
+++ b/packages/reaction-core/client/main.js
@@ -143,8 +143,7 @@ _.extend(ReactionCore, {
       ReactionCore.Log.debug("alowGuestCheckout: " + allowGuest);
       return allowGuest;
     }
-    Meteor.Error("400", "Package subscription not ready when allowGuestCheckout was checked");
-    return false;
+    throw new Meteor.Error("400", "Package subscription not ready when allowGuestCheckout was checked");
   },
   getSellerShopId: function () {
     return Roles.getGroupsForUser(this.userId, "admin");

--- a/packages/reaction-core/client/main.js
+++ b/packages/reaction-core/client/main.js
@@ -139,22 +139,11 @@ _.extend(ReactionCore, {
         name: "core",
         shopId: this.shopId
       });
-      if (typeof packageRegistry === "undefined") {
-        throw Meteor.Error("400", "Package Info not available, couldn't check value");
-      }
-      // we can disable in admin, let's check.
-      if (typeof packageRegistry === "object" &&
-        typeof packageRegistry.settings === "object" &&
-        typeof packageRegistry.settings.public === "object" &&
-        typeof packageRegistry.settings.public.allowGuestCheckout === "boolean") {
-        allowGuest = packageRegistry.settings.public.allowGuestCheckout;
-      } else {
-        allowGuest = true;
-      }
-      ReactionCore.Log.info("alowGuestCheckout: " + allowGuest);
+      allowGuest = packageRegistry.settings.public.allowGuestCheckout;
+      ReactionCore.Log.debug("alowGuestCheckout: " + allowGuest);
       return allowGuest;
     }
-    console.log("Package subscription not ready when allowGuestCheckout was checked");
+    Meteor.Error("400", "Package subscription not ready when allowGuestCheckout was checked");
     return false;
   },
   getSellerShopId: function () {

--- a/packages/reaction-core/client/main.js
+++ b/packages/reaction-core/client/main.js
@@ -133,21 +133,26 @@ _.extend(ReactionCore, {
     return this.shopName;
   },
   allowGuestCheckout: function () {
-    let allowGuest;
-    let packageRegistry = ReactionCore.Collections.Packages.findOne({
-      name: "core",
-      shopId: this.shopId
-    });
-    // we can disable in admin, let's check.
-    if (typeof packageRegistry === "object" &&
-      typeof packageRegistry.settings === "object" &&
-      typeof packageRegistry.settings.public === "object" &&
-      typeof packageRegistry.settings.public.allowGuestCheckout === "boolean") {
-      allowGuest = packageRegistry.settings.public.allowGuestCheckout;
-    } else {
-      allowGuest = true;
+    if (ReactionCore.Subscriptions.Packages.ready()) {
+      let allowGuest;
+      let packageRegistry = ReactionCore.Collections.Packages.findOne({
+        name: "core",
+        shopId: this.shopId
+      });
+      // we can disable in admin, let's check.
+      if (typeof packageRegistry === "object" &&
+        typeof packageRegistry.settings === "object" &&
+        typeof packageRegistry.settings.public === "object" &&
+        typeof packageRegistry.settings.public.allowGuestCheckout === "boolean") {
+        allowGuest = packageRegistry.settings.public.allowGuestCheckout;
+      } else {
+        allowGuest = true;
+      }
+      ReactionCore.Log.info("alowGuestCheckout: " + allowGuest);
+      return allowGuest;
     }
-    return allowGuest;
+    console.log("Package subscription not ready when allowGuestCheckout was checked");
+    return false;
   },
   getSellerShopId: function () {
     return Roles.getGroupsForUser(this.userId, "admin");
@@ -191,10 +196,6 @@ _.extend(ReactionCore, {
 
   hideActionView: function () {
     Session.set("admin/showActionView", false);
-  },
-
-  clearActionView: function () {
-    Session.set("admin/actionView", undefined);
   },
 
   getCurrentTag: function () {

--- a/packages/reaction-core/client/main.js
+++ b/packages/reaction-core/client/main.js
@@ -133,7 +133,7 @@ _.extend(ReactionCore, {
     return this.shopName;
   },
   allowGuestCheckout: function () {
-    let allowGuest = true;
+    let allowGuest;
     let packageRegistry = ReactionCore.Collections.Packages.findOne({
       name: "core",
       shopId: this.shopId
@@ -141,8 +141,11 @@ _.extend(ReactionCore, {
     // we can disable in admin, let's check.
     if (typeof packageRegistry === "object" &&
       typeof packageRegistry.settings === "object" &&
-      packageRegistry.settings.allowGuestCheckout) {
-      allowGuest = packageRegistry.settings.allowGuestCheckout;
+      typeof packageRegistry.settings.public === "object" &&
+      typeof packageRegistry.settings.public.allowGuestCheckout === "boolean") {
+      allowGuest = packageRegistry.settings.public.allowGuestCheckout;
+    } else {
+      allowGuest = true;
     }
     return allowGuest;
   },

--- a/packages/reaction-core/client/main.js
+++ b/packages/reaction-core/client/main.js
@@ -139,6 +139,9 @@ _.extend(ReactionCore, {
         name: "core",
         shopId: this.shopId
       });
+      if (typeof packageRegistry === "undefined") {
+        throw Meteor.Error("400", "Package Info not available, couldn't check value");
+      }
       // we can disable in admin, let's check.
       if (typeof packageRegistry === "object" &&
         typeof packageRegistry.settings === "object" &&


### PR DESCRIPTION
Fix for issue #778 . The wrong registry setting was being checked, the logic was incorrect so it always returned true and this value was never used to control when the login was changed.

@mikemurray If you could take a quick look at what I did there and make sure that's how we want that handled? I saw some other (possibly unused?) logic about `anonymousWorkflow` but I didn't see how it was controlling the display here.