### PR TITLE
Allow any user who has the createProduct permission to also delete products

### DIFF
--- a/.reaction/docker/scripts/.gitignore
+++ b/.reaction/docker/scripts/.gitignore
@@ -1,0 +1,1 @@
+/entrypoint-PROD-build-with-src.sh

--- a/.reaction/docker/scripts/.gitignore
+++ b/.reaction/docker/scripts/.gitignore
@@ -1,1 +1,0 @@
-/entrypoint-PROD-build-with-src.sh

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -700,7 +700,7 @@ Meteor.methods({
   "products/deleteProduct": function (productId) {
     check(productId, Match.OneOf(Array, String));
     // must have admin permission to delete
-    if (!Reaction.hasAdminAccess()) {
+    if (!Reaction.hasPermission("createProduct") && !Reaction.hasAdminAccess()) {
       throw new Meteor.Error(403, "Access Denied");
     }
 


### PR DESCRIPTION
This change allows any user who has the `createProduct` permission to also delete products. This is necessary to allow users to be sellers when running Reaction in marketplace mode.