### PR TITLE
Patches for v0.12.0

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -150,7 +150,7 @@ reactioncommerce:reaction-analytics@1.2.3
 reactioncommerce:reaction-analytics-libs@1.1.0
 reactioncommerce:reaction-auth-net@0.6.0
 reactioncommerce:reaction-braintree@1.5.3
-reactioncommerce:reaction-catalog@0.2.1
+reactioncommerce:reaction-catalog@0.2.2
 reactioncommerce:reaction-checkout@1.0.0
 reactioncommerce:reaction-collections@2.0.1
 reactioncommerce:reaction-dashboard@1.0.0
@@ -165,7 +165,7 @@ reactioncommerce:reaction-paypal@1.3.0
 reactioncommerce:reaction-product-variant@1.0.0
 reactioncommerce:reaction-router@1.1.0
 reactioncommerce:reaction-sample-data@0.1.2
-reactioncommerce:reaction-schemas@2.0.3
+reactioncommerce:reaction-schemas@2.0.4
 reactioncommerce:reaction-shipping@0.8.0
 reactioncommerce:reaction-social@0.4.3
 reactioncommerce:reaction-stripe@3.1.2

--- a/packages/reaction-catalog/package.js
+++ b/packages/reaction-catalog/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary: "Reaction Catalog",
   name: "reactioncommerce:reaction-catalog",
-  version: "0.2.1",
+  version: "0.2.2",
   git: "https://github.com/reactioncommerce/reaction-catalog.git"
 });
 

--- a/packages/reaction-product-variant/client/templates/products/productDetail/attributes/attributes.js
+++ b/packages/reaction-product-variant/client/templates/products/productDetail/attributes/attributes.js
@@ -6,12 +6,7 @@ Template.productMetaFieldForm.events({
   "click .metafield-remove": function () {
     let productId;
     productId = ReactionProduct.selectedProductId();
-    // todo: whats happen here? why we update collection directly?
-    return ReactionCore.Collections.Products.update(productId, {
-      $pull: {
-        metafields: this
-      }
-    });
+    Meteor.call("products/removeMetaFields", productId, this);
   }
 });
 

--- a/packages/reaction-schemas/common/schemas/products.js
+++ b/packages/reaction-schemas/common/schemas/products.js
@@ -67,8 +67,6 @@ ReactionCore.Schemas.ProductPosition = new SimpleSchema({
 ReactionCore.Schemas.ProductVariant = new SimpleSchema({
   _id: {
     type: String,
-    optional: true,
-    index: 1,
     label: "Variant ID"
   },
   ancestors: {
@@ -271,7 +269,7 @@ ReactionCore.Schemas.PriceRange = new SimpleSchema({
 ReactionCore.Schemas.Product = new SimpleSchema({
   _id: {
     type: String,
-    optional: true
+    label: "Product Id"
   },
   ancestors: {
     type: [String],

--- a/packages/reaction-schemas/package.js
+++ b/packages/reaction-schemas/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary: "Reaction Schemas - core reaction commerce collection schemas",
   name: "reactioncommerce:reaction-schemas",
-  version: "2.0.3",
+  version: "2.0.4",
   documentation: "README.md"
 });
 


### PR DESCRIPTION
Resolves #932 with a new server method "products/removeMetaFields". Delete is moved to the server.

Resolves #865 resolve mongo unique index error for versions of `MongoDB > 2.6 and < 3.2` by removing optional: true from _id fields of product/productVariant schema.


Test mongo resolution by running through all versions of mongo available in `brew switch mongodb 3.0.6 `, using `MONGO_URL="mongodb://127.0.0.1:27017/meteor" meteor`, resetting between each test.