### PR TITLE
Fix Stripe dashboard panel saving key to database

### DIFF
--- a/imports/plugins/included/stripe/client/settings/stripe.html
+++ b/imports/plugins/included/stripe/client/settings/stripe.html
@@ -5,7 +5,7 @@
       Don't have a Stripe API key? <a href="https://dashboard.stripe.com/account/apikeys" target="_blank">Get it here.</a> (Need to sign in)
     </div>
     <div class="panel-body">
-      {{#autoForm collection="Reaction.Collections.Packages" schema=StripePackageConfig doc=packageData type="update" id="stripe-update-form"}}
+      {{#autoForm collection=Collections.Packages schema=StripePackageConfig doc=packageData type="update" id="stripe-update-form"}}
         {{>afQuickField name='settings.api_key'}}
         <button type="submit" class="btn btn-primary pull-right">Update</button>
       {{/autoForm}}


### PR DESCRIPTION
- [X] Description explains the issue / use-case resolved
- [X] Only contains code directly related to the issue
- [X] Has been linted and follows the style guide

Prior to this fix, the Stripe package would not save the stripe API key to the database from the dashboard. This PR fixes that issue.

thanks to @paulgrever for the discovery on this.