### PR TITLE
Update Product Publications Data

### DIFF
--- a/imports/plugins/included/product-variant/client/templates/products/products.js
+++ b/imports/plugins/included/product-variant/client/templates/products/products.js
@@ -86,9 +86,8 @@ Template.products.onCreated(function () {
     // use shop name as `base` name for `positions` object
     const currentTag = ReactionProduct.getTag();
     const productCursor = Products.find({
-      ancestors: []
-      // keep this, as an example
-      // type: { $in: ["simple"] }
+      ancestors: [],
+      type: { $in: ["simple"] }
     }, {
       sort: {
         [`positions.${currentTag}.position`]: 1,

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -82,8 +82,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
     const selector = {
       isDeleted: { $in: [null, false] },
       ancestors: {
-        $exists: true,
-        $eq: []
+        $exists: true
       },
       shopId: shop._id
     };


### PR DESCRIPTION
Updates the `Products` publication to publish all products. Previously, only products that had an empty `ancestors` object were being published, which meant any Variant was not published, as they all have a populated `ancestors` object.

Since all products are now being published, this update also filters the product grid to only show products with `type: simple`. 