### PR TITLE
Fix console error in checkout form

### DIFF
--- a/client/modules/core/helpers/templates.js
+++ b/client/modules/core/helpers/templates.js
@@ -51,7 +51,7 @@ if (Package.blaze) {
  * @summary formats moment.js months into an array for autoform selector
  * @return {Array} returns array of months [value:, label:]
  */
-Template.registerHelper("monthOptions", function () {
+Template.registerHelper("monthOptions", function (showDefaultOption = true) {
   const label = i18next.t("app.monthOptions", "Choose month");
   const localLocale = tz;
 
@@ -69,10 +69,14 @@ Template.registerHelper("monthOptions", function () {
   }
 
   localLocale.locale(lang);
-  const monthOptions = [{
-    value: "",
-    label: label
-  }];
+  const monthOptions = [];
+
+  if (showDefaultOption) {
+    monthOptions.push({
+      value: "",
+      label: label
+    });
+  }
 
   const months = localLocale.months();
   // parse into autoform array
@@ -95,12 +99,17 @@ Template.registerHelper("monthOptions", function () {
  * @summary formats moment.js next 9 years into array for autoform selector
  * @return {Array} returns array of years [value:, label:]
  */
-Template.registerHelper("yearOptions", function () {
+Template.registerHelper("yearOptions", function (showDefaultOption = true) {
   const label = i18next.t("app.yearOptions", "Choose year");
-  const yearOptions = [{
-    value: "",
-    label: label
-  }];
+  const yearOptions = [];
+
+  if (showDefaultOption) {
+    yearOptions.push({
+      value: "",
+      label: label
+    });
+  }
+
   let year = new Date().getFullYear();
   for (let i = 1; i < 9; i++) {
     yearOptions.push({

--- a/imports/plugins/included/payments-authnet/client/checkout/authnet.html
+++ b/imports/plugins/included/payments-authnet/client/checkout/authnet.html
@@ -20,7 +20,7 @@
   <div class="row">
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-        {{>afFieldInput name="expireMonth" options=monthOptions firstOption=false placeholder="Exp. Month"}}
+        {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
         {{#if afFieldIsInvalid name="expireMonth"}}
         <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
         {{/if}}
@@ -28,7 +28,7 @@
 
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-        {{>afFieldInput name="expireYear" options=yearOptions firstOption=false placeholder="Exp. Year"}}
+        {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
         {{#if afFieldIsInvalid name="expireYear"}}
         <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
         {{/if}}

--- a/imports/plugins/included/payments-example/client/checkout/example.html
+++ b/imports/plugins/included/payments-example/client/checkout/example.html
@@ -20,7 +20,7 @@
   <div class="row">
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-        {{>afFieldInput name="expireMonth" options=monthOptions firstOption=false placeholder="Exp. Month"}}
+        {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
         {{#if afFieldIsInvalid name="expireMonth"}}
         <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
         {{/if}}
@@ -28,11 +28,12 @@
 
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-        {{>afFieldInput name="expireYear" options=yearOptions firstOption=false placeholder="Exp. Year"}}
+        {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
         {{#if afFieldIsInvalid name="expireYear"}}
         <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
         {{/if}}
     </div>
+
   </div>
   <div class="row">
     <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.html
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.html
@@ -21,7 +21,7 @@
     <div class="row">
       <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-        {{>afFieldInput name="expireMonth" options=monthOptions firstOption=false placeholder="Exp. Month"}}
+        {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
         {{#if afFieldIsInvalid name="expireMonth"}}
         <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
         {{/if}}
@@ -29,7 +29,7 @@
 
       <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-        {{>afFieldInput name="expireYear" options=yearOptions firstOption=false placeholder="Exp. Year"}}
+        {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
         {{#if afFieldIsInvalid name="expireYear"}}
         <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
         {{/if}}

--- a/imports/plugins/included/payments-stripe/client/checkout/stripe.html
+++ b/imports/plugins/included/payments-stripe/client/checkout/stripe.html
@@ -20,7 +20,7 @@
   <div class="row">
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-        {{>afFieldInput name="expireMonth" options=monthOptions firstOption=false placeholder="Exp. Month"}}
+        {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
         {{#if afFieldIsInvalid name="expireMonth"}}
         <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
         {{/if}}
@@ -28,11 +28,12 @@
 
     <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-        {{>afFieldInput name="expireYear" options=yearOptions firstOption=false placeholder="Exp. Year"}}
+        {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
         {{#if afFieldIsInvalid name="expireYear"}}
         <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
         {{/if}}
     </div>
+
   </div>
   <div class="row">
     <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">


### PR DESCRIPTION
We were receiving a console error in the checkout form when choosing a shipping options.

it stemmed from a combination of autoforms `firstOption` setting, which created a `null` first option, combined with our Template Helper that puts a placeholder message in the Month and Year Select boxes.

This update removes the `firstOption=false` from the payment forms, which fixes the error, and then uses the i18n translation directly in the html file, instead of in the helper.