### PR TITLE
Fix for broken loading of non-core translation files

### DIFF
--- a/lib/collections/schemas/assets.js
+++ b/lib/collections/schemas/assets.js
@@ -8,6 +8,13 @@ export const Assets = new SimpleSchema({
     type: String,
     optional: true
   },
+  /**
+   * namespace for i18n. This allows to load translation for custom plugins
+   */
+  ns: {
+    type: String,
+    optional: true
+  },
   path: {
     type: String,
     optional: true

--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -27,7 +27,8 @@ export function loadCoreTranslations() {
 
           Assets.update({
             type: "i18n",
-            name: content[0].i18n
+            name: content[0].i18n,
+            ns: content[0].ns
           }, {
             $set: {
               content: json
@@ -39,11 +40,11 @@ export function loadCoreTranslations() {
       }
 
       Assets.find({ type: "i18n" }).forEach((t) => {
-        Logger.info(`Importing ${t.name} translation`);
+        Logger.info(`Importing ${t.name} translation for \"${t.ns}\"`);
         if (t.content) {
           Reaction.Import.process(t.content, ["i18n"], Reaction.Import.translation);
         } else {
-          Logger.warn(`No translation content found for ${t.name} asset`);
+          Logger.warn(`No translation content found for ${t.name} - ${t.ns} asset`);
         }
       });
     }));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Hello, we should pass additional `ns` field to correctly load files with different translation namespaces. Before this PR only language name was passed to Assets doc. This is not enough in situations like so, when I have several files: `en.json`, `en-plugin1.json`, `en-plugin2.json`.

- [ ] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide

- added additional "ns" field for Assets schema  which
 is translation namespace;
- `loadCoreTranslations` now correctly loads non-core namespace
translation files;