### PR TITLE
Reaction.getShopId() race condition

### DIFF
--- a/imports/plugins/included/analytics/server/security.js
+++ b/imports/plugins/included/analytics/server/security.js
@@ -1,9 +1,32 @@
+import { Meteor } from "meteor/meteor";
 import { AnalyticsEvents } from "/lib/collections";
-import { Reaction } from "/server/api";
+import { Reaction, Logger } from "/server/api";
 
 
-AnalyticsEvents.permit("insert").ifLoggedIn().allowInClientCode();
-AnalyticsEvents.permit(["update", "remove"]).ifHasRole({
-  role: ["admin", "owner"],
-  group: Reaction.getShopId()
-}).allowInClientCode();
+Meteor.startup(() => {
+  let i = 0;
+
+  const handle = Meteor.setInterval(() => {
+    i++;
+    const shopId = Reaction.getShopId();
+
+    if (shopId) {
+      AnalyticsEvents.permit("insert").ifLoggedIn().allowInClientCode();
+
+      AnalyticsEvents.permit(["update", "remove"]).ifHasRole({
+        role: ["admin", "owner"],
+        group: shopId
+      }).allowInClientCode();
+
+      return Meteor.clearInterval(handle);
+    }
+
+    if (i > 30) {
+      // stop checking and warn if the shopId isn't available within 30 secs
+      Meteor.clearInterval(handle);
+      Logger.warn("Error getting shopId for 'AnalyticsEvents.permit()'");
+    }
+
+    return null;
+  }, 1000);
+});

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -26,6 +26,15 @@ AnalyticsEvents.attachSchema(Schemas.AnalyticsEvents);
 
 
 /**
+ *  Assets Collection
+ *  Store file asset paths or contents in a Collection
+ */
+export const Assets = new Mongo.Collection("Assets");
+
+Assets.attachSchema(Schemas.Assets);
+
+
+/**
 * Cart Collection
 */
 export const Cart = new Mongo.Collection("Cart", {

--- a/lib/collections/schemas/assets.js
+++ b/lib/collections/schemas/assets.js
@@ -1,0 +1,19 @@
+import { SimpleSchema } from "meteor/aldeed:simple-schema";
+
+export const Assets = new SimpleSchema({
+  type: {
+    type: String
+  },
+  name: {
+    type: String,
+    optional: true
+  },
+  path: {
+    type: String,
+    optional: true
+  },
+  content: {
+    type: String,
+    optional: true
+  }
+});

--- a/lib/collections/schemas/index.js
+++ b/lib/collections/schemas/index.js
@@ -1,6 +1,7 @@
 export * from "./accounts";
 export * from "./address";
 export * from "./analytics";
+export * from "./assets";
 export * from "./cart";
 export * from "./discounts";
 export * from "./inventory";

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -181,11 +181,12 @@ export default {
   },
 
   getShopId() {
-    const currentShop = this.getCurrentShop();
-    if (typeof currentShop === "object") {
-      return currentShop._id;
-    }
-    return null;
+    const domain = this.getDomain();
+    const shop = Shops.find({ domains: domain }, {
+      limit: 1,
+      fields: { _id: 1 }
+    }).fetch()[0];
+    return shop && shop._id;
   },
 
   getDomain() {
@@ -193,11 +194,12 @@ export default {
   },
 
   getShopName() {
-    const currentShop = this.getCurrentShop();
-    if (typeof currentShop === "object") {
-      return currentShop.name;
-    }
-    return null;
+    const domain = this.getDomain();
+    const shop = Shops.find({ domains: domain }, {
+      limit: 1,
+      fields: { name: 1 }
+    }).fetch()[0];
+    return shop && shop.name;
   },
 
   /**

--- a/server/main.js
+++ b/server/main.js
@@ -1,16 +1,11 @@
-// import Fixtures from "./fixtures";  // TODO: get this working!
 import "./methods"; // TODO: refactor all of the methods to use import/export
-// import Publications from "./publications";  // TODO: wrap each file in a closure
-
-import Security from "./security";
 import Startup from "./startup";
-// import "/imports/server";
+import Security from "./security";
 
-// Fixtures();
-// Methods();
-// Publications();
-Security();
-Meteor.startup(() => Startup());
+Meteor.startup(() => {
+  Startup();
+  Security();
+});
 
 
 /**

--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -53,7 +53,7 @@ export default function () {
   /**
    * Hook to setup core i18n imports during Reaction init
    */
-  Hooks.Events.add("afterCoreInit", () => {
+  Hooks.Events.add("onCoreInit", () => {
     loadCoreTranslations();
   });
 }

--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { Assets } from "/lib/collections";
 import { Hooks, Logger, Reaction } from "/server/api";
 
 // taken from here: http://stackoverflow.com/a/32749571
@@ -21,9 +22,25 @@ export function loadCoreTranslations() {
         if (~file.indexOf("json")) {
           Logger.debug(`Importing Translations from ${file}`);
           const json = fs.readFileSync(i18nFolder + file, "utf8");
-          Reaction.Import.process(json, ["i18n"], Reaction.Import.translation);
+          const content = JSON.parse(json);
+
+          Assets.update({
+            type: "i18n",
+            name: content[0].i18n
+          }, {
+            $set: {
+              content: json
+            }
+          }, {
+            upsert: true
+          });
         }
       }
+
+      Assets.find({ type: "i18n" }).forEach((t) => {
+        Logger.info(`Importing ${t.name} translations...`);
+        Reaction.Import.process(t.content, ["i18n"], Reaction.Import.translation);
+      });
     }));
   }
 }
@@ -32,7 +49,7 @@ export default function () {
   /**
    * Hook to setup core i18n imports during Reaction init
    */
-  Hooks.Events.add("onCoreInit", () => {
+  Hooks.Events.add("afterCoreInit", () => {
     loadCoreTranslations();
   });
 }

--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -38,7 +38,7 @@ export function loadCoreTranslations() {
       }
 
       Assets.find({ type: "i18n" }).forEach((t) => {
-        Logger.info(`Importing ${t.name} translation...`);
+        Logger.info(`Importing ${t.name} translation`);
         if (t.content) {
           Reaction.Import.process(t.content, ["i18n"], Reaction.Import.translation);
         } else {

--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -38,7 +38,7 @@ export function loadCoreTranslations() {
       }
 
       Assets.find({ type: "i18n" }).forEach((t) => {
-        Logger.info(`Importing ${t.name} translations...`);
+        Logger.info(`Importing ${t.name} translation...`);
         if (t.content) {
           Reaction.Import.process(t.content, ["i18n"], Reaction.Import.translation);
         } else {

--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -39,7 +39,11 @@ export function loadCoreTranslations() {
 
       Assets.find({ type: "i18n" }).forEach((t) => {
         Logger.info(`Importing ${t.name} translations...`);
-        Reaction.Import.process(t.content, ["i18n"], Reaction.Import.translation);
+        if (t.content) {
+          Reaction.Import.process(t.content, ["i18n"], Reaction.Import.translation);
+        } else {
+          Logger.warn(`No translation content found for ${t.name} asset`);
+        }
       });
     }));
   }


### PR DESCRIPTION
Fixes #960 and #1006

`Reaction.getShopId()` was returning `null` for more than half of the times it was being called on initial startup.  This was mostly just an issue with a fresh database because the shop hadn't been inserted yet.  This was the main issue behind the `createDefaulAdminUser` issue in #960 and the translation loading issue in #1006.  (both should be fixed now)

Part of the solution was to reorder several imports that were trying to use `Reaction.getShopId()` before the initial shop was created and the other part of it was because the query behind that method was not very efficient.  It was querying for the entire shop document (which is a fairly large object), but it really only needed the `_id`.  That said, I changed the query to only return the `_id`.  It didn't totally solve the problem, but it should be significantly more performant considering how often `Reaction.getShopId()` gets called.

The issue with the translations loading was because it was using Node's native `fs` utility to read the `i18n` directory and get all available translations files.  By default, Meteor runs all `fs` commands before compiling the app and executing anything.  The problem with _that_ is it was trying to then insert those translations at a point in time where the shop document hadn't been created yet.  That would cause a few of the first translations to have a `null` shopId and _that_ would cause them to not be returned in the `Translations` publication (which relies on that `shopId` to fetch the translations).  

My solution for that was to use `fs` to scan for all of the translation files and then insert them into an `Assets` collection.  Then I read the `Assets` collection at startup and load the translations from there.  This guarantees that Meteor will run it when things are _actually_ ready.  I figure it'll also be useful to store file names, paths, and content of server side asset files in there in the future (since native Node, NPM, fs, etc. is the future of Meteor).  For now, only `i18n` stuff is being imported there.

As far as I can see, all shopId related issues appear to be fixed now and `Reaction.getShopId()` never returns `null` at any point in first startup or any subsequent startup.