### PR TITLE
Fix for the `productGrid` products loading

### DIFF
--- a/packages/reaction-product-variant/client/templates/products/productGrid/productGrid.js
+++ b/packages/reaction-product-variant/client/templates/products/productGrid/productGrid.js
@@ -142,7 +142,16 @@ Template.productGrid.helpers({
       return 0;
     }
 
-    let gridProducts = ReactionCore.Collections.Products.find({}).fetch();
+    // we are passing `type`, because in case when we turn back from PDP
+    // for a moment we still subscribed to variants too, and we will get an error
+    // because of it, because our `productGrid` component can't work with variants
+    // objects.
+    // In future we could add more type to this list
+    // Also, we it is possible to change this selector to the following:
+    // `ancestors: []`
+    let gridProducts = ReactionCore.Collections.Products.find({
+      type: { $in: ["simple"] }
+    }).fetch();
     const products = gridProducts.sort(compare);
     Template.instance().products = products;
     return products;

--- a/packages/reaction-product-variant/client/templates/products/productGrid/productGrid.js
+++ b/packages/reaction-product-variant/client/templates/products/productGrid/productGrid.js
@@ -142,15 +142,19 @@ Template.productGrid.helpers({
       return 0;
     }
 
-    // we are passing `type`, because in case when we turn back from PDP
+    // we are passing `ancestors: []`, because in case when we turn back from PDP
     // for a moment we still subscribed to variants too, and we will get an error
     // because of it, because our `productGrid` component can't work with variants
     // objects.
-    // In future we could add more type to this list
+    //
     // Also, we it is possible to change this selector to the following:
-    // `ancestors: []`
+    // `type: { $in: ["simple"] }`, but I found this way is not kind to package
+    // creators, because to specify they new product type, they will need to change
+    // this file, which broke another piece of compatibility with `reaction`
     let gridProducts = ReactionCore.Collections.Products.find({
-      type: { $in: ["simple"] }
+      ancestors: []
+      // keep this, as an example
+      // type: { $in: ["simple"] }
     }).fetch();
     const products = gridProducts.sort(compare);
     Template.instance().products = products;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Hello. `ProductsGrid` loads variants after backing from PDP via old-PDP subscription. It's just a little moment till subscription will be updated. T consider that, we have to specify our `selector`.

We have two ways to specify selector: `type: { $in: ["simple", "bundle", etc..] }` or `ancestors: []`. I decide to use second, because it is shows more respect to package creators. With this selector, they no need to add one more incompatibility to their projects.


- [ ] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [x] Has been linted and follows the style guide