### PR TITLE
Fix Payflow capture

### DIFF
--- a/imports/plugins/included/paypal/client/templates/checkout/payflowForm.js
+++ b/imports/plugins/included/paypal/client/templates/checkout/payflowForm.js
@@ -122,8 +122,9 @@ AutoForm.addHooks("paypal-payment-form", {
           })();
 
           // just auth, not transaction
-          let authId = transaction.response.id;
+          let transactionId = transaction.response.id;
           // when auth and transaction
+          let authId;
           if (typeof transaction.response.transactions[0].related_resources[0] === "object") {
             authId = transaction.response.transactions[0].related_resources[0].authorization.id;
           }
@@ -132,8 +133,10 @@ AutoForm.addHooks("paypal-payment-form", {
             processor: "PayflowPro",
             storedCard: storedCard,
             method: transaction.response.payer.payment_method,
-            transactionId: authId,
+            authorization: authId,
+            transactionId: transactionId,
             metadata: {
+              transactionId: transactionId,
               authorizationId: authId
             },
             amount: Number(transaction.response.transactions[0].amount.total),

--- a/imports/plugins/included/paypal/server/methods/payflow.js
+++ b/imports/plugins/included/paypal/server/methods/payflow.js
@@ -128,7 +128,7 @@ Meteor.methods({
   },
 
   "payflowpro/refund/list": function (paymentMethod) {
-    check(paymentMethod, Object);
+    check(paymentMethod, Reaction.Schemas.PaymentMethod);
     this.unblock();
 
     PayFlow.configure(Paypal.payflowAccountOptions());

--- a/imports/plugins/included/paypal/server/methods/payflow.js
+++ b/imports/plugins/included/paypal/server/methods/payflow.js
@@ -1,4 +1,5 @@
 import PayFlow from "paypal-rest-sdk"; // PayFlow is PayPal PayFlow lib
+import moment from "moment";
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Reaction, Logger } from "/server/api";
@@ -127,7 +128,7 @@ Meteor.methods({
   },
 
   "payflowpro/refund/list": function (paymentMethod) {
-    check(paymentMethod, Reaction.Schemas.PaymentMethod);
+    check(paymentMethod, Object);
     this.unblock();
 
     PayFlow.configure(Paypal.payflowAccountOptions());
@@ -136,7 +137,8 @@ Meteor.methods({
     let result = [];
     // todo: review parentPaymentId vs authorizationId, are they both correct?
     // added authorizationId without fully understanding the intent of parentPaymentId
-    let authId = paymentMethod.metadata.parentPaymentId || paymentMethod.metadata.authorizationId;
+    // let authId = paymentMethod.metadata.parentPaymentId || paymentMethod.metadata.authorizationId;
+    let authId = paymentMethod.metadata.transactionId;
 
     if (authId) {
       Logger.debug("payflowpro/refund/list: paymentMethod.metadata.parentPaymentId", authId);
@@ -149,10 +151,10 @@ Meteor.methods({
               if (resource.refund.state === "completed") {
                 result.push({
                   type: "refund",
-                  created: resource.refund.create_time,
+                  created: moment(resource.refund.create_time).unix(),
                   amount: Math.abs(resource.refund.amount.total),
                   currency: resource.refund.amount.currency,
-                  rawTransaction: resource.refund
+                  raw: response
                 });
               }
             }
@@ -165,7 +167,7 @@ Meteor.methods({
         };
       }
     }
-
+    Logger.info(JSON.stringify(result, null, 4));
     return result;
   },
 

--- a/imports/plugins/included/paypal/server/methods/payflow.js
+++ b/imports/plugins/included/paypal/server/methods/payflow.js
@@ -151,7 +151,7 @@ Meteor.methods({
               if (resource.refund.state === "completed") {
                 result.push({
                   type: "refund",
-                  created: moment(resource.refund.create_time).unix(),
+                  created: moment(resource.refund.create_time).unix() * 1000,
                   amount: Math.abs(resource.refund.amount.total),
                   currency: resource.refund.amount.currency,
                   raw: response

--- a/imports/plugins/included/paypal/server/methods/payflow.js
+++ b/imports/plugins/included/paypal/server/methods/payflow.js
@@ -167,7 +167,6 @@ Meteor.methods({
         };
       }
     }
-    Logger.info(JSON.stringify(result, null, 4));
     return result;
   },
 


### PR DESCRIPTION
This fixes #1146 
However, currently you can only use a credit card you create [here](https://www.paypal-knowledge.com/infocenter/index?page=content&widgetview=true&id=FAQ1413&viewlocale=en_US&direct=en) using your test account.

I have created one so if someone at RC needs one just PM me (these are attached to our account so I can't make it public, I think)

This is still pending the status of https://github.com/paypal/PayPal-node-SDK/issues/168 since you are supposed to be able to test it with any card that passes MOD10
