### PR TITLE
Check if billing address exists

### DIFF
--- a/server/methods/core/hooks/cart.js
+++ b/server/methods/core/hooks/cart.js
@@ -22,7 +22,11 @@ MethodHooks.after("cart/submitPayment", function (options) {
 
     // create order
     if (cart) {
-      if (cart.items && cart.billing[0].paymentMethod) {
+      if (!cart.billing) {
+        Logger.info("MethodHooks after cart/submitPayment. No billing address after payment! userId:", Meteor.userId(), "options:", options);
+      }
+
+      if (cart.items && cart.billing && cart.billing[0].paymentMethod) {
         const orderId = Meteor.call("cart/copyCartToOrder", cart._id);
         // Return orderId as result from this after hook call.
         // This is done by extending the existing result.


### PR DESCRIPTION
Prevents exception if there is no billing address in the `cart/submitPayment` after-hook.