### PR TITLE
Renamed i18n locale code of Simplified Chinese from "cn" to "zh"

### DIFF
--- a/packages/reaction-i18n/package.js
+++ b/packages/reaction-i18n/package.js
@@ -64,7 +64,6 @@ Package.onUse(function (api) {
   // i18n translations
   api.addAssets("private/data/i18n/ar.json", "server");
   api.addAssets("private/data/i18n/bg.json", "server");
-  api.addAssets("private/data/i18n/cn.json", "server");
   api.addAssets("private/data/i18n/cs.json", "server");
   api.addAssets("private/data/i18n/de.json", "server");
   api.addAssets("private/data/i18n/en.json", "server");
@@ -85,6 +84,8 @@ Package.onUse(function (api) {
   api.addAssets("private/data/i18n/tr.json", "server");
   api.addAssets("private/data/i18n/vi.json", "server");
   api.addAssets("private/data/i18n/nb.json", "server");
+  api.addAssets("private/data/i18n/zh.json", "server");
+
   // exports
   api.imply("jquery");
   api.export("i18next");

--- a/packages/reaction-i18n/private/data/i18n/zh.json
+++ b/packages/reaction-i18n/private/data/i18n/zh.json
@@ -1,6 +1,6 @@
 [{
   "language": "中文(简体)",
-  "i18n": "cn",
+  "i18n": "zh",
   "ns": "core",
   "translation": {
     "core": {

--- a/packages/reaction-sample-data/private/data/Shops.json
+++ b/packages/reaction-sample-data/private/data/Shops.json
@@ -382,7 +382,7 @@
     "enabled": true
   }, {
     "label": "中文(简体)",
-    "i18n": "cn",
+    "i18n": "zh",
     "enabled": true
   }, {
     "label": "České",


### PR DESCRIPTION
- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide

Hi all, I noticed the i18n file (cn.json) of Simplified Chinese and the locale code do not follow the naming convention by http://i18next.com/translate/. (RFC 4646)

> 1. en-US language + region
> 2. en language only

i.e. the file's name and the value of the key "i18n" should be "zh" or "zh-CN".