### PR TITLE
Module structure namespacing [WIP]

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -1,0 +1,5 @@
+import { Reaction } from "/client/modules/core";
+
+export {
+  Reaction
+};

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -1,5 +1,10 @@
 import { Reaction } from "/client/modules/core";
 
+// Legacy globals
+// TODO: add deprecation warnings
+ReactionCore = Reaction;
+ReactionRouter = Reaction.Router;
+
 export {
   Reaction
 };

--- a/client/modules/accounts/helpers/templates.js
+++ b/client/modules/accounts/helpers/templates.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import * as Collections from "/lib/collections";
 
 Template.registerHelper("getGravatar", function (currentUser, size) {

--- a/client/modules/accounts/templates/dashboard/dashboard.js
+++ b/client/modules/accounts/templates/dashboard/dashboard.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 
 /**
  * Accounts helpers

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -1,6 +1,5 @@
 import { Reaction } from "/client/modules/core";
 import Logger from "/client/modules/logger";
-import { ReactionRouter } from "/client/modules/router";
 import { Tags } from "/lib/collections";
 
 Template.loginDropdown.events({
@@ -31,8 +30,8 @@ Template.loginDropdown.events({
       }
       // go home on logout
       Reaction.Subscriptions.Manager.reset();
-      ReactionRouter.reload();
-      ReactionRouter.go("/");
+      Reaction.Router.reload();
+      Reaction.Router.go("/");
     });
   },
 
@@ -59,7 +58,7 @@ Template.loginDropdown.events({
           if (currentTag) {
             Meteor.call("products/updateProductTags", productId, currentTag.name, currentTagId);
           }
-          ReactionRouter.go("product", {
+          Reaction.Router.go("product", {
             handle: productId
           });
         }
@@ -68,7 +67,7 @@ Template.loginDropdown.events({
       event.preventDefault();
       template.$(".dropdown-toggle").dropdown("toggle");
       const route = this.name || this.route;
-      ReactionRouter.go(route);
+      Reaction.Router.go(route);
     }
   }
 });

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import Logger from "/client/modules/logger";
 import { Tags } from "/lib/collections";
 

--- a/client/modules/accounts/templates/members/member.js
+++ b/client/modules/accounts/templates/members/member.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Packages, Shops } from "/lib/collections";
 
 const getPermissionMap = (permissions) => {

--- a/client/modules/accounts/templates/members/memberForm.js
+++ b/client/modules/accounts/templates/members/memberForm.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 
 /**
  * memberForm events

--- a/client/modules/analytics/startup.js
+++ b/client/modules/analytics/startup.js
@@ -1,4 +1,3 @@
-import { FlowRouter as ReactionRouter } from "meteor/kadira:flow-router-ssr";
 import { AnalyticsEvents, Packages } from "/lib/collections";
 import { Reaction } from "/client/modules/core";
 import { i18next } from "/client/modules/i18n";
@@ -118,7 +117,7 @@ function notifyMixpanel(context) {
   }
 }
 
-ReactionRouter.triggers.enter([notifySegment, notifyGoogleAnalytics, notifyMixpanel]);
+Reaction.Router.triggers.enter([notifySegment, notifyGoogleAnalytics, notifyMixpanel]);
 
 //
 // Initialize analytics event tracking

--- a/client/modules/analytics/startup.js
+++ b/client/modules/analytics/startup.js
@@ -1,5 +1,5 @@
 import { AnalyticsEvents, Packages } from "/lib/collections";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { i18next } from "/client/modules/i18n";
 
 // Create a queue, but don't obliterate an existing one!

--- a/client/modules/checkout/methods/cart.js
+++ b/client/modules/checkout/methods/cart.js
@@ -1,6 +1,6 @@
 import { i18next } from "/client/modules/i18n";
 import Logger from "/client/modules/logger";
-import { ReactionRouter } from "/client/modules/router";
+import { Reaction } from "/client/modules/core";
 import { Cart } from "/lib/collections";
 import * as Schemas from "/lib/collections/schemas";
 
@@ -65,7 +65,7 @@ Meteor.methods({
           "paymentSubmitted");
         // Client Stub Actions
         if (result === 1) {
-          ReactionRouter.go("cart/completed", {}, {
+          Reaction.Router.go("cart/completed", {}, {
             _id: cartId
           });
         } else {

--- a/client/modules/checkout/methods/cart.js
+++ b/client/modules/checkout/methods/cart.js
@@ -1,6 +1,6 @@
 import { i18next } from "/client/modules/i18n";
 import Logger from "/client/modules/logger";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Cart } from "/lib/collections";
 import * as Schemas from "/lib/collections/schemas";
 

--- a/client/modules/checkout/templates/cart/cartDrawer/cartDrawer.js
+++ b/client/modules/checkout/templates/cart/cartDrawer/cartDrawer.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Cart } from "/lib/collections";
 
 /**

--- a/client/modules/checkout/templates/cart/cartDrawer/cartDrawer.js
+++ b/client/modules/checkout/templates/cart/cartDrawer/cartDrawer.js
@@ -1,5 +1,4 @@
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 import { Cart } from "/lib/collections";
 
 /**
@@ -53,7 +52,7 @@ Template.openCartDrawer.events({
   "click #btn-checkout": function () {
     $("#cart-drawer-container").fadeOut();
     Session.set("displayCart", false);
-    return ReactionRouter.go("cart/checkout");
+    return Reaction.Router.go("cart/checkout");
   },
   "click .remove-cart-item": function (event) {
     event.stopPropagation();

--- a/client/modules/checkout/templates/cart/cartIcon/cartIcon.js
+++ b/client/modules/checkout/templates/cart/cartIcon/cartIcon.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Cart } from "/lib/collections";
 
 /**

--- a/client/modules/checkout/templates/cart/cartPanel/cartPanel.js
+++ b/client/modules/checkout/templates/cart/cartPanel/cartPanel.js
@@ -1,4 +1,4 @@
-import { ReactionRouter } from "/client/modules/router";
+import { Reaction } from "/client/modules/core";
 /**
  * cartPanel events
  *
@@ -9,6 +9,6 @@ Template.cartPanel.events({
   "click #btn-checkout": function () {
     $("#cart-drawer-container").fadeOut();
     Session.set("displayCart", false);
-    return ReactionRouter.go("cart/checkout");
+    return Reaction.Router.go("cart/checkout");
   }
 });

--- a/client/modules/checkout/templates/cart/cartPanel/cartPanel.js
+++ b/client/modules/checkout/templates/cart/cartPanel/cartPanel.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 /**
  * cartPanel events
  *

--- a/client/modules/checkout/templates/cart/checkout/checkout.js
+++ b/client/modules/checkout/templates/cart/checkout/checkout.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Cart } from "/lib/collections";
 
 //

--- a/client/modules/checkout/templates/cart/checkout/completed/completed.js
+++ b/client/modules/checkout/templates/cart/checkout/completed/completed.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Orders } from "/lib/collections";
 
 /**

--- a/client/modules/checkout/templates/cart/checkout/completed/completed.js
+++ b/client/modules/checkout/templates/cart/checkout/completed/completed.js
@@ -1,6 +1,5 @@
 import { i18next } from "/client/modules/i18n";
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 import { Orders } from "/lib/collections";
 
 /**
@@ -10,13 +9,13 @@ import { Orders } from "/lib/collections";
  */
 Template.cartCompleted.helpers({
   order: function () {
-    const id =  ReactionRouter.getQueryParam("_id");
+    const id =  Reaction.Router.getQueryParam("_id");
     if (id) {
       const ccoSub = Meteor.subscribe("CompletedCartOrder", Meteor.userId(), id);
       if (ccoSub.ready()) {
         return Orders.findOne({
           userId: Meteor.userId(),
-          cartId: ReactionRouter.getQueryParam("_id")
+          cartId: Reaction.Router.getQueryParam("_id")
         });
       }
     }
@@ -46,7 +45,7 @@ Template.cartCompleted.events({
   "click #update-order": function (event, template) {
     const email = template.find("input[name=email]").value;
     check(email, String);
-    const cartId = ReactionRouter.getQueryParam("_id");
+    const cartId = Reaction.Router.getQueryParam("_id");
     return Meteor.call("orders/addOrderEmail", cartId, email);
   }
 });

--- a/client/modules/checkout/templates/cart/checkout/login/login.js
+++ b/client/modules/checkout/templates/cart/checkout/login/login.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Cart } from "/lib/collections";
 
 /**

--- a/client/modules/core/helpers/apps.js
+++ b/client/modules/core/helpers/apps.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import Logger from "/client/modules/logger";
 import { Packages } from "/lib/collections";
 

--- a/client/modules/core/index.js
+++ b/client/modules/core/index.js
@@ -4,12 +4,21 @@ import * as Globals from "./helpers/globals";
 import * as Utils from "./helpers/utils";
 import { Subscriptions } from "./subscriptions";
 
+import Log from "/client/modules/logger";
 import { Router } from "/client/modules/router";
+
+import * as Collections from "/lib/collections";
+import * as Schemas from "/lib/collections/schemas";
+
+
 export const Reaction = Object.assign(
   Core,
   Apps,
   Globals,
   Utils,
   { Subscriptions },
-  { Router }
+  { Log },
+  { Router },
+  { Collections },
+  { Schemas }
 );

--- a/client/modules/core/index.js
+++ b/client/modules/core/index.js
@@ -4,10 +4,12 @@ import * as Globals from "./helpers/globals";
 import * as Utils from "./helpers/utils";
 import { Subscriptions } from "./subscriptions";
 
+import { Router } from "/client/modules/router";
 export const Reaction = Object.assign(
   Core,
   Apps,
   Globals,
   Utils,
-  { Subscriptions }
+  { Subscriptions },
+  { Router }
 );

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -3,7 +3,6 @@ import { Tracker } from "meteor/tracker";
 import Logger from "/client/modules/logger";
 import { Countries } from "/client/collections";
 import { localeDep } from  "/client/modules/i18n";
-import { ReactionRouter } from "/client/modules/router";
 import { Packages, Shops } from "/lib/collections";
 
 /**
@@ -212,15 +211,15 @@ export default {
   },
 
   getCurrentTag() {
-    if (ReactionRouter.getRouteName() === "tag") {
-      return ReactionRouter.current().params.slug;
+    if (this.Router.getRouteName() === "tag") {
+      return this.Router.current().params.slug;
     }
   },
 
   getRegistryForCurrentRoute(provides = "dashboard") {
-    ReactionRouter.watchPathChange();
-    const currentRouteName = ReactionRouter.getRouteName();
-    const currentRoute = ReactionRouter.current();
+    this.Router.watchPathChange();
+    const currentRouteName = this.Router.getRouteName();
+    const currentRoute = this.Router.current();
     const template = currentRoute.route.options.template;
     // find registry entries for routeName
     let reactionApp = Packages.findOne({

--- a/client/modules/dashboard/templates/dashboard.js
+++ b/client/modules/dashboard/templates/dashboard.js
@@ -1,14 +1,13 @@
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 
 //
 // registry helper for the dashboard, assembles i18n labels
 //
 Template.dashboardHeader.helpers({
-  registry: function () {
+  registry() {
     // just some handle little helpers for default package i18nKey/i18nLabel
-    let route = ReactionRouter.getRouteName();
-    let registry = Reaction.getRegistryForCurrentRoute() || {};
+    const route = Reaction.Router.getRouteName();
+    const registry = Reaction.getRegistryForCurrentRoute() || {};
     if (registry && route) {
       return Reaction.translateRegistry(registry);
     }
@@ -19,7 +18,7 @@ Template.dashboardHeader.helpers({
 // dashboard events
 //
 Template.dashboardHeader.events({
-  "click [data-event-action=showPackageSettings]": function () {
+  "click [data-event-action=showPackageSettings]"() {
     Reaction.showActionView();
   }
 });

--- a/client/modules/dashboard/templates/dashboard.js
+++ b/client/modules/dashboard/templates/dashboard.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 
 //
 // registry helper for the dashboard, assembles i18n labels

--- a/client/modules/dashboard/templates/import/import.js
+++ b/client/modules/dashboard/templates/import/import.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Media, Products } from "/lib/collections";
 
 function uploadHandler(event) {

--- a/client/modules/dashboard/templates/packages/grid/grid.js
+++ b/client/modules/dashboard/templates/packages/grid/grid.js
@@ -1,6 +1,5 @@
 import { i18next } from "/client/modules/i18n";
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 
 function pkgPermissions(pkg) {
   // if (Reaction.hasPermission("dashboard")) {
@@ -33,7 +32,7 @@ function enableReactionPackage(reactionPackage) {
         );
         if (self.name || self.route) {
           const route = self.name || self.route;
-          return ReactionRouter.go(route);
+          return Reaction.Router.go(route);
         }
       } else if (error) {
         return Alerts.toast(

--- a/client/modules/dashboard/templates/packages/grid/grid.js
+++ b/client/modules/dashboard/templates/packages/grid/grid.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 
 function pkgPermissions(pkg) {
   // if (Reaction.hasPermission("dashboard")) {

--- a/client/modules/dashboard/templates/packages/grid/package/package.js
+++ b/client/modules/dashboard/templates/packages/grid/package/package.js
@@ -1,5 +1,4 @@
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 
 /* eslint no-loop-func: 0 */
 
@@ -12,10 +11,10 @@ function showPackageDashboard(reactionPackage) {
   const routeName = reactionPackage.name || reactionPackage.route;
 
   if (routeName && reactionPackage.route) {
-    const route = ReactionRouter.path(routeName);
+    const route = Reaction.Router.path(routeName);
 
     if (route && Reaction.hasPermission(route, Meteor.userId())) {
-      ReactionRouter.go(route);
+      Reaction.Router.go(route);
       return true;
     }
   }

--- a/client/modules/dashboard/templates/packages/grid/package/package.js
+++ b/client/modules/dashboard/templates/packages/grid/package/package.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 
 /* eslint no-loop-func: 0 */
 

--- a/client/modules/dashboard/templates/settings/settings.js
+++ b/client/modules/dashboard/templates/settings/settings.js
@@ -1,5 +1,4 @@
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 import { Packages } from "/lib/collections";
 
 /**
@@ -20,9 +19,9 @@ Template.settingsHeader.helpers({
    * @return {Object} Registry entry for item
    */
   thisApp() {
-    let reactionApp = Packages.findOne({
+    const reactionApp = Packages.findOne({
       "registry.provides": "settings",
-      "registry.route": ReactionRouter.getRouteName()
+      "registry.route": Reaction.Router.getRouteName()
     }, {
       enabled: 1,
       registry: 1,
@@ -31,8 +30,8 @@ Template.settingsHeader.helpers({
     });
 
     if (reactionApp) {
-      let settingsData = _.find(reactionApp.registry, function (item) {
-        return item.route === ReactionRouter.getRouteName() && item.provides === "settings";
+      const settingsData = _.find(reactionApp.registry, function (item) {
+        return item.route === Reaction.Router.getRouteName() && item.provides === "settings";
       });
 
       return settingsData;

--- a/client/modules/dashboard/templates/settings/settings.js
+++ b/client/modules/dashboard/templates/settings/settings.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Packages } from "/lib/collections";
 
 /**

--- a/client/modules/dashboard/templates/shop/settings/settings.js
+++ b/client/modules/dashboard/templates/shop/settings/settings.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Media, Packages, Shops } from "/lib/collections";
 
 Template.shopBrandImageOption.helpers({

--- a/client/modules/i18n/helpers.js
+++ b/client/modules/i18n/helpers.js
@@ -1,7 +1,7 @@
 import accounting from "accounting-js";
 import i18next from "i18next";
 import { localeDep, i18nextDep } from  "./main";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import Logger from "/client/modules/logger";
 
 /**

--- a/client/modules/i18n/main.js
+++ b/client/modules/i18n/main.js
@@ -8,7 +8,7 @@ import { Tracker } from "meteor/tracker";
 import { Session } from "meteor/session";
 import { _ } from "meteor/underscore";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Packages, Shops, Translations } from "/lib/collections";
 import * as Schemas from "/lib/collections/schemas";
 

--- a/client/modules/i18n/templates/header/i18n.js
+++ b/client/modules/i18n/templates/header/i18n.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Shops } from "/lib/collections";
 
 /**

--- a/client/modules/i18n/templates/i18nSettings.js
+++ b/client/modules/i18n/templates/i18nSettings.js
@@ -1,6 +1,6 @@
 import i18next from "i18next";
 import { Countries } from "/client/collections";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Shops } from "/lib/collections";
 
 Template.i18nSettings.helpers({

--- a/client/modules/layout/templates/layout/admin/admin.js
+++ b/client/modules/layout/templates/layout/admin/admin.js
@@ -1,7 +1,6 @@
 import { i18next } from "/client/modules/i18n";
 import Drop from "tether-drop";
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 import { Packages } from "/lib/collections";
 
 Template.coreAdminLayout.onRendered(function () {
@@ -28,8 +27,8 @@ Template.coreAdminLayout.helpers({
       for (let shortcut of shortcuts) {
         items.push({
           type: "link",
-          href: ReactionRouter.pathFor(shortcut.name),
-          className: ReactionRouter.isActiveClassName(shortcut.name),
+          href: Reaction.Router.pathFor(shortcut.name),
+          className: Reaction.Router.isActiveClassName(shortcut.name),
           icon: shortcut.icon,
           tooltip: shortcut.label || "",
           i18nKeyTooltip: shortcut.i18nKeyLabel,
@@ -90,7 +89,7 @@ Template.coreAdminLayout.helpers({
   },
 
   packageButtons() {
-    const routeName = ReactionRouter.getRouteName();
+    const routeName = Reaction.Router.getRouteName();
 
     if (routeName !== "dashboard") {
       const registryItems = Reaction.Apps({provides: "settings", container: routeName});
@@ -136,9 +135,9 @@ Template.coreAdminLayout.helpers({
    * @return {Object} Registry entry for item
    */
   thisApp() {
-    let reactionApp = Packages.findOne({
+    const reactionApp = Packages.findOne({
       "registry.provides": "settings",
-      "registry.route": ReactionRouter.getRouteName()
+      "registry.route": Reaction.Router.getRouteName()
     }, {
       enabled: 1,
       registry: 1,
@@ -147,8 +146,8 @@ Template.coreAdminLayout.helpers({
     });
 
     if (reactionApp) {
-      let settingsData = _.find(reactionApp.registry, function (item) {
-        return item.route === ReactionRouter.getRouteName() && item.provides === "settings";
+      const settingsData = _.find(reactionApp.registry, function (item) {
+        return item.route === Reaction.Router.getRouteName() && item.provides === "settings";
       });
 
       return settingsData;
@@ -186,7 +185,7 @@ Template.coreAdminLayout.helpers({
 //       event.preventDefault();
 //       event.stopPropagation();
 //
-//       ReactionRouter.go(this.name);
+//       Reaction.Router.go(this.name);
 //     }
 //   }
 // });

--- a/client/modules/layout/templates/layout/admin/admin.js
+++ b/client/modules/layout/templates/layout/admin/admin.js
@@ -1,6 +1,6 @@
 import { i18next } from "/client/modules/i18n";
 import Drop from "tether-drop";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Packages } from "/lib/collections";
 
 Template.coreAdminLayout.onRendered(function () {

--- a/client/modules/layout/templates/layout/createContentMenu/createContentMenu.js
+++ b/client/modules/layout/templates/layout/createContentMenu/createContentMenu.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Tags } from "/lib/collections";
 
 Template.createContentMenu.helpers({

--- a/client/modules/layout/templates/layout/createContentMenu/createContentMenu.js
+++ b/client/modules/layout/templates/layout/createContentMenu/createContentMenu.js
@@ -1,5 +1,4 @@
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 import { Tags } from "/lib/collections";
 
 Template.createContentMenu.helpers({
@@ -25,7 +24,7 @@ Template.createContentMenu.helpers({
                   Meteor.call("products/updateProductTags", productId, currentTag.name, currentTagId);
                 }
                 // go to new product
-                ReactionRouter.go("product", {
+                Reaction.Router.go("product", {
                   handle: productId
                 });
               }

--- a/client/modules/layout/templates/layout/header/header.js
+++ b/client/modules/layout/templates/layout/header/header.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Tags } from "/lib/collections";
 
 /**

--- a/client/modules/layout/templates/theme/theme.js
+++ b/client/modules/layout/templates/theme/theme.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Shops } from "/lib/collections";
 
 Meteor.startup(() => {

--- a/client/modules/orders/templates/dashboard/orders/orders.js
+++ b/client/modules/orders/templates/dashboard/orders/orders.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Orders, Shops } from "/lib/collections";
 
 const orderFilters = [{

--- a/client/modules/orders/templates/dashboard/orders/orders.js
+++ b/client/modules/orders/templates/dashboard/orders/orders.js
@@ -1,6 +1,5 @@
 import { i18next } from "/client/modules/i18n";
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 import { Orders, Shops } from "/lib/collections";
 
 const orderFilters = [{
@@ -88,7 +87,7 @@ Template.orders.onCreated(function () {
   // fetch available orders
   this.autorun(() => {
     this.subscribe("Orders");
-    const filter = ReactionRouter.getQueryParam("filter");
+    const filter = Reaction.Router.getQueryParam("filter");
     const query = OrderHelper.makeQuery(filter);
     const orders = Orders.find(query).fetch();
 
@@ -107,10 +106,10 @@ Template.orders.onCreated(function () {
   // Open the action view when necessary
   this.autorun(() => {
     const isActionViewOpen = Reaction.isActionViewOpen();
-    const queryParams = ReactionRouter.current().queryParams;
+    const queryParams = Reaction.Router.current().queryParams;
 
     if (isActionViewOpen === false) {
-      ReactionRouter.go("orders", {}, queryParams);
+      Reaction.Router.go("orders", {}, queryParams);
     }
   });
 });
@@ -132,7 +131,7 @@ Template.orders.helpers({
 
   currentFilterLabel() {
     let foundFilter = _.find(orderFilters, (filter) => {
-      return filter.name === ReactionRouter.getQueryParam("filter");
+      return filter.name === Reaction.Router.getQueryParam("filter");
     });
 
     if (foundFilter) {
@@ -142,7 +141,7 @@ Template.orders.helpers({
     return "";
   },
   activeClassname(orderId) {
-    if (ReactionRouter.getQueryParam("_id") === orderId) {
+    if (Reaction.Router.getQueryParam("_id") === orderId) {
       return "panel-info";
     }
     return "panel-default";
@@ -154,7 +153,7 @@ Template.ordersListItem.helpers({
     return Template.currentData().order;
   },
   activeClassname(orderId) {
-    if (ReactionRouter.getQueryParam("_id") === orderId) {
+    if (Reaction.Router.getQueryParam("_id") === orderId) {
       return "active";
     }
   },
@@ -180,7 +179,7 @@ Template.ordersListItem.events({
         template: "coreOrderWorkflow"
       });
     }
-    ReactionRouter.setQueryParams({
+    Reaction.Router.setQueryParams({
       _id: instance.data.order._id
     });
   },
@@ -204,7 +203,7 @@ Template.ordersListItem.events({
         template: "coreOrderWorkflow"
       });
     }
-    ReactionRouter.setQueryParams({
+    Reaction.Router.setQueryParams({
       filter: "processing",
       _id: order._id
     });
@@ -215,7 +214,7 @@ Template.orderListFilters.onCreated(function () {
   this.state = new ReactiveDict();
 
   this.autorun(() => {
-    const queryFilter = ReactionRouter.getQueryParam("filter");
+    const queryFilter = Reaction.Router.getQueryParam("filter");
     this.subscribe("Orders");
 
     const filters = orderFilters.map((filter) => {
@@ -242,7 +241,7 @@ Template.orderListFilters.events({
     if (isActionViewOpen === true) {
       Reaction.hideActionView();
     }
-    ReactionRouter.setQueryParams({
+    Reaction.Router.setQueryParams({
       filter: filter,
       _id: null
     });

--- a/client/modules/orders/templates/dashboard/orders/workflow/shippingInvoice/shippingInvoice.js
+++ b/client/modules/orders/templates/dashboard/orders/workflow/shippingInvoice/shippingInvoice.js
@@ -2,7 +2,7 @@ require("money");
 require("autonumeric");
 import $ from "jquery";
 import accounting from "accounting-js";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { NumericInput } from "/client/modules/ui/components/numericInput/numericInput";
 import { Media, Orders, Shops } from "/lib/collections";
 

--- a/client/modules/orders/templates/dashboard/orders/workflow/workflow.js
+++ b/client/modules/orders/templates/dashboard/orders/workflow/workflow.js
@@ -1,4 +1,4 @@
-import { ReactionRouter } from "/client/modules/router";
+import { Reaction } from "/client/modules/core";
 import { Orders } from "/lib/collections";
 
 /**
@@ -33,7 +33,7 @@ Template.coreOrderWorkflow.helpers({
    * @return {Object|Boolean} An order or false
    */
   order() {
-    let id = ReactionRouter.getQueryParam("_id");
+    let id = Reaction.Router.getQueryParam("_id");
     if (id) {
       return Orders.findOne(id);
     }

--- a/client/modules/orders/templates/dashboard/orders/workflow/workflow.js
+++ b/client/modules/orders/templates/dashboard/orders/workflow/workflow.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Orders } from "/lib/collections";
 
 /**

--- a/client/modules/product-variant/templates/products/productDetail/edit/edit.js
+++ b/client/modules/product-variant/templates/products/productDetail/edit/edit.js
@@ -3,7 +3,6 @@ import { i18next } from "/client/modules/i18n";
 import { Reaction } from "/client/modules/core";
 import Logger from "/client/modules/logger";
 import { ReactionProduct } from "/lib/api";
-import { ReactionRouter } from "/client/modules/router";
 
 /**
  * productDetailEdit helpers
@@ -51,7 +50,7 @@ Template.productDetailEdit.events({
                   });
                 }
                 if (res) {
-                  ReactionRouter.go("product", {
+                  Reaction.Router.go("product", {
                     handle: res
                   });
                 }

--- a/client/modules/product-variant/templates/products/productDetail/edit/edit.js
+++ b/client/modules/product-variant/templates/products/productDetail/edit/edit.js
@@ -1,6 +1,6 @@
 import autosize from "autosize";
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import Logger from "/client/modules/logger";
 import { ReactionProduct } from "/lib/api";
 

--- a/client/modules/product-variant/templates/products/productDetail/images/productImageGallery.js
+++ b/client/modules/product-variant/templates/products/productDetail/images/productImageGallery.js
@@ -1,5 +1,5 @@
 import { $ } from "meteor/jquery";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { ReactionProduct } from "/lib/api";
 import { Media } from "/lib/collections";
 

--- a/client/modules/product-variant/templates/products/productDetail/productDetail.js
+++ b/client/modules/product-variant/templates/products/productDetail/productDetail.js
@@ -5,7 +5,6 @@ import { $ } from "meteor/jquery";
 import { Reaction } from "/client/modules/core";
 import Logger from "/client/modules/logger";
 import { ReactionProduct } from "/lib/api";
-import { ReactionRouter } from "/client/modules/router";
 import { Tags } from "/lib/collections";
 
 // load modules
@@ -19,8 +18,8 @@ Template.productDetail.onCreated(function () {
     tags: []
   });
   this.subscribe("Tags");
-  this.productId = () => ReactionRouter.getParam("handle");
-  this.variantId = () => ReactionRouter.getParam("variantId");
+  this.productId = () => Reaction.Router.getParam("handle");
+  this.variantId = () => Reaction.Router.getParam("variantId");
   this.autorun(() => {
     if (this.productId()) {
       this.subscribe("Product", this.productId());
@@ -80,7 +79,7 @@ Template.productDetail.helpers({
             Meteor.call("products/setHandleTag", productId, tag._id,
               function (error, result) {
                 if (result) {
-                  return ReactionRouter.go("product", {
+                  return Reaction.Router.go("product", {
                     handle: result
                   });
                 }

--- a/client/modules/product-variant/templates/products/productDetail/productDetail.js
+++ b/client/modules/product-variant/templates/products/productDetail/productDetail.js
@@ -2,7 +2,7 @@ import { i18next } from "/client/modules/i18n";
 import { ReactiveDict } from "meteor/reactive-dict";
 import { _ } from "meteor/underscore";
 import { $ } from "meteor/jquery";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import Logger from "/client/modules/logger";
 import { ReactionProduct } from "/lib/api";
 import { Tags } from "/lib/collections";

--- a/client/modules/product-variant/templates/products/productDetail/tags/tags.js
+++ b/client/modules/product-variant/templates/products/productDetail/tags/tags.js
@@ -1,7 +1,6 @@
 import { $ } from "meteor/jquery";
 import { ReactionProduct } from "/lib/api";
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 import { Tags } from "/lib/collections";
 
 // load modules
@@ -44,7 +43,7 @@ Template.productTagInputForm.events({
     return Meteor.call("products/setHandleTag", ReactionProduct.selectedProductId(), this._id,
       function (error, result) {
         if (result) {
-          return ReactionRouter.go("product", {
+          return Reaction.Router.go("product", {
             handle: result
           });
         }

--- a/client/modules/product-variant/templates/products/productDetail/tags/tags.js
+++ b/client/modules/product-variant/templates/products/productDetail/tags/tags.js
@@ -1,6 +1,6 @@
 import { $ } from "meteor/jquery";
 import { ReactionProduct } from "/lib/api";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Tags } from "/lib/collections";
 
 // load modules

--- a/client/modules/product-variant/templates/products/productDetail/variants/variant.js
+++ b/client/modules/product-variant/templates/products/productDetail/variants/variant.js
@@ -1,5 +1,5 @@
 import { $ } from "meteor/jquery";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { ReactionProduct } from "/lib/api";
 
 // load modules

--- a/client/modules/product-variant/templates/products/productDetail/variants/variantForm/variantForm.js
+++ b/client/modules/product-variant/templates/products/productDetail/variants/variantForm/variantForm.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { ReactionProduct } from "/lib/api";
 
 /**

--- a/client/modules/product-variant/templates/products/productGrid/item/item.js
+++ b/client/modules/product-variant/templates/products/productGrid/item/item.js
@@ -1,5 +1,5 @@
 import { $ } from "meteor/jquery";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import Logger from "/client/modules/logger";
 import { ReactionProduct } from "/lib/api";
 import { Media } from "/lib/collections";

--- a/client/modules/product-variant/templates/products/productGrid/productGrid.js
+++ b/client/modules/product-variant/templates/products/productGrid/productGrid.js
@@ -1,8 +1,5 @@
 import { i18next } from "/client/modules/i18n";
 import { Reaction } from "/client/modules/core";
-import { ReactionProduct } from "/lib/api";
-import { ReactionRouter } from "/client/modules/router";
-import { Products, Tags } from "/lib/collections";
 
 /**
  * productGrid helpers

--- a/client/modules/product-variant/templates/products/productGrid/productGrid.js
+++ b/client/modules/product-variant/templates/products/productGrid/productGrid.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 
 /**
  * productGrid helpers

--- a/client/modules/product-variant/templates/products/products.js
+++ b/client/modules/product-variant/templates/products/products.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { ReactionProduct } from "/lib/api";
 import { Products, Tags } from "/lib/collections";
 

--- a/client/modules/product-variant/templates/products/products.js
+++ b/client/modules/product-variant/templates/products/products.js
@@ -1,5 +1,4 @@
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
 import { ReactionProduct } from "/lib/api";
 import { Products, Tags } from "/lib/collections";
 
@@ -47,7 +46,7 @@ Template.products.onCreated(function () {
 
   // Update product subscription
   this.autorun(() => {
-    const slug = ReactionRouter.getParam("slug");
+    const slug = Reaction.Router.getParam("slug");
     const tag = Tags.findOne({ slug: slug }) || Tags.findOne(slug);
     const scrollLimit = Session.get("productScrollLimit");
     let tags = {}; // this could be shop default implementation needed
@@ -67,7 +66,7 @@ Template.products.onCreated(function () {
 
     this.state.set("slug", slug);
 
-    const queryParams = Object.assign({}, tags, ReactionRouter.current().queryParams);
+    const queryParams = Object.assign({}, tags, Reaction.Router.current().queryParams);
     this.subscribe("Products", scrollLimit, queryParams);
 
     // we are caching `currentTag` or if we are not inside tag route, we will
@@ -105,7 +104,7 @@ Template.products.onRendered(() => {
 
 Template.products.helpers({
   tag: function () {
-    const id = ReactionRouter.getParam("_tag");
+    const id = Reaction.Router.getParam("_tag");
     return {
       tag: Tags.findOne({ slug: id }) || Tags.findOne(id)
     };
@@ -156,7 +155,7 @@ Template.products.events({
   },
   "click .product-list-item": function () {
     // go to new product
-    ReactionRouter.go("product", {
+    Reaction.Router.go("product", {
       handle: this._id
     });
   },

--- a/client/modules/router/helpers.js
+++ b/client/modules/router/helpers.js
@@ -1,5 +1,5 @@
 import { BlazeLayout } from "meteor/kadira:blaze-layout";
-import ReactionRouter from "./main";
+import Router from "./main";
 
 //
 // Layout container uses body
@@ -10,14 +10,14 @@ BlazeLayout.setRoot("body");
 // pathFor
 // template helper to return path
 //
-Template.registerHelper("pathFor", ReactionRouter.pathFor);
+Template.registerHelper("pathFor", Router.pathFor);
 
 //
 // urlFor
 // template helper to return absolute + path
 //
 Template.registerHelper("urlFor", (path, params) => {
-  return Meteor.absoluteUrl(ReactionRouter.pathFor(path, params).substr(1));
+  return Meteor.absoluteUrl(Router.pathFor(path, params).substr(1));
 });
 
-Template.registerHelper("active", ReactionRouter.isActiveClassName);
+Template.registerHelper("active", Router.isActiveClassName);

--- a/client/modules/router/index.js
+++ b/client/modules/router/index.js
@@ -1,5 +1,1 @@
-import ReactionRouter from "./main";
-
-export {
-  ReactionRouter
-};
+export { default as Router } from "./main";

--- a/client/modules/router/main.js
+++ b/client/modules/router/main.js
@@ -1,6 +1,6 @@
 import { FlowRouter as Router } from "meteor/kadira:flow-router-ssr";
 import { BlazeLayout } from "meteor/kadira:blaze-layout";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Logger } from "/client/modules/logger";
 import { Packages, Shops } from "/lib/collections";
 import { MetaData } from "/lib/api/router/metadata";

--- a/client/modules/router/startup.js
+++ b/client/modules/router/startup.js
@@ -1,14 +1,14 @@
 import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
 import { Reaction } from "/client/modules/core";
-import { ReactionRouter } from "/client/modules/router";
+import Router from "./main";
 
 Meteor.startup(function () {
   Tracker.autorun(function () {
     // initialize client routing
     if (Reaction.Subscriptions.Packages.ready() && Reaction.Subscriptions.Shops.ready()) {
-      if (!ReactionRouter._initialized) {
-        ReactionRouter.initPackageRoutes();
+      if (!Router._initialized) {
+        Router.initPackageRoutes();
       }
     }
   });

--- a/client/modules/router/startup.js
+++ b/client/modules/router/startup.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import Router from "./main";
 
 Meteor.startup(function () {

--- a/client/modules/shipping/templates/shipping.js
+++ b/client/modules/shipping/templates/shipping.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Packages, Shipping } from "/lib/collections";
 import { i18next } from "/client/modules/i18n";
 

--- a/client/modules/social/templates/social.js
+++ b/client/modules/social/templates/social.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Packages } from "/lib/collections";
 
 Template.reactionSocial.onCreated(function () {

--- a/client/modules/ui-navbar/components/brand/brand.js
+++ b/client/modules/ui-navbar/components/brand/brand.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Media, Shops } from "/lib/collections";
 
 Template.coreNavigationBrand.helpers({

--- a/client/modules/ui-navbar/components/navbar/navbar.js
+++ b/client/modules/ui-navbar/components/navbar/navbar.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Tags } from "/lib/collections";
 
 Template.CoreNavigationBar.onCreated(function () {

--- a/client/modules/ui/components/button/button.js
+++ b/client/modules/ui/components/button/button.js
@@ -1,7 +1,7 @@
 import { i18next } from "/client/modules/i18n";
 import { Template }  from "meteor/templating";
 import { _ } from "meteor/underscore";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { i18nextDep } from  "/client/modules/i18n";
 import { Icon } from "/client/modules/ui/components";
 import Tooltip from "tether-tooltip";

--- a/client/modules/ui/components/tags/tag.jsx
+++ b/client/modules/ui/components/tags/tag.jsx
@@ -1,6 +1,6 @@
 // import { i18next } from "/client/modules/i18n";
 // import React from "react";
-// import { Reaction } from "/client/modules/core";
+// import { Reaction } from "/client/api";
 // import { PropTypes } from "/lib/api";
 // import { Tags } from "/lib/collections";
 //

--- a/client/modules/ui/components/tags/tagItem.js
+++ b/client/modules/ui/components/tags/tagItem.js
@@ -1,5 +1,5 @@
 import $ from "jquery";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { Tags } from "/lib/collections";
 import classnames from "classnames";
 

--- a/client/modules/ui/templates/themeDetails/themeDetails.js
+++ b/client/modules/ui/templates/themeDetails/themeDetails.js
@@ -1,5 +1,5 @@
 import { i18next } from "/client/modules/i18n";
-import { Reaction } from "/client/modules/core";
+import { Reaction } from "/client/api";
 import { ReactionRouter } from "/client/modules/router";
 import { Themes } from "/lib/collections";
 

--- a/server/api/core/index.js
+++ b/server/api/core/index.js
@@ -2,11 +2,15 @@ import Core from "./core";
 import * as AssignRoles from "./assignRoles";
 import Import from "./import";
 import * as LoadSettings from "./loadSettings";
+import Log from "../logger";
 import Router from "../router";
 import * as SetDomain from "./setDomain";
 import * as ShopName from "./shopName";
 import * as UI from "./ui";
 import * as Utils from "./utils";
+
+import * as Collections from "/lib/collections";
+import * as Schemas from "/lib/collections/schemas";
 
 /**
  * Reaction methods (server)
@@ -14,9 +18,12 @@ import * as Utils from "./utils";
 const Reaction = Object.assign(
   Core,
   AssignRoles,
+  { Collections },
   { Import },
   LoadSettings,
+  { Log },
   { Router },
+  { Schemas },
   SetDomain,
   ShopName,
   UI,

--- a/server/api/core/index.js
+++ b/server/api/core/index.js
@@ -2,6 +2,7 @@ import Core from "./core";
 import * as AssignRoles from "./assignRoles";
 import Import from "./import";
 import * as LoadSettings from "./loadSettings";
+import Router from "../router";
 import * as SetDomain from "./setDomain";
 import * as ShopName from "./shopName";
 import * as UI from "./ui";
@@ -15,6 +16,7 @@ const Reaction = Object.assign(
   AssignRoles,
   { Import },
   LoadSettings,
+  { Router },
   SetDomain,
   ShopName,
   UI,

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -1,5 +1,5 @@
 import Reaction from "./core";
-import ReactionRouter from "./router";
+import Router from "./router";
 import { GeoCoder } from "./geocoder";
 import Hooks from "./hooks";
 import Logger from "./logger";
@@ -8,7 +8,7 @@ import { MethodHooks } from "./method-hooks";
 
 export {
   Reaction,
-  ReactionRouter,
+  Router,
   GeoCoder,
   Hooks,
   Logger,

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -5,6 +5,20 @@ import Hooks from "./hooks";
 import Logger from "./logger";
 import { MethodHooks } from "./method-hooks";
 
+// Legacy globals
+// TODO: add deprecation warnings
+ReactionCore = Reaction;
+ReactionRouter = Router;
+ReactionRegistry = {
+  assignOwnerRoles: Reaction.assignOwnerRoles,
+  createDefaultAdminUser: Reaction.createDefaultAdminUser,
+  getRegistryDomain: Reaction.getRegistryDomain,
+  loadPackages: Reaction.loadPackages,
+  loadSettings: Reaction.loadSettings,
+  Packages: Reaction.Packages,
+  setDomain: Reaction.setDomain,
+  setShopName: Reaction.setShopName
+};
 
 export {
   Reaction,

--- a/server/api/router.js
+++ b/server/api/router.js
@@ -1,6 +1,6 @@
-import { FlowRouter as ReactionRouter } from "meteor/kadira:flow-router-ssr";
+import { FlowRouter as Router } from "meteor/kadira:flow-router-ssr";
 
 // server can defer loading
-ReactionRouter.setDeferScriptLoading(true);
+Router.setDeferScriptLoading(true);
 
-export default ReactionRouter;
+export default Router;


### PR DESCRIPTION
- move ReactionRouter to Reaction.Router
- add Collections, Schemas, Log to Reaction namespace on client and server
- add temporary legacy globals on client and server (ReactionCore, ReactionRouter, ReactionRegistry)
- import Reaction from `/client/api` (instead of `/client/modules/core`)