### PR TITLE
Prerender.io Integration - Feature #1249

### DIFF
--- a/client/templates/index.html
+++ b/client/templates/index.html
@@ -1,4 +1,5 @@
 <head>
+  <meta name="fragment" content="!">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <noscript><div style="padding: 40px; font-size: 200%; text-align: center;">This site requires JavaScript. Please enable it in your browser settings.</div></noscript>
 </head>

--- a/imports/plugins/core/layout/client/index.js
+++ b/imports/plugins/core/layout/client/index.js
@@ -16,6 +16,7 @@ import "./templates/layout/loading/loading.html";
 import "./templates/layout/notFound/notFound.html";
 import "./templates/layout/notFound/notFound.js";
 import "./templates/layout/notice/unauthorized.html";
+import "./templates/layout/notice/unauthorized.js";
 import "./templates/layout/layout.html";
 
 import "./templates/theme/theme.html";

--- a/imports/plugins/core/layout/client/templates/layout/notFound/notFound.js
+++ b/imports/plugins/core/layout/client/templates/layout/notFound/notFound.js
@@ -1,3 +1,5 @@
+import { Template } from "meteor/templating";
+
 Template.notFound.onCreated(function () {
   document.getElementsByTagName("head")[0].insertAdjacentHTML("beforeend", "<meta name='prerender-status-code' content='404'>");
   // todo report not found source

--- a/imports/plugins/core/layout/client/templates/layout/notFound/notFound.js
+++ b/imports/plugins/core/layout/client/templates/layout/notFound/notFound.js
@@ -1,3 +1,4 @@
 Template.notFound.onCreated(function () {
+  document.getElementsByTagName("head")[0].insertAdjacentHTML("beforeend", "<meta name='prerender-status-code' content='404'>");
   // todo report not found source
 });

--- a/imports/plugins/core/layout/client/templates/layout/notice/unauthorized.js
+++ b/imports/plugins/core/layout/client/templates/layout/notice/unauthorized.js
@@ -1,0 +1,6 @@
+import { Template } from "meteor/templating";
+
+Template.unauthorized.onCreated(function () {
+  document.getElementsByTagName("head")[0].insertAdjacentHTML("beforeend", "<meta name='prerender-status-code' content='403'>");
+  // todo report not found source
+});

--- a/imports/plugins/included/product-variant/client/templates/products/products.js
+++ b/imports/plugins/included/product-variant/client/templates/products/products.js
@@ -48,6 +48,10 @@ Template.products.onCreated(function () {
     canLoadMoreProducts: false
   });
 
+  // We're not ready to serve prerendered page until products have loaded
+  window.prerenderReady = false;
+
+
   // Update product subscription
   this.autorun(() => {
     const slug = Reaction.Router.getParam("slug");
@@ -71,7 +75,12 @@ Template.products.onCreated(function () {
     this.state.set("slug", slug);
 
     const queryParams = Object.assign({}, tags, Reaction.Router.current().queryParams);
-    this.subscribe("Products", scrollLimit, queryParams);
+    const productsSubscription = this.subscribe("Products", scrollLimit, queryParams);
+
+    // Once our products subscription is ready, we are ready to render
+    if (productsSubscription.ready()) {
+      window.prerenderReady = true;
+    }
 
     // we are caching `currentTag` or if we are not inside tag route, we will
     // use shop name as `base` name for `positions` object

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "paypal-rest-sdk": "^1.6.9",
     "postcss": "^5.2.5",
     "postcss-js": "^0.1.3",
+    "prerender-node": "^2.6.0",
     "radium": "^0.18.1",
     "react": "^15.3.2",
     "react-addons-create-fragment": "^15.3.2",

--- a/server/startup/index.js
+++ b/server/startup/index.js
@@ -4,6 +4,7 @@ import Load from "./load-data";
 import Packages from "./packages";
 import Registry from "./registry";
 import Init from "./init";
+import Prerender from "./prerender";
 import { initTemplates } from "/server/api/core/templates";
 
 
@@ -15,4 +16,5 @@ export default function () {
   Packages();
   Registry();
   Init();
+  Prerender();
 }

--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -9,7 +9,5 @@ export default function () {
     prerender.set("protocol", "https");
     WebApp.rawConnectHandlers.use(prerender);
     Logger.info("Prerender Initialization finished.");
-  } else {
-    Logger.info("Prerender Not Configured. Skipping");
   }
 }

--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -1,0 +1,15 @@
+import prerender from "prerender-node";
+import { WebApp } from "meteor/webapp";
+import { Logger } from "/server/api";
+
+export default function () {
+  if (process.env.PRERENDER_TOKEN && process.env.PRERENDER_HOST) {
+    prerender.set("prerenderToken", process.env.PRERENDER_TOKEN);
+    prerender.set("host", process.env.PRERENDER_HOST);
+    prerender.set("protocol", "https");
+    WebApp.rawConnectHandlers.use(prerender);
+    Logger.info("Prerender Initialization finished.");
+  } else {
+    Logger.info("Prerender Not Configured. Skipping");
+  }
+}


### PR DESCRIPTION
Feature #1249

* Integrates `prerender-node` npm package
* Initializes prerender.io if PRERENDER_TOKEN and PRERENDER_HOST are set as ENV variables.
* Adds an escaped fragment meta tag so web crawlers know to look for prerendered versions of pages.
* Uses `window.prerenderReady` in the products grid as an example of how to tell prerender not to capture a page until a subscription has finished.
* Sets `prerender-status-code` to `404` when rendering the `notFound` template
* Sets `prerender-status-code` to `403` when rendering the `unauthorized` template
* Docs added in [reaction-docs#146](https://github.com/reactioncommerce/reaction-docs/pull/146)