### PR TITLE
Variants without media to inherit media from their parents

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
@@ -213,6 +213,7 @@ function composer(props, onData) {
       const selectedVariant = ReactionProduct.selectedVariant();
 
       if (selectedVariant) {
+        // Find the media for the selected variant
         mediaArray = Media.find({
           "metadata.variantId": selectedVariant._id
         }, {
@@ -220,6 +221,26 @@ function composer(props, onData) {
             "metadata.priority": 1
           }
         }).fetch();
+
+        // If no media found, broaden the search to include other media from parents
+        if (Array.isArray(mediaArray) && mediaArray.length === 0 && selectedVariant.ancestors) {
+          // Loop through ancestors in reverse to find a variant that has media to use
+          for (const ancestor of selectedVariant.ancestors.reverse()) {
+            const media = Media.find({
+              "metadata.variantId": ancestor
+            }, {
+              sort: {
+                "metadata.priority": 1
+              }
+            }).fetch();
+
+            // If we found some media, then stop here
+            if (Array.isArray(media) && media.length) {
+              mediaArray = media;
+              break;
+            }
+          }
+        }
       }
 
       let priceRange;


### PR DESCRIPTION
Resolves #1322

Child variants with missing media will now attempt to find media from their parents.

This applies only to the image gallery when the variant is selected.

This should lower / prevent cases where a placeholder image is shown instead of an available product image.