### PR TITLE
1622 Add audience permissions to registry items

### DIFF
--- a/client/modules/accounts/templates/dropdown/dropdown.html
+++ b/client/modules/accounts/templates/dropdown/dropdown.html
@@ -35,7 +35,7 @@
   <ul class="user-accounts-dropdown-apps">
     {{> userAccountsDropdown}}
     <!--administrative shortcut icons -->
-    {{#each reactionApps provides="shortcut" enabled=true}}
+    {{#each reactionApps reactionAppsOptions}}
       <li class="dropdown-apps-icon">
         <a href={{pathFor name}} id="dropdown-apps-{{name}}" title="{{label}}">
           <i class="{{icon}}"></i>

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -72,10 +72,13 @@ Template.loginDropdown.events({
 
 Template.accountsDropdownApps.helpers({
   reactionAppsOptions() {
+    // get shortcuts with audience permissions based on user roles
+    const roles = Roles.getRolesForUser(Meteor.userId(), Reaction.getShopId());
+
     return {
       provides: "shortcut",
       enabled: true,
-      audience: "guest"
+      audience: roles
     };
   }
 });

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -69,3 +69,13 @@ Template.loginDropdown.events({
     template.$(".dropdown-toggle").dropdown("toggle");
   }
 });
+
+Template.accountsDropdownApps.helpers({
+  reactionAppsOptions() {
+    return {
+      provides: "shortcut",
+      enabled: true,
+      audience: "guest"
+    };
+  }
+});

--- a/lib/collections/schemas/registry.js
+++ b/lib/collections/schemas/registry.js
@@ -88,6 +88,11 @@ export const Registry = new SimpleSchema({
   permissions: {
     type: [Permissions],
     optional: true
+  },
+  audience: {
+    type: [String],
+    optional: true,
+    label: "Audience"
   }
 });
 

--- a/server/publications/collections/packages.js
+++ b/server/publications/collections/packages.js
@@ -36,14 +36,6 @@ function transform(doc, userId) {
       registry.packageName = registry.packageName || doc.name;
       registry.settingsKey = (registry.name || doc.name).split("/").splice(-1)[0];
 
-      if(registry.name === "shopSettings") {
-        console.log(registry.packageName, " - ", registry, " ", registry.name);
-      }
-
-     /* if(registry.audience) {
-
-        debugger;
-      }*/
       // check and set package enabled state
       // todo could add audience permissions to registry
       if (doc.settings && doc.settings[registry.settingsKey]) {


### PR DESCRIPTION
- Added audience permissions to registry schema
- Reaction.Apps now checks audience permissions against loggedIn user roles and registry item audience (if any)
- Registry items can now use `audience: ["guest","seller"]` permissions, which are safely passed on the client for the UI to adjust based on any user/audience role
- Safely ignores audience permissions for owner

To test it easily just add `audience: ["guest"]` to any registry item containing a `provides: "shortcut"` and see the shortcut item in the menu for a guest user