### PR TITLE
fixes non-rtl bootstrap column issue

### DIFF
--- a/packages/my-custom-theme-template/main.less
+++ b/packages/my-custom-theme-template/main.less
@@ -14,7 +14,8 @@
 @import "styles/variables.less";
 
 // Import Reaction Core Theme Styles
-@import "{reactioncommerce:core-theme}/default/bootstrap.rtl.less";
+// Disabled: Reaction-UI can handle RTL
+// @import "{reactioncommerce:core-theme}/default/bootstrap.rtl.less";
 @import "{reactioncommerce:core-theme}/default/alerts.less";
 @import "{reactioncommerce:core-theme}/default/dropdowns.less";
 @import "{reactioncommerce:core-theme}/default/forms.less";


### PR DESCRIPTION
`bootstrap.rtl.less` is no longer used in `reaction-default-theme` but the import stuck around in the custom theme template. This file causes bootstrap columns to get floated right, even if the language in use is not RTL and the `<html>` element does not have the `.rtl` class on it.

This PR fixes that issue.