### PR TITLE
publish authorize-net module on npm

### DIFF
--- a/imports/plugins/included/authnet/server/methods/authnet.js
+++ b/imports/plugins/included/authnet/server/methods/authnet.js
@@ -6,7 +6,7 @@ import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Promise } from "meteor/promise";
 
-import AuthNetAPI from "authorize-net";
+import AuthNetAPI from "@reactioncommerce/authorize-net";
 import { Reaction, Logger } from "/server/api";
 import { Packages } from "/lib/collections";
 import { PaymentMethod } from "/lib/collections/schemas";

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "url": "https://github.com/reactioncommerce/reaction/issues"
   },
   "dependencies": {
+    "@reactioncommerce/authorize-net": "^1.0.7",
     "accounting-js": "^1.1.1",
-    "authorize-net": "github:ongoworks/node-authorize-net",
     "autonumeric": "^1.9.45",
     "autosize": "^3.0.17",
     "avalara-taxrates": "^1.0.1",


### PR DESCRIPTION
Moves `authorize-net` to `@reactioncommerce/authorize-net` because some Windows users are having issues when npm tries to install packages from a Github repo.

Should fix #1450