### PR TITLE
Fix for page title not updating when selecting product.

### DIFF
--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -5,6 +5,7 @@ import { FlowRouter } from "meteor/kadira:flow-router-ssr";
 import { getCurrentTag, getShopName } from "/lib/api";
 import { Products } from "/lib/collections";
 import Catalog from "./catalog";
+import { MetaData } from "/lib/api/router/metadata";
 
 // ReactionProduct is only intended to be used on the client, but it's placed
 // in common code because of it is imported by the Products schema
@@ -105,6 +106,9 @@ ReactionProduct.setProduct = (currentProductId, currentVariantId) => {
     ReactionProduct.set("productId", productId);
     ReactionProduct.set("variantId", variantId);
   }
+
+  // Update the meta data when a product is selected
+  MetaData.init(FlowRouter.current());
 
   return applyProductRevision(product);
 };


### PR DESCRIPTION
Resolves #1539 

This fix also ensures all metadata related to a product is updated when
the product is selected.