### PR TITLE
add admin settings translation for templates

### DIFF
--- a/imports/plugins/core/templates/server/i18n/en.json
+++ b/imports/plugins/core/templates/server/i18n/en.json
@@ -4,6 +4,11 @@
   "ns": "reaction-templates",
   "translation": {
     "reaction-templates": {
+      "admin": {
+        "settings": {
+          "templateSettingsLabel": "Template Settings"
+        }
+      },
       "templateGrid": {
         "noTemplatesFound": "No templates found",
         "columns": {


### PR DESCRIPTION
We were missing an i18n key for Template settings, which was causing the title to not be updated correctly.

Fixes #1653