### PR TITLE
React MultiSelect component implementation

### DIFF
--- a/imports/plugins/core/ui/client/components/index.js
+++ b/imports/plugins/core/ui/client/components/index.js
@@ -24,3 +24,4 @@ export * from "./toolbar";
 export { default as Popover } from "./popover/popover";
 export * from "./menu";
 export * from "./buttonGroup";
+export { default as MultiSelect } from "./multiselect/multiselect";

--- a/imports/plugins/core/ui/client/components/multiselect/multiselect.js
+++ b/imports/plugins/core/ui/client/components/multiselect/multiselect.js
@@ -1,0 +1,42 @@
+import React, { Component, PropTypes } from "react";
+import Select from "react-select";
+
+class MultiSelect extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: props.value || []
+    };
+  }
+
+  handleOnChange(value) {
+    this.setState({
+      value
+    });
+
+    this.props.onChange(value);
+  }
+
+  render() {
+    return (
+      <Select
+        multi
+        simpleValue
+        value={this.state.value}
+        placeholder={this.props.placeholder}
+        options={this.props.options}
+        onChange={this.handleOnChange.bind(this)}
+      />
+    );
+  }
+}
+
+MultiSelect.propTypes = {
+  onChange: PropTypes.func,
+  options: PropTypes.array,
+  placeholder: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
+};
+
+export default MultiSelect;

--- a/imports/plugins/included/default-theme/client/styles/main.less
+++ b/imports/plugins/included/default-theme/client/styles/main.less
@@ -48,6 +48,8 @@
 // @import "{}/node_modules/bootstrap/less/tooltip.less";
 @import "{}/node_modules/bootstrap/less/popovers.less";
 @import "{}/node_modules/bootstrap/less/carousel.less";
+@import "{}/node_modules/react-select/less/default.less";
+
 
 // Utility classes
 @import "{}/node_modules/bootstrap/less/utilities.less";

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-helmet": "^3.1.0",
     "react-komposer": "^2.0.0",
     "react-onclickoutside": "^5.7.1",
+    "react-select": "^1.0.0-rc.2",
     "react-simple-di": "^1.2.0",
     "react-taco-table": "^0.5.0",
     "react-tether": "^0.5.2",


### PR DESCRIPTION
Bringing React MultiSelect (initially built for Keystone) into Reaction as a standard component. 
https://github.com/JedWatson/react-select

If adjusted to have the `multi` option set to false, this component could easily replace the existing select component.

- [x] Description explains the issue / use-case resolved
- [x] Only contains code directly related to the issue
- [ ] Has tests.
- [x] Has docs.
- [x] Passes all tests
- [x] Has been linted and follows the style guide

# Import

```js

import { MultiSelect } from "/imports/plugins/core/ui/client/components";
```

# Usage Example
```js

import { MultiSelect } from "/imports/plugins/core/ui/client/components";

Template.myTemplate.helpers({
  MultiSelect() {
    return MultiSelect;
  },

  multiSelectOptions() {
    return {
      name: "multiselect",
      options: [{value: 'one', label: 'One'},{value:'two',label:'Two'},{value:'three',label:'Three'}],
      placeholder: "Please choose",
      value: [],
      onChange: () => {
        return (values) => {
          console.log("Values are ", values);
        };
      }
    };
  }
});
```

```html

<template name="myTemplate">
  {{#let options=multiSelectOptions}}
    <div>{{> React component=MultiSelect
      options=options.options
      placeholder=options.placeholder
      name=options.name
      value=options.value
      onChange=options.onChange}}</div>
  {{/let}}
</template>
```
