### PR TITLE
Fix #1083 accounts dashboard list of users

### DIFF
--- a/packages/reaction-accounts/client/templates/dashboard/dashboard.js
+++ b/packages/reaction-accounts/client/templates/dashboard/dashboard.js
@@ -65,16 +65,12 @@ Template.accountsDashboard.helpers({
           member.roles = user.roles;
           member.services = user.services;
 
-          if (Roles.userIsInRole(member.userId, "dashboard", shopId)) {
-            member.role = "dashboard";
-          }
-
-          if (Roles.userIsInRole(member.userId, "admin", shopId)) {
-            member.role = "admin";
-          }
-
           if (Roles.userIsInRole(member.userId, "owner", shopId)) {
             member.role = "owner";
+          } else if (Roles.userIsInRole(member.userId, "admin", shopId)) {
+            member.role = "admin";
+          } else if (Roles.userIsInRole(member.userId, "dashboard", shopId)) {
+            member.role = "dashboard";
           } else if (Roles.userIsInRole(member.userId, "guest", shopId)) {
             member.role = "guest";
           }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [x] Has been linted and follows the style guide

Issue was that for the purpose of the list, any non-owner user was being assigned a role of `guest` after they were potentially assigned a role of `dashboard` or `admin`.

Fix causes role listed to cascade from `owner` -> `admin` -> `dashboard` -> `guest` only assigning a `guest` role if no other roles are present
fixes #1083