### PR TITLE
FIX for #1017 and #548

### DIFF
--- a/packages/reaction-core/server/import.js
+++ b/packages/reaction-core/server/import.js
@@ -289,7 +289,7 @@ ReactionImport.layout = function (layout, shopId) {
     _id: shopId
   };
   return this.object(ReactionCore.Collections.Shops, key, {
-    "_id:": shopId,
+    "_id": shopId,
     "layout": layout
   });
 };
@@ -315,6 +315,79 @@ ReactionImport.tag = function (key, tag) {
 };
 
 /**
+ * @summary Returns an disjoint object as right join. For a visualization, see:
+ *          http://www.codeproject.com/KB/database/Visual_SQL_Joins/Visual_SQL_JOINS_orig.jpg
+ *          Additionally, the join is done recursively on properties of
+ *          nested objects as well. Nested arrays are handled like
+ *          primitive values.
+ * @param {Object} leftSet An object that can contain nested sub-objects
+ * @param {Object} rightSet An object that can contain nested sub-objects
+ * @returns {Object} The disjoint object that does only contain properties
+ *                   from the rightSet. But only those, that were not present
+ *                   in the leftSet.
+ */
+function doRightJoinNoIntersection (leftSet, rightSet) {
+  if (rightSet === null) return null;
+
+  let rightJoin;
+  if (Array.isArray(rightSet)) {
+     rightJoin = [];
+  } else {
+     rightJoin = {};
+  }
+  let findRightOnlyProperties = function () {
+    return Object.keys(rightSet).filter(function(key) {
+      if (typeof(rightSet[key]) === "object" &&
+          !Array.isArray(rightSet[key])) {
+            // Nested objects are always considered
+            return true;
+      } else {
+        // Array or primitive value
+        return !leftSet.hasOwnProperty(key);
+      }
+    })
+  };
+
+  for (let key of findRightOnlyProperties()){
+    if (typeof(rightSet[key]) === "object") {
+      // subobject or array
+      if (leftSet.hasOwnProperty(key) && (typeof(leftSet[key]) !== "object" ||
+           Array.isArray(leftSet[key])!== Array.isArray(rightSet[key]))) {
+        // This is not expected!
+        throw new Error(
+          "Left object and right object's internal structure must be " +
+          "congruent! Offending key: " + key
+        );
+      }
+      let rightSubJoin = doRightJoinNoIntersection(
+        leftSet.hasOwnProperty(key) ? leftSet[key] : {},
+        rightSet[key]
+      );
+
+      let obj = {};
+      if (rightSubJoin === null){
+        obj[key] = null;
+      } else if (Object.keys(rightSubJoin).length !== 0 ||
+                 Array.isArray(rightSubJoin)) {
+        // object or (empty) array
+        obj[key] = rightSubJoin;
+      }
+      rightJoin = Object.assign(rightJoin, obj);
+    } else {
+      // primitive value (or array)
+      if (Array.isArray(rightSet)) {
+        rightJoin.push(rightSet[key]);
+      } else {
+        let obj = {};
+        obj[key] = rightSet[key];
+        rightJoin = Object.assign(rightJoin, obj);
+      }
+    }
+  }
+  return rightJoin;
+}
+
+/**
  * @summary Push a new upsert document to the import buffer.
  * @param {Mongo.Collection} collection The target collection
  * @param {Object} key A key to look up the object
@@ -332,18 +405,29 @@ ReactionImport.object = function (collection, key, object) {
   if (!collection.findOne(key) && !object._id) key._id = Random.id();
   // hooks for additional import manipulation.
   const importObject = ReactionCore.Hooks.Events.run(`onImport${this._name(collection)}`, object);
-  // Clean and validate the object.
-  collection.simpleSchema(importObject).clean(importObject);
-  this.context(collection, selector).validate(importObject, {});
+
+  // Clone object for cleaning
+  let cleanedObject = Object.assign({}, importObject);
+
+  // Cleaning the object adds default values from schema, if value doesn't exist
+  collection.simpleSchema(importObject).clean(cleanedObject);
+  // And validate the object against the schema
+  this.context(collection, selector).validate(cleanedObject, {});
+
+  // Disjoint importObject and cleanedObject again
+  // to prevent `Cannot update '<field>' and '<field>' at the same time` errors
+  let defaultValuesObject = doRightJoinNoIntersection(importObject, cleanedObject);
+
   // Upsert the object.
   let find = this.buffer(collection).find(key);
-  if (this._upsert()) {
+  if (Object.keys(defaultValuesObject).length === 0){
     find.upsert().update({
       $set: importObject
     });
   } else {
     find.upsert().update({
-      $setOnInsert: importObject
+      $set: importObject,
+      $setOnInsert: defaultValuesObject
     });
   }
   if (this._count[this._name(collection)]++ >= this._limit) {


### PR DESCRIPTION
The idea is that all default values from schema are only relevant if the document is newly inserted. Therefore it is ensured that defaultValues from schemas are passed to mongo with `$setOnInsert` qualifier. 

Nevertheless we ensure full compliance with the schema. The difference between `Fixtures` and `Imports` is somewhat irrelevant with this proposal. All document updates are cumulative.