### PR TITLE
use docker-compose to run CI curl test on container

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,8 @@ test:
   override:
     - cd $HOME/reaction
     - VELOCITY_TEST_PACKAGES=1 meteor test-packages --driver-package velocity:html-reporter --velocity
+    - docker-compose -f docker/docker-compose.test.yml up -d; sleep 10
+    - curl --retry 10 --retry-delay 5 -v http://localhost
 
 deployment:
   prequel:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,15 @@
+# used for CircleCI curl tests
+
+reaction:
+  image: reactioncommerce/prequel
+  links:
+    - mongo
+  ports:
+    - "80:80"
+  environment:
+    ROOT_URL: "http://localhost"
+    MONGO_URL: "mongodb://mongo:27017/reaction"
+
+mongo:
+  image: mongo:2.6.11
+  command: mongod --smallfiles


### PR DESCRIPTION
Post-build `curl` test of container no longer requires Mongo to be installed inside the container.  Docker Compose runs the config at `docker/docker-compose.test.yml` to pull down and link a Mongo container.