### PR TITLE
make sure Windows generates Posix import paths for plugins

### DIFF
--- a/server/startup/plugins.js
+++ b/server/startup/plugins.js
@@ -80,7 +80,8 @@ function getImportPaths(baseDirPath) {
 
   // create the import path
   const getImportPath = (pluginFile) => {
-    return "/" + path.relative(appRoot, pluginFile);
+    const importPath = "/" + path.relative(appRoot, pluginFile);
+    return importPath.replace(/\\/g, "/");
   };
 
   // get all plugin directories at provided base path


### PR DESCRIPTION
Fixes #1186 

The [development plugin loader](https://github.com/reactioncommerce/reaction/blob/master/server/startup/plugins.js) generates import files at `client/plugins.js` and `server/plugins.js` with the JS imports for all plugins in the `/imports/plugins` directory.  This was working, but the import paths added to the files were using Windows paths with `\`'s when running in development on a Windows machine.  

The paths are now normalized to use `/`'s instead via a simple regex.