### PR TITLE
only load plugins when in development

### DIFF
--- a/server/startup/plugins.js
+++ b/server/startup/plugins.js
@@ -133,7 +133,7 @@ const includedPlugins = pluginsPath + "included/";
 
 
 export default function () {
-  if (process.env.NODE_ENV !== "production") {
+  if (process.env.NODE_ENV !== "production" && !Meteor.isAppTest) {
     // get imports from each plugin directory
     const core = getImportPaths(corePlugins);
     const custom = getImportPaths(customPlugins);


### PR DESCRIPTION
this workaround assumes that either the load-plugins script has been
run by docker, or development has previously been run.