### PR TITLE
Docker security updates

### DIFF
--- a/.reaction/docker/base.dockerfile
+++ b/.reaction/docker/base.dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 MAINTAINER Reaction Commerce <admin@reactioncommerce.com>
 
-ENV NODE_VERSION "4.6.0"
+ENV NODE_VERSION 4.6.1
 
 # Install MongoDB
 ENV INSTALL_MONGO "true"

--- a/.reaction/docker/base.dockerfile
+++ b/.reaction/docker/base.dockerfile
@@ -1,16 +1,19 @@
 FROM debian:jessie
 MAINTAINER Reaction Commerce <admin@reactioncommerce.com>
 
+RUN groupadd -r node && useradd -m -g node node
+
 ENV NODE_VERSION 4.6.1
+ENV GOSU_VERSION 1.9
 
 # Install MongoDB
-ENV INSTALL_MONGO "true"
-ENV MONGO_VERSION "3.2.10"
-ENV MONGO_MAJOR "3.2"
+ENV INSTALL_MONGO true
+ENV MONGO_VERSION 3.2.10
+ENV MONGO_MAJOR 3.2
 
 # Install PhantomJS
-ENV INSTALL_PHANTOMJS "true"
-ENV PHANTOM_VERSION "2.1.1"
+ENV INSTALL_PHANTOMJS true
+ENV PHANTOM_VERSION 2.1.1
 
 # build directories
 ENV APP_SOURCE_DIR "/opt/reaction/src"
@@ -22,28 +25,27 @@ COPY .reaction/docker/scripts $BUILD_SCRIPTS_DIR
 RUN chmod -R +x $BUILD_SCRIPTS_DIR
 
 # install base dependencies and clean up
-RUN cd $BUILD_SCRIPTS_DIR && \
-		bash $BUILD_SCRIPTS_DIR/install-deps.sh && \
-		bash $BUILD_SCRIPTS_DIR/install-node.sh && \
-		bash $BUILD_SCRIPTS_DIR/install-mongo.sh && \
-		bash $BUILD_SCRIPTS_DIR/install-phantom.sh && \
-		bash $BUILD_SCRIPTS_DIR/post-install-cleanup.sh
+RUN bash $BUILD_SCRIPTS_DIR/install-deps.sh && \
+    bash $BUILD_SCRIPTS_DIR/install-node.sh && \
+    bash $BUILD_SCRIPTS_DIR/install-mongo.sh && \
+    bash $BUILD_SCRIPTS_DIR/install-phantom.sh && \
+    bash $BUILD_SCRIPTS_DIR/post-install-cleanup.sh
 
 # copy the app to the container
 ONBUILD COPY . $APP_SOURCE_DIR
 
 # install Meteor, build app, clean up
-ONBUILD RUN cd $APP_SOURCE_DIR && \
-            bash $BUILD_SCRIPTS_DIR/install-meteor.sh && \
+ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-meteor.sh && \
             bash $BUILD_SCRIPTS_DIR/build-meteor.sh && \
             bash $BUILD_SCRIPTS_DIR/post-build-cleanup.sh
 
 # set the default port that Node will listen on
-ENV PORT 80
-EXPOSE 80
+# (can't be 80 because the process is run by a non-root user)
+ENV PORT 3000
+EXPOSE 3000
 
 WORKDIR $APP_BUNDLE_DIR/bundle
 
 # start the app
-ENTRYPOINT ./entrypoint.sh
-CMD []
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["node", "main.js"]

--- a/.reaction/docker/scripts/build-meteor.sh
+++ b/.reaction/docker/scripts/build-meteor.sh
@@ -1,30 +1,35 @@
 #!/bin/bash
 
 #
-# builds a production meteor bundle directory
+# builds a production meteor bundle
 #
 set -e
-
-printf "\n[-] Building Meteor application...\n\n"
-
-: ${APP_BUNDLE_DIR:="/var/www"}
-: ${BUILD_SCRIPTS_DIR:="/opt/reaction"}
 
 cd $APP_SOURCE_DIR
 
 # Customize packages
-bash $BUILD_SCRIPTS_DIR/build-packages.sh
+$BUILD_SCRIPTS_DIR/build-packages.sh
 
 # Generate plugin import files
-bash $BUILD_SCRIPTS_DIR/plugin-loader.sh
+printf "\n[-] Running Reaction plugin loader...\n\n"
+$BUILD_SCRIPTS_DIR/plugin-loader.sh
 
 # Install app deps
+printf "\n[-] Running npm install...\n\n"
 meteor npm install
 
-# build the source
+# build the production bundle
+printf "\n[-] Building Meteor application...\n\n"
 mkdir -p $APP_BUNDLE_DIR
-meteor build --directory $APP_BUNDLE_DIR
-cd $APP_BUNDLE_DIR/bundle/programs/server/ && meteor npm install --production
+meteor build --unsafe-perm --directory $APP_BUNDLE_DIR
+
+# run npm install in bundle
+printf "\n[-] Running npm install in server bundle...\n\n"
+cd $APP_BUNDLE_DIR/bundle/programs/server/
+meteor npm install --production
 
 # put the entrypoint script in WORKDIR
 mv $BUILD_SCRIPTS_DIR/entrypoint.sh $APP_BUNDLE_DIR/bundle/entrypoint.sh
+
+# change ownership of the app to the node user
+chown -R node:node $APP_BUNDLE_DIR

--- a/.reaction/docker/scripts/build-packages.sh
+++ b/.reaction/docker/scripts/build-packages.sh
@@ -7,5 +7,5 @@
 
 if [ -f .reaction/docker/packages ]; then
   echo "[-] Using custom Meteor packages file..."
-  cp docker/packages .meteor/packages
+  cp .reaction/docker/packages .meteor/packages
 fi

--- a/.reaction/docker/scripts/entrypoint.sh
+++ b/.reaction/docker/scripts/entrypoint.sh
@@ -7,6 +7,13 @@
 #
 set -e
 
+
+# Set a delay to wait to start meteor container
+if [[ $DELAY ]]; then
+  echo "Delaying startup for $DELAY seconds"
+  sleep $DELAY
+fi
+
 # try to start local MongoDB if no external MONGO_URL was set
 if [[ "${MONGO_URL}" == *"127.0.0.1"* ]]; then
   if hash mongod 2>/dev/null; then

--- a/.reaction/docker/scripts/entrypoint.sh
+++ b/.reaction/docker/scripts/entrypoint.sh
@@ -7,17 +7,36 @@
 #
 set -e
 
-# start local mongodb if no external MONGO_URL was set
+# try to start local MongoDB if no external MONGO_URL was set
 if [[ "${MONGO_URL}" == *"127.0.0.1"* ]]; then
   if hash mongod 2>/dev/null; then
-    mkdir -p /data/db
+    mkdir -p /data/{db,configdb,logs}
     printf "\n[-] External MONGO_URL not found. Starting local MongoDB...\n\n"
-    mongod --storageEngine=wiredTiger --fork --logpath /var/log/mongodb.log
+    mongod --storageEngine=wiredTiger --fork --logpath /data/logs/mongodb.log
   else
-    echo "ERROR: Mongo not installed inside the container. Rebuild with INSTALL_MONGO=true"
+    echo "ERROR: Mongo not installed inside the container."
+    echo "Rebuild with INSTALL_MONGO=true or supply a MONGO_URL environment variable."
     exit 1
   fi
 fi
 
-# Run meteor
-exec node ./main.js
+if [ "${1:0:1}" = '-' ]; then
+	set -- node "$@"
+fi
+
+# allow the container to be started with `--user`
+if [ "$1" = "node" -a "$(id -u)" = "0" ]; then
+  chown -R node:node $APP_BUNDLE_DIR
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = "node" ]; then
+	numa="numactl --interleave=all"
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+fi
+
+# Start the app
+echo "=> Starting Reaction on port $PORT..."
+exec "$@"

--- a/.reaction/docker/scripts/install-deps.sh
+++ b/.reaction/docker/scripts/install-deps.sh
@@ -2,9 +2,37 @@
 
 set -e
 
-
 printf "\n[-] Installing base OS dependencies...\n\n"
 
-apt-get update -qq -y
+apt-get update -y
 
-apt-get install -qq -y --no-install-recommends curl ca-certificates bzip2 build-essential python graphicsmagick
+apt-get install -y --no-install-recommends \
+  build-essential \
+  bzip2 \
+  ca-certificates \
+  curl \
+  graphicsmagick \
+  numactl \
+  python \
+  wget
+
+
+# Install gosu to build and run the app as a non-root user
+# https://github.com/tianon/gosu
+set -x
+
+dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
+
+wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"
+wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"
+
+export GNUPGHOME="$(mktemp -d)"
+
+gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
+
+rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc
+
+chmod +x /usr/local/bin/gosu
+
+gosu nobody true

--- a/.reaction/docker/scripts/install-meteor.sh
+++ b/.reaction/docker/scripts/install-meteor.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-if [ "$DEV_BUILD" = "true" ]; then
+if [ "$DEV_BUILD" = true ]; then
+  # if this is a devbuild, we don't have an app to check the .meteor/release file yet,
+  # so just install the latest version of Meteor
+  printf "\n[-] Installing the latest version of Meteor...\n\n"
   curl https://install.meteor.com/ | sh
 else
   # download installer script
@@ -12,7 +15,7 @@ else
   METEOR_VERSION=$(head $APP_SOURCE_DIR/.meteor/release | cut -d "@" -f 2)
 
   # set the release version in the install script
-  sed -i "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /tmp/install_meteor.sh
+  sed -i.bak "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /tmp/install_meteor.sh
 
   # install
   printf "\n[-] Installing Meteor $METEOR_VERSION...\n\n"

--- a/.reaction/docker/scripts/install-mongo.sh
+++ b/.reaction/docker/scripts/install-mongo.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "${INSTALL_MONGO}" = "true" ]; then
+if [ "${INSTALL_MONGO}" = true ]; then
 
   printf "\n[-] Installing MongoDB ${MONGO_VERSION}...\n\n"
 
@@ -17,11 +17,11 @@ if [ "${INSTALL_MONGO}" = "true" ]; then
     mongodb-org=$MONGO_VERSION \
     mongodb-org-server=$MONGO_VERSION \
     mongodb-org-shell=$MONGO_VERSION \
-    mongodb-org-mongos=$MONGO_VERSION \
     mongodb-org-tools=$MONGO_VERSION
 
-	rm -rf /var/lib/apt/lists/*
-	rm -rf /var/lib/mongodb
+  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/mongodb
+
   mv /etc/mongod.conf /etc/mongod.conf.orig
 
 fi

--- a/.reaction/docker/scripts/install-phantom.sh
+++ b/.reaction/docker/scripts/install-phantom.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "${INSTALL_PHANTOMJS}" = "true" ]; then
+if [ "${INSTALL_PHANTOMJS}" = true ]; then
 
   printf "\n[-] Installing Phantom.js...\n\n"
 
@@ -19,7 +19,5 @@ if [ "${INSTALL_PHANTOMJS}" = "true" ]; then
   ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin/phantomjs
   ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/bin/phantomjs
 
-  apt-get -y purge wget
-
-  phantomjs -v
+  printf "\n[-] Successfully installed PhantomJS $(phantomjs -v)\n\n"
 fi

--- a/.reaction/docker/scripts/post-build-cleanup.sh
+++ b/.reaction/docker/scripts/post-build-cleanup.sh
@@ -3,28 +3,23 @@ set -e
 
 printf "\n[-] Performing final cleanup...\n"
 
+# get out of the src dir, so we can delete it
+cd $APP_BUNDLE_DIR
+
 # Clean out docs
-rm -rf /usr/share/doc /usr/share/doc-base /usr/share/man /usr/share/locale /usr/share/zoneinfo
+rm -rf /usr/share/{doc,doc-base,man,locale,zoneinfo}
 
 # Clean out package management dirs
-rm -rf /var/lib/cache /var/lib/log
+rm -rf /var/lib/{cache,log}
 
 # clean additional files created outside the source tree
-rm -rf /root/.cache /root/.config /root/.local
+rm -rf /root/{.cache,.config,.local,.npm,.cordova}
 rm -rf /tmp/*
 
-# clean source tree
-rm -rf $APP_SOURCE_DIR/packages/*/lib/bower
-rm -rf $APP_SOURCE_DIR/packages/*/.git
-rm -rf $APP_SOURCE_DIR/packages/*/.npm
-rm -rf $APP_SOURCE_DIR/.meteor/local
-
-# clean additional files created outside the source tree
-rm -rf /root/.npm /root/.cache /root/.config /root/.cordova /root/.local
-rm -rf /tmp/*
+# remove app source
+rm -rf $APP_SOURCE_DIR
 
 # remove npm
-npm cache clean
 rm -rf /opt/nodejs/bin/npm
 rm -rf /opt/nodejs/lib/node_modules/npm/
 

--- a/.reaction/docker/scripts/post-install-cleanup.sh
+++ b/.reaction/docker/scripts/post-install-cleanup.sh
@@ -4,15 +4,16 @@ set -e
 printf "\n[-] Performing post install cleanup...\n\n"
 
 # Clean out docs
-rm -rf /usr/share/doc /usr/share/doc-base /usr/share/man /usr/share/locale /usr/share/zoneinfo
+rm -rf /usr/share/{doc,doc-base,man,locale,zoneinfo}
 
 # Clean out package management dirs
-rm -rf /var/lib/cache /var/lib/log
+rm -rf /var/lib/{cache,log}
 
 # clean additional files created outside the source tree
-rm -rf /root/.cache /root/.config /root/.local
+rm -rf /root/{.cache,.config,.local}
 rm -rf /tmp/*
 
 # remove os dependencies
+apt-get -y purge wget
 apt-get -y autoremove
 rm -rf /var/lib/apt/lists/*

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,6 @@ dependencies:
     - "~/docker"
   override:
     - cd $HOME/reaction
-    - .reaction/scripts/clone-packages.sh
     - .reaction/docker/scripts/plugin-loader.sh
 
 test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ reaction:
   links:
     - mongo
   ports:
-    - "80:80"
+    - "80:3000"
   environment:
     ROOT_URL: "http://localhost"
     MONGO_URL: "mongodb://mongo:27017/reaction"


### PR DESCRIPTION
Meteor 1.4.2 attempts to enforce not using root to build the app and tanks the Docker build in some cases (not totally sure why it doesn't always happen).  This refactor fixes the build error, corrects permissions in the production bundle, and uses [gosu](https://github.com/tianon/gosu) to run the app as a non-root user (which is highly recommended for security anyway)

Commit details...

- refactor Docker build to run app as a non-root user
- cleanup the cleanup scripts
- remove app source after build is done
- don’t install mongos if mongo install happens in container
- update container port in docker-compose example file
- add a delay option to the Docker entrypoint
- remove unused script from CircleCI
- fix custom package file script

To test...

```sh
reaction init -b docker-security-updates docker-test

cd docker-test

.reaction/docker/build.sh

docker-compose up -d

# app available on http://localhost
```

Note that non-root users can't run processes on port 80, so the container now exposes port 3000 instead.  The `docker-compose.yml` that gets used above takes care of mapping port 3000 to port 80 and you can do the same thing with `docker run -p 80:3000 ...` 