### PR TITLE
Replace deprecated eslint key

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -213,7 +213,7 @@
       "before": false,
       "after": true
     }],
-    "space-after-keywords": 2, // http://eslint.org/docs/rules/space-after-keywords
+    "keyword-spacing": 2, // http://eslint.org/docs/rules/keyword-spacing
     "space-before-blocks": 2, // http://eslint.org/docs/rules/space-before-blocks
     "space-before-function-paren": [2, {
       "anonymous": "always",


### PR DESCRIPTION
Replace [`space-after-keywords`](http://eslint.org/docs/rules/space-after-keywords) with [`keyword-spacing`](http://eslint.org/docs/rules/keyword-spacing).