### PR TITLE
Fix Safari websocket connection browser policy

### DIFF
--- a/server/security/policy.js
+++ b/server/security/policy.js
@@ -1,3 +1,4 @@
+import url from "url";
 import { BrowserPolicy } from "meteor/browser-policy-common";
 import { WebApp } from "meteor/webapp";
 
@@ -23,8 +24,13 @@ if (process.env.NODE_ENV === "development") {
   BrowserPolicy.content.allowConnectOrigin("https://localhost:*");
   BrowserPolicy.framing.allowAll();
 }
-// allow production local websockets
-BrowserPolicy.content.allowConnectOrigin("ws://localhost:*");
+
+// get current hostname of app
+const { hostname } = url.parse(Meteor.absoluteUrl());
+
+// allow websockets (Safari fails without this)
+BrowserPolicy.content.allowConnectOrigin(`ws://${hostname}`);
+BrowserPolicy.content.allowConnectOrigin(`wss://${hostname}`);
 
 BrowserPolicy.content.allowOriginForAll("*.facebook.com");
 BrowserPolicy.content.allowOriginForAll("*.fbcdn.net");


### PR DESCRIPTION
Fixes a browser policy config that prevented ~~Internet Explorer~~ Safari from being able to make a websocket connection to the app.

It's 2016 Apple.  Get it together, man.   ;)