### PR TITLE
Fixes #1537 - Alerts throwing error

### DIFF
--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -70,7 +70,12 @@ Object.assign(Alerts, {
         if (isConfirm === true && typeof messageOrCallback === "function") {
           messageOrCallback(isConfirm);
         }
-      }).catch(_.noop);
+      }).catch(function (err) {
+        if (err === "cancel" || err === "overlay" || err === "timer") {
+          return undefined; // Silence error
+        }
+        throw err;
+      });
     }
 
     const title = titleOrOptions;
@@ -85,7 +90,12 @@ Object.assign(Alerts, {
       if (isConfirm === true && typeof callback === "function") {
         callback(isConfirm);
       }
-    }).catch(_.noop);
+    }).catch(function (err) {
+      if (err === "cancel" || err === "overlay" || err === "timer") {
+        return undefined; // Silence error
+      }
+      throw err;
+    });
   },
 
   toast(message, type, options) {

--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -70,7 +70,7 @@ Object.assign(Alerts, {
         if (isConfirm === true && typeof messageOrCallback === "function") {
           messageOrCallback(isConfirm);
         }
-      });
+      }).catch(_.noop);
     }
 
     const title = titleOrOptions;
@@ -85,7 +85,7 @@ Object.assign(Alerts, {
       if (isConfirm === true && typeof callback === "function") {
         callback(isConfirm);
       }
-    });
+    }).catch(_.noop);
   },
 
   toast(message, type, options) {


### PR DESCRIPTION
Catch and silently handle errors thrown by SweetAlert2 such as `Uncaught (in promise) overlay` with lodash noop
