### PR TITLE
restore email verification link in console

### DIFF
--- a/server/api/core/accounts/password.js
+++ b/server/api/core/accounts/password.js
@@ -199,6 +199,22 @@ export function sendVerificationEmail(userId, email) {
     userEmailAddress: address
   };
 
+  if (!Reaction.Email.getMailUrl()) {
+    Logger.warn(`
+
+  ***************************************************
+          IMPORTANT! EMAIL VERIFICATION LINK
+
+           Email sending is not configured.
+
+  Go to the following URL to verify email: ${address}
+
+  ${url}
+  ***************************************************
+
+    `);
+  }
+
   const tpl = "accounts/verifyEmail";
   const subject = "accounts/verifyEmail/subject";
 

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -299,13 +299,9 @@ export default {
           "emails.$.verified": true
         }
       });
-    } else { // send verification email to admin
-      try {
-        // if server is not configured. Error in configuration are caught, but admin isn't verified.
-        sendVerificationEmail(accountId);
-      } catch (error) {
-        Logger.warn(error, "Unable to send admin account verification email.");
-      }
+    } else {
+      // send verification email to admin
+      sendVerificationEmail(accountId);
     }
 
     //


### PR DESCRIPTION
When a new shop doesn't have email sending configured, the default admin's verification link used to get printed to the console.  This was changed when we switched to Nodemailer because Meteor's email package printed failed emails to the console by default.  This PR restores that behavior by adding a warning log with the URL to the server side console.

![email_verify](https://cloud.githubusercontent.com/assets/3077956/22001181/5f860cc4-dc11-11e6-9fd9-f39ca649ea34.png)

