### PR TITLE
Implementation of i18n namespaces support

### DIFF
--- a/packages/reaction-core/server/import.js
+++ b/packages/reaction-core/server/import.js
@@ -253,7 +253,8 @@ ReactionImport.package = function (pkg, shopId) {
  * @returns {Object} updated translation buffer
  */
 ReactionImport.translation = function (key, translation) {
-  return this.object(ReactionCore.Collections.Translations, key, translation);
+  const modifiedKey = Object.assign(key, { ns: translation.ns });
+  return this.object(ReactionCore.Collections.Translations, modifiedKey, translation);
 };
 
 //

--- a/packages/reaction-i18n/client/helpers/i18n.js
+++ b/packages/reaction-i18n/client/helpers/i18n.js
@@ -131,7 +131,13 @@ Tracker.autorun(function () {
       }).fetch();
     // map reduce translations into i18next formatting
     const resources = translations.reduce(function (x, y) {
-      x[y.i18n] = y.translation;
+      const ns = Object.keys(y.translation)[0];
+      // first creating the structure, when add additional namespaces
+      if (x[y.i18n]) {
+        x[y.i18n][ns] = y.translation[ns];
+      } else {
+        x[y.i18n] = y.translation;
+      }
       return x;
     }, {});
 

--- a/packages/reaction-i18n/private/data/i18n/ar.json
+++ b/packages/reaction-i18n/private/data/i18n/ar.json
@@ -2,6 +2,7 @@
     {
         "language": "Arabic",
         "i18n": "ar",
+        "ns": "core",
         "translation": {
             "core": {
                 "languageDirection": "rtl",

--- a/packages/reaction-i18n/private/data/i18n/bg.json
+++ b/packages/reaction-i18n/private/data/i18n/bg.json
@@ -1,6 +1,7 @@
 [{
 	"language": "Български",
 	"i18n": "bg",
+	"ns": "core",
 	"translation": {
 		"core": {
 			"languages": {

--- a/packages/reaction-i18n/private/data/i18n/cn.json
+++ b/packages/reaction-i18n/private/data/i18n/cn.json
@@ -1,6 +1,7 @@
 [{
   "language": "中文(简体)",
   "i18n": "cn",
+  "ns": "core",
   "translation": {
     "core": {
       "languages": {

--- a/packages/reaction-i18n/private/data/i18n/cs.json
+++ b/packages/reaction-i18n/private/data/i18n/cs.json
@@ -2,6 +2,7 @@
     {
         "language": "Czech",
         "i18n": "cs",
+        "ns": "core",
         "translation": {
             "core": {
                 "accountsUI": {

--- a/packages/reaction-i18n/private/data/i18n/de.json
+++ b/packages/reaction-i18n/private/data/i18n/de.json
@@ -2,6 +2,7 @@
     {
         "language": "German",
         "i18n": "de",
+        "ns": "core",
         "translation": {
             "core": {
                 "languages": {

--- a/packages/reaction-i18n/private/data/i18n/el.json
+++ b/packages/reaction-i18n/private/data/i18n/el.json
@@ -2,6 +2,7 @@
     {
         "language": "Ελληνικά",
         "i18n": "el",
+        "ns": "core",
         "translation": {
             "core": {
                 "languages": {

--- a/packages/reaction-i18n/private/data/i18n/en.json
+++ b/packages/reaction-i18n/private/data/i18n/en.json
@@ -1,6 +1,7 @@
 [{
   "language": "English",
   "i18n": "en",
+  "ns": "core",
   "translation": {
     "core": {
       "languages": {

--- a/packages/reaction-i18n/private/data/i18n/es.json
+++ b/packages/reaction-i18n/private/data/i18n/es.json
@@ -2,6 +2,7 @@
     {
         "language": "Spanish",
         "i18n": "es",
+        "ns": "core",
         "entryText": "Español",
         "translation": {
             "core": {

--- a/packages/reaction-i18n/private/data/i18n/fr.json
+++ b/packages/reaction-i18n/private/data/i18n/fr.json
@@ -2,6 +2,7 @@
     {
         "language": "French",
         "i18n": "fr",
+        "ns": "core",
         "translation": {
             "core": {
                 "accountsUI": {

--- a/packages/reaction-i18n/private/data/i18n/he.json
+++ b/packages/reaction-i18n/private/data/i18n/he.json
@@ -2,6 +2,7 @@
     {
         "language": "Hebrew",
         "i18n": "he",
+        "ns": "core",
         "translation": {
             "core": {
                 "languageDirection": "rtl",

--- a/packages/reaction-i18n/private/data/i18n/hr.json
+++ b/packages/reaction-i18n/private/data/i18n/hr.json
@@ -2,6 +2,7 @@
     {
         "language": "Croatian",
         "i18n": "hr",
+        "ns": "core",
         "translation": {
             "core": {
                 "languages": {

--- a/packages/reaction-i18n/private/data/i18n/hu.json
+++ b/packages/reaction-i18n/private/data/i18n/hu.json
@@ -2,6 +2,7 @@
     {
         "language": "Hungarian",
         "i18n": "hu",
+        "ns": "core",
         "translation": {
             "core": {
                 "languages": {

--- a/packages/reaction-i18n/private/data/i18n/it.json
+++ b/packages/reaction-i18n/private/data/i18n/it.json
@@ -2,6 +2,7 @@
     {
         "language": "Italian",
         "i18n": "it",
+        "ns": "core",
         "translation": {
             "core": {
                 "languages": {

--- a/packages/reaction-i18n/private/data/i18n/my.json
+++ b/packages/reaction-i18n/private/data/i18n/my.json
@@ -2,6 +2,7 @@
     {
         "language": "Burmese",
         "i18n": "my",
+        "ns": "core",
         "translation": {
             "core": {
                 "languages": {

--- a/packages/reaction-i18n/private/data/i18n/nb.json
+++ b/packages/reaction-i18n/private/data/i18n/nb.json
@@ -1,6 +1,7 @@
 [{
   "language": "Norwegian",
   "i18n": "nb",
+  "ns": "core",
   "translation": {
     "core": {
       "languages": {

--- a/packages/reaction-i18n/private/data/i18n/nl.json
+++ b/packages/reaction-i18n/private/data/i18n/nl.json
@@ -2,6 +2,7 @@
     {
         "i18n": "nl",
         "language": "Nederlands",
+        "ns": "core",
         "translation": {
             "core": {
                 "accountsUI": {

--- a/packages/reaction-i18n/private/data/i18n/pl.json
+++ b/packages/reaction-i18n/private/data/i18n/pl.json
@@ -2,6 +2,7 @@
     {
         "language": "Polish",
         "i18n": "pl",
+        "ns": "core",
         "translation": {
             "core": {
                 "accountsUI": {

--- a/packages/reaction-i18n/private/data/i18n/pt.json
+++ b/packages/reaction-i18n/private/data/i18n/pt.json
@@ -2,6 +2,7 @@
     {
         "language": "Portuguese",
         "i18n": "pt",
+        "ns": "core",
         "translation": {
             "core": {
                 "accountsUI": {

--- a/packages/reaction-i18n/private/data/i18n/ru.json
+++ b/packages/reaction-i18n/private/data/i18n/ru.json
@@ -1,6 +1,7 @@
 [{
   "language": "Russian",
   "i18n": "ru",
+  "ns": "core",
   "translation": {
     "core": {
       "languages": {

--- a/packages/reaction-i18n/private/data/i18n/sl.json
+++ b/packages/reaction-i18n/private/data/i18n/sl.json
@@ -2,6 +2,7 @@
     {
         "language": "Slovenian",
         "i18n": "sl",
+        "ns": "core",
         "translation": {
             "core": {
                 "accountsUI": {

--- a/packages/reaction-i18n/private/data/i18n/sv.json
+++ b/packages/reaction-i18n/private/data/i18n/sv.json
@@ -2,6 +2,7 @@
     {
         "language": "Swedish",
         "i18n": "sv",
+        "ns": "core",
         "translation": {
             "core": {
                 "accountsUI": {

--- a/packages/reaction-i18n/private/data/i18n/tr.json
+++ b/packages/reaction-i18n/private/data/i18n/tr.json
@@ -2,6 +2,7 @@
     {
         "language": "Türkçe",
         "i18n": "tr",
+        "ns": "core",
         "translation": {
             "core": {
                 "languages": {

--- a/packages/reaction-i18n/private/data/i18n/vi.json
+++ b/packages/reaction-i18n/private/data/i18n/vi.json
@@ -2,6 +2,7 @@
     {
         "language": "Vietnamese",
         "i18n": "vi",
+        "ns": "core",
         "translation": {
             "core": {
                 "accountsUI": {

--- a/packages/reaction-i18n/server/import.js
+++ b/packages/reaction-i18n/server/import.js
@@ -1,17 +1,33 @@
+const fs = Npm.require("fs");
+
+// taken from here: http://stackoverflow.com/a/32749571
+const directoryExists = dirPath => {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch (err) {
+    return false;
+  }
+};
+
 loadCoreTranslations = () => {
-  const fs = Npm.require("fs");
-  const packageName = "reactioncommerce_reaction-i18n";
   const readFolder = Meteor.wrapAsync(fs.readdir, fs);
   const meteorPath = fs.realpathSync(process.cwd() + "/../");
-  const i18nFolder = `${meteorPath}/server/assets/packages/${packageName}/private/data/i18n/`;
-  readFolder(i18nFolder, function (err, files) {
-    if (err) throw new Meteor.Error("No translations found for import.", err);
-    for (const file of files) {
-      if (file.indexOf("json")) {
-        ReactionCore.Log.debug(`Importing Translations from ${file}`);
-        const json = Assets.getText("private/data/i18n/" + file);
-        ReactionImport.process(json, ["i18n"], ReactionImport.translation);
-      }
+  // get the list of package folder names which have assets.
+  const packagesList = fs.readdirSync(`${meteorPath}/server/assets/packages/`);
+  packagesList.forEach(pkg => {
+    const i18nFolder = `${meteorPath}/server/assets/packages/${pkg}/private/data/i18n/`;
+    // we are avoiding packages w/o correct path
+    if (directoryExists(i18nFolder)) {
+      readFolder(i18nFolder, function (err, files) {
+        if (err) throw new Meteor.Error("No translations found for import.", err);
+        for (let file of files) {
+          if (file.indexOf("json")) {
+            ReactionCore.Log.debug(`Importing Translations from ${file}`);
+            let json = fs.readFileSync(i18nFolder + file, "utf8");
+            ReactionImport.process(json, ["i18n"], ReactionImport.translation);
+          }
+        }
+      });
     }
   });
 };

--- a/packages/reaction-schemas/common/schemas/translations.js
+++ b/packages/reaction-schemas/common/schemas/translations.js
@@ -20,6 +20,10 @@ ReactionCore.Schemas.Translation = new SimpleSchema({
     type: String,
     index: 1
   },
+  ns: {
+    type: String,
+    label: "Namespace"
+  },
   translation: {
     type: Object,
     blackbox: true


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
This is an implementation of namespaces support for `reaction-i18n`.
- [x] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide

To make it works with import, we have to add new `ns` field to `Translations` schema. Also, it is now always correctly load `en` translations within publication, don't know why, but this happens only on first load after reset and then works fine.

Package creators will need to copy directory structure to make this work: `private/data/i18n`