### PR TITLE
Prevent no image being found

### DIFF
--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/item.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/item.js
@@ -35,9 +35,10 @@ Template.productGridItems.helpers({
   media: function () {
     const media = Media.findOne({
       "metadata.productId": this._id,
-      "metadata.priority": 0,
       "metadata.toGrid": 1
-    }, { sort: { uploadedAt: 1 } });
+    }, {
+      sort: { "metadata.priority": 1, uploadedAt: 1 }
+    });
 
     return media instanceof FS.File ? media : false;
   },

--- a/imports/plugins/included/product-variant/client/templates/products/productList/productList.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productList/productList.js
@@ -15,8 +15,9 @@ Template.productList.helpers({
     if (variants.length > 0) {
       const variantId = variants[0]._id;
       defaultImage = Media.findOne({
-        "metadata.variantId": variantId,
-        "metadata.priority": 0
+        "metadata.variantId": variantId
+      }, {
+        sort: { "metadata.priority": 1, uploadedAt: 1 }
       });
     }
     if (defaultImage) {


### PR DESCRIPTION
Prevent no image being found if no image has priority 0. `"metadata.priority": 0` filter will fail to find an image if none has priority 0, so sort is used instead.