### PR TITLE
don't slugify productId when used as handle, add random id fallback

### DIFF
--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -52,13 +52,10 @@ ReactionProduct.setProduct = (currentProductId, currentVariantId) => {
   let productId = currentProductId || FlowRouter.getParam("handle");
   let variantId = currentVariantId || FlowRouter.getParam("variantId");
   let product;
-  let handle;
 
-  if (!productId.match(/^[A-Za-z0-9]{17}$/)) {
-    handle = productId.toLowerCase();
-    product = Products.findOne({
-      handle: handle
-    });
+  if (!productId.match(/^[23456789ABCDEFGHJKLMNPQRSTWXYZabcdefghijkmnopqrstuvwxyz]{17}$/)) {
+    const handle = productId.toLowerCase();
+    product = Products.findOne({ handle });
     productId = product && product._id;
   } else {
     product = Products.findOne({

--- a/lib/collections/schemas/products.js
+++ b/lib/collections/schemas/products.js
@@ -1,4 +1,5 @@
 import { Meteor } from "meteor/meteor";
+import { Random } from "meteor/random";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
 import { ReactionProduct, getSlug } from "/lib/api";
 import { shopIdAutoValue } from "./helpers";
@@ -397,7 +398,7 @@ export const Product = new SimpleSchema({
       if (!slug && this.siblingField("title").value) {
         slug = getSlug(this.siblingField("title").value);
       } else if (!slug) {
-        slug = getSlug(this.siblingField("_id").value) || "";
+        slug = this.siblingField("_id").value || Random.id();
       }
       if (this.isInsert) {
         return slug;


### PR DESCRIPTION
Fixes #1127 

Handle was being set as a lowercase product ID when title wasn't set on creation.  Now remains mixed case so a query by ID in the handle field returns a product.

Updates the regex check that tries to discern between a handle and an ID (based on `SimpleSchema.Regex.Id`).