### PR TITLE
Workaround for error that occurs on startup in Docker containers because `shopId` is not ready

### DIFF
--- a/packages/reaction-core/server/import.js
+++ b/packages/reaction-core/server/import.js
@@ -108,15 +108,11 @@ ReactionImport.identify = function (document) {
  * @param {function} callback Function to execute after flush succeeded
  * @returns {undefined}
  */
-ReactionImport.flush = function (collection, callback) {
+ReactionImport.flush = function (collection) {
   check(collection, Match.Optional(Mongo.Collection));
-  check(callback, Match.OneOf(undefined, Function));
   if (!collection) {
     for (let name of Object.keys(this._buffers)) {
       this.flush(ReactionCore.Collections[name]);
-    }
-    if (callback) {
-      callback();
     }
     return;
   }
@@ -162,9 +158,6 @@ ReactionImport.flush = function (collection, callback) {
     // Reset the buffer.
     delete this._buffers[name];
     this._count[name] = 0;
-  }
-  if (callback) {
-    callback();
   }
 };
 

--- a/packages/reaction-core/server/import.js
+++ b/packages/reaction-core/server/import.js
@@ -105,14 +105,18 @@ ReactionImport.identify = function (document) {
 /**
  * @summary Commit the buffer for a given collection to the database.
  * @param {Mongo.Collection} collection The target collection to be flushed to disk
+ * @param {function} callback Function to execute after flush succeeded
  * @returns {undefined}
  */
-ReactionImport.flush = function (collection) {
+ReactionImport.flush = function (collection, callback) {
   check(collection, Match.Optional(Mongo.Collection));
-
+  check(callback, Match.OneOf(undefined, Function));
   if (!collection) {
     for (let name of Object.keys(this._buffers)) {
       this.flush(ReactionCore.Collections[name]);
+    }
+    if (callback) {
+      callback();
     }
     return;
   }
@@ -158,6 +162,9 @@ ReactionImport.flush = function (collection) {
     // Reset the buffer.
     delete this._buffers[name];
     this._count[name] = 0;
+  }
+  if (callback) {
+    callback();
   }
 };
 

--- a/packages/reaction-core/server/main.js
+++ b/packages/reaction-core/server/main.js
@@ -17,12 +17,11 @@ _.extend(ReactionCore, {
     // Jobs.setLogStream(process.stdout);
     ReactionRegistry.loadPackages();
     // process imports from packages and any hooked imports
-    ReactionCore.Log.info("Flushing db and creating default admin user");
+    ReactionImport.flush();
     // timing is important, packages are rqd
-    // for initial permissions configuration.
-    ReactionImport.flush(null);
-    // hook after init finished
+    // for initilial permissions configuration.
     ReactionRegistry.createDefaultAdminUser();
+    // hook after init finished
     ReactionCore.Hooks.Events.run("afterCoreInit", this);
     return true;
   },
@@ -31,7 +30,7 @@ _.extend(ReactionCore, {
    * server permissions checks
    * hasPermission exists on both the server and the client.
    * @param {String | Array} checkPermissions -String or Array of permissions if empty, defaults to "admin, owner"
-   * @param {String} userId - userId, defaults to Meteor.userId()
+   * @param {String} checkUserId - userId, defaults to Meteor.userId()
    * @param {String} checkGroup group - default to shopId
    * @return {Boolean} Boolean - true if has permission
    */

--- a/packages/reaction-core/server/main.js
+++ b/packages/reaction-core/server/main.js
@@ -17,10 +17,10 @@ _.extend(ReactionCore, {
     // Jobs.setLogStream(process.stdout);
     ReactionRegistry.loadPackages();
     // process imports from packages and any hooked imports
-    ReactionImport.flush();
+    ReactionCore.Log.info("Flushing db and creating default admin user");
+    ReactionImport.flush(null, ReactionRegistry.createDefaultAdminUser);
     // timing is important, packages are rqd
-    // for initilial permissions configuration.
-    ReactionRegistry.createDefaultAdminUser();
+    // for initial permissions configuration.
     // hook after init finished
     ReactionCore.Hooks.Events.run("afterCoreInit", this);
     return true;
@@ -30,7 +30,7 @@ _.extend(ReactionCore, {
    * server permissions checks
    * hasPermission exists on both the server and the client.
    * @param {String | Array} checkPermissions -String or Array of permissions if empty, defaults to "admin, owner"
-   * @param {String} checkUserId - userId, defaults to Meteor.userId()
+   * @param {String} userId - userId, defaults to Meteor.userId()
    * @param {String} checkGroup group - default to shopId
    * @return {Boolean} Boolean - true if has permission
    */

--- a/packages/reaction-core/server/main.js
+++ b/packages/reaction-core/server/main.js
@@ -18,9 +18,9 @@ _.extend(ReactionCore, {
     ReactionRegistry.loadPackages();
     // process imports from packages and any hooked imports
     ReactionCore.Log.info("Flushing db and creating default admin user");
-    ReactionImport.flush(null);
     // timing is important, packages are rqd
     // for initial permissions configuration.
+    ReactionImport.flush(null);
     // hook after init finished
     ReactionRegistry.createDefaultAdminUser();
     ReactionCore.Hooks.Events.run("afterCoreInit", this);

--- a/packages/reaction-core/server/main.js
+++ b/packages/reaction-core/server/main.js
@@ -18,10 +18,11 @@ _.extend(ReactionCore, {
     ReactionRegistry.loadPackages();
     // process imports from packages and any hooked imports
     ReactionCore.Log.info("Flushing db and creating default admin user");
-    ReactionImport.flush(null, ReactionRegistry.createDefaultAdminUser);
+    ReactionImport.flush(null);
     // timing is important, packages are rqd
     // for initial permissions configuration.
     // hook after init finished
+    ReactionRegistry.createDefaultAdminUser();
     ReactionCore.Hooks.Events.run("afterCoreInit", this);
     return true;
   },

--- a/packages/reaction-core/server/registry/defaultAdmin.js
+++ b/packages/reaction-core/server/registry/defaultAdmin.js
@@ -7,14 +7,21 @@
  * @returns {String} return userId
  */
 ReactionRegistry.createDefaultAdminUser = function () {
+  ReactionCore.Log.info("Starting createDefaultAdminUser");
   let options = {};
   const domain = ReactionRegistry.getRegistryDomain();
   const defaultAdminRoles = ["owner", "admin", "guest", "account/profile"];
-  const shopId = ReactionCore.getShopId();
   let accountId;
+
+  while (!ReactionCore.getShopId()) {
+    ReactionCore.Log.info("No shopId, waiting one second...");
+    Meteor._sleepForMs(1000);
+  }
+  const shopId = ReactionCore.getShopId();
 
   // if an admin user has already been created, we'll exit
   if (Roles.getUsersInRole(defaultAdminRoles, shopId).count() !== 0) {
+    ReactionCore.Log.info("Not creating default admin user, already exists");
     return ""; // this default admin has already been created for this shop.
   }
 


### PR DESCRIPTION
When starting up in a docker container `getShopId` is not ready when the `createDefaultAdmin` function is run so that function fails with an error concerning roles. This temporary workaround forces `createDefaultAdmin` to wait for `shopid` to be available before continuing.

A slightly more elegant fix of putting `createDefaultAdmin` in a callback for `flush` did not seem to affect it as I believe the latency may be in the db layer and therefore not visible to the application.

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [x] Passes all tests
- [x] Has been linted and follows the style guide