### PR TITLE
Fix bodyClass for Not Found page

### DIFF
--- a/imports/plugins/core/layout/client/templates/theme/theme.js
+++ b/imports/plugins/core/layout/client/templates/theme/theme.js
@@ -43,10 +43,18 @@ function getRouteLayout(context) {
  * @param  {Object} context - route context
  */
 function addBodyClasses(context) {
-  let classes = [
-    // push clean route-name
-    "app-" + context.route.name.replace(/[\/_]/i, "-")
-  ];
+  let classes;
+
+  if (context.route.name === undefined) {
+    classes = [
+      "app-not-found"
+    ];
+  } else {
+    classes = [
+      // push clean route-name
+      "app-" + context.route.name.replace(/[\/_]/i, "-")
+    ];
+  }
 
   // find the layout combo for this route
   const currentLayout = getRouteLayout(context);


### PR DESCRIPTION
A fix for the new `bodyClass` function when accessing the not found page.

See ticket https://github.com/reactioncommerce/reaction/issues/1734

With the fix in place, some new errors are showing. Most probably have to do with the new UIX fixes currently being worked on and not with the "Not found" page directly.
Accessing the not found page will show these errors in the console.
![image](https://cloud.githubusercontent.com/assets/670954/22327208/b6d9af58-e3be-11e6-9e35-9223dcf23468.png)

