### PR TITLE
New `shop/createTag` method

### DIFF
--- a/packages/reaction-catalog/server/methods.js
+++ b/packages/reaction-catalog/server/methods.js
@@ -845,14 +845,12 @@ Meteor.methods({
       });
     }
 
-    newTag.isTopLevel = false;
-    newTag.shopId = ReactionCore.getShopId();
-    newTag.updatedAt = new Date();
-    newTag.createdAt = new Date();
-    newTag._id = ReactionCore.Collections.Tags.insert(newTag);
+    // newTagId could be an Error... we don't check it. Maybe we should add this
+    // check in future.
+    const newTagId = Meteor.call("shop/createTag", tagName, false);
     return ReactionCore.Collections.Products.update(productId, {
       $push: {
-        hashtags: newTag._id
+        hashtags: newTagId
       }
     }, {
       selector: {

--- a/packages/reaction-core/package.js
+++ b/packages/reaction-core/package.js
@@ -120,6 +120,7 @@ Package.onUse(function (api) {
   // method hooks
   api.addFiles("server/methods/hooks/hooks.js");
   api.addFiles("server/methods/hooks/cart.js", "server");
+  api.addFiles("server/methods/hooks/shop.js");
 
   // misc hooks
   api.addFiles("server/hooks.js", "server");

--- a/packages/reaction-core/server/methods/hooks/shop.js
+++ b/packages/reaction-core/server/methods/hooks/shop.js
@@ -1,0 +1,11 @@
+ReactionCore.MethodHooks.after("shop/createTag", function (options) {
+  if (options.error) {
+    ReactionCore.Log.warn("Failed to add new tag:", options.error.reason);
+    return options.error;
+  }
+  if (typeof options.result === "string") {
+    ReactionCore.Log.info(`Created tag with _id: ${options.result}`);
+  }
+
+  return options.result;
+});

--- a/packages/reaction-core/tests/jasmine/server/integration/methods.js
+++ b/packages/reaction-core/tests/jasmine/server/integration/methods.js
@@ -80,6 +80,37 @@ describe("core methods", function () {
     });
   });
 
+  describe("shop/createTag", () => {
+    beforeAll(() => {
+      ReactionCore.Collections.Tags.remove({});
+    });
+
+    it(
+      "should throw 403 error by non admin",
+      () => {
+        spyOn(Roles, "userIsInRole").and.returnValue(false);
+        spyOn(ReactionCore.Collections.Tags, "insert");
+
+        expect(function () {
+          return Meteor.call("shop/createTag", "testTag", true);
+        }).toThrow(new Meteor.Error(403, "Access Denied"));
+        expect(ReactionCore.Collections.Tags.insert).not.toHaveBeenCalled();
+      }
+    );
+
+    it(
+      "should create new tag",
+      done => {
+        spyOn(Roles, "userIsInRole").and.returnValue(true);
+        spyOn(ReactionCore.Collections.Tags, "insert").and.returnValue(1);
+        expect(Meteor.call("shop/createTag", "testTag", true)).toEqual(1);
+        expect(ReactionCore.Collections.Tags.insert).toHaveBeenCalled();
+
+        return done();
+      }
+    );
+  });
+
   describe("shop/locateAddress", function () {
     it("should locate an address based on known US coordinates", function (done) {
       let address = Meteor.call("shop/locateAddress", 34.043125, -118.267118);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] Only contains code directly related to the issue
- [x] Has tests.
- [x] Description explains the issue / use-case resolved
- [x] Has docs.
- [x] Passes all tests
- [x] Has been linted and follows the style guide

Hello, I needed this method for blog package I'm working on and I suppose it could be used in future by reaction itself. I think this is a good way to pick out this functionality.

Also, I added new file for `shop` hooks. This is how I manage logs in my packages. I believe this is a good pattern to manage logs separately from method. It looks cleaner. It would be cool to implement such pattern for all reaction methods in future. What do you think?

I'm not using `newTag.shopId = ReactionCore.getShopId();` because `shopId` is `autovalue`.
Also added two tests for new method. All tests passed well for me.