### PR TITLE
Moved style import to index.less

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ results
 allure-results
 
 client/plugins.js
+client/plugins.css
+client/plugins.less
+client/plugins.styl
+client/plugins.scss
 server/plugins.js
 
 custom/client/*

--- a/imports/plugins/included/default-theme/client/index.js
+++ b/imports/plugins/included/default-theme/client/index.js
@@ -1,8 +1,5 @@
 // Favicons
 import "./favicons";
 
-// Styles
-import "./styles/main.less";
-
 // Scripts
 import "bootstrap/dist/js/npm.js";

--- a/imports/plugins/included/default-theme/client/index.less
+++ b/imports/plugins/included/default-theme/client/index.less
@@ -1,0 +1,2 @@
+// Styles
+@import "styles/main.less";


### PR DESCRIPTION
Related to #1695 but does not resolve.
( Note - This fixes issues related to non prefixed flexbox styling throughout the app while using the `default-theme` )

To be merged when reaction-cli style loader is available. **Update** `reaction-cli v0.6.4` is live!

The issue is that required vendor prefixes are not being applied to built CSS. autoprefixer doesn't seem to run when you import your styles into a `js` file.

This change, and the addition of a style loader to reaction-cli should get around this issue by importing styles (css, less, stylus, scss) into `/client/plugins.{css|less|styles|scss}` files; thusly, allowing for the meteor built tool to pick them up normally.

--

Testing

- `npm install -g reaction-cli@0.6.4`   or higher
- run reaction command as usual
- look for file `/client/plugins.less`
- and obviously, if styles are loaded you'll see in browser
- rejoice