### PR TITLE
Fix permissions on Order when "guest" user

### DIFF
--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -33,7 +33,7 @@ Template.coreOrderShippingInvoice.onCreated(function () {
     // template.order = getOrder(currentData.orderId);
     if (order) {
       const paymentMethod = order.billing[0].paymentMethod;
-      Meteor.call("orders/refunds/list", paymentMethod, (error, result) => {
+      Meteor.call("orders/refunds/list", order, (error, result) => {
         if (!error) {
           this.refunds.set(result);
         }

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -387,7 +387,7 @@ Meteor.methods({
       }
     }
 
-    const refundResult = Meteor.call("orders/refunds/list", order.billing[0].paymentMethod);
+    const refundResult = Meteor.call("orders/refunds/list", order);
 
     let refundTotal = 0;
 
@@ -850,10 +850,12 @@ Meteor.methods({
    * @param {Object} paymentMethod - paymentMethod object
    * @return {null} no return value
    */
-  "orders/refunds/list": function (paymentMethod) {
-    check(paymentMethod, Object);
+  "orders/refunds/list": function (order) {
+    check(order, Object);
 
-    if (!Reaction.hasPermission("orders")) {
+    const paymentMethod = order.billing[0].paymentMethod;
+
+    if (!this.userId === order.userId && !Reaction.hasPermission("orders")) {
       throw new Meteor.Error(403, "Access Denied");
     }
 


### PR DESCRIPTION
Fixes #1602 and #1595

When a guest / non-admin user created an order, our permissions were not allowing refunds to be accessed, which in turn was not allowing emails to be sent, as refunds are listed inside order emails.

This update grants extra permissions so if an order is owned by the current user, they are allowed to access the needed information