### PR TITLE
Don't blank out titles when cloning variants

### DIFF
--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -349,7 +349,7 @@ Meteor.methods({
         type = "parent";
         Object.assign(clone, variant, {
           _id: variantNewId,
-          title: ""
+          title: `${variant.title} - copy`
         });
       } else {
         const parentIndex = variant.ancestors.indexOf(variantId);
@@ -358,27 +358,24 @@ Meteor.methods({
         !!~parentIndex && ancestorsClone.splice(parentIndex, 1, variantNewId);
         Object.assign(clone, variant, {
           _id: Random.id(),
-          ancestors: ancestorsClone,
-          optionTitle: "",
-          title: ""
+          ancestors: ancestorsClone
         });
       }
       delete clone.updatedAt;
       delete clone.createdAt;
       delete clone.inventoryQuantity;
       copyMedia(productId, oldId, clone._id);
-
       return Products.insert(clone, {
         validate: false
       }, (error, result) => {
         if (result) {
           if (type === "child") {
-            Logger.info(
+            Logger.debug(
               `products/cloneVariant: created sub child clone: ${
                 clone._id} from ${variantId}`
             );
           } else {
-            Logger.info(
+            Logger.debug(
               `products/cloneVariant: created clone: ${
                 clone._id} from ${variantId}`
             );
@@ -386,8 +383,7 @@ Meteor.methods({
         }
         if (error) {
           Logger.error(
-            `products/cloneVariant: cloning of ${variantId} was failed: ${
-              error}`
+            `products/cloneVariant: cloning of ${variantId} was failed: ${error}`
           );
         }
       });
@@ -1266,8 +1262,5 @@ Meteor.methods({
 
     // if collection updated we return new `isVisible` state
     return res === 1 && !product.isVisible;
-
-    Logger.debug("invalid product visibility ", productId);
-    throw new Meteor.Error(400, "Bad Request");
   }
 });


### PR DESCRIPTION
Resolves #1610 

This is not so much a bug fix as a change in intentional behavior but I feel like it makes sense.

If I created a shoe with 15 different sizes and now I wanted to clone that to another color, producing a clone with all the option names blanked out pretty much negates most of the benefit I get from cloning a product rather than creating it from scratch. It also makes it hard to determine which is which.

Maybe there was a reason for this that I don't see in which case this PR and bug can just be closed.