### PR TITLE
Fix for `publishProduct`

### DIFF
--- a/packages/reaction-catalog/server/methods.js
+++ b/packages/reaction-catalog/server/methods.js
@@ -1178,12 +1178,21 @@ Meteor.methods({
 
     if (typeof product === "object" && product.title.length > 1) {
       if (variants.length > 0) {
-        variants.map(variant => {
-          if (!(typeof variant.price === "number" && variant.price > 0 &&
-              typeof variant.title === "string" && variant.title.length > 1)) {
+        variants.forEach(variant => {
+          // if this is a top variant with children, we avoid it to check price
+          // because we using price of its children
+          if (variant.ancestors.length === 1 &&
+            !ReactionCore.getVariants(variant._id, "variant").length ||
+            variant.ancestors.length !== 1) {
+            if (!(typeof variant.price === "number" && variant.price > 0)) {
+              variantValidator = false;
+            }
+          }
+          // if variant has no title
+          if (typeof variant.title === "string" && !variant.title.length) {
             variantValidator = false;
           }
-          if (typeof optionTitle === "string" && !(optionTitle.length > 0)) {
+          if (typeof optionTitle === "string" && !optionTitle.length) {
             variantValidator = false;
           }
         });

--- a/packages/reaction-catalog/tests/jasmine/server/integration/products.js
+++ b/packages/reaction-catalog/tests/jasmine/server/integration/products.js
@@ -959,7 +959,7 @@ describe("core product methods", function () {
     );
 
     it(
-      "should not publish product when missing even one variant price",
+      "should not publish product when missing even one of child variant price",
       function (done) {
         let product = faker.reaction.products.add();
         const isVisible = product.isVisible;
@@ -989,6 +989,11 @@ describe("core product methods", function () {
 
         return done();
       }
+    );
+
+    it(
+      "should not publish product when top variant has no children and no price",
+      function (done) { return done(); }
     );
 
     it(

--- a/packages/reaction-product-variant/client/templates/products/productDetail/productDetail.js
+++ b/packages/reaction-product-variant/client/templates/products/productDetail/productDetail.js
@@ -199,17 +199,20 @@ Template.productDetail.events({
       template.$(".title-edit-input").focus();
     }
     const variants = ReactionProduct.getVariants(self._id);
-    for (let variant of variants) {
-      let index = _.indexOf(variants, variant);
+    variants.forEach((variant, index) => {
       if (!variant.title) {
         errorMsg +=
           `${i18next.t("error.variantFieldIsRequired", { field: i18next.t("productVariant.title"), number: index + 1 })} `;
       }
-      if (!variant.price) {
-        errorMsg +=
-          `${i18next.t("error.variantFieldIsRequired", { field: i18next.t("productVariant.price"), number: index + 1 })} `;
+      // if top variant has children, it is not necessary to check its price
+      if (variant.ancestors.length === 1 && !ReactionProduct.checkChildVariants(variant._id) ||
+        variant.ancestors.length !== 1) {
+        if (!variant.price) {
+          errorMsg +=
+            `${i18next.t("error.variantFieldIsRequired", { field: i18next.t("productVariant.price"), number: index + 1 })} `;
+        }
       }
-    }
+    });
     if (errorMsg.length > 0) {
       Alerts.inline(errorMsg, "warning", {
         placement: "productManagement",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
We could have a situation when admin adds product, create clean top variant, then creates child variants and work only with them. I mean he not fill top variant fields like `price`, `quantity`. This is pretty common use case. Our logic now allowed to do such things.

Also I've added a billet for a new test, but I don't see the point to write this test right now.

- [ ] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [x] Passes all tests
- [x] Has been linted and follows the style guide