### PR TITLE
Route theme body class

### DIFF
--- a/imports/plugins/core/layout/client/templates/theme/theme.js
+++ b/imports/plugins/core/layout/client/templates/theme/theme.js
@@ -1,7 +1,65 @@
-import { Reaction } from "/client/api";
-import { Shops } from "/lib/collections";
+import { Reaction, Router } from "/client/api";
+import { Packages, Shops } from "/lib/collections";
 import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
+
+/**
+ * getRouteLayout
+ * Gets layout combo based on current route context
+ * @param  {Object} context - route context
+ * @returns {Object|null} The layout hash
+ */
+function getRouteLayout(context) {
+  const registry = Packages.findOne({ "registry.name": context.route.name, "enabled": true }).registry;
+  const registryRoute = registry.find((x) => {
+    return x.name === context.route.name;
+  });
+
+  // set a default layout if none is given
+  if (!registryRoute.layout) {
+    registryRoute.layout = Session.get("DEFAULT_LAYOUT") || "coreLayout";
+  }
+
+  const shop = Shops.findOne(Reaction.getShopId());
+  const currentLayout = shop.layout.find((x) => {
+    if (x.layout === registryRoute.layout && x.workflow === registryRoute.workflow && x.enabled === true) {
+      return true;
+    }
+  });
+
+  return currentLayout || null;
+}
+
+/**
+ * addBodyClasses
+ * Adds body classes to help themes distinguish pages and components based on route name and theme
+ * @param  {Object} context - route context
+ */
+function addBodyClasses(context) {
+  let classes = [
+    // push clean route-name
+    "app-" + context.route.name.replace(/[\/_]/i, "-")
+  ];
+
+  // no theme defined for index
+  if (context.route.name !== "index") {
+    // find the layout combo for this route
+    const currentLayout = getRouteLayout(context);
+
+    if (currentLayout.theme) {
+      classes.push(currentLayout.theme);
+    }
+  }
+
+  classes = classes.join(" ");
+
+  $("body").removeClass(Session.get("BODY_CLASS")).addClass(classes);
+
+  // save for removal on next enter
+  Session.set("BODY_CLASS", classes);
+}
+
+Router.triggers.enter(addBodyClasses);
 
 Meteor.startup(() => {
   Tracker.autorun(() => {

--- a/imports/plugins/core/layout/client/templates/theme/theme.js
+++ b/imports/plugins/core/layout/client/templates/theme/theme.js
@@ -1,7 +1,7 @@
-import { Reaction, Router } from "/client/api";
-import { Packages, Shops } from "/lib/collections";
 import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
+import { Reaction, Router } from "/client/api";
+import { Packages, Shops } from "/lib/collections";
 
 /**
  * getRouteLayout


### PR DESCRIPTION
Add body classes for current route and theme to help with CSS scoping, so that themes can target specific pages on a route and/or theme basis.

To test this easily, just see the classes change in the body

- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [x] Passes all tests
- [x] Has been linted and follows the style guide

EDIT - 
Something I forgot to mention is that there is no DEFAULT_THEME or in other words a theme for "index" and so the theme will always be `default` for that route, until a theme can be declared in INDEX_OPTIONS or a DEFAULT_THEME is introduced.