### PR TITLE
Get rid of the errors when using umlauls in payer name

### DIFF
--- a/imports/plugins/core/checkout/client/helpers/cart.js
+++ b/imports/plugins/core/checkout/client/helpers/cart.js
@@ -65,22 +65,3 @@ Template.registerHelper("cart", function () {
   };
   return cartHelpers;
 });
-
-/**
- * cartPayerName
- * @summary gets current cart billing address / payment name
- * @return {String} returns cart.billing[0].fullName
- */
-
-Template.registerHelper("cartPayerName", function () {
-  const cart = Cart.findOne();
-  if (cart) {
-    if (cart.billing) {
-      if (cart.billing[0].address) {
-        if (cart.billing[0].address.fullName) {
-          return cart.billing[0].address.fullName;
-        }
-      }
-    }
-  }
-});

--- a/imports/plugins/included/authnet/client/checkout/authnet.html
+++ b/imports/plugins/included/authnet/client/checkout/authnet.html
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-        {{>afFieldInput name="payerName" value=cartPayerName}}
+        {{>afFieldInput name="payerName"}}
         {{#if afFieldIsInvalid name="payerName"}}
         <span class="help-block">{{afFieldMessage name="payerName"}}</span>
         {{/if}}

--- a/imports/plugins/included/braintree/client/checkout/braintree.html
+++ b/imports/plugins/included/braintree/client/checkout/braintree.html
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
       <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-      {{>afFieldInput name="payerName" value=cartPayerName}}
+      {{>afFieldInput name="payerName"}}
       {{#if afFieldIsInvalid name="payerName"}}
       <span class="help-block">{{afFieldMessage name="payerName"}}</span>
       {{/if}}

--- a/imports/plugins/included/example-paymentmethod/client/checkout/example.html
+++ b/imports/plugins/included/example-paymentmethod/client/checkout/example.html
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-        {{>afFieldInput name="payerName" value=cartPayerName}}
+        {{>afFieldInput name="payerName"}}
         {{#if afFieldIsInvalid name="payerName"}}
         <span class="help-block">{{afFieldMessage name="payerName"}}</span>
         {{/if}}

--- a/imports/plugins/included/paypal/client/templates/checkout/payflowForm.html
+++ b/imports/plugins/included/paypal/client/templates/checkout/payflowForm.html
@@ -4,7 +4,7 @@
     <div class="row">
       <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-        {{>afFieldInput name="payerName" value=cartPayerName}}
+        {{>afFieldInput name="payerName"}}
         {{#if afFieldIsInvalid name="payerName"}}
         <span class="help-block">{{afFieldMessage name="payerName"}}</span>
         {{/if}}

--- a/imports/plugins/included/stripe/client/checkout/stripe.html
+++ b/imports/plugins/included/stripe/client/checkout/stripe.html
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-        {{>afFieldInput name="payerName" value=cartPayerName}}
+        {{>afFieldInput name="payerName"}}
         {{#if afFieldIsInvalid name="payerName"}}
         <span class="help-block">{{afFieldMessage name="payerName"}}</span>
         {{/if}}


### PR DESCRIPTION
Removed `cartPayerName` helper as it takes the name from the profile, where it (the name) could contain umlauts and other non-latin characters,
which are not accepted by payment gateways and the payment form produces an error as the result.  This should not be a problem as the customer
should always type in the name as it is on the credit card anyway.