### PR TITLE
Adds namespace field to layout schema

### DIFF
--- a/lib/collections/schemas/layouts.js
+++ b/lib/collections/schemas/layouts.js
@@ -110,6 +110,10 @@ export const Layout = new SimpleSchema({
     type: String,
     optional: true
   },
+  namespace: {
+    type: String,
+    optional: true
+  },
   container: {
     type: String,
     optional: true


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
**Are you submitting to `development`?**

We currently only accept PR's to `development` not `master`

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [x] Has been linted and follows the style guide

Our current need for this is to override checkout templates. 

Currently if I add templates to the registry for checkout steps, they are added to the existing checkout steps and as far as I can tell there isn't a good way to replace or override these checkout step templates.

This PR permits overriding of checkout step templates in the following way: 

```
{{ each reactionTemplate workflow="coreCartWorkflow" container="checkout-steps-main" namespace="getoutfitted" }}
  // Loads only checkout step templates with `namespace: getoutfitted`
  {{> checkoutSteps }}
{{/each}}
```

and in a custom module defining checkout step layouts that look like:
```
{
      template: "goCheckoutLogin",
      label: "Login",
      workflow: "coreCartWorkflow",
      container: "checkout-steps-main",
      namespace: "getoutfitted",
      audience: ["guest", "anonymous"],
      priority: 1,
      position: "1"
    },
```

I think there will be other uses that become obvious as I continue to override templates and build out our custom theme.