### PR TITLE
Fix `shipping/getShippingRates` missed `let`

### DIFF
--- a/packages/reaction-core/server/methods/shipping.js
+++ b/packages/reaction-core/server/methods/shipping.js
@@ -111,7 +111,7 @@ Meteor.methods({
         if (!method.handling) {
           method.handling = 0;
         }
-        rate = method.rate + method.handling;
+        let rate = method.rate + method.handling;
         _results.push(rates.push({
           carrier: shipping.provider.label,
           method: method,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [x] Has been linted and follows the style guide

