### PR TITLE
Feature/product detail editors

### DIFF
--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/edit.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/edit.html
@@ -1,14 +1,19 @@
 <template name="productDetailEdit">
 {{#if condition type "eq" "textarea"}}
-<p class="product-detail-edit {{field}}-edit">
-  <textarea class="form-control {{field}}-edit-input" name="{{field}}" placeholder="{{i18nPlaceholder}}">{{value}}</textarea>
-</p>
-{{else}}
 <div class="product-detail-edit {{field}}-edit">
-  <input type="text" value="{{value}}" class="{{field}}-edit-input" placeholder="{{i18nPlaceholder}}"/>
+  {{> React TextArea }}
 </div>
+{{else}}
+  {{#if condition type "eq" "select"}}
+    <div class="product-detail-edit {{field}}-edit">
+      {{> React Select }}
+    </div>  
+  {{else}}
+    <div class="product-detail-edit {{field}}-edit">
+    {{> React TextBox }}
+    </div>
+  {{/if}}
 {{/if}}
-<span class="product-detail-message" id="{{field}}-message"></span>
 </template>
 
 <template name="productDetailField">

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/edit.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/edit.js
@@ -1,78 +1,119 @@
-import autosize from "autosize";
 import { Reaction, i18next, Logger } from "/client/api";
 import { ReactionProduct } from "/lib/api";
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
 import { Template } from "meteor/templating";
+import { Product } from "/lib/collections/schemas";
+import { TextArea, TextBox, Select } from "./editors";
+
+function i18nPlaceholder(field) {
+  const i18nKey = `productDetailEdit.${field}`;
+  if (i18next.t(i18nKey) === i18nKey) {
+    Logger.info(`returning empty placeholder productDetailEdit: ${i18nKey} no i18n key found.`);
+  } else {
+    return i18next.t(i18nKey);
+  }
+
+  return "";
+}
+
+function processChange({ name, value }) {
+  const productId = ReactionProduct.selectedProductId();
+
+  Meteor.call("products/updateProductField", productId, name, value,
+    (error, result) => {
+      if (error) {
+        return Alerts.toast(error.reason, "error", {
+          i18nKey: "productDetail.errorMsg"
+        });
+      }
+
+      if (result) {
+        // redirect to new url on title change
+        if (name === "title") {
+          Meteor.call("products/setHandle", productId,
+            (err, res) => {
+              if (err) {
+                Alerts.toast(err.reason, "error", {
+                  i18nKey: "productDetail.errorMsg"
+                });
+              }
+              if (res) {
+                Reaction.Router.go("product", {
+                  handle: res
+                });
+              }
+            }
+          );
+        }
+      }});
+  return Session.set("editing-" + name, false);
+}
+
+function setupEditor({ field, value, templateInstance, component, ...additionalProps }) {
+  return {
+    className: `form-control ${field}-edit-input`,
+    name: field,
+    onChange: processChange.bind(templateInstance),
+    placeholder: i18nPlaceholder(field),
+    value,
+    component,
+    ...additionalProps
+  };
+}
+
+Template.productDetailEdit.onCreated(() => {
+  const t = Template.instance();
+
+  if (t.data.type) {
+    // respect explicit field type
+    return;
+  }
+
+  const fieldDefinition = Product.getDefinition(t.data.field);
+
+  if (fieldDefinition && fieldDefinition.allowedValues) {
+    t.type = "select";
+    t.allowedValues = fieldDefinition.allowedValues;
+  }
+});
 
 /**
  * productDetailEdit helpers
  */
 
 Template.productDetailEdit.helpers({
-  i18nPlaceholder: function () {
-    const i18nKey = `productDetailEdit.${this.field}`;
-    if (i18next.t(i18nKey) === i18nKey) {
-      Logger.info(`returning empty placeholder productDetailEdit: ${i18nKey} no i18n key found.`);
-    } else {
-      return i18next.t(i18nKey);
-    }
-  }
-});
+  TextArea() {
+    return setupEditor({
+      field: this.field,
+      value: this.value,
+      templateInstance: Template.instance(),
+      component: TextArea
+    });
+  },
 
-/**
- * productDetailEdit events
- */
+  TextBox() {
+    return setupEditor({
+      field: this.field,
+      value: this.value,
+      templateInstance: Template.instance(),
+      component: TextBox
+    });
+  },
 
-Template.productDetailEdit.events({
-  "change input,textarea": function (event) {
-    const self = this;
-    const productId = ReactionProduct.selectedProductId();
-    Meteor.call("products/updateProductField", productId, self.field,
-      $(event.currentTarget).val(),
-      (error, result) => {
-        if (error) {
-          return Alerts.inline(error.reason, "error", {
-            placement: "productManagement",
-            i18nKey: "productDetail.errorMsg",
-            id: self._id
-          });
-        }
-        if (result) {
-          // redirect to new url on title change
-          if (self.field === "title") {
-            Meteor.call("products/setHandle", productId,
-              (err, res) => {
-                if (err) {
-                  Alerts.inline(err.reason, "error", {
-                    placement: "productManagement",
-                    i18nKey: "productDetail.errorMsg",
-                    id: self._id
-                  });
-                }
-                if (res) {
-                  Reaction.Router.go("product", {
-                    handle: res
-                  });
-                }
-              }
-            );
-          }
-          // animate updated field
-          // TODO this needs to be moved into a component
-          return $(event.currentTarget).animate({
-            backgroundColor: "#e2f2e2"
-          }).animate({
-            backgroundColor: "#fff"
-          });
-        }
-      });
+  Select() {
+    return setupEditor({
+      field: this.field,
+      value: this.value,
+      templateInstance: Template.instance(),
+      component: Select,
+      options: Template.instance().allowedValues
+    });
+  },
 
-    if (this.type === "textarea") {
-      autosize($(event.currentTarget));
-    }
-
-    return Session.set("editing-" + this.field, false);
+  type() {
+    const t = Template.instance();
+    return t.type || t.data.type;
   }
 });
 
@@ -89,12 +130,4 @@ Template.productDetailField.events({
       return $(`.${this.field}-edit-input`).focus();
     }
   }
-});
-
-/**
- * productDetailEdit onRendered
- */
-
-Template.productDetailEdit.onRendered(function () {
-  return autosize($("textarea"));
 });

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/edit.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/edit.js
@@ -50,11 +50,11 @@ function processChange({ name, value }) {
   return Session.set("editing-" + name, false);
 }
 
-function setupEditor({ field, value, templateInstance, component, ...additionalProps }) {
+function setupEditor({ component, field, value, ...additionalProps }) {
   return {
     className: `form-control ${field}-edit-input`,
     name: field,
-    onChange: processChange.bind(templateInstance),
+    onChange: processChange,
     placeholder: i18nPlaceholder(field),
     value,
     component,
@@ -70,6 +70,9 @@ Template.productDetailEdit.onCreated(() => {
     return;
   }
 
+  // If not given explicit type to use in the editor
+  // look into Product schema to figure out the most
+  // appropriate editor to use
   const fieldDefinition = Product.getDefinition(t.data.field);
 
   if (fieldDefinition && fieldDefinition.allowedValues) {
@@ -85,28 +88,25 @@ Template.productDetailEdit.onCreated(() => {
 Template.productDetailEdit.helpers({
   TextArea() {
     return setupEditor({
+      component: TextArea,
       field: this.field,
-      value: this.value,
-      templateInstance: Template.instance(),
-      component: TextArea
+      value: this.value
     });
   },
 
   TextBox() {
     return setupEditor({
+      component: TextBox,
       field: this.field,
-      value: this.value,
-      templateInstance: Template.instance(),
-      component: TextBox
+      value: this.value
     });
   },
 
   Select() {
     return setupEditor({
+      component: Select,
       field: this.field,
       value: this.value,
-      templateInstance: Template.instance(),
-      component: Select,
       options: Template.instance().allowedValues
     });
   },

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/editors/Select.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/editors/Select.js
@@ -1,0 +1,38 @@
+import React, { Component, PropTypes } from "react";
+
+class Select extends Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(e) {
+    const { name, onChange } = this.props;
+    onChange({ name, value: e.target.value });
+  }
+
+  render() {
+    const { className, name, value, options } = this.props;
+    return (
+      <select
+        className={className}
+        defaultValue={value}
+        name={name}
+        onBlur={this.handleChange}
+        type="text"
+      >
+        { options.map(o => <option key={`key-${o}`} value={o}>{o}</option>) }
+      </select>
+    );
+  }
+}
+
+Select.propTypes = {
+  className: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  value: PropTypes.string
+};
+
+export default Select;

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/editors/TextArea.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/editors/TextArea.js
@@ -1,0 +1,36 @@
+import React, { Component, PropTypes } from "react";
+
+class TextArea extends Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(e) {
+    const { name, onChange } = this.props;
+    onChange({ name, value: e.target.value });
+  }
+
+  render() {
+    const { className, name, value, placeholder } = this.props;
+    return (
+      <textarea
+        className={className}
+        defaultValue={value}
+        name={name}
+        onBlur={this.handleChange}
+        placeholder={placeholder}
+      />
+    );
+  }
+}
+
+TextArea.propTypes = {
+  className: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  value: PropTypes.string
+};
+
+export default TextArea;

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/editors/TextBox.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/editors/TextBox.js
@@ -1,0 +1,37 @@
+import React, { Component, PropTypes } from "react";
+
+class TextBox extends Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(e) {
+    const { name, onChange } = this.props;
+    onChange({ name, value: e.target.value });
+  }
+
+  render() {
+    const { className, name, placeholder, value } = this.props;
+    return (
+      <input
+        className={className}
+        defaultValue={value}
+        name={name}
+        onBlur={this.handleChange}
+        placeholder={placeholder}
+        type="text"
+      />
+    );
+  }
+}
+
+TextBox.propTypes = {
+  className: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  value: PropTypes.string
+};
+
+export default TextBox;

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/editors/index.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/editors/index.js
@@ -1,0 +1,7 @@
+import TextBox from "./TextBox";
+import Select from "./Select";
+import TextArea from "./TextArea";
+
+export {
+  TextArea, TextBox, Select
+};


### PR DESCRIPTION
# Motivation

This started with us needing support for **select** controls in product detail editor. I then got sucked into refactoring product detail "editors" into separate React components. The idea is to have nicely isolated field editors available for most standard data types people might use in data fields (and eventually support custom editors passed in as params).

# Missing parts/improvements

I had to remove autosizer for textarea since it's now a React component. If you are generally interested by this PR, I will look into adding this on a component level. Field after-edit animation is missing as well. I have also replaced Alerts.inline with Alerts.Toast since inline did not seem to be working as expected anyways.

- [ ] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide
