### PR TITLE
Preserve custom profile fields in Accounts.onCreateUser

### DIFF
--- a/server/startup/accounts.js
+++ b/server/startup/accounts.js
@@ -82,7 +82,7 @@ export default function () {
     const defaultRoles =  ["guest", "account/profile", "product", "tag", "index", "cart/checkout", "cart/completed"];
     const roles = {};
     const additionals = {
-      profile: {}
+      profile: Object.assign({}, options && options.profile)
     };
     if (!user.emails) user.emails = [];
     // init default user roles


### PR DESCRIPTION
# Motivation

I found myself customizing **loginFormSignUpView** which required passing additional profile fields to **Accounts.createUser**. As per [documentation](https://docs.meteor.com/api/passwords.html#Accounts-createUser), **Accounts.createUser** accepts additional _profile_ object as part of the options argument. RC's current handling of **Accounts.onCreateUser** does not take this data into consideration. This PR addresses this issue.

Since Accounts' collection profile schema is enforced using SimpleSchema, I had to extend Profile schema in my customization which minimizes potential security risks from passing profile object along to Accounts collection    

- [ ] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide

