### PR TITLE
Fixed broken dashboard labels

### DIFF
--- a/packages/reaction-dashboard/client/templates/dashboard/settings/settings.html
+++ b/packages/reaction-dashboard/client/templates/dashboard/settings/settings.html
@@ -12,7 +12,9 @@
     <div class="nav-settings-heading">
       <h3 class="nav-settings-title">
         {{#with registry}}
-         <span data-i18n="{{i18nKeyLabel}}">{{label}}</span>
+         <span data-i18n="{{i18nKeyLabel}}">
+           <span>{{label}}</span>
+         </span>
         {{/with}}
         {{> Template.dynamic template=settingsHeaderControls}}
       </h3>

--- a/packages/reaction-i18n/private/data/i18n/en.json
+++ b/packages/reaction-i18n/private/data/i18n/en.json
@@ -93,7 +93,9 @@
           "inventorySettingsLabel": "Inventory Settings",
           "analyticsSettingsLabel": "Analytics Settings",
           "paypalSettingsLabel": "PayPal Settings",
-          "genericPaymentSettingsLabel": "Generic Payment Settings"
+          "genericPaymentSettingsLabel": "Generic Payment Settings",
+          "reactionConnectLabel": "Reaction Connect",
+          "examplePaymentSettingsLabel": "Example Payment"
         },
         "userAccountDropdown": {
           "profileLabel": "Profile"

--- a/packages/reaction-ui/.npm/package/npm-shrinkwrap.json
+++ b/packages/reaction-ui/.npm/package/npm-shrinkwrap.json
@@ -127,7 +127,6 @@
           "dependencies": {
             "jstransform": {
               "version": "10.1.0",
-              "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
               "from": "jstransform@>=10.0.1 <11.0.0",
               "dependencies": {
                 "base62": {
@@ -189,8 +188,8 @@
               "from": "promise@>=7.0.3 <8.0.0",
               "dependencies": {
                 "asap": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz",
                   "from": "asap@>=2.0.3 <2.1.0"
                 }
               }


### PR DESCRIPTION
fixes #978 

Added i18n missing translations for packages.
Wrapped in a span to avoid blaze / jQuery update conflicts.