### PR TITLE
Fix inventory tests

### DIFF
--- a/imports/plugins/included/example-paymentmethod/server/methods/example-payment-methods.app-test.js
+++ b/imports/plugins/included/example-paymentmethod/server/methods/example-payment-methods.app-test.js
@@ -72,6 +72,7 @@ describe("Submit payment", function () {
   });
 
   it("should call Example API with card and payment data", function () {
+    this.timeout(3000);
     let cardData = {
       name: "Test User",
       number: "4242424242424242",
@@ -97,7 +98,6 @@ describe("Submit payment", function () {
       cardData: cardData,
       paymentData: paymentData
     });
-
     expect(results.saved).to.be.true;
   });
 

--- a/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
+++ b/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
@@ -101,6 +101,7 @@ describe("Inventory Hooks", function () {
   });
 
   it("should move allocated inventory to 'shipped' when an order is shipped", function (done) {
+    this.timeout(5000);
     sandbox.stub(Meteor.server.method_handlers, "orders/sendNotification", function () {
       check(arguments, [Match.Any]);
       Logger.warn("running stub notification");

--- a/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
+++ b/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
@@ -100,7 +100,7 @@ describe("Inventory Hooks", function () {
     expect(updatedInventoryItem.workflow.status).to.equal("sold");
   });
 
-  it("should move allocated inventory to 'shipped' when an order is shipped", function () {
+  it("should move allocated inventory to 'shipped' when an order is shipped", function (done) {
     sandbox.stub(Meteor.server.method_handlers, "orders/sendNotification", function () {
       check(arguments, [Match.Any]);
       Logger.warn("running stub notification");
@@ -136,8 +136,11 @@ describe("Inventory Hooks", function () {
     const orderId = Meteor.call("cart/copyCartToOrder", cart._id);
     const order = Orders.findOne(orderId);
     const shipping = { items: [] };
-    Meteor.call("orders/shipmentShipped", order, shipping);
-    const shippedInventoryItem = Inventory.findOne(inventoryItem._id);
-    expect(shippedInventoryItem.workflow.status).to.equal("shipped");
+    Meteor.call("orders/shipmentShipped", order, shipping, () => {
+      Meteor._sleepForMs(500);
+      const shippedInventoryItem = Inventory.findOne(inventoryItem._id);
+      expect(shippedInventoryItem.workflow.status).to.equal("shipped");
+      return done();
+    });
   });
 });

--- a/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
+++ b/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
@@ -1,13 +1,31 @@
 /* eslint dot-notation: 0 */
 import { Meteor } from "meteor/meteor";
-import { Inventory, Orders }  from "/lib/collections";
-import { Reaction } from "/server/api";
+import { Inventory, Orders, Cart }  from "/lib/collections";
+import { Reaction, Logger } from "/server/api";
 import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";
 import Fixtures from "/server/imports/fixtures";
 import { getShop } from "/server/imports/fixtures/shops";
 
 Fixtures();
+
+function reduceCart(cart) {
+  Cart.update(cart._id, {
+    $set: {
+      "items.0.quantity": 1
+    }
+  });
+  Cart.update(cart._id, {
+    $set: {
+      "items.1.quantity": 1
+    }
+  });
+  Cart.update(cart._id, {
+    $pull: {
+      "items.$.quantity": {$gt: 1}
+    }
+  });
+}
 
 describe("Inventory Hooks", function () {
   let originals;
@@ -41,14 +59,16 @@ describe("Inventory Hooks", function () {
   }
 
   it("should move allocated inventory to 'sold' when an order is created", function () {
-    this.timeout(50000);
-    Inventory.direct.remove({});
-    const cart = Factory.create("cartToOrder");
-    sandbox.stub(Reaction, "getShopId", function () {
-      return cart.shopId;
-    });
     sandbox.stub(Meteor.server.method_handlers, "orders/sendNotification", function () {
       check(arguments, [Match.Any]);
+      Logger.warn("running stub notification");
+      return true;
+    });
+    Inventory.direct.remove({});
+    const cart = Factory.create("cartToOrder");
+    reduceCart(cart);
+    sandbox.stub(Reaction, "getShopId", function () {
+      return cart.shopId;
     });
     let shop = getShop();
     let product = cart.items[0];
@@ -81,15 +101,17 @@ describe("Inventory Hooks", function () {
   });
 
   it("should move allocated inventory to 'shipped' when an order is shipped", function () {
-    this.timeout(50000);
-    Inventory.direct.remove({});
-    const cart = Factory.create("cartToOrder");
-    sandbox.stub(Reaction, "getShopId", function () {
-      return cart.shopId;
-    });
-    sandbox.stub(Reaction, "hasPermission", () => true);
     sandbox.stub(Meteor.server.method_handlers, "orders/sendNotification", function () {
       check(arguments, [Match.Any]);
+      Logger.warn("running stub notification");
+      return true;
+    });
+    sandbox.stub(Reaction, "hasPermission", () => true);
+    Inventory.direct.remove({});
+    const cart = Factory.create("cartToOrder");
+    reduceCart(cart);
+    sandbox.stub(Reaction, "getShopId", function () {
+      return cart.shopId;
     });
     let shop = getShop();
     let product = cart.items[0];

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -614,6 +614,7 @@ describe("core product methods", function () {
       Meteor.call("products/updateVariantsPosition", [
         product2._id, product3._id, product._id
       ]);
+      Meteor._sleepForMs(500);
       const modifiedProduct = Products.findOne(product._id);
       const modifiedProduct2 = Products.findOne(product2._id);
       const modifiedProduct3 = Products.findOne(product3._id);

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -149,6 +149,7 @@ describe("core product methods", function () {
       expect(variants.length).to.equal(1);
 
       Meteor.call("products/createVariant", product._id, newVariant);
+      Meteor._sleepForMs(500);
       variants = Products.find({ ancestors: [product._id] }).fetch();
       const createdVariant = variants.filter(v => v._id !== firstVariantId);
       expect(variants.length).to.equal(2);


### PR DESCRIPTION
When the cart fixture creates a cart it has several items each of which has a random quantity on it, usually in the 50-100 range. When you call `copyCartToOrder` each item gets broken out into an individual item. If you have larger quantities this takes a long time (too long for the test at least).

This change just reduces the cart down to a quantity of 1 which makes the test take less than 2 seconds.

This is probably a performance issue we should track. Also it would appear that collection-hooks are blocking?
