### PR TITLE
Fixes mismatched key name on i18n data-attribute (Closing #779)

### DIFF
--- a/imports/plugins/core/ui/client/components/upload/upload.js
+++ b/imports/plugins/core/ui/client/components/upload/upload.js
@@ -22,7 +22,7 @@ Template.upload.helpers({
     return {
       className: "btn-block",
       label: instance.data.label || "Drop file to upload",
-      i18nLabel: instance.data.i18nLabel || "productDetail.dropFile",
+      i18nLabel: instance.data.i18nLabel || "productDetail.dropFiles",
       onClick() {
         instance.$("input[name=files]").click();
       }

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/productImageGallery.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/productImageGallery.html
@@ -32,7 +32,7 @@
 {{#if hasPermission "createProduct"}}
   <div id="dropzone" class="dropzone">
    <input name="files" id="files" class="hidden" type="file" multiple/>
-    <div class="btn btn-default btn-block" id="btn-upload" data-i18n="productDetail.dropFile">Drop file to upload</div>
+    <div class="btn btn-default btn-block" id="btn-upload" data-i18n="productDetail.dropFiles">Drop file to upload</div>
   </div>
 {{/if}}
 </template>


### PR DESCRIPTION
The issue (#779) here is in our i18n files (en.js and ru.js are the only two where it's available), we are using dropFiles (plural) as the as the key, where in the data-i18n attribute, as well as in one other location, we are using dropFile (singular). I've updated this to use dropFiles in all locations.