### PR TITLE
Added shipment summary information to main Orders page

### DIFF
--- a/client/modules/router/main.js
+++ b/client/modules/router/main.js
@@ -1,7 +1,6 @@
 import { FlowRouter as Router } from "meteor/kadira:flow-router-ssr";
 import { BlazeLayout } from "meteor/kadira:blaze-layout";
-import { Reaction } from "/client/api";
-import { Logger } from "/client/modules/logger";
+import { Reaction, Logger } from "/client/api";
 import { Packages, Shops } from "/lib/collections";
 import { MetaData } from "/lib/api/router/metadata";
 import { Session } from "meteor/session";

--- a/imports/plugins/core/orders/client/templates/orders.html
+++ b/imports/plugins/core/orders/client/templates/orders.html
@@ -72,7 +72,7 @@
   <div class="col-xs-8">
     <div data-i18n="orderDetail.created">Created {{orderAge}} {{dateFormat createdAt format="MMM D, YYYY hh:mm:ss A"}}</div>
     <p>
-      Tracking: <a href="#">{{shipmentTracking}}</a>
+      Tracking: <a href="#">{{shipmentTracking}}</a> - 
       <span class="badge badge-{{shipmentStatus.status}}">{{shipmentStatus.label}}</span>
     </p>
   </div>

--- a/imports/plugins/core/orders/client/templates/orders.html
+++ b/imports/plugins/core/orders/client/templates/orders.html
@@ -71,9 +71,10 @@
 <template name="orderStatusDetail">
   <div class="col-xs-8">
     <div data-i18n="orderDetail.created">Created {{orderAge}} {{dateFormat createdAt format="MMM D, YYYY hh:mm:ss A"}}</div>
-    {{#if shipmentTracking}}
-    <p>Tracking: <a href="#">{{shipmentTracking}}</a></p>
-    {{/if}}
+    <p>
+      Tracking: <a href="#">{{shipmentTracking}}</a>
+      <span class="badge badge-{{shipmentStatus.status}}">{{shipmentStatus.label}}</span>
+    </p>
   </div>
 </template>
 


### PR DESCRIPTION
Added shipment information to the main page, instead of just having it in the admin side panel. This creates easier reference for the admin when they are viewing all orders in one place.

![screen shot 2016-07-28 at 3 39 58 pm](https://cloud.githubusercontent.com/assets/4482263/17231958/bf744854-54d9-11e6-89ff-e49af3a9ffab.png)

To reproduce:

1) Purchase items
2) Log in as an admin
3) Go through the fulfillment process, all the way to the end

- you should see the changes as they happen on both the main left side and in the admin panel.


- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [x] Passes all tests
- [x] Has been linted and follows the style guide
