### PR TITLE
Fix dashboard package links for non-owner users

### DIFF
--- a/packages/reaction-dashboard/client/templates/dashboard/packages/grid/package/package.js
+++ b/packages/reaction-dashboard/client/templates/dashboard/packages/grid/package/package.js
@@ -11,7 +11,7 @@ function showPackageDashboard(reactionPackage) {
   if (routeName && reactionPackage.route) {
     const route = ReactionRouter.path(routeName);
 
-    if (route && ReactionCore.hasPermission(route, Meteor.userId())) {
+    if (route && ReactionCore.hasPermission(routeName, Meteor.userId())) {
       ReactionRouter.go(route);
       return true;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] Description explains the issue / use-case resolved
- [X] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [X] Has been linted and follows the style guide

The issue was that `showPackageDashboard` checked permissions against `route` instead of `routename`

fixes #1081