### PR TITLE
Add Prerender.io Integration - Feature #1249

### DIFF
--- a/imports/plugins/included/default-theme/client/escapedFragment.js
+++ b/imports/plugins/included/default-theme/client/escapedFragment.js
@@ -1,0 +1,6 @@
+// Meta tag required to get web crawlers to use
+// https://example.com/?_escaped_fragment_= when crawling.
+// This is necessary for either prerender or phantomjs
+
+const tag = "<meta name='fragment' content='!'>";
+document.getElementsByTagName("head")[0].insertAdjacentHTML("beforeend", tag);

--- a/imports/plugins/included/default-theme/client/index.js
+++ b/imports/plugins/included/default-theme/client/index.js
@@ -1,6 +1,9 @@
 // Favicons
 import "./favicons";
 
+// Escaped Fragment
+import "./escapedFragment";
+
 // Styles
 import "./styles/main.less";
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "paypal-rest-sdk": "^1.6.9",
     "postcss": "^5.2.5",
     "postcss-js": "^0.1.3",
+    "prerender-node": "^2.6.0",
     "react": "^15.3.2",
     "react-addons-create-fragment": "^15.3.2",
     "react-addons-pure-render-mixin": "^15.3.2",

--- a/server/startup/index.js
+++ b/server/startup/index.js
@@ -4,6 +4,7 @@ import Load from "./load-data";
 import Packages from "./packages";
 import Registry from "./registry";
 import Init from "./init";
+import Prerender from "./prerender";
 
 export default function () {
   Accounts();
@@ -12,4 +13,5 @@ export default function () {
   Packages();
   Registry();
   Init();
+  Prerender();
 }

--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -1,0 +1,15 @@
+import prerender from "prerender-node";
+import { WebApp } from "meteor/webapp";
+import { Logger } from "/server/api";
+
+export default function () {
+  if (process.env.PRERENDER_TOKEN && process.env.PRERENDER_HOST) {
+    prerender.set("prerenderToken", process.env.PRERENDER_TOKEN);
+    prerender.set("host", process.env.PRERENDER_HOST);
+    prerender.set("protocol", "https");
+    WebApp.rawConnectHandlers.use(prerender);
+    Logger.info("Prerender Initialization finished.");
+  } else {
+    Logger.info("Prerender Not Configured. Skipping");
+  }
+}


### PR DESCRIPTION
Feature #1249 

Initializes prerender.io if PRERENDER_TOKEN and PRERENDER_HOST are set as ENV variables.

Not really sure how I could add tests for this, but let me know if there are any changes this PR needs.

Could also potentially extract this to it's own module/package but it's so simple and necessary with spiderable not being reliable that it seems like it might belong in core.