### PR TITLE
React no-ui Slider component implementation

### DIFF
--- a/imports/plugins/core/ui/client/components/index.js
+++ b/imports/plugins/core/ui/client/components/index.js
@@ -24,3 +24,4 @@ export * from "./toolbar";
 export { default as Popover } from "./popover/popover";
 export * from "./menu";
 export * from "./buttonGroup";
+export { default as Slider } from "./slider/slider";

--- a/imports/plugins/core/ui/client/components/slider/slider.js
+++ b/imports/plugins/core/ui/client/components/slider/slider.js
@@ -1,0 +1,51 @@
+/**
+ * Implementing No UI Slider
+ * https://www.npmjs.com/package/react-nouislider
+ */
+import React, { Component, PropTypes } from "react";
+import Nouislider from "react-nouislider";
+
+class Slider extends Component {
+  render() {
+    return (
+      <Nouislider
+        range={this.props.range}
+        start={this.props.start}
+        tooltips={this.props.tooltips}
+        connect={this.props.connect}
+        step={this.props.step}
+        orientation={this.props.orientation}
+        margin={this.props.margin}
+        padding={this.props.padding}
+        onChange={this.props.onChange}
+      />
+    );
+  }
+}
+
+Slider.propTypes = {
+  range: PropTypes.object,
+  start: PropTypes.arrayOf(PropTypes.number),
+  connect: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
+  step: PropTypes.number,
+  orientation: PropTypes.string,
+  tooltips: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
+  margin: PropTypes.number,
+  padding: PropTypes.number,
+  onChange: PropTypes.func
+};
+
+Slider.defaultProps = {
+  range: {
+    min: 0,
+    max: 100
+  },
+  start: [0, 100],
+  step: 5,
+  orientation: "horizontal",
+  tooltips: true,
+  margin: 0,
+  padding: 0
+};
+
+export default Slider;

--- a/imports/plugins/core/ui/client/index.js
+++ b/imports/plugins/core/ui/client/index.js
@@ -31,3 +31,8 @@ import "./components/textfield/textfield.html";
 
 import "./components/upload/upload.html";
 import "./components/upload/upload.js";
+
+// Safe css import for npm package
+import "nouislider-algolia-fork/src/nouislider.css";
+import "nouislider-algolia-fork/src/nouislider.pips.css";
+import "nouislider-algolia-fork/src/nouislider.tooltips.css";

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-dropzone": "^3.6.0",
     "react-helmet": "^3.1.0",
     "react-komposer": "^2.0.0",
+    "react-nouislider": "^1.14.2",
     "react-onclickoutside": "^5.7.1",
     "react-simple-di": "^1.2.0",
     "react-taco-table": "^0.5.0",


### PR DESCRIPTION
Bringing React NoUI Slider into Reaction as a standard React component 
https://www.npmjs.com/package/react-nouislider

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [x] Has docs.
- [x] Passes all tests
- [x] Has been linted and follows the style guide

# Import

```js
import { Slider } from "/imports/plugins/core/ui/client/components";
```


# Usage Example #

```js
import { Slider } from "/imports/plugins/core/ui/client/components";

Template.myTemplate.helpers({
  Slider() {
    return Slider;
  },

  sliderOptions() {
    return {
      range: { min: 0, max: 5000 },
      start: [0, 2000],
      margin: 50,
      connect: true,
      step: 50,
      onChange: () => {
        return (values, handle, unencoded, tap, positions) => {
          console.log("slider changed", values);
        };
      }
    };
  }
});
```
```html
<template name="myTemplate">
  {{#let options=sliderOptions}}
    <div class="slider">
      {{> React component=Slider
        range=options.range
        start=options.start
        margin=options.margin
        connect=options.connect
        step=options.step
        onChange=options.onChange}}
    </div>
  {{/let}}
</template>
```
