### PR TITLE
add check to make sure subscription is ready before displaying Shipping options

### DIFF
--- a/imports/plugins/core/shipping/client/templates/checkout/shipping.html
+++ b/imports/plugins/core/shipping/client/templates/checkout/shipping.html
@@ -7,17 +7,23 @@
         <span data-i18n="checkoutShipping.selectShippingOption">Select shipping option</span>
       </h3>
     </div>
-    {{#each reactionApps provides='shippingMethod' enabled=true}}
-      {{> Template.dynamic template=template}}
-    {{else}}
-      <div class="panel-body">
-        <div class="alert alert-danger">
-          <span data-i18n="checkoutShipping.noShippingPackages">No shipping packages are configured. </span>
-          <a href="{{pathFor 'dashboard/shipping'}}">
-            <span data-i18n="checkoutShipping.configureNow">Configure now.</span>
-          </a>
+    {{#if isReady}}
+      {{#each reactionApps provides='shippingMethod' enabled=true}}
+        {{> Template.dynamic template=template}}
+      {{else}}
+        <div class="panel-body">
+          <div class="alert alert-danger">
+            <span data-i18n="checkoutShipping.noShippingPackages">No shipping packages are configured. </span>
+            <a href="{{pathFor 'dashboard/shipping'}}">
+              <span data-i18n="checkoutShipping.configureNow">Configure now.</span>
+            </a>
+          </div>
         </div>
+      {{/each}}
+    {{else}}
+      <div class="spinner-container">
+        <div class="spinner"></div>
       </div>
-    {{/each}}
+    {{/if}}
   </div>
 </template>

--- a/imports/plugins/core/shipping/client/templates/checkout/shipping.js
+++ b/imports/plugins/core/shipping/client/templates/checkout/shipping.js
@@ -65,6 +65,17 @@ Template.coreCheckoutShipping.helpers({
       return "active";
     }
     return null;
+  },
+
+  isReady() {
+    const instance = Template.instance();
+    const isReady = instance.subscriptionsReady();
+
+    if (isReady) {
+      return true;
+    }
+
+    return false;
   }
 });
 


### PR DESCRIPTION
Fixes #1650 

In checkout, our “No shipping packages are configured” message was showing when our shipping subscription had not yet loaded.

This change adds a check that shows the loading circle when the subscription isn’t yet loaded, instead of that error.