### PR TITLE
Updated publish controls UX and fixing issues

### DIFF
--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -43,12 +43,46 @@ class PublishControls extends Component {
     return "app.hideChanges";
   }
 
+  get hasRevisions() {
+    return Array.isArray(this.props.revisions) && this.props.revisions.length;
+  }
+
   get diffs() {
     return this.props.revisions;
   }
 
   get showDiffs() {
     return this.diffs && this.state.showDiffs;
+  }
+
+  /**
+   * Getter hasChanges
+   * @return {Boolean} one or more revision has changes
+   */
+  get hasChanges() {
+    // Verify we even have any revision at all
+    if (this.hasRevisions) {
+      // Loop through all revisions to determin if they have changes
+      const diffHasActualChanges = this.props.revisions.map((revision) => {
+        // We probably do have chnages to publish
+        // Note: Sometimes "updatedAt" will cause false positives, but just incase, lets
+        // enable the publish button anyway.
+        if (Array.isArray(revision.diff) && revision.diff.length) {
+          return true;
+        }
+
+        // If all else fails, we will disable the button
+        return false;
+      });
+
+      // If even one revision as changes we should enable the publish button
+      return diffHasActualChanges.some((element) => {
+        return element === true;
+      });
+    }
+
+    // No revisions, no publishing
+    return false;
   }
 
   renderChanges() {
@@ -66,6 +100,18 @@ class PublishControls extends Component {
     return null;
   }
 
+  renderPublishButton() {
+    return (
+      <Button
+        disabled={this.hasChanges === false}
+        i18nKeyLabel="app.publishChanges"
+        label="Publish Changes"
+        onClick={this.handlePublishClick}
+        status="success"
+      />
+    );
+  }
+
   render() {
     if (this.props.isEnabled) {
       return (
@@ -76,12 +122,7 @@ class PublishControls extends Component {
             onClick={this.handleToggleShowChanges}
             status="link"
           />
-          <Button
-            i18nKeyLabel="app.publishChanges"
-            label="Publish Changes"
-            onClick={this.handlePublishClick}
-            primary={true}
-          />
+          {this.renderPublishButton()}
           {this.showDiffs && <hr />}
           {this.renderChanges()}
         </div>

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -75,7 +75,7 @@ class PublishControls extends Component {
         return false;
       });
 
-      // If even one revision as changes we should enable the publish button
+      // If even one revision has changes we should enable the publish button
       return diffHasActualChanges.some((element) => {
         return element === true;
       });

--- a/imports/plugins/core/revisions/client/containers/publishContainer.js
+++ b/imports/plugins/core/revisions/client/containers/publishContainer.js
@@ -40,7 +40,7 @@ export function handlePublishClick(revisions) {
     Meteor.call("revisions/publish", documentIds, (error, result) => {
       if (result === true) {
         const message = i18next.t("revisions.changedPublished", {
-          defaultValue: "Changes published successfuly"
+          defaultValue: "Changes published successfully"
         });
 
         Alerts.toast(message, "success");

--- a/imports/plugins/core/revisions/client/containers/publishContainer.js
+++ b/imports/plugins/core/revisions/client/containers/publishContainer.js
@@ -5,6 +5,7 @@ import { Revisions } from "/lib/collections";
 import { Meteor } from "meteor/meteor";
 import TranslationProvider from "/imports/plugins/core/ui/client/providers/translationProvider";
 import { isRevisionControlEnabled } from "../../lib/api";
+import { i18next } from "/client/api";
 
 /**
  * Publish container is a stateless container component connected to Meteor data source.
@@ -35,7 +36,22 @@ export function handlePublishClick(revisions) {
     const documentIds = revisions.map((revision) => {
       return revision.documentId;
     });
-    Meteor.call("revisions/publish", documentIds);
+
+    Meteor.call("revisions/publish", documentIds, (error, result) => {
+      if (result === true) {
+        const message = i18next.t("revisions.changedPublished", {
+          defaultValue: "Changes published successfuly"
+        });
+
+        Alerts.toast(message, "success");
+      } else {
+        const message = i18next.t("revisions.noChangesPublished", {
+          defaultValue: "There are no changes to publish"
+        });
+
+        Alerts.toast(message, "warning");
+      }
+    });
   }
 }
 
@@ -45,8 +61,22 @@ function composer(props, onData) {
 
     if (subscription.ready()) {
       const revisions = Revisions.find({
-        documentId: {
-          $in: props.documentIds
+        "$or": [
+          {
+            documentId: {
+              $in: props.documentIds
+            }
+          },
+          {
+            "documentData.ancestors": {
+              $in: props.documentIds
+            }
+          }
+        ],
+        "workflow.status": {
+          $nin: [
+            "revision/published"
+          ]
         }
       }).fetch();
 

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -64,7 +64,7 @@ Meteor.methods({
     let updatedDocuments = 0;
 
     if (revisions) {
-      for (let revision of revisions) {
+      for (const revision of revisions) {
         const res = Products.update({
           _id: revision.documentId
         }, {
@@ -81,6 +81,6 @@ Meteor.methods({
       return true;
     }
 
-    throw new Meteor.Error(403, "Forbidden", "Could not publish product revision");
+    return false;
   }
 });

--- a/private/data/i18n/en.json
+++ b/private/data/i18n/en.json
@@ -568,7 +568,10 @@
         "unpublishedChanges": "Unpublished Changes",
         "publishChanges": "Publish Changes",
         "showChanges": "Show Changes",
-        "hideChanges": "Hide Changes"
+        "hideChanges": "Hide Changes",
+        "changedPublished": "Changes published successfuly",
+        "noChanges": "No Changes",
+        "noChangesPublished": "There are no changes to publish"
       },
       "address": {
         "country": "Country",

--- a/private/data/i18n/en.json
+++ b/private/data/i18n/en.json
@@ -569,7 +569,7 @@
         "publishChanges": "Publish Changes",
         "showChanges": "Show Changes",
         "hideChanges": "Hide Changes",
-        "changedPublished": "Changes published successfuly",
+        "changedPublished": "Changes published successfully",
         "noChanges": "No Changes",
         "noChangesPublished": "There are no changes to publish"
       },


### PR DESCRIPTION
Resolves #1463 

- Fix bug causing error in console when publishing nothing.
- Disabled the publish button if there is nothing to publish.
- Added alert toasts for successful and unsuccessful publish.
- Publish container now properly finds relevant revisions based on workflow status and ancestor fields.