### PR TITLE
Pass isConfirm when calling callback

### DIFF
--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -68,7 +68,7 @@ Object.assign(Alerts, {
         ...titleOrOptions
       }).then((isConfirm) => {
         if (isConfirm === true) {
-          messageOrCallback();
+          messageOrCallback(isConfirm);
         }
       });
     }
@@ -83,7 +83,7 @@ Object.assign(Alerts, {
       ...options
     }).then((isConfirm) => {
       if (isConfirm === true) {
-        callback();
+        callback(isConfirm);
       }
     });
   },


### PR DESCRIPTION
The problem was that refunds were not working for any payment method. This was because the confirmation alert was always returning `undefined`. @mikemurray informed me that a new version of Alerts had been rolled out and he had to patch this version to use callbacks.

I discovered that when calling the callback, `isConfirm` was not being passed in, which was why it was never `true`.

To Verify that this PR works:
Place an order.
Approve and Capture.
Issue a Refund and verify that it works.


