### PR TITLE
move import settings

### DIFF
--- a/imports/plugins/core/dashboard/client/templates/import/import.html
+++ b/imports/plugins/core/dashboard/client/templates/import/import.html
@@ -1,3 +1,26 @@
+<template name="importSettings">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="panel-title">
+          <a
+            href="#import"
+            aria-controls="import"
+            role="button"
+            data-toggle="collapse"
+            data-parent="#shopSettingsAccordian"
+            data-i18n="shopSettings.import">Import</a>
+        </div>
+      </div>
+      <div id="import" class="panel-collapse collapse" role="tabpanel" aria-labelledby="import">
+        <div class="panel-body">
+          {{> import}}
+        </div>
+      </div>
+
+    </div>
+</template>
+
+
 <template name="import">
   <div class="container-fluid-sm">
     <div class="panel panel-default">

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
@@ -108,25 +108,6 @@
       </div>
     </div>
 
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class="panel-title">
-          <a
-            href="#import"
-            aria-controls="import"
-            role="button"
-            data-toggle="collapse"
-            data-parent="#shopSettingsAccordian"
-            data-i18n="shopSettings.import">Import</a>
-        </div>
-      </div>
-      <div id="import" class="panel-collapse collapse" role="tabpanel" aria-labelledby="import">
-        <div class="panel-body">
-          {{> import}}
-        </div>
-      </div>
-
-    </div>
   </div>
 </template>
 


### PR DESCRIPTION
- moved “Import” from settings/settings.html to import/import.html
- is currently not used and won’t be visible, but can be basis for
import settings.

resolves #1050