### PR TITLE
Add templates to database

### DIFF
--- a/imports/plugins/included/email-templates/lib/paths.js
+++ b/imports/plugins/included/email-templates/lib/paths.js
@@ -13,4 +13,4 @@ export const coreOrderCreatedTemplate = "orders/coreOrderCreated";
 export const coreOrderShippingInvoiceTemplate = "orders/coreOrderShippingInvoice";
 export const coreOrderShippingSummaryTemplate = "orders/coreOrderShippingSummary";
 export const coreOrderShippingTrackingTemplate = "orders/coreOrderShippingTracking";
-export const coreOrderNewTemplate = "orders/coreOrderNew";
+export const coreOrderNewTemplate = "orders/new";

--- a/imports/plugins/included/email-templates/lib/paths.js
+++ b/imports/plugins/included/email-templates/lib/paths.js
@@ -1,16 +1,16 @@
 // Tempalte paths relative to private/email/templates
-export const coreDefaultTemplate = "coreDefaultTemplate";
+export const coreDefaultTemplate = "coreDefault";
 
 export const resetPaswordTemplate = "accounts/reset_password";
 export const inviteShopMemberTemplate = "accounts/inviteShopMember";
 export const welcomeEmailTemplate = "accounts/sendWelcomeEmail";
-export const verifyEmailTemplate = "accounts/verifyEmail";
+export const verifyEmailTemplate = "accounts/verify_email";
 
 export const checkoutLoginTemplate = "checkout/checkoutLogin";
 
-export const coreOrderCompletedTemplate = "checkout/coreOrderCompleted";
-export const coreOrderCreatedTemplate = "checkout/coreOrderCreated";
-export const coreOrderShippingInvoiceTemplate = "checkout/coreOrderShippingInvoice";
-export const coreOrderShippingSummaryTemplate = "checkout/coreOrderShippingSummary";
-export const coreOrderShippingTrackingTemplate = "checkout/coreOrderShippingTracking";
-export const coreOrderNewTemplate = "checkout/coreOrderNew";
+export const coreOrderCompletedTemplate = "orders/coreOrderCompleted";
+export const coreOrderCreatedTemplate = "orders/coreOrderCreated";
+export const coreOrderShippingInvoiceTemplate = "orders/coreOrderShippingInvoice";
+export const coreOrderShippingSummaryTemplate = "orders/coreOrderShippingSummary";
+export const coreOrderShippingTrackingTemplate = "orders/coreOrderShippingTracking";
+export const coreOrderNewTemplate = "orders/coreOrderNew";

--- a/imports/plugins/included/email-templates/lib/paths.js
+++ b/imports/plugins/included/email-templates/lib/paths.js
@@ -1,0 +1,16 @@
+// Tempalte paths relative to private/email/templates
+export const coreDefaultTemplate = "coreDefaultTemplate";
+
+export const resetPaswordTemplate = "accounts/reset_password";
+export const inviteShopMemberTemplate = "accounts/inviteShopMember";
+export const welcomeEmailTemplate = "accounts/sendWelcomeEmail";
+export const verifyEmailTemplate = "accounts/verifyEmail";
+
+export const checkoutLoginTemplate = "checkout/checkoutLogin";
+
+export const coreOrderCompletedTemplate = "checkout/coreOrderCompleted";
+export const coreOrderCreatedTemplate = "checkout/coreOrderCreated";
+export const coreOrderShippingInvoiceTemplate = "checkout/coreOrderShippingInvoice";
+export const coreOrderShippingSummaryTemplate = "checkout/coreOrderShippingSummary";
+export const coreOrderShippingTrackingTemplate = "checkout/coreOrderShippingTracking";
+export const coreOrderNewTemplate = "checkout/coreOrderNew";

--- a/imports/plugins/included/email-templates/server/index.js
+++ b/imports/plugins/included/email-templates/server/index.js
@@ -1,9 +1,90 @@
 import { Reaction } from "/server/api";
-import StandardTemplate from "../lib/templates/standard";
+import * as TemplatePaths from "../lib/paths.js";
+
+// Default
+Reaction.registerTemplate({
+  title: "Default",
+  name: TemplatePaths.coreDefaultTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.coreDefaultTemplate)
+});
+
+// Accounts
+Reaction.registerTemplate({
+  title: "Reset Password",
+  name: TemplatePaths.resetPaswordTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.resetPaswordTemplate)
+});
 
 Reaction.registerTemplate({
-  title: "Standard Email",
-  name: "standard-email",
+  title: "Invite Shop Member",
+  name: TemplatePaths.inviteShopMemberTemplate,
   type: "email",
-  template: StandardTemplate
+  template: Reaction.Email.getTemplate(TemplatePaths.inviteShopMemberTemplate)
+});
+
+Reaction.registerTemplate({
+  title: "Welcome Email",
+  name: TemplatePaths.welcomeEmailTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.welcomeEmailTemplate)
+});
+
+Reaction.registerTemplate({
+  title: "Verify Account",
+  name: TemplatePaths.verifyEmailTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.verifyEmailTemplate)
+});
+
+// Checkout
+Reaction.registerTemplate({
+  title: "Checkout Login",
+  name: TemplatePaths.checkoutLoginTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.checkoutLoginTemplate)
+});
+
+// Order workflow
+Reaction.registerTemplate({
+  title: "Order Completed",
+  name: TemplatePaths.coreOrderCompletedTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderCompletedTemplate)
+});
+
+Reaction.registerTemplate({
+  title: "Order Created",
+  name: TemplatePaths.coreOrderCreatedTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderCreatedTemplate)
+});
+
+Reaction.registerTemplate({
+  title: "Shipping Invoice",
+  name: TemplatePaths.coreOrderShippingInvoiceTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderShippingInvoiceTemplate)
+});
+
+Reaction.registerTemplate({
+  title: "Shipping Summary",
+  name: TemplatePaths.coreOrderShippingSummaryTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderShippingSummaryTemplate)
+});
+
+Reaction.registerTemplate({
+  title: "Shipping Tracking",
+  name: TemplatePaths.coreOrderShippingTrackingTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderShippingTrackingTemplate)
+});
+
+Reaction.registerTemplate({
+  title: "New Order Started Processing",
+  name: TemplatePaths.coreOrderNewTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderNewTemplate)
 });

--- a/imports/plugins/included/email-templates/server/index.js
+++ b/imports/plugins/included/email-templates/server/index.js
@@ -6,7 +6,7 @@ Reaction.registerTemplate({
   title: "Default",
   name: TemplatePaths.coreDefaultTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.coreDefaultTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.coreDefaultTemplate)
 });
 
 // Accounts
@@ -14,28 +14,28 @@ Reaction.registerTemplate({
   title: "Reset Password",
   name: TemplatePaths.resetPaswordTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.resetPaswordTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.resetPaswordTemplate)
 });
 
 Reaction.registerTemplate({
   title: "Invite Shop Member",
   name: TemplatePaths.inviteShopMemberTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.inviteShopMemberTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.inviteShopMemberTemplate)
 });
 
 Reaction.registerTemplate({
   title: "Welcome Email",
   name: TemplatePaths.welcomeEmailTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.welcomeEmailTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.welcomeEmailTemplate)
 });
 
 Reaction.registerTemplate({
   title: "Verify Account",
   name: TemplatePaths.verifyEmailTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.verifyEmailTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.verifyEmailTemplate)
 });
 
 // Checkout
@@ -43,7 +43,7 @@ Reaction.registerTemplate({
   title: "Checkout Login",
   name: TemplatePaths.checkoutLoginTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.checkoutLoginTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.checkoutLoginTemplate)
 });
 
 // Order workflow
@@ -51,40 +51,40 @@ Reaction.registerTemplate({
   title: "Order Completed",
   name: TemplatePaths.coreOrderCompletedTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderCompletedTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.coreOrderCompletedTemplate)
 });
 
 Reaction.registerTemplate({
   title: "Order Created",
   name: TemplatePaths.coreOrderCreatedTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderCreatedTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.coreOrderCreatedTemplate)
 });
 
 Reaction.registerTemplate({
   title: "Shipping Invoice",
   name: TemplatePaths.coreOrderShippingInvoiceTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderShippingInvoiceTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.coreOrderShippingInvoiceTemplate)
 });
 
 Reaction.registerTemplate({
   title: "Shipping Summary",
   name: TemplatePaths.coreOrderShippingSummaryTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderShippingSummaryTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.coreOrderShippingSummaryTemplate)
 });
 
 Reaction.registerTemplate({
   title: "Shipping Tracking",
   name: TemplatePaths.coreOrderShippingTrackingTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderShippingTrackingTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.coreOrderShippingTrackingTemplate)
 });
 
 Reaction.registerTemplate({
   title: "New Order Started Processing",
   name: TemplatePaths.coreOrderNewTemplate,
   type: "email",
-  template: Reaction.Email.getTemplate(TemplatePaths.coreOrderNewTemplate)
+  template: Reaction.Email.getTemplateFile(TemplatePaths.coreOrderNewTemplate)
 });

--- a/server/api/core/email/email.js
+++ b/server/api/core/email/email.js
@@ -50,6 +50,7 @@ export function getTemplate(template) {
     return tmpl.template;
   }
 
+  // otherwise, use the default template from the filesystem
   return getTemplateFile(template);
 }
 

--- a/server/api/core/email/email.js
+++ b/server/api/core/email/email.js
@@ -50,11 +50,23 @@ export function getTemplate(template) {
     return tmpl.template;
   }
 
-  // otherwise, use the default template from the filesystem
-  const file = `email/templates/${template}.html`;
+  return getTemplateFile(template);
+}
+
+/**
+ * Reaction.Email.getTemplateFile
+ * @param  {String} file name of the template on file system
+ * @return {String} returns source
+ */
+export function getTemplateFile(file) {
+  if (typeof file !== "string") {
+    const msg = "Reaction.Email.getTemplateFile() requires a template name";
+    Logger.error(msg);
+    throw new Meteor.Error("no-template-name", msg);
+  }
 
   try {
-    return Assets.getText(file);
+    return Assets.getText(`email/templates/${file}.html`);
   } catch (e) {
     Logger.warn(`Template not found: ${file}. Falling back to coreDefault.html`);
     return Assets.getText("email/templates/coreDefault.html");

--- a/server/api/core/email/email.js
+++ b/server/api/core/email/email.js
@@ -43,11 +43,11 @@ export function getTemplate(template) {
   }
 
   // check database for a matching template
-  const tmpl = Templates.findOne({ template, language });
+  const tmpl = Templates.findOne({ name: template, language });
 
   // use that template if found
-  if (tmpl && tmpl.source) {
-    return tmpl.source;
+  if (tmpl && tmpl.template) {
+    return tmpl.template;
   }
 
   // otherwise, use the default template from the filesystem


### PR DESCRIPTION
Related To: #1515 

Adds emails that are on disc in `private/email/templates/` into the `Templates` collection in the database.

Fetches email template from database when it exists using `Reaction.Email.getTemplate()`.