### PR TITLE
loginhandler causes an exeption

### DIFF
--- a/server/startup/accounts.js
+++ b/server/startup/accounts.js
@@ -49,7 +49,7 @@ export default function () {
    */
   Accounts.registerLoginHandler(function (options) {
     if (!options.anonymous) {
-      return {};
+      return undefined;
     }
     let loginHandler;
     let stampedToken = Accounts._generateStampedLoginToken();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide

Hi

Congratulations on the new (pre) release!

With my current project i ran in to a really small bug, see description below.
The bug stopped meteors login handler runner from reaching my own login handler.
Changing the one line, fixed this.

It's a small fix, perhaps you can consider fixing it for your new release?

Kind regards,
Shane Smith

--
Meteor login handler runner expects either and object with an user id, or an error, otherwise you are not supposed to return anything, or undefined, so it can continue with other login handlers.
Currently we are returning an empty object, when we are sure the login attempt is not meant for this handler. The empty object however will actually cause an exception and stop the handler from running more login attempts later in the chain and throw an error instead.

-------
Account_server.js:318
throw new Error("A login method must specify a userId or an error");
------

Is it possible for you to change the return value from and empty object to undefined?