### PR TITLE
Make close button work on tag nav bar in mobile mode

### DIFF
--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
@@ -312,6 +312,9 @@ Template.tagNav.events({
       const tags = instance.data.tags;
       const selectedTag = instance.state.get("selectedTag");
 
+      // click close button to make navbar left disappear
+      $(".rui.button.btn.btn-default.close-button").trigger("click");
+
       if (selectedTag && selectedTag._id === tagId) {
         return instance.state.set("selectedTag", null);
       }


### PR DESCRIPTION
Make close button work on tag nav bar in mobile mode by auto-clicking close button to make navbar left disappear.