### PR TITLE
Integration 0.12 with filtration 0.0.5

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -71,3 +71,5 @@ reactioncommerce:reaction-sample-data   # default Reaction data
 # Themes
 reactioncommerce:default-theme          # default Reaction theme
 #my:custom-theme
+
+ramusus:reaction-filtration

--- a/packages/reaction-collections/package.js
+++ b/packages/reaction-collections/package.js
@@ -30,6 +30,8 @@ Package.onUse(function (api) {
   api.use("alanning:roles@1.2.14");
   api.use("meteorhacks:subs-manager@1.6.3");
   api.use("alanning:roles@1.2.14");
+  api.use("tmeasday:publish-counts@0.7.3");
+
   // ReactionCore declaration
   api.addFiles("common/globals.js");
 
@@ -76,9 +78,9 @@ Package.onUse(function (api) {
   api.imply("vsivsi:job-collection");
   api.imply("ongoworks:security");
   api.imply("alanning:roles");
-  api.imply("alanning:roles");
   api.imply("meteorhacks:subs-manager");
   api.imply("reactioncommerce:reaction-schemas");
+  api.imply("tmeasday:publish-counts");
 
   // ensure schemas vars are passed through
   api.export("ReactionCore");

--- a/packages/reaction-collections/tests/jasmine/server/integration/publications.js
+++ b/packages/reaction-collections/tests/jasmine/server/integration/publications.js
@@ -1,300 +1,249 @@
 /* eslint dot-notation: 0 */
 
-describe("Publication", function () {
+describe("Publication", () => {
   const shop = faker.reaction.shops.getShop();
 
-  beforeAll(function () {
+  beforeAll(() => {
     // We are mocking inventory hooks, because we don't need them here, but
     // if you want to do a real stress test, you could try to comment out
     // this spyOn lines. This is needed only for ./reaction test. In one
     // package test this is ignoring.
-    if (Array.isArray(ReactionCore.Collections.Products._hookAspects.remove.
-      after) && ReactionCore.Collections.Products._hookAspects.remove.after.
-      length) {
-      spyOn(ReactionCore.Collections.Products._hookAspects.remove.after[0],
-        "aspect");
-      spyOn(ReactionCore.Collections.Products._hookAspects.insert.after[0],
-        "aspect");
+    if (Array.isArray(ReactionCore.Collections.Products._hookAspects.remove.after)
+      && ReactionCore.Collections.Products._hookAspects.remove.after.length) {
+      spyOn(ReactionCore.Collections.Products._hookAspects.remove.after[0], "aspect");
+      spyOn(ReactionCore.Collections.Products._hookAspects.insert.after[0], "aspect");
     }
     ReactionCore.Collections.Products.remove({});
     // really strange to see this, but without this `remove` finishes in
     // async way (somewhere in a middle of testing process)
-    Meteor.setTimeout(function () {
+    Meteor.setTimeout(() => {
       ReactionCore.Collections.Orders.remove({});
     }, 500);
   });
 
-  describe("with products", function () {
+  describe("with products", () => {
     const productsPub = Meteor.server.publish_handlers["Products"];
     const productPub = Meteor.server.publish_handlers["Product"];
     const thisContext = {
-      ready: function () { return "ready"; }
+      ready: () => "ready",
+      added: () => "added",
+      onStop: () => "onStop",
+      changed: () => "changed"
     };
     const priceRangeA = {
       range: "1.00 - 12.99",
       min: 1.00,
       max: 12.99
     };
-
     const priceRangeB = {
       range: "12.99 - 19.99",
       min: 12.99,
       max: 19.99
     };
+    const product1 = {
+      ancestors: [],
+      title: "My Little Pony",
+      shopId: shop._id,
+      type: "simple",
+      price: priceRangeA,
+      isVisible: false,
+      isLowQuantity: false,
+      isSoldOut: false,
+      isBackorder: false
+    };
+    const product2 = {
+      ancestors: [],
+      title: "Shopkins - Peachy",
+      shopId: shop._id,
+      price: priceRangeB,
+      type: "simple",
+      isVisible: true,
+      isLowQuantity: false,
+      isSoldOut: false,
+      isBackorder: false
+    };
+    const product3 = {
+      ancestors: [],
+      title: "Fresh Tomatoes",
+      shopId: shop._id,
+      price: priceRangeA,
+      type: "simple",
+      isVisible: true,
+      isLowQuantity: false,
+      isSoldOut: false,
+      isBackorder: false
+    };
 
-    beforeAll(function () {
+    beforeAll(() => {
       // a product with price range A, and not visible
-      ReactionCore.Collections.Products.insert({
-        ancestors: [],
-        title: "My Little Pony",
-        shopId: shop._id,
-        type: "simple",
-        price: priceRangeA,
-        isVisible: false,
-        isLowQuantity: false,
-        isSoldOut: false,
-        isBackorder: false
-      });
+      ReactionCore.Collections.Products.insert(product1);
       // a product with price range B, and visible
-      ReactionCore.Collections.Products.insert({
-        ancestors: [],
-        title: "Shopkins - Peachy",
-        shopId: shop._id,
-        price: priceRangeB,
-        type: "simple",
-        isVisible: true,
-        isLowQuantity: false,
-        isSoldOut: false,
-        isBackorder: false
+      ReactionCore.Collections.Products.insert(product2, (err) => {
+        if (err) return;
+        ReactionCore.Collections.Products.insert({
+          ancestors: [product2._id],
+          title: "Shopkins - Peachy #1",
+          price: 12.99,
+          weight: 20,
+          shopId: shop._id,
+          type: "variant"
+        });
       });
       // a product with price range A, and visible
-      ReactionCore.Collections.Products.insert({
-        ancestors: [],
-        title: "Fresh Tomatoes",
-        shopId: shop._id,
-        price: priceRangeA,
-        type: "simple",
-        isVisible: true,
-        isLowQuantity: false,
-        isSoldOut: false,
-        isBackorder: false
+      ReactionCore.Collections.Products.insert(product3, (err) => {
+        if (err) return;
+        // a product descendant of product3
+        ReactionCore.Collections.Products.insert({
+          ancestors: [product3._id],
+          title: "Fresh Tomatoes #1",
+          price: 1,
+          weight: 10,
+          shopId: shop._id,
+          type: "variant"
+        });
+        // another product descendant of product3
+        ReactionCore.Collections.Products.insert({
+          ancestors: [product3._id],
+          title: "Fresh Tomatoes #2",
+          price: 12.99,
+          weight: 15,
+          shopId: shop._id,
+          type: "variant"
+        });
       });
     });
 
-    describe("Products", function () {
-      it(
-        "should return all products to admins",
-        function () {
-          // setup
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
+    describe("Products", () => {
+      it("should return products from all shops when multiple shops are provided", () => {
+        spyOn(ReactionCore, "getCurrentShop").and.returnValue({_id: "123"});
+        spyOn(Roles, "userIsInRole").and.returnValue(true);
+        const cursor = Meteor.server.publish_handlers.Products.apply(thisContext, [undefined, {shops: [shop._id]}]);
+        expect(cursor.fetch().length).toEqual(3);
+      });
+
+      describe("of one shop for admins", () => {
+        beforeAll(() => {
+          spyOn(ReactionCore, "getCurrentShop").and.returnValue(shop);
           spyOn(Roles, "userIsInRole").and.returnValue(true);
-          // execute
-          const cursor = productsPub();
-          // verify
+        });
+
+        it("should return all products", () => {
+          const cursor = productsPub.apply(thisContext, []);
           expect(cursor.fetch().length).toEqual(3);
-          // check product data
-          const data = cursor.fetch()[1];
-          expect(["My Little Pony", "Shopkins - Peachy"].
-            some(title => title === data.title)).toBeTruthy();
-        }
-      );
+        });
 
-      it(
-        "should return only visible products to visitors",
-        function () {
-          // setup
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
-          spyOn(Roles, "userIsInRole").and.returnValue(false);
-          // execute
-          const cursor = productsPub();
-          // verify
-          const data = cursor.fetch()[0];
+        it("should return visible products in visible query", () => {
+          const cursor = productsPub.apply(thisContext, [undefined, {visibility: true}]);
           expect(cursor.fetch().length).toEqual(2);
-          // check first product result
-          expect(["Fresh Tomatoes", "Shopkins - Peachy"].
-            some(title => title === data.title)).toBeTruthy();
-        }
-      );
+        });
 
-      it(
-        "should return only products matching query",
-        function () {
-          // setup
-          const productScrollLimit = 24;
-          const filters = {query: "Shopkins"};
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
-          spyOn(Roles, "userIsInRole").and.returnValue(false);
-          // execute
-          const cursor = productsPub(productScrollLimit, filters);
-          // verify
-          const data = cursor.fetch()[0];
-          expect(data.title).toEqual("Shopkins - Peachy");
-        }
-      );
+        it("should return invisible products in invisible query", () => {
+          const cursor = productsPub.apply(thisContext, [undefined, {visibility: false}]);
+          expect(cursor.fetch().length).toEqual(1);
+        });
+      });
 
-      it(
-        "should not return products not matching query",
-        function () {
-          // setup
-          const productScrollLimit = 24;
-          const filters = {query: "random search"};
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
+      describe("of one shop for visitors", () => {
+        beforeAll(() => {
+          spyOn(ReactionCore, "getCurrentShop").and.returnValue(shop);
           spyOn(Roles, "userIsInRole").and.returnValue(false);
-          // execute
-          const cursor = productsPub(productScrollLimit, filters);
-          // verify
+        });
+
+        it("should return only visible products", () => {
+          const cursor = productsPub.apply(thisContext, []);
+          expect(cursor.fetch().length).toEqual(2);
+          cursor.fetch().map(p => expect(p.isVisible).toEqual(true));
+        });
+
+        it("should return only products matching query", () => {
+          const cursor = productsPub.apply(thisContext, [undefined, {query: "Shopkins"}]);
+          expect(cursor.fetch().length).toEqual(1);
+          cursor.fetch().map(p => expect(p.title).toEqual("Shopkins - Peachy"));
+        });
+
+        it("should not return products not matching query", () => {
+          const cursor = productsPub.apply(thisContext, [undefined, {query: "random search"}]);
           expect(cursor.fetch().length).toEqual(0);
-        }
-      );
+        });
 
-      it(
-        "should return products in price.min query",
-        function () {
-          // setup
-          const productScrollLimit = 24;
-          const filters = {"price.min": "2.00"};
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
-          spyOn(Roles, "userIsInRole").and.returnValue(false);
-          // execute
-          const cursor = productsPub(productScrollLimit, filters);
-          // verify
+        it("should return products in price.min query", () => {
+          const price = {min: 13.00};
+          const cursor = productsPub.apply(thisContext, [undefined, {price: price}]);
           expect(cursor.fetch().length).toEqual(1);
-        }
-      );
+          cursor.fetch().map(p => expect(p.price.max).toBeGreaterThan(price.min));
+        });
 
-      it(
-        "should return products in price.max query",
-        function () {
-          // setup
-          const productScrollLimit = 24;
-          const filters = {"price.max": "24.00"};
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
-          spyOn(Roles, "userIsInRole").and.returnValue(false);
-          // execute
-          const cursor = productsPub(productScrollLimit, filters);
-          // verify
-          expect(cursor.fetch().length).toEqual(2);
-        }
-      );
-
-      it(
-        "should return products in price.min - price.max range query",
-        function () {
-          // setup
-          const productScrollLimit = 24;
-          const filters = {"price.min": "12.00", "price.max": "19.98"};
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
-          spyOn(Roles, "userIsInRole").and.returnValue(false);
-          // execute
-          const cursor = productsPub(productScrollLimit, filters);
-          // verify
-          expect(cursor.fetch().length).toEqual(2);
-        }
-      );
-
-      it(
-        "should return products where value is in price set query",
-        function () {
-          // setup
-          const productScrollLimit = 24;
-          const filters = {"price.min": "13.00", "price.max": "24.00"};
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
-          spyOn(Roles, "userIsInRole").and.returnValue(false);
-          // execute
-          const cursor = productsPub(productScrollLimit, filters);
-          // verify
+        it("should return products in price.max query", () => {
+          const price = {max: 11.00};
+          const cursor = productsPub.apply(thisContext, [undefined, {price: price}]);
           expect(cursor.fetch().length).toEqual(1);
-        }
-      );
+          cursor.fetch().map(p => expect(p.price.min).toBeLessThan(price.max));
+        });
 
-      it(
-        "should return products from all shops when multiple shops are provided",
-        function () {
-          // setup
-          const filters = {shops: [shop._id]};
-          const productScrollLimit = 24;
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue({
-            _id: "123"
-          });
-          spyOn(Roles, "userIsInRole").and.returnValue(true);
-          // execute
-          const cursor = Meteor.server.publish_handlers.Products(productScrollLimit, filters);
-          // verify
-          expect(cursor.fetch().length).toEqual(3);
-          const data = cursor.fetch()[1];
-          expect(["My Little Pony", "Shopkins - Peachy"].some(title => title === data.title)).toBeTruthy();
-        }
-      );
+        it("should return products in price.min - price.max range query", () => {
+          const price = {min: 12.00, max: 19.98};
+          const cursor = productsPub.apply(thisContext, [undefined, {price: price}]);
+          expect(cursor.fetch().length).toEqual(2);
+          cursor.fetch().map(p => expect(p.price.min).toBeLessThan(price.max));
+          cursor.fetch().map(p => expect(p.price.max).toBeGreaterThan(price.min));
+        });
+
+        it("should return products where value is in price set query", () => {
+          const price = {min: 13.00, max: 24.00};
+          const cursor = productsPub.apply(thisContext, [undefined, {price: price}]);
+          expect(cursor.fetch().length).toEqual(1);
+          cursor.fetch().map(p => expect(p.price.min).toBeLessThan(price.max));
+          cursor.fetch().map(p => expect(p.price.max).toBeGreaterThan(price.min));
+        });
+
+        it("should return products in weight.min query", () => {
+          const cursor = productsPub.apply(thisContext, [undefined, {weight: {min: 14}}]);
+          expect(cursor.fetch().length).toEqual(2);
+        });
+
+        it("should return products in weight.max query", () => {
+          const cursor = productsPub.apply(thisContext, [undefined, {weight: {max: 16}}]);
+          expect(cursor.fetch().length).toEqual(1);
+        });
+
+        it("should return products in weight.min - weight.max range query", () => {
+          const cursor = productsPub.apply(thisContext, [undefined, {weight: {min: 14, max: 16}}]);
+          expect(cursor.fetch().length).toEqual(1);
+        });
+      });
     });
 
-    describe("Product", function () {
-      it(
-        "should return a product based on an id",
-        function () {
-          // setup
-          const product = ReactionCore.Collections.Products.findOne({
-            isVisible: true
-          });
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
-          // execute
-          const cursor = Meteor.server.publish_handlers.Product(
-            product._id);
-          // verify
-          const data = cursor.fetch()[0];
-          expect(data.title).toEqual(product.title);
-        }
-      );
+    describe("Product", () => {
+      beforeAll(() => {
+        spyOn(ReactionCore, "getCurrentShop").and.returnValue(shop);
+      });
 
-      it(
-        "should return a product based on a regex",
-        function () {
-          // setup
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(
-            shop);
-          // execute
-          const cursor = Meteor.server.publish_handlers.Product(
-            "shopkins");
-          // verify
-          const data = cursor.fetch()[0];
-          expect(data.title).toEqual("Shopkins - Peachy");
-        }
-      );
+      it("should return a product and it's descendants based on an id", () => {
+        const product = ReactionCore.Collections.Products.findOne({ancestors: {
+          $exists: true,
+          $eq: []
+        }, isVisible: true});
+        const cursor = Meteor.server.publish_handlers.Product(product._id);
+        expect(cursor.fetch().length).toEqual(3);
+        expect(cursor.fetch()[0]._id).toEqual(product._id);
+      });
 
-      it(
-        "should not return a product based on a regex if it isn't visible",
-        function () {
-          // setup
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(shop);
-          spyOn(Roles, "userIsInRole").and.returnValue(false);
-          // execute
-          const cursor = productPub.apply(thisContext, ["my"]);
-          // verify
-          expect(cursor).toEqual("ready");
-        }
-      );
+      it("should return a product based on a regex", () => {
+        const cursor = Meteor.server.publish_handlers.Product("shopkins");
+        expect(cursor.fetch()[0].title).toEqual("Shopkins - Peachy #1");
+      });
 
-      it(
-        "should return a product based on a regex to admin if it isn't visible",
-        function () {
-          // setup
-          spyOn(ReactionCore, "getCurrentShop").and.returnValue(shop);
-          spyOn(Roles, "userIsInRole").and.returnValue(true);
-          // execute
-          const cursor = Meteor.server.publish_handlers.Product("my");
-          // verify
-          const data = cursor.fetch()[0];
-          expect(data.title).toEqual("My Little Pony");
-        }
-      );
+      it("should not return a product based on a regex if it isn't visible", () => {
+        spyOn(Roles, "userIsInRole").and.returnValue(false);
+        const cursor = productPub.apply(thisContext, ["my"]);
+        expect(cursor).toEqual("ready");
+      });
+
+      it("should return a product based on a regex to admin if it isn't visible", () => {
+        spyOn(Roles, "userIsInRole").and.returnValue(true);
+        const cursor = Meteor.server.publish_handlers.Product("my");
+        expect(cursor.fetch()[0].title).toEqual("My Little Pony");
+      });
     });
   });
 
@@ -302,7 +251,7 @@ describe("Publication", function () {
     const publication = Meteor.server.publish_handlers["Orders"];
     const thisContext = {
       userId: "userId",
-      ready: function () { return "ready"; }
+      ready: () => "ready"
     };
     let order;
 
@@ -311,35 +260,24 @@ describe("Publication", function () {
       // we need to mock collectionHooks to Inventory. This way we do all things
       // in a right order. This is make sense only for --velocity (all package)
       // tests.
-      order = Factory.create("order", { status: "created" });
+      order = Factory.create("order", {status: "created"});
     });
 
     beforeEach(() => {
       spyOn(ReactionCore, "getShopId").and.returnValue(shop._id);
     });
 
-    it(
-      "should return shop orders for an admin",
-      function () {
-        // setup
-        spyOn(Roles, "userIsInRole").and.returnValue(true);
-        // execute
-        const cursor = publication.apply(thisContext);
-        // verify
-        const data = cursor.fetch()[0];
-        expect(data.shopId).toBe(order.shopId);
-      }
-    );
+    it("should return shop orders for an admin", () => {
+      spyOn(Roles, "userIsInRole").and.returnValue(true);
+      const cursor = publication.apply(thisContext);
+      expect(cursor.fetch()[0].shopId).toBe(order.shopId);
+    });
 
-    it(
-      "should not return shop orders for non admin",
-      function () {
-        // setup
-        spyOn(Roles, "userIsInRole").and.returnValue(false);
-        const cursor = publication.apply(thisContext);
-        expect(cursor.fetch()).toEqual([]);
-      }
-    );
+    it("should not return shop orders for non admin", () => {
+      spyOn(Roles, "userIsInRole").and.returnValue(false);
+      const cursor = publication.apply(thisContext);
+      expect(cursor.fetch()).toEqual([]);
+    });
   });
 
   describe("Cart", () => {
@@ -359,24 +297,16 @@ describe("Publication", function () {
       Meteor.call("cart/createCart", userId, sessionId);
     });
 
-    it(
-      "should return a cart cursor",
-      () => {
-        const cursor = cartPub.apply(thisContext, [sessionId]);
-        const data = cursor.fetch()[0];
-        expect(data.userId).toEqual(userId);
-      }
-    );
+    it("should return a cart cursor", () => {
+      const cursor = cartPub.apply(thisContext, [sessionId]);
+      expect(cursor.fetch()[0].userId).toEqual(userId);
+    });
 
-    it(
-      "should return only one cart in cursor",
-      () => {
-        const user2 = Factory.create("registeredUser");
-        Meteor.call("cart/createCart", user2._id, sessionId);
-        const cursor = cartPub.apply(thisContext, [sessionId]);
-        const data = cursor.fetch();
-        expect(data.length).toEqual(1);
-      }
-    );
+    it("should return only one cart in cursor", () => {
+      const user2 = Factory.create("registeredUser");
+      Meteor.call("cart/createCart", user2._id, sessionId);
+      const cursor = cartPub.apply(thisContext, [sessionId]);
+      expect(cursor.fetch().length).toEqual(1);
+    });
   });
 });

--- a/packages/reaction-i18n/private/data/i18n/en.json
+++ b/packages/reaction-i18n/private/data/i18n/en.json
@@ -15,6 +15,9 @@
           "accountsLabel": "Accounts"
         },
         "dashboard": {
+          "filtrationLabel": "Filtration",
+          "filtrationTitle": "Filtration",
+          "filtrationDescription": "Products filtration for Reaction",
           "accountsLabel": "Accounts",
           "accountsTitle": "Accounts",
           "accountsDescription": "Manage how members sign into your shop",
@@ -66,9 +69,7 @@
           "themesTitle": "Themes",
           "themesDescription": "Themes and UI Components",
           "stripeLabel": "Stripe",
-          "stripeDescription": "Stripe payments",
-          "filtrationLabel": "Filtration",
-          "filtrationDescription": "Products filtration for Reaction"
+          "stripeDescription": "Stripe payments"
         },
         "groups": {
           "appearance": "Appearance",
@@ -80,6 +81,7 @@
           "utilities": "Utilities"
         },
         "settings": {
+          "filtersLabel": "Filters",
           "accountSettingsLabel": "Account Settings",
           "addShopMemberLabel": "Add Shop Member",
           "authorizenetSettingsLabel": "Authorize.net Settings",
@@ -617,6 +619,27 @@
         "isRequired": "{{field}} is required.",
         "mustBeNumber": "{{field}} must be a number.",
         "variantFieldIsRequired": "Variant {{number}} {{field}} is required."
+      },
+      "filtration": {
+          "filters": {
+            "titleLabel": "Title",
+          "titlePlaceholder": "Filter by title",
+          "priceLabel": "Price",
+          "weightLabel": "Weight",
+          "tagLabel": "Tag",
+          "tagPlaceholder": "Filter by tag",
+          "detailsLabel": "Details",
+          "detailNamePlaceholder": "Filter by detail name",
+          "detailValuePlaceholder": "Filter by detail value",
+          "visibilityLabel": "Visibility",
+          "visibilityAny": "Any",
+          "visibilityNotVisible": "Not visible",
+          "visibilityVisible": "Visible"
+        },
+        "showFilters": "Show Filters",
+        "settings": "Filters",
+        "found": "Found",
+        "products": "products"
       }
     }
   }

--- a/packages/reaction-i18n/private/data/i18n/ru.json
+++ b/packages/reaction-i18n/private/data/i18n/ru.json
@@ -15,6 +15,9 @@
           "accountsLabel": "Пользователи"
         },
         "dashboard": {
+          "filtrationLabel": "Фильтрация",
+          "filtrationTitle": "Фильтрация",
+          "filtrationDescription": "Фильтры для товаров",
           "accountsLabel": "Учётные записи",
           "accountsTitle": "Учётные записи",
           "accountsDescription": "Управление сервисами авторизации",
@@ -75,6 +78,7 @@
           "utilities": "Утилиты"
         },
         "settings": {
+          "filtersLabel": "Фильтры",
           "accountSettingsLabel": "Настройки учетных записей",
           "addShopMemberLabel": "Добавить сотрудника",
           "authorizenetSettingsLabel": "Настройки Authorize.net",
@@ -599,6 +603,27 @@
         "isRequired": "Поле \"{{field}}\" обязательно.",
         "mustBeNumber": "Поле \"{{field}}\" должно быть числом.",
         "variantFieldIsRequired": "Поле \"{{field}}\" варианта {{number}} обязательно."
+      },
+        "filtration": {
+            "filters": {
+              "titleLabel": "Название",
+            "titlePlaceholder": "Введите название",
+            "priceLabel": "Цена",
+            "weightLabel": "Вес",
+            "tagLabel": "Тэг",
+            "tagPlaceholder": "Введите тег",
+            "detailsLabel": "Характеристики",
+            "detailNamePlaceholder": "Название",
+            "detailValuePlaceholder": "Значение",
+            "visibilityLabel": "Видимость",
+            "visibilityAny": "Все",
+            "visibilityNotVisible": "Невидимые",
+            "visibilityVisible": "Видимые"
+          },
+        "showFilters": "Показать фильтры",
+        "settings": "Фильтры",
+        "found": "Найдено",
+        "products": "продуктов"
       }
     }
   }

--- a/packages/reaction-product-variant/client/templates/products/productGrid/productGrid.js
+++ b/packages/reaction-product-variant/client/templates/products/productGrid/productGrid.js
@@ -36,17 +36,16 @@ function loadMoreProducts() {
 
 Template.productGrid.onCreated(function () {
   Session.set("productGrid/selectedProducts", []);
+  ReactionFiltration.reset();
   // Update product subscription
   this.autorun(() => {
     const slug = ReactionRouter.getParam("slug");
     const { Tags } = ReactionCore.Collections;
     const tag = Tags.findOne({ slug: slug }) || Tags.findOne(slug);
-    let tags = {}; // this could be shop default implementation needed
     if (tag) {
-      tags = {tags: [tag._id]};
+      ReactionFiltration.update("tags", [tag._id]);
     }
-    const queryParams = Object.assign({}, tags, ReactionRouter.current().queryParams);
-    Meteor.subscribe("Products", Session.get("productScrollLimit"), queryParams);
+    Meteor.subscribe("Products", Session.get("productScrollLimit"), Session.get("productFilters"));
   });
 
   this.autorun(() => {

--- a/packages/reaction-product-variant/client/templates/products/products.html
+++ b/packages/reaction-product-variant/client/templates/products/products.html
@@ -1,5 +1,5 @@
 <template name="products">
-  {{>productGrid tag}}
+  {{>productGrid}}
 </template>
 
 <template name="productListGrid">

--- a/packages/reaction-product-variant/client/templates/products/products.js
+++ b/packages/reaction-product-variant/client/templates/products/products.js
@@ -1,12 +1,3 @@
-Template.products.helpers({
-  tag: function () {
-    const id = ReactionRouter.getParam("_tag");
-    return {
-      tag: ReactionCore.Collections.Tags.findOne({ slug: id }) || ReactionCore.Collections.Tags.findOne(id)
-    };
-  }
-});
-
 /**
  * products events
  */

--- a/packages/reaction-product-variant/package.js
+++ b/packages/reaction-product-variant/package.js
@@ -32,6 +32,7 @@ Package.onUse(function (api) {
   // community packages
   api.use("reactioncommerce:reaction-router@1.1.0");
   api.use("reactioncommerce:core@0.12.0");
+  api.use("ramusus:reaction-filtration@0.0.5");
 
   // register package
   api.addFiles("server/register.js", "server");

--- a/packages/reaction-router/common/init.js
+++ b/packages/reaction-router/common/init.js
@@ -102,6 +102,7 @@ ReactionRouter.initPackageRoutes = () => {
   shop.route("/", {
     name: "index",
     action: function () {
+      ReactionFiltration.reset();
       ReactionLayout();
     }
   });

--- a/packages/reaction-router/package.js
+++ b/packages/reaction-router/package.js
@@ -17,6 +17,8 @@ Package.onUse(function (api) {
   api.use("kadira:flow-router-ssr@3.11.2");
   api.use("kadira:blaze-layout@2.3.0");
   api.use("kadira:dochead@1.4.0");
+  api.use("ramusus:reaction-filtration@0.0.5");
+
   // register reaction package
   api.addFiles("server/register.js", "server");
 


### PR DESCRIPTION
This is the way how is possible to integrate my package https://github.com/ramusus/reaction-filtration with current development branch of reaction core.

I added tests for Products publication and refactor some existent tests `packages/reaction-collections/tests/jasmine/server/integration/publications.js` to make them more compact, readable and well-organised. I keep in mind that we need to migrate to native meteor tests framework, but it was hard to working with old version of file.
Also I changed format of publication filters argument: `price` and `weight` keys are contains objects in format `{min: float, max: float}`.

I'm not sure this PR is ready for merging into the core at this stage. May be there is way better to do the same. I don't like dependancy from ReactionFilter in reaction-router and reaction-product-variant, I prefer to keep these packages more independent. And I'm not sure about dependancy from `tmeasday:publish-counts`, we need to test it against massive number of products.

Any thought about this version are appreciated.

- [*] Description explains the issue / use-case resolved
- [*] Only contains code directly related to the issue
- [*] Has tests.
- [*] Has docs.
- [*] Passes all tests
- [*] Has been linted and follows the style guide