### PR TITLE
New `shop/createTag` method: 0.14.0

### DIFF
--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -846,14 +846,16 @@ Meteor.methods({
       });
     }
 
-    newTag.isTopLevel = false;
-    newTag.shopId = Reaction.getShopId();
-    newTag.updatedAt = new Date();
-    newTag.createdAt = new Date();
-    newTag._id = Tags.insert(newTag);
+    const newTagId = Meteor.call("shop/createTag", tagName, false);
+
+    // if result is an Error object, we return it immediately
+    if (typeof newTagId !== "string") {
+      return newTagId;
+    }
+
     return Products.update(productId, {
       $push: {
-        hashtags: newTag._id
+        hashtags: newTagId
       }
     }, {
       selector: {

--- a/server/methods/core/hooks/cart.js
+++ b/server/methods/core/hooks/cart.js
@@ -1,6 +1,8 @@
 import { Meteor } from "meteor/meteor";
 import { Cart } from "/lib/collections";
 import { Logger, MethodHooks } from "/server/api";
+// this needed to keep correct loading order. Methods should be loaded before hooks
+import "../cart";
 
 // // Meteor.after to call after
 MethodHooks.after("cart/submitPayment", function (options) {

--- a/server/methods/core/hooks/shop.js
+++ b/server/methods/core/hooks/shop.js
@@ -1,0 +1,15 @@
+import { Logger, MethodHooks } from "/server/api";
+// this needed to keep correct loading order. Methods should be loaded before hooks
+import "../shop";
+
+MethodHooks.after("shop/createTag", function (options) {
+  if (options.error) {
+    Logger.warn("Failed to add new tag:", options.error.reason);
+    return options.error;
+  }
+  if (typeof options.result === "string") {
+    Logger.info(`Created tag with _id: ${options.result}`);
+  }
+
+  return options.result;
+});

--- a/server/methods/core/methods.app-test.js
+++ b/server/methods/core/methods.app-test.js
@@ -52,6 +52,29 @@ describe("Server/Core", function () {
     });
   });
 
+  describe("shop/createTag", () => {
+    beforeEach(() => {
+      Tags.remove({});
+    });
+
+    it("should throw 403 error by non admin", () => {
+      sandbox.stub(Roles, "userIsInRole", () => false);
+      sandbox.spy(Tags, "insert");
+      expect(function () {
+        return Meteor.call("shop/createTag", "testTag", true);
+      }).to.throw(Meteor.Error, /Access Denied/);
+      expect(Tags.insert).not.to.have.been.called;
+    });
+
+    it("should create new tag", done => {
+      sandbox.stub(Roles, "userIsInRole", () => true);
+      sandbox.spy(Tags, "insert");
+      expect(Meteor.call("shop/createTag", "testTag", true)).to.be.a("string");
+      expect(Tags.insert).to.have.been.called;
+      return done();
+    });
+  });
+
   describe("shop/updateHeaderTags", function () {
     beforeEach(function () {
       Shops.remove({});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Hello, this is a replacement for #1030
- [ ] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [x] Has tests.
- [ ] Has docs.
- [x] Passes all tests
- [x] Has been linted and follows the style guide

##### Changes:
- added new shop server method `createTag`;
- added hook to this method;
- method covered by 2 tests;
- updated `products/updateProductTags` &
`shop/updateHeaderTags`;
- removed `transliteration` import from `shop.js`. It is replaced by `Reaction.getSlug()`;
- fixed typo in `shop/updateShopExternalServices`;