### PR TITLE
Fix race condition that was happening at checkout

### DIFF
--- a/packages/reaction-core/server/methods/cart.js
+++ b/packages/reaction-core/server/methods/cart.js
@@ -972,14 +972,11 @@ Meteor.methods({
       };
     }
 
-    return ReactionCore.Collections.Cart.update(selector, update,
-      function (error, result) {
-        if (error) {
-          ReactionCore.Log.warn(error);
-          throw new Meteor.Error("An error occurred saving the order",
-            error);
-        }
-        return result;
-      });
+    try {
+      ReactionCore.Collections.Cart.update(selector, update);
+    } catch (e) {
+      ReactionCore.Log.warn(e);
+      throw new Meteor.Error("An error occurred saving the order", e);
+    }
   }
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [x] Has been linted and follows the style guide

Fixes issue with `Cart.update` being called asynchronously which would trigger a race condition between the cart update and the functionality in the `cart/submitPayment` method. If the database was not updated fast enough, `copyCartToOrder` would never get called, leaving the customer with a blank white checkout complete screen, leaving the order in it's cart stage, and processing the payment anyway.