### PR TITLE
bump react versions to 15.1

### DIFF
--- a/packages/reaction-ui/common/global.js
+++ b/packages/reaction-ui/common/global.js
@@ -1,8 +1,8 @@
 import { checkNpmVersions } from "meteor/tmeasday:check-npm-versions";
 
 checkNpmVersions({
-  "react": "15.0.x",
-  "react-dom": "15.0.x",
+  "react": "15.1.x",
+  "react-dom": "15.1.x",
   "meteor-node-stubs": "0.2.x"
 }, "reactioncommerce:reaction-ui");
 


### PR DESCRIPTION
- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [x] Has been linted and follows the style guide

Fixes issue reported in gitter yesterday where this warning would be reported to the client. Initially I only saw it on deployed builds, but am now seeing it on my local dev enviornment too.
```
WARNING: npm peer requirements (for reactioncommerce:reaction-ui) not installed:
 - react@15.0.2 installed, react@15.1.x needed
 - react-dom@15.0.2 installed, react-dom@15.1.x needed

Read more about installing npm peer dependencies:
  http://guide.meteor.com/using-packages.html#peer-npm-dependencies
```

We may need more discussion and/or @mikemurray might have thoughts on if this is premature, but it's fixed the warning for us and react@15.1.x was being installed anyway in our environments.