### PR TITLE
Use current versions of AuthNet and Braintree packages

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -141,8 +141,8 @@ reactioncommerce:launchdock-connect@0.2.2
 reactioncommerce:reaction-accounts@1.7.0
 reactioncommerce:reaction-analytics@1.3.0
 reactioncommerce:reaction-analytics-libs@1.2.0
-reactioncommerce:reaction-auth-net@0.6.2
-reactioncommerce:reaction-braintree@1.5.3
+reactioncommerce:reaction-auth-net@0.6.3
+reactioncommerce:reaction-braintree@1.5.4
 reactioncommerce:reaction-catalog@0.2.3
 reactioncommerce:reaction-checkout@1.0.1
 reactioncommerce:reaction-collections@2.2.2


### PR DESCRIPTION
Closes #970 (after re-publishing these packages)

Zenweasel, closing trivial bugs that I myself opened since 2015
