### PR TITLE
Add convenience function to globally change layouts.

### DIFF
--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -667,5 +667,23 @@ Meteor.methods({
         enabled: !enabled
       }
     });
+  },
+  /*
+  * shop/changeLayout
+  * @summary Change the layout for all workflows so you can use a custom one
+  * @param {String} shopId - the shop's ID
+  * @param {String} layout - new layout to use
+  * @return {Number} mongo update result
+   */
+  "shop/changeLayouts": function (shopId, newLayout) {
+    check(shopId, String);
+    check(newLayout, String);
+    let shop = Collections.Shops.findOne(shopId);
+    for (let i = 0; i < shop.layout.length; i++) {
+      shop.layout[i].layout = newLayout;
+    }
+    return Collections.Shops.update(shopId, {
+      $set: {layout: shop.layout}
+    });
   }
 });

--- a/server/methods/core/shops.app-test.js
+++ b/server/methods/core/shops.app-test.js
@@ -69,8 +69,7 @@ describe("core shop methods", function () {
   });
 });
 
-describe.only("modify layout records", function () {
-
+describe("shop/changeLayouts", function () {
   it("should replace every layout with the new layout", function () {
     const shop = Factory.create("shop");
     Meteor.call("shop/changeLayouts", shop._id, "myNewLayout");
@@ -78,5 +77,5 @@ describe.only("modify layout records", function () {
     for (let layout of myShop.layout) {
       expect(layout.layout).to.equal("myNewLayout");
     }
-  })
+  });
 });

--- a/server/methods/core/shops.app-test.js
+++ b/server/methods/core/shops.app-test.js
@@ -68,3 +68,15 @@ describe("core shop methods", function () {
     });
   });
 });
+
+describe.only("modify layout records", function () {
+
+  it("should replace every layout with the new layout", function () {
+    const shop = Factory.create("shop");
+    Meteor.call("shop/changeLayouts", shop._id, "myNewLayout");
+    const myShop = Shops.findOne(shop._id);
+    for (let layout of myShop.layout) {
+      expect(layout.layout).to.equal("myNewLayout");
+    }
+  })
+});


### PR DESCRIPTION
If you want to use a custom layout template you need to override it in DEFAULT_LAYOUT but also in every layout record in Shops. This just adds a convenience feature so that plugins can easily override all layout records. It is not called in current code.