### PR TITLE
Release v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Reaction is a modern reactive, real-time event driven ecommerce platform.
 Reaction is built with JavaScript (ES6), Meteor, Node.js and works nicely with Docker.
 
 ## Status
-- 0.11.1 Master
-- 0.12.0 Development (new feature release)
+- 0.12.0 Master
+- 0.13.0 Development (new feature release)
 
 Currently good for contributing/observing progress, testing. It goes without saying that we're constantly refactoring, even things that are functionally done. We'd encourage due diligence in production usage, be very comfortable with the code, and risk tolerant. There are still many parts in development!
 
@@ -45,6 +45,8 @@ For grouping of development channels by feature, review the [project milestones]
 And finally for the kanban-esque, hardcore real time progress overview of Reaction, take a look our [waffle board](https://waffle.io/reactioncommerce/reaction)
 
 ## Feedback
-**GitHub Issues** on the [Reaction](https://github.com/reactioncommerce/reaction) project are the best way to let us know about a feature request, or to report an issue.
+**Create a GitHub Issue** on the [Reaction project ](https://github.com/reactioncommerce/reaction) to report an issue.
 
-Join us on our **[Gitter chat room](https://gitter.im/reactioncommerce/reaction)** to discuss, communicate, and share community support.
+Visit the **[Reaction discourse forum](http://discourse.reactioncommerce.com/)** to engage with the core team and community on new feature requests, or get community support with customization of Reaction.
+
+Join us on our **[Gitter chat room](https://gitter.im/reactioncommerce/reaction)** to engage with other Meteor and Reaction users.

--- a/packages/reaction-core/server/registry/assignRoles.js
+++ b/packages/reaction-core/server/registry/assignRoles.js
@@ -63,7 +63,7 @@ ReactionRegistry.assignOwnerRoles = (shopId, pkgName, registry) => {
       }
     }
   } else {
-    ReactionCore.Log.info(`No routes loaded for ${pkgName}`);
+    ReactionCore.Log.debug(`No routes loaded for ${pkgName}`);
   }
   // only unique roles
   const defaultOwnerRoles = _.uniq(defaultRoles);


### PR DESCRIPTION
Release Notes v0.12 

There are breaking changes with this release, it is recommended to start with a `reset` as existing data may not be compatible, but the key collection changes are for `Shops` and `Packages`. 

There are 155 passing server integration tests for this release.

**Changes**

- Iron Router removed.
- [Flow Router SSR](https://github.com/kadirahq/flow-router/tree/ssr) added in new `reaction-router` package.
- `Router` deprecated, use `ReactionRouter`
-  ReactionLayout adds BlazeLayout functionality with layout structure
- Packages can use the registry for all route declarations.
- Permissions and Registry refactored for registry usage.
- Layout Structure, use router uses `renderLayout`
- Titles and Meta Data now uses [kadira:dochead](https://github.com/kadirahq/meteor-dochead)
- New hierarchical `Tags` navigation and management.
- Merged main navigation and tag navigation into single component
- Updated Docker build process for much smaller images.
- New  (WIP) theming utilities in the `reaction-ui `package.
- Updated dashboard layout
- Upload a brand image for navigation in the `Core` Dashboard settings.
- Subscriptions moved to the template level.
-  Multi-shop now in sample data, in progress dashboard
- multi-store routing implemented with definable prefix
- add `icon-reaction-logo` font
- new `Alerts` methods `toast` and `inline` and `alert`.
- Template helpers `pathForSeo` and `currentRoute` are deprecated, use `pathFor`.
- Languages now configurable using i18n settings UI in dashboard.
- `i18n` deprecated, use  `i18next`. 
- `i18next` updated to v2.0
- new i18n helpers attached to `reactionApps`, `reactionTemplates`, use: `{{i18n i18nKeyLabel label}}`
- Permissions and Routes now use  `package.registry.name` as the key (not route).
- `Products` collections now use a [flattened, multi-schema](https://docs.reactioncommerce.com/reaction-docs/development/simple-schema) [implementation](https://github.com/reactioncommerce/reaction/pull/741).
- Core split into multiple new packages, and all packages have been updated.
	* 	reactioncommerce:core@0.12.0
	* 	reactioncommerce:core-theme@2.0.1
	* 	reactioncommerce:default-theme@1.0.4
	* 	reactioncommerce:launchdock-connect@0.2.1
	* 	reactioncommerce:reaction-accounts@1.7.0
	* 	reactioncommerce:reaction-analytics@1.2.3
	* 	reactioncommerce:reaction-analytics-libs@1.1.0
	* 	reactioncommerce:reaction-auth-net@0.6.0
	* 	reactioncommerce:reaction-braintree@1.5.3
	* 	reactioncommerce:reaction-catalog@0.2.1
	* 	reactioncommerce:reaction-checkout@1.0.0
	* 	reactioncommerce:reaction-collections@2.0.1
	* 	reactioncommerce:reaction-dashboard@1.0.0
	* 	reactioncommerce:reaction-email-templates@0.2.0
	* 	reactioncommerce:reaction-i18n@2.0.0
	* 	reactioncommerce:reaction-inventory@0.2.3
	* 	reactioncommerce:reaction-layout@1.0.0
	* 	reactioncommerce:reaction-logger@0.1.0
	* 	reactioncommerce:reaction-orders@1.0.0
	* 	reactioncommerce:reaction-paymentmethod@0.0.4
	* 	reactioncommerce:reaction-paypal@1.3.0
	* 	reactioncommerce:reaction-product-variant@1.0.0
	* 	reactioncommerce:reaction-router@1.1.0
	* 	reactioncommerce:reaction-sample-data@0.1.2
	* 	reactioncommerce:reaction-schemas@2.0.3
	* 	reactioncommerce:reaction-shipping@0.8.0
	* 	reactioncommerce:reaction-social@0.4.3
	* 	reactioncommerce:reaction-stripe@3.1.2
	* 	reactioncommerce:reaction-ui@0.6.0
	* 	reactioncommerce:reaction-ui-navbar@0.1.0
	* 	reactioncommerce:reaction-ui-tagnav@0.1.0

**Contributions**

A sincere thanks from the core team of @aaronjudd, @mikemurray, @jshimko, @zenweasel, @saralouhicks  for all the community contributions we accepted into this release.  We merged requests from @newsiberian, @lijiming,  @hrath2015, @spencern, @ramusus, @meladawy, @johannes-scharlach, @tdecaluwe, @uniquarkD 
