### PR TITLE
import moment-timezone

### DIFF
--- a/client/modules/core/helpers/templates.js
+++ b/client/modules/core/helpers/templates.js
@@ -4,7 +4,7 @@ import * as Collections from "/lib/collections";
 import * as Schemas from "/lib/collections/schemas";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
-import moment from "moment";
+import moment from "moment-timezone";
 
 /*
  *


### PR DESCRIPTION
- fixes error .names undefined
- for loading tz in i18n settings