### PR TITLE
update viewAs to used profile saved data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,3 @@ imports/plugins/custom/*
 !imports/plugins/custom/.gitkeep
 
 .reaction/config.json
-
-yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ imports/plugins/custom/*
 !imports/plugins/custom/.gitkeep
 
 .reaction/config.json
+
+yarn.lock

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -196,6 +196,25 @@ export default {
     return this.hasPermission(dashboardPermissions);
   },
 
+  getUserPreferences(packageName, preference, defaultValue) {
+    const profile = Meteor.user().profile;
+    if (profile && profile.preferences && profile.preferences[packageName] && profile.preferences[packageName][preference]) {
+      return profile.preferences[packageName][preference];
+    }
+    return defaultValue || undefined;
+  },
+
+  setUserPreferences(packageName, preference, value) {
+    if (Meteor.user()) {
+      return Meteor.users.update(Meteor.userId(), {
+        $set: {
+          [`profile.preferences.${packageName}.${preference}`]: value
+        }
+      });
+    }
+    return false;
+  },
+
   getShopId() {
     return this.shopId;
   },

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -29,16 +29,7 @@ const handleAddProduct = () => {
 };
 
 const handleViewContextChange = (event, value) => {
-  const viewAs = value;
-
-  // Save viewAs status to profile for consistant use across app
-  if (Meteor.user()) {
-    Meteor.users.update(Meteor.userId(), {
-      $set: {
-        "profile.preferences.reaction-dashboard.viewAs": viewAs
-      }
-    });
-  }
+  Reaction.setUserPreferences("reaction-dashboard", "viewAs", value);
 };
 
 function composer(props, onData) {

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -43,7 +43,7 @@ const handleViewContextChange = (event, value) => {
 
 function composer(props, onData) {
   // Reactive data sources
-  const viewAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
+  const viewAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
   const routeName = Reaction.Router.getRouteName();
 
   // Standard variables

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -29,12 +29,21 @@ const handleAddProduct = () => {
 };
 
 const handleViewContextChange = (event, value) => {
-  Reaction.Router.setQueryParams({ as: value });
+  const viewAs = value;
+
+  // Save viewAs status to profile for consistant use across app
+  if (Meteor.user()) {
+    Meteor.users.update(Meteor.userId(), {
+      $set: {
+        "profile.preferences.reaction-dashboard.viewAs": viewAs
+      }
+    });
+  }
 };
 
 function composer(props, onData) {
   // Reactive data sources
-  const viewAs = Reaction.Router.getQueryParam("as");
+  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
   const routeName = Reaction.Router.getRouteName();
 
   // Standard variables

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -43,7 +43,7 @@ const handleViewContextChange = (event, value) => {
 
 function composer(props, onData) {
   // Reactive data sources
-  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
+  const viewAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
   const routeName = Reaction.Router.getRouteName();
 
   // Standard variables

--- a/imports/plugins/core/revisions/client/containers/publishContainer.js
+++ b/imports/plugins/core/revisions/client/containers/publishContainer.js
@@ -97,7 +97,7 @@ PublishContainer.propTypes = {
 };
 
 function composer(props, onData) {
-  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs;
+  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
 
   if (props.documentIds) {
     const subscription = Meteor.subscribe("Revisions", props.documentIds);

--- a/imports/plugins/core/revisions/client/containers/publishContainer.js
+++ b/imports/plugins/core/revisions/client/containers/publishContainer.js
@@ -97,7 +97,7 @@ PublishContainer.propTypes = {
 };
 
 function composer(props, onData) {
-  const viewAs = Reaction.Router.getQueryParam("as");
+  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs;
 
   if (props.documentIds) {
     const subscription = Meteor.subscribe("Revisions", props.documentIds);

--- a/imports/plugins/core/revisions/client/containers/publishContainer.js
+++ b/imports/plugins/core/revisions/client/containers/publishContainer.js
@@ -97,7 +97,7 @@ PublishContainer.propTypes = {
 };
 
 function composer(props, onData) {
-  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
+  const viewAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   if (props.documentIds) {
     const subscription = Meteor.subscribe("Revisions", props.documentIds);

--- a/imports/plugins/core/revisions/client/containers/publishContainer.js
+++ b/imports/plugins/core/revisions/client/containers/publishContainer.js
@@ -97,7 +97,7 @@ PublishContainer.propTypes = {
 };
 
 function composer(props, onData) {
-  const viewAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
+  const viewAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   if (props.documentIds) {
     const subscription = Meteor.subscribe("Revisions", props.documentIds);

--- a/imports/plugins/core/ui/client/containers/editContainer.js
+++ b/imports/plugins/core/ui/client/containers/editContainer.js
@@ -164,7 +164,7 @@ EditContainer.propTypes = {
 
 function composer(props, onData) {
   let hasPermission;
-  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
+  const viewAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   if (props.disabled === true || viewAs === "customer") {
     hasPermission = false;

--- a/imports/plugins/core/ui/client/containers/editContainer.js
+++ b/imports/plugins/core/ui/client/containers/editContainer.js
@@ -164,7 +164,7 @@ EditContainer.propTypes = {
 
 function composer(props, onData) {
   let hasPermission;
-  const viewAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
+  const viewAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   if (props.disabled === true || viewAs === "customer") {
     hasPermission = false;

--- a/imports/plugins/core/ui/client/containers/editContainer.js
+++ b/imports/plugins/core/ui/client/containers/editContainer.js
@@ -164,7 +164,7 @@ EditContainer.propTypes = {
 
 function composer(props, onData) {
   let hasPermission;
-  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs;
+  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
 
   if (props.disabled === true || viewAs === "customer") {
     hasPermission = false;

--- a/imports/plugins/core/ui/client/containers/editContainer.js
+++ b/imports/plugins/core/ui/client/containers/editContainer.js
@@ -164,7 +164,7 @@ EditContainer.propTypes = {
 
 function composer(props, onData) {
   let hasPermission;
-  const viewAs = Reaction.Router.getQueryParam("as");
+  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs;
 
   if (props.disabled === true || viewAs === "customer") {
     hasPermission = false;

--- a/imports/plugins/core/ui/client/containers/mediaGalleryContainer.js
+++ b/imports/plugins/core/ui/client/containers/mediaGalleryContainer.js
@@ -194,7 +194,7 @@ function appendRevisionsToMedia(props, media) {
 function composer(props, onData) {
   let media;
   let editable;
-  const viewAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
+  const viewAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   if (!props.media) {
     // Fetch media based on props

--- a/imports/plugins/core/ui/client/containers/mediaGalleryContainer.js
+++ b/imports/plugins/core/ui/client/containers/mediaGalleryContainer.js
@@ -194,7 +194,7 @@ function appendRevisionsToMedia(props, media) {
 function composer(props, onData) {
   let media;
   let editable;
-  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
+  const viewAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   if (!props.media) {
     // Fetch media based on props

--- a/imports/plugins/core/ui/client/containers/mediaGalleryContainer.js
+++ b/imports/plugins/core/ui/client/containers/mediaGalleryContainer.js
@@ -194,7 +194,7 @@ function appendRevisionsToMedia(props, media) {
 function composer(props, onData) {
   let media;
   let editable;
-  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs;
+  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
 
   if (!props.media) {
     // Fetch media based on props

--- a/imports/plugins/core/ui/client/containers/mediaGalleryContainer.js
+++ b/imports/plugins/core/ui/client/containers/mediaGalleryContainer.js
@@ -194,7 +194,7 @@ function appendRevisionsToMedia(props, media) {
 function composer(props, onData) {
   let media;
   let editable;
-  const viewAs = Reaction.Router.getQueryParam("as");
+  const viewAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs;
 
   if (!props.media) {
     // Fetch media based on props

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
@@ -185,7 +185,7 @@ function composer(props, onData) {
   const productId = Reaction.Router.getParam("handle");
   const variantId = Reaction.Router.getParam("variantId");
   const revisionType = Reaction.Router.getQueryParam("revision");
-  const viewProductAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
+  const viewProductAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   let productSub;
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
@@ -185,7 +185,7 @@ function composer(props, onData) {
   const productId = Reaction.Router.getParam("handle");
   const variantId = Reaction.Router.getParam("variantId");
   const revisionType = Reaction.Router.getQueryParam("revision");
-  const viewProductAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs;
+  const viewProductAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
 
   let productSub;
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
@@ -185,7 +185,7 @@ function composer(props, onData) {
   const productId = Reaction.Router.getParam("handle");
   const variantId = Reaction.Router.getParam("variantId");
   const revisionType = Reaction.Router.getQueryParam("revision");
-  const viewProductAs = Reaction.Router.getQueryParam("as");
+  const viewProductAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs;
 
   let productSub;
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
@@ -185,7 +185,7 @@ function composer(props, onData) {
   const productId = Reaction.Router.getParam("handle");
   const variantId = Reaction.Router.getParam("variantId");
   const revisionType = Reaction.Router.getQueryParam("revision");
-  const viewProductAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
+  const viewProductAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   let productSub;
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productToolbarContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productToolbarContainer.js
@@ -37,7 +37,7 @@ function composer(props, onData) {
   const productId = Reaction.Router.getParam("handle");
   const variantId = Reaction.Router.getParam("variantId");
   const revisionType = Reaction.Router.getQueryParam("revision");
-  const viewProductAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
+  const viewProductAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   let productSub;
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productToolbarContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productToolbarContainer.js
@@ -37,7 +37,7 @@ function composer(props, onData) {
   const productId = Reaction.Router.getParam("handle");
   const variantId = Reaction.Router.getParam("variantId");
   const revisionType = Reaction.Router.getQueryParam("revision");
-  const viewProductAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
+  const viewProductAs = getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
   let productSub;
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productToolbarContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productToolbarContainer.js
@@ -17,7 +17,16 @@ const handleProductFieldChange = (productId, fieldName, value) => {
 };
 
 const handleViewContextChange = (event, value) => {
-  Reaction.Router.setQueryParams({ as: value });
+  const viewAs = value;
+
+  // Save viewAs status to profile for consistant use across app
+  if (Meteor.user()) {
+    Meteor.users.update(Meteor.userId(), {
+      $set: {
+        "profile.preferences.reaction-dashboard.viewAs": viewAs
+      }
+    });
+  }
 };
 
 const handleDeleteProduct = (product) => {
@@ -28,7 +37,7 @@ function composer(props, onData) {
   const productId = Reaction.Router.getParam("handle");
   const variantId = Reaction.Router.getParam("variantId");
   const revisionType = Reaction.Router.getQueryParam("revision");
-  const viewProductAs = Reaction.Router.getQueryParam("as");
+  const viewProductAs = Meteor.user().profile.preferences["reaction-dashboard"].viewAs || "administrator";
 
   let productSub;
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productToolbarContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productToolbarContainer.js
@@ -17,16 +17,7 @@ const handleProductFieldChange = (productId, fieldName, value) => {
 };
 
 const handleViewContextChange = (event, value) => {
-  const viewAs = value;
-
-  // Save viewAs status to profile for consistant use across app
-  if (Meteor.user()) {
-    Meteor.users.update(Meteor.userId(), {
-      $set: {
-        "profile.preferences.reaction-dashboard.viewAs": viewAs
-      }
-    });
-  }
+  Reaction.setUserPreferences("reaction-dashboard", "viewAs", value);
 };
 
 const handleDeleteProduct = (product) => {

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
@@ -101,14 +101,7 @@ Template.productGrid.events({
       selectedProducts = _.without(selectedProducts, event.target.value);
     }
 
-    // Save the selected items to the user profile, for use when returing to the grid view
-    if (Meteor.user()) {
-      Meteor.users.update(Meteor.userId(), {
-        $set: {
-          "profile.preferences.reaction-product-variant.selectedGridItems": selectedProducts
-        }
-      });
-    }
+    Reaction.setUserPreferences("reaction-product-variant", "selectedGridItems", selectedProducts);
 
     // Save the selected items to the Session
     Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));


### PR DESCRIPTION
Fixes #1749 

This update takes our preview toggle, and saves its state to your Meteor.user() profile.

This allows us to keep a persistent preview state across the app, and also takes away the need for url queries which were causing some issues.

Also have added `Reaction.getUserPreferences` and `Reaction.setUserPreferences` to take care of a lot of the "does this exist" checks for you.