### PR TITLE
When the overridden layout is not found, fall back to the default

### DIFF
--- a/packages/reaction-router/common/layout.js
+++ b/packages/reaction-router/common/layout.js
@@ -55,7 +55,7 @@ ReactionLayout = (options = {}) => {
           // Look for a layout using the coreLayout and fall back to that
           ReactionCore.Log.debug("Could not find custom layout, falling back to core");
           fallbackLayout = shop.layout.reverse().find((x) => selectLayout(x, defaultLayout, workflow));
-          if(!fallbackLayout) {
+          if (!fallbackLayout) {
             // still not found, log and render the notfound template
             ReactionCore.Log.warn(`Missing layout for ${layout}/${workflow}`);
             BlazeLayout.render("notFound");

--- a/packages/reaction-router/common/layout.js
+++ b/packages/reaction-router/common/layout.js
@@ -45,17 +45,24 @@ ReactionLayout = (options = {}) => {
 
   // autorun router rendering
   Tracker.autorun(function () {
+    const defaultLayout = "coreLayout";
     if (ReactionCore.Subscriptions.Shops.ready()) {
       const shop = ReactionCore.Collections.Shops.findOne(ReactionCore.getShopId());
       if (shop) {
-        const newLayout = shop.layout.reverse().find((x) => selectLayout(x, layout, workflow));
-        // oops this layout wasn't found. render notFound
+        let newLayout = shop.layout.reverse().find((x) => selectLayout(x, layout, workflow));
+        let fallbackLayout = {};
         if (!newLayout) {
-          BlazeLayout.render("notFound");
-        } else {
-          const layoutToRender = Object.assign({}, newLayout.structure, options, unauthorized);
-          BlazeLayout.render(layout, layoutToRender);
+          // Look for a layout using the coreLayout and fall back to that
+          ReactionCore.Log.debug("Could not find custom layout, falling back to core");
+          fallbackLayout = shop.layout.reverse().find((x) => selectLayout(x, defaultLayout, workflow));
+          if(!fallbackLayout) {
+            // still not found, log and render the notfound template
+            ReactionCore.Log.warn(`Missing layout for ${layout}/${workflow}`);
+            BlazeLayout.render("notFound");
+          }
         }
+        const layoutToRender = Object.assign({}, newLayout.structure, fallbackLayout.structure, options, unauthorized);
+        BlazeLayout.render(layout, layoutToRender);
       }
     }
   });


### PR DESCRIPTION
When overriding the default layout, we need to fallback to the default whenever a custom layout/workflow combination is not found.

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [x] Has been linted and follows the style guide

