### PR TITLE
metafields -> details for client visibility

### DIFF
--- a/imports/plugins/included/search-mongo/client/settings/search.html
+++ b/imports/plugins/included/search-mongo/client/settings/search.html
@@ -46,7 +46,7 @@
 
         <div class="row">
           <div class="form-group col-md-8">
-            {{>afFieldInput name="settings.products.includes.metafields" i18nKey="searchSettings.productSearchSettings.includeMetafields" template="searchCheckbox"}}
+            {{>afFieldInput name="settings.products.includes.metafields" i18nKey="searchSettings.productSearchSettings.includeDetails" template="searchCheckbox"}}
           </div>
 
           <div class="form-group{{#if afFieldIsInvalid name="settings.products.weights.metafields"}} has-error{{/if}} col-md-3">

--- a/imports/plugins/included/search-mongo/lib/collections/schemas/search.js
+++ b/imports/plugins/included/search-mongo/lib/collections/schemas/search.js
@@ -41,12 +41,12 @@ export const SearchPackageConfig = new SimpleSchema([
     },
     "settings.products.includes.metafields": {
       type: Boolean,
-      label: "Include metafields",
+      label: "Include details",
       defaultValue: true
     },
     "settings.products.weights.metafields": {
       type: Number,
-      label: "Metafields weight",
+      label: "Details weight",
       defaultValue: 6,
       max: 10,
       min: 1
@@ -65,4 +65,3 @@ export const SearchPackageConfig = new SimpleSchema([
     }
   }
 ]);
-

--- a/private/data/i18n/en.json
+++ b/private/data/i18n/en.json
@@ -154,7 +154,7 @@
           "includeTitle": "Include title",
           "includeDescription": "Include description",
           "includePageTitle": "Include page title",
-          "includeMetafields": "Include metafields",
+          "includeDetails": "Include details",
           "includeVendor": "Include vendor"
         },
         "orderSearchSettings": {


### PR DESCRIPTION
Changed “Metafields” to “details” in the search settings panel.

Metafields was confusing to people we were showing the search to