### PR TITLE
proposed fix to assignRoles.js

### DIFF
--- a/packages/reaction-core/server/registry/assignRoles.js
+++ b/packages/reaction-core/server/registry/assignRoles.js
@@ -41,9 +41,9 @@ const getRouteName = (packageName, registryItem) => {
 
 ReactionRegistry.assignOwnerRoles = (shopId, pkgName, registry) => {
   const defaultRoles = ["owner", "admin", "guest"];
-  var packageRoles = defaultRoles.slice();
+  let packageRoles = defaultRoles.slice();
   packageRoles.push(pkgName);
-  var globalRoles = packageRoles.slice();
+  let globalRoles = packageRoles.slice();
 
   if (registry) {
       // for each registry item define and push roles
@@ -69,7 +69,7 @@ ReactionRegistry.assignOwnerRoles = (shopId, pkgName, registry) => {
   }
   // only unique roles
   packageRoles = _.uniq(packageRoles);
-  //globalRoles = _.uniq(globalRoles);
+  // globalRoles = _.uniq(globalRoles);
   const defaultOwnerRoles = ["owner"];
   // get existing shop owners to add new roles to
   const owners = [];

--- a/packages/reaction-core/server/registry/assignRoles.js
+++ b/packages/reaction-core/server/registry/assignRoles.js
@@ -40,8 +40,10 @@ const getRouteName = (packageName, registryItem) => {
  */
 
 ReactionRegistry.assignOwnerRoles = (shopId, pkgName, registry) => {
-  const defaultRoles = ["owner", "admin", "createProduct", "guest", pkgName];
-  const globalRoles = defaultRoles;
+  const defaultRoles = ["owner", "admin", "guest"];
+  var packageRoles = defaultRoles.slice();
+  packageRoles.push(pkgName);
+  var globalRoles = packageRoles.slice();
 
   if (registry) {
       // for each registry item define and push roles
@@ -51,14 +53,14 @@ ReactionRegistry.assignOwnerRoles = (shopId, pkgName, registry) => {
       // todo: check dependency on this.
       const roleName = getRouteName(pkgName, registryItem);
       if (roleName) {
-        defaultRoles.push(roleName);
+        packageRoles.push(roleName);
       }
 
       // Get all defined permissions, add them to an array
       // define permissions if you need to check custom permission
       if (registryItem.permissions) {
         for (let permission of registryItem.permissions) {
-          defaultRoles.push(permission.permission);
+          packageRoles.push(permission.permission);
         }
       }
     }
@@ -66,7 +68,9 @@ ReactionRegistry.assignOwnerRoles = (shopId, pkgName, registry) => {
     ReactionCore.Log.debug(`No routes loaded for ${pkgName}`);
   }
   // only unique roles
-  const defaultOwnerRoles = _.uniq(defaultRoles);
+  packageRoles = _.uniq(packageRoles);
+  //globalRoles = _.uniq(globalRoles);
+  const defaultOwnerRoles = ["owner"];
   // get existing shop owners to add new roles to
   const owners = [];
   const shopOwners = Roles.getUsersInRole(defaultOwnerRoles).fetch();
@@ -80,7 +84,7 @@ ReactionRegistry.assignOwnerRoles = (shopId, pkgName, registry) => {
     owners.push(account._id);
   }
   // we don't use accounts/addUserPermissions here because we may not yet have permissions
-  Roles.addUsersToRoles(owners, defaultOwnerRoles, shopId);
+  Roles.addUsersToRoles(owners, packageRoles, shopId);
 
   // the reaction owner has permissions to all sites by default
   Roles.addUsersToRoles(owners, globalRoles, Roles.GLOBAL_GROUP);


### PR DESCRIPTION
The assignOwnerRoles method in reaction-core/server/registry/assignRoles.js doesnt do what it says in its description.

Issues

1. The code tries to copy Arrays via simple assignment, that way globalRoles array becomes larger than intended
2. I think the process of selecting owners is flawed, it selects everyone who has a default (or package) permission set in Roles.GLOBAL_GROUP.
Might technically work, but might be a problem with more fine grained access controls (ie users who are global admins but not global owners).
3. "createProduct" is a permission defined in reaction-product-variants package and should be set automatically in every shop for (global_group) owners, without it being included in the defaultRoles array. </br>
Removing it from there has the consquence of owners not having the permission in global_group, which should theoretically be irrelevant (looking at hasPermission, the permission is checked against the current shop permissions)

Fix

- Make new arrays real copies (copy by value)
  * Split defaultRoles variable from further processing, so that it could possibly be imported from configuration
- Reduced defaultOwnerRoles array to role "owner". Also query should be less expensive.
- Removed "createProduct" permission from defaultRoles array because I think it should not be there.

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [x] Passes all tests. Well, I tested it, but not with automated tests 
- [x] Has been linted and follows the style guide, I think