### PR TITLE
Fix message on completed page

### DIFF
--- a/packages/reaction-checkout/client/templates/cart/checkout/completed/completed.html
+++ b/packages/reaction-checkout/client/templates/cart/checkout/completed/completed.html
@@ -6,7 +6,7 @@
         <div class="completed-order-confirmation">
           <h3><span data-i18n="cartCompleted.thankYou">Thank you!</span></h3>
           <div id="order-status">
-            <p><span data-i18n="cartCompleted.yourOrderIsNow">Your order is now </span>{{orderStatus}}.</p>
+            <p><span data-i18n="cartCompleted.yourOrderIsNow">Your order is now</span> {{orderStatus}}.</p>
           </div>
           <div>
             {{#unless email}}


### PR DESCRIPTION
Closes #1026 
The space was in the string to be translated so it was lost when i18n replaced it.

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide

