### PR TITLE
Fix for broken `removeFromCart` test

### DIFF
--- a/packages/reaction-core/tests/jasmine/server/integration/cart.js
+++ b/packages/reaction-core/tests/jasmine/server/integration/cart.js
@@ -251,6 +251,9 @@ describe("cart methods", function () {
   describe("cart/removeFromCart", function () {
     beforeEach(function () {
       ReactionCore.Collections.Cart.remove({});
+      // we want to avoid calling this method while testing `cart/removeFromCart`
+      spyOn(Meteor.server.method_handlers, "cart/resetShipmentMethod").and.
+      callFake(() => true);
     });
 
     it(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Test was broken by #983. I've mocked `cart/resetShipmentMethod`, because we don't need it in this test. Original problem is that then we call one method from another while testing second, we don't have `this.userId` in first :)

- [ ] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [x] Passes all tests
- [ ] Has been linted and follows the style guide

