### PR TITLE
update cardNumber schemas

### DIFF
--- a/imports/plugins/included/authnet/lib/collections/schemas/package.js
+++ b/imports/plugins/included/authnet/lib/collections/schemas/package.js
@@ -37,7 +37,8 @@ export const AuthNetPayment = new SimpleSchema({
   cardNumber: {
     type: String,
     label: "Card number",
-    min: 16
+    min: 12,
+    max: 19
   },
   expireMonth: {
     type: String,

--- a/imports/plugins/included/paypal/lib/collections/schemas/paypal.js
+++ b/imports/plugins/included/paypal/lib/collections/schemas/paypal.js
@@ -67,7 +67,8 @@ export const PaypalPayment = new SimpleSchema({
   },
   cardNumber: {
     type: String,
-    min: 16,
+    min: 12,
+    max: 19,
     label: "Card number"
   },
   expireMonth: {


### PR DESCRIPTION
cardNumber schemas were not allowing valid credit cards, such as Amex
(15 digits), some Visa (13 digits), and foreign Maestro (12 - 19
digits). This updates to allow these lengths to be input. Braintree is left out of this PR, as it is updated inside of #1265.