### PR TITLE
Fix print layout for order invoice

### DIFF
--- a/imports/plugins/core/layout/client/templates/layout/layout.html
+++ b/imports/plugins/core/layout/client/templates/layout/layout.html
@@ -1,5 +1,5 @@
-<template name="print">
-  {{> Template.dynamic template=printLayout}}
+<template name="printLayout">
+  {{> Template.dynamic template=template}}
 </template>
 
 <template name="coreLayout">

--- a/imports/plugins/core/orders/client/templates/list/pdf.html
+++ b/imports/plugins/core/orders/client/templates/list/pdf.html
@@ -46,9 +46,9 @@
       </div>
       <div class="row">
         <div style="font-family:monospace; text-align: left;" class="col-xs-4 col-sm-3 col-md-3 col-lg-3">
-          <h3>DATE:{{dateFormat createdAt format="MM/D/YY"}}</h3>
+          <h3>DATE:{{dateFormat order.createdAt format="MM/D/YY"}}</h3>
         </div>
-        <div style="font-family:monospace;" class="col-xs-6 col-xs-offset-3 col-sm-4 col-md-3 col-lg-3 col-md-offset-5">ORDER:{{_id}}</div>
+        <div style="font-family:monospace;" class="col-xs-6 col-xs-offset-3 col-sm-4 col-md-3 col-lg-3 col-md-offset-5">ORDER:{{order._id}}</div>
       </div>
     </div>
   </header>
@@ -57,7 +57,7 @@
       <div class="row">
         <div class="col-md-6 col-xs-6">
           <h2 style='margin-top:1em'>Ship To</h2>
-          {{#each shipment in shipping}}
+          {{#each shipment in order.shipping}}
             {{#with shipment.address}}
               <strong><div>{{fullName}}</div></strong>
               <div>{{address1}}</div>
@@ -70,7 +70,7 @@
         <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
 
           <h2 style='margin-top:1em'>Bill To</h2>
-          {{#each payment in billing}}
+          {{#each payment in order.billing}}
             {{#with payment.address}}
               <strong><div>{{fullName}}</div></strong>
               <div>{{address1}}</div>
@@ -82,57 +82,57 @@
         </div>
       </div>
 
+    <br>
+    <h3>Payment</h3>
+    {{#with billing.paymentMethod }}
+      <div style="margin-top:1em"><h4>{{processor}}</h4></div>
+      <div>{{storedCard}}</div>
+      <div>Ref: {{transactionId}}</div>
+    {{/with}}
 
-  </div>
-  <br>
-  <h3>Payment</h3>
-  {{#each payment.paymentMethod}}
-    <div style="style='margin-top:1em'"><h4>{{processor}}</h4></div>
-    <div>{{storedCard}}</div>
-    <div>Ref: {{transactionId}}</div>
-  {{/each}}
-
-  <h2 style='margin-top:2em'>ITEMS</h2>
-  <table class="table table-bordered">
-    <tr>
-      <th>Quantity</th>
-      <th>Title</th>
-      <th>Price</th>
-    </tr>
-    {{#each items}}
+    <h2 style='margin-top:2em'>ITEMS</h2>
+    <table class="table table-bordered">
       <tr>
-        <td>{{quantity}}</td>
-        <td>{{variants.title}}</td>
-        <td>{{variants.price}}</td>
+        <th>Quantity</th>
+        <th>Title</th>
+        <th>Price</th>
       </tr>
-    {{/each}}
-  </table>
+      {{#each order.items}}
+        <tr>
+          <td>{{quantity}}</td>
+          <td>{{variants.title}}</td>
+          <td>{{variants.price}}</td>
+        </tr>
+      {{/each}}
+    </table>
 
-  <h2 style='margin-top:1em'>SUMMARY</h2>
-  {{#with invoice}}
-    <div class="container">
-      <div class="row">
-        <div class="col-md-3"><span data-i18n='cartSubTotals.subtotal'>Sub total</span>:</div>
-        <div class="col-md-2 col-md-offset-1">{{subtotal}}</div>
+    <h2 style='margin-top:1em'>SUMMARY</h2>
+    {{#with billing.invoice}}
+      <div class="container">
+        <div class="row">
+          <div class="col-md-3"><span data-i18n='cartSubTotals.subtotal'>Sub total</span>:</div>
+          <div class="col-md-2 col-md-offset-1">{{subtotal}}</div>
+        </div>
+        <div class="row">
+          <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.shipping'>Shipping</span>:</div>
+          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{shipping}}</div>
+        </div>
+        <div class="row">
+          <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.tax'>Tax</span>:</div>
+          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{taxes}}</div>
+        </div>
+        <div class="row">
+          <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.discount'>Discount</span>:</div>
+          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{discounts}}</div>
+        </div>
+        <div class="row">
+          <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.total'>Total</span>:</div>
+          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1"><strong>{{total}}</strong></div>
+        </div>
       </div>
-      <div class="row">
-        <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.shipping'>Shipping</span>:</div>
-        <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{shipping}}</div>
-      </div>
-      <div class="row">
-        <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.tax'>Tax</span>:</div>
-        <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{taxes}}</div>
-      </div>
-      <div class="row">
-        <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.discount'>Discount</span>:</div>
-        <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{discounts}}</div>
-      </div>
-      <div class="row">
-        <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.total'>Total</span>:</div>
-        <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1"><strong>{{total}}</strong></div>
-      </div>
-    </div>
-  {{/with}}
-  <div style='margin-top: 1em' data-i18n="cartCompleted.summaryMessage">Thank you for your order.</div>
+    {{/with}}
+    <div style='margin-top: 1em' data-i18n="cartCompleted.summaryMessage">Thank you for your order.</div>
+  </div>
+
 </body>
 </template>

--- a/imports/plugins/core/orders/client/templates/list/pdf.js
+++ b/imports/plugins/core/orders/client/templates/list/pdf.js
@@ -1,16 +1,45 @@
 import { Template } from "meteor/templating";
+import { Router } from "/client/api";
+import { Orders } from "/lib/collections";
+import { ReactiveDict } from "meteor/reactive-dict";
 
 /**
 * completedPDFLayout
 * inheritsHelpersFrom dashboardOrdersList
 * Uses the browser print function.
 */
-Template.completedPDFLayout.inheritsHelpersFrom("dashboardOrdersList");
+Template.completedPDFLayout.onCreated(function () {
+  this.state = new ReactiveDict();
+  this.state.setDefault({
+    order: {}
+  });
 
-Template.completedPDFLayout.inheritsEventsFrom("dashboardOrdersList");
+  const currentRoute = Router.current();
+
+  this.autorun(() => {
+    this.subscribe("Orders");
+
+    const order = Orders.findOne({
+      _id: currentRoute.params.id
+    });
+
+    this.state.set({
+      order
+    });
+  });
+});
+
 
 Template.completedPDFLayout.helpers({
-  invoice: function () {
-    return this.billing[0].invoices;
+  order() {
+    return Template.instance().state.get("order");
+  },
+  billing() {
+    const order = Template.instance().state.get("order");
+    if (order) {
+      return order.billing[0];
+    }
+
+    return null;
   }
 });

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
@@ -98,7 +98,7 @@
       {{#if paymentApproved}}
           <a
             class="btn btn-link"
-            href="/dashboard/pdf/orders/{{orderId}}?shipment={{fulfillment._id}}"
+            href="{{pathFor "dashboard/pdf/orders" id=orderId }}?shipment={{fulfillment._id}}"
             target="_blank"
             data-i18n="app.print">
             Print

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
@@ -141,11 +141,20 @@
         </div>
       </div>
       <hr>
-      <button
-        class="btn btn-success flex-item-fill"
-        type="submit"
-        data-event-action="appluRefund"
-        data-i18n="order.applyRefund" {{refundSubmitDisabled}}>Apply Refund</button>
+      <div class="flex">
+        <a
+          class="btn btn-link"
+          href="{{pathFor "dashboard/pdf/orders" id=orderId }}?shipment={{fulfillment._id}}"
+          target="_blank"
+          data-i18n="app.printInvoice">
+          Print Invoice
+        </a>
+        <button
+          class="btn btn-success flex-item-fill"
+          type="submit"
+          data-event-action="appluRefund"
+          data-i18n="order.applyRefund" {{refundSubmitDisabled}}>Apply Refund</button>
+      </div>
     </form>
   {{else}}
 

--- a/imports/plugins/core/orders/register.js
+++ b/imports/plugins/core/orders/register.js
@@ -27,6 +27,12 @@ Reaction.registerPackage({
     description: "Fulfill your orders",
     icon: "fa fa-sun-o",
     priority: 1
+  }, {
+    route: "/dashboard/pdf/orders/:id",
+    workflow: "coreOrderPrintWorkflow",
+    layout: "printLayout",
+    name: "dashboard/pdf/orders",
+    template: "completedPDFLayout"
   }],
   layout: [{
     layout: "coreLayout",
@@ -46,8 +52,11 @@ Reaction.registerPackage({
     }
   }, {
     layout: "printLayout",
-    workflow: "coreOrderWorkflow",
+    workflow: "coreOrderPrintWorkflow",
+    collection: "Orders",
+    enabled: true,
     structure: {
+      template: "completedPDFLayout",
       layoutHeader: "layoutHeader",
       layoutFooter: "layoutFooter"
     }


### PR DESCRIPTION
Fixes #1121 

- Added proper registry entries for order print layout.
- Updated template helpers order print template.
- Fixing UI issues with horizontal width of some items being incorrect.
- Renamed layout template "print" to "printLayout" to better reflect its purpose.
- Added a print invoice button for captured payments.