### PR TITLE
Extra char causing Cart Remove Execution Flow to Break without warning

### DIFF
--- a/packages/reaction-checkout/common/methods/workflow.js
+++ b/packages/reaction-checkout/common/methods/workflow.js
@@ -226,7 +226,7 @@ Meteor.methods({
     // get index of `newWorkflowStatus`
     const resetToIndex = workflow.indexOf(newWorkflowStatus);
     // exit if no such step in workflow
-    if (!~resetToIndex) return false;
+    if (!resetToIndex) return false;
     // remove all steps that further `newWorkflowStatus` and itself
     const resetedWorkflow = workflow.slice(0, resetToIndex);
 


### PR DESCRIPTION
Found extra char ~ while debug the remove from Cart flow in below line.
if (!~resetToIndex) return false;