### PR TITLE
save selected gridItems to profile

### DIFF
--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
@@ -11,8 +11,10 @@ import Sortable from "sortablejs";
  */
 
 Template.productGrid.onCreated(function () {
-  if (Meteor.user() && Meteor.user().profile && Meteor.user().profile.preferences && Meteor.user().profile.preferences.gridItems) {
-    let selectedProducts = Meteor.user().profile.preferences.gridItems;
+  const profile = Meteor.user().profile;
+
+  if (profile && profile.preferences && profile.preferences.gridItems) {
+    let selectedProducts = profile.preferences.gridItems;
 
     if (_.isEmpty(selectedProducts)) {
       Reaction.hideActionView();
@@ -101,7 +103,11 @@ Template.productGrid.events({
 
     // Save the selected items to the user profile, for use when returing to the grid view
     if (Meteor.user()) {
-      Meteor.users.update(Meteor.userId(), { $set: { "profile.preferences.gridItems": selectedProducts } });
+      Meteor.users.update(Meteor.userId(), {
+        $set: {
+          "profile.preferences.gridItems": selectedProducts
+        }
+      });
     }
 
     // Save the selected items to the Session

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
@@ -13,8 +13,8 @@ import Sortable from "sortablejs";
 Template.productGrid.onCreated(function () {
   const profile = Meteor.user().profile;
 
-  if (profile && profile.preferences && profile.preferences.gridItems) {
-    let selectedProducts = profile.preferences.gridItems;
+  if (profile && profile.preferences && profile.preferences['reaction-product-variant'] && profile.preferences['reaction-product-variant'].selectedGridItems) {
+    let selectedProducts = profile.preferences['reaction-product-variant'].selectedGridItems;
 
     if (_.isEmpty(selectedProducts)) {
       Reaction.hideActionView();
@@ -105,7 +105,7 @@ Template.productGrid.events({
     if (Meteor.user()) {
       Meteor.users.update(Meteor.userId(), {
         $set: {
-          "profile.preferences.gridItems": selectedProducts
+          "profile.preferences.reaction-product-variant.selectedGridItems": selectedProducts
         }
       });
     }

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
@@ -11,7 +11,42 @@ import Sortable from "sortablejs";
  */
 
 Template.productGrid.onCreated(function () {
-  Session.set("productGrid/selectedProducts", []);
+  if (Meteor.user() && Meteor.user().profile && Meteor.user().profile.preferences && Meteor.user().profile.preferences.gridItems) {
+    let selectedProducts = Meteor.user().profile.preferences.gridItems;
+
+    if (_.isEmpty(selectedProducts)) {
+      Reaction.hideActionView();
+    } else {
+      if (event.target.checked) {
+        selectedProducts.push(event.target.value);
+      } else {
+        selectedProducts = _.without(selectedProducts, event.target.value);
+      }
+
+      // Save the selected items to the Session
+      Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
+
+      const products = Template.currentData().products;
+
+      if (products) {
+        const filteredProducts = _.filter(products, (product) => {
+          return _.includes(selectedProducts, product._id);
+        });
+
+        Reaction.showActionView({
+          label: "Grid Settings",
+          i18nKeyLabel: "gridSettingsPanel.title",
+          template: "productSettings",
+          type: "product",
+          data: {
+            products: filteredProducts
+          }
+        });
+      }
+    }
+  } else {
+    Reaction.hideActionView();
+  }
 });
 
 Template.productGrid.onRendered(function () {
@@ -64,6 +99,12 @@ Template.productGrid.events({
       selectedProducts = _.without(selectedProducts, event.target.value);
     }
 
+    // Save the selected items to the user profile, for use when returing to the grid view
+    if (Meteor.user()) {
+      Meteor.users.update(Meteor.userId(), { $set: { "profile.preferences.gridItems": selectedProducts } });
+    }
+
+    // Save the selected items to the Session
     Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
 
     const products = Template.currentData().products;
@@ -74,8 +115,8 @@ Template.productGrid.events({
       });
 
       Reaction.showActionView({
-        label: "Product Settings",
-        i18nKeyLabel: "productDetailEdit.productSettings",
+        label: "Grid Settings",
+        i18nKeyLabel: "gridSettingsPanel.title",
         template: "productSettings",
         type: "product",
         data: {

--- a/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.html
@@ -9,7 +9,7 @@
   </div>
   <div class="panel panel-default">
     <div class="panel-heading panel-heading-flex">
-      <div class="panel-title" data-i18n="productDetailEdit.product">Product</div>
+      <div class="panel-title" data-i18n="gridSettingsPanel.selected">Selected</div>
       <div class="panel-controls">
         <button
           type="button"

--- a/private/data/i18n/en.json
+++ b/private/data/i18n/en.json
@@ -411,6 +411,10 @@
         "pkgEnabled": "{{app}} is now enabled.",
         "pkgDisabled": "{{app}} is now disabled."
       },
+      "gridSettingsPanel": {
+        "title": "Grid Settings",
+        "selected": "Selected"
+      },
       "cartDrawer": {
         "empty": "We're sad. Your cart is empty.",
         "keepShopping": "Keep on shopping",


### PR DESCRIPTION
Saving the selected items to `Meteor.user().profile.preferences["reaction-product-variant"].gridItems` allows us to easily recall the items a user previously had selected, and allows the actionView panel to have better context when returning to the grid view.