### PR TITLE
Default product to blank object for instances where it may be undefined.

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/containers/socialContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/socialContainer.js
@@ -24,7 +24,7 @@ class ProductSocialContainer extends Component {
 }
 
 function composer(props, onData) {
-  const product = ReactionProduct.selectedProduct();
+  const product = ReactionProduct.selectedProduct() || {};
   const selectedVariant = ReactionProduct.selectedVariant() || {};
   let title = product.title;
   let mediaUrl;


### PR DESCRIPTION
Resolves #1484 

Stops the error from showing up when the product is undefined.