### PR TITLE
make circleci target repo configurable using env var

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,20 +26,24 @@ deployment:
   prequel:
     branch: development
     commands:
-      - docker tag reactioncommerce/base:latest reactioncommerce/base:devel
-      - docker tag reactioncommerce/reaction:latest reactioncommerce/prequel:latest
-      - docker tag reactioncommerce/reaction:latest reactioncommerce/prequel:$CIRCLE_BUILD_NUM
+      - DOCKER_NAMESPACE=${DOCKER_NAMESPACE:-reactioncommerce}
+      - docker tag reactioncommerce/base:latest $DOCKER_NAMESPACE/base:devel
+      - docker tag reactioncommerce/reaction:latest $DOCKER_NAMESPACE/prequel:latest
+      - docker tag reactioncommerce/reaction:latest $DOCKER_NAMESPACE/prequel:$CIRCLE_BUILD_NUM
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker push reactioncommerce/base:devel
-      - docker push reactioncommerce/prequel:$CIRCLE_BUILD_NUM
-      - docker push reactioncommerce/prequel:latest
+      - docker push $DOCKER_NAMESPACE/base:devel
+      - docker push $DOCKER_NAMESPACE/prequel:$CIRCLE_BUILD_NUM
+      - docker push $DOCKER_NAMESPACE/prequel:latest
   release:
     branch: master
     commands:
-      - docker tag reactioncommerce/base:latest  reactioncommerce/base:$CIRCLE_BUILD_NUM
-      - docker tag reactioncommerce/reaction:latest  reactioncommerce/reaction:$CIRCLE_BUILD_NUM
+      - DOCKER_NAMESPACE=${DOCKER_NAMESPACE:-reactioncommerce}
+      - docker tag reactioncommerce/base:latest  $DOCKER_NAMESPACE/base:latest
+      - docker tag reactioncommerce/base:latest  $DOCKER_NAMESPACE/base:$CIRCLE_BUILD_NUM
+      - docker tag reactioncommerce/reaction:latest  $DOCKER_NAMESPACE/reaction:latest
+      - docker tag reactioncommerce/reaction:latest  $DOCKER_NAMESPACE/reaction:$CIRCLE_BUILD_NUM
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker push reactioncommerce/base:$CIRCLE_BUILD_NUM
-      - docker push reactioncommerce/base:latest
-      - docker push reactioncommerce/reaction:$CIRCLE_BUILD_NUM
-      - docker push reactioncommerce/reaction:latest
+      - docker push $DOCKER_NAMESPACE/base:$CIRCLE_BUILD_NUM
+      - docker push $DOCKER_NAMESPACE/base:latest
+      - docker push $DOCKER_NAMESPACE/reaction:$CIRCLE_BUILD_NUM
+      - docker push $DOCKER_NAMESPACE/reaction:latest


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
**Are you submitting to `development`?**

We currently only accept PR's to `development` not `master`

- [ ] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide

- use DOCKER_NAMESPACE env var to identify target repo

defaults to reactioncommerce if not set.

example:

when no env var set

	target-repo = reactioncommerce/base:latest

when DOCKER_NAMESPACE set to frankg

	target-repo = frankg/base:latest