### PR TITLE
select and open newly created variants

### DIFF
--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/childVariant.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/childVariant.js
@@ -12,6 +12,7 @@ Template.onRendered(function () {
 
     $(`div.child-variant-collapse:not(#child-variant-form-${selectedVariantId})`).collapse("hide");
     $(`#child-variant-form-${selectedVariantId}`).collapse("show");
+    $(`#option-child-variant-form-${selectedVariantId}`).focus();
   });
 });
 

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/variantForm.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/variantForm.js
@@ -144,7 +144,19 @@ Template.variantForm.events({
     if (!productId) {
       return;
     }
-    Meteor.call("products/createVariant", template.data._id);
+    Meteor.call("products/createVariant", template.data._id, function (error, result) {
+      if (result) {
+        const newVariantId = result;
+        const selectedProduct = ReactionProduct.selectedProduct();
+        ReactionProduct.setCurrentVariant(newVariantId);
+        Session.set("variant-form-" + newVariantId, true);
+
+        Reaction.Router.go("product", {
+          handle: selectedProduct.handle,
+          variantId: newVariantId
+        });
+      }
+    });
   },
   "click .btn-clone-variant": function (event, template) {
     event.stopPropagation();


### PR DESCRIPTION
When a new variant option is created, we keep focus on whatever variant was previously opened.

This update closes all other variants, opens the newly created and focuses on the title field for editing.

Fixes #1614