### PR TITLE
1782 fix navbar tags

### DIFF
--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.html
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.html
@@ -8,6 +8,7 @@
         status="default"
         onClick=handleMenuClose
       }}
+      {{> coreNavigationBrand}}
     </div>
     <div class="navbar-items">
       {{#each tag in tags}}
@@ -25,7 +26,7 @@
         </div>
       {{/if}}
       {{#if canEdit}}
-        <div class="navbar-item">
+        <div class="navbar-item edit-button">
           {{> React EditButton }}
         </div>
       {{/if}}

--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.html
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.html
@@ -32,5 +32,5 @@
       {{/if}}
     </div>
   </div>
-  <div class="rui tagnav-overlay {{navbarPosition}} {{navbarVisibility}}" data-event-action="close-tagnav-overlay"></div>
+  <div>{{> React OverlayComponent}}</div>
 </template>

--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.html
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.html
@@ -32,4 +32,5 @@
       {{/if}}
     </div>
   </div>
+  <div class="rui tagnav-overlay {{navbarPosition}} {{navbarVisibility}}" data-event-action="close-tagnav-overlay"></div>
 </template>

--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
@@ -88,6 +88,10 @@ Template.tagNav.onCreated(function () {
     this.state.set(NavbarStates.Visible, !isVisible);
   };
 
+  this.closeNavbar = () => {
+    this.state.set(NavbarStates.Visible, false);
+  };
+
   this.data.onToggleMenu(this.toggleNavbarVisibility);
 
   if (this.data.name) {
@@ -318,7 +322,7 @@ Template.tagNav.events({
 
       if (hasSubTags === false) {
         // click close button to make navbar left disappear
-        $(".rui.button.btn.btn-default.close-button").trigger("click");
+        instance.closeNavbar();
       } else {
         event.preventDefault();
       }
@@ -329,6 +333,10 @@ Template.tagNav.events({
         instance.state.set("selectedTag", TagNavHelpers.tagById(tagId, tags));
       }
     }
+  },
+
+  "click [data-event-action=close-tagnav-overlay]"(event, instance) {
+    instance.closeNavbar();
   },
 
   "mouseover .navbar-item, focus .navbar-item"(event, instance) {

--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
@@ -3,7 +3,7 @@ import { Template } from "meteor/templating";
 import { ReactiveDict } from "meteor/reactive-dict";
 import { Reaction } from "/client/api";
 import { TagHelpers } from "/imports/plugins/core/ui-tagnav/client/helpers";
-import { IconButton } from "/imports/plugins/core/ui/client/components";
+import { IconButton, Overlay } from "/imports/plugins/core/ui/client/components";
 
 const NavbarStates = {
   Orientation: "stateNavbarOrientation",
@@ -208,6 +208,19 @@ Template.tagNav.helpers({
       toggleOn: isEditing,
       onClick() {
         state.set("isEditing", !isEditing);
+      }
+    };
+  },
+
+  OverlayComponent() {
+    const instance = Template.instance();
+    const isVisible = instance.state.get(NavbarStates.Visible);
+
+    return {
+      component: Overlay,
+      isVisible,
+      onClick() {
+        instance.closeNavbar();
       }
     };
   },

--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
@@ -1,6 +1,7 @@
 import Sortable from "sortablejs";
 import { Template } from "meteor/templating";
 import { ReactiveDict } from "meteor/reactive-dict";
+import { Reaction } from "/client/api";
 import { TagHelpers } from "/imports/plugins/core/ui-tagnav/client/helpers";
 import { IconButton } from "/imports/plugins/core/ui/client/components";
 
@@ -251,7 +252,7 @@ Template.tagNav.helpers({
   },
 
   canEdit() {
-    return Template.instance().data.editable;
+    return Template.instance().data.editable && Reaction.isPreview() === false;
   },
 
   handleMenuClose() {

--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
@@ -195,6 +195,8 @@ Template.tagNav.helpers({
 
     return {
       component: IconButton,
+      bezelStyle: "solid",
+      primary: true,
       icon: "fa fa-pencil",
       onIcon: "fa fa-check",
       toggle: true,
@@ -306,21 +308,23 @@ Template.tagNav.helpers({
 
 
 Template.tagNav.events({
-  "click .navbar-item > .rui.tag.link"(event, instance) {
+  "click .navbar-item .rui.tag.link"(event, instance) {
     if (TagNavHelpers.isMobile()) {
       const tagId = event.target.dataset.id;
       const tags = instance.data.tags;
       const selectedTag = instance.state.get("selectedTag");
+      const hasSubTags = TagNavHelpers.hasSubTags(tagId, tags);
 
-      // click close button to make navbar left disappear
-      $(".rui.button.btn.btn-default.close-button").trigger("click");
-
-      if (selectedTag && selectedTag._id === tagId) {
-        return instance.state.set("selectedTag", null);
+      if (hasSubTags === false) {
+        // click close button to make navbar left disappear
+        $(".rui.button.btn.btn-default.close-button").trigger("click");
+      } else {
+        event.preventDefault();
       }
 
-      if (TagNavHelpers.hasSubTags(tagId, tags)) {
-        event.preventDefault();
+      if (selectedTag && selectedTag._id === tagId) {
+        instance.state.set("selectedTag", null);
+      } else if (hasSubTags) {
         instance.state.set("selectedTag", TagNavHelpers.tagById(tagId, tags));
       }
     }

--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
@@ -133,6 +133,7 @@ Template.tagNav.onCreated(function () {
       this.state.set(NavbarStates.Orientation, NavbarOrientation.Horizontal);
       this.state.set(NavbarStates.Position, NavbarPosition.Static);
       this.state.set(NavbarStates.Anchor, NavbarAnchor.None);
+      this.state.set(NavbarStates.Visible, false);
     }
   };
 });

--- a/imports/plugins/core/ui/client/components/index.js
+++ b/imports/plugins/core/ui/client/components/index.js
@@ -29,3 +29,4 @@ export { Switch } from "./switch";
 export { List, ListItem } from "./list";
 export { default as Slider } from "./slider/slider";
 export { default as MultiSelect } from "./multiselect/multiselect";
+export { Overlay } from "./modal";

--- a/imports/plugins/core/ui/client/components/modal/index.js
+++ b/imports/plugins/core/ui/client/components/modal/index.js
@@ -1,0 +1,1 @@
+export { default as Overlay } from "./overlay";

--- a/imports/plugins/core/ui/client/components/modal/overlay.js
+++ b/imports/plugins/core/ui/client/components/modal/overlay.js
@@ -1,0 +1,71 @@
+import React, { Component, PropTypes } from "react";
+import { VelocityTransitionGroup } from "velocity-react";
+import Radium from "radium";
+import classnames from "classnames";
+
+const styles = {
+  base: {
+    position: "fixed",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    backgroundColor: "rgba(0, 0, 0, 0.7)",
+    zIndex: 1040,
+    padding: 0
+  }
+};
+
+class Overlay extends Component {
+  static defaultProps = {
+    isVisible: true
+  };
+
+  static propTypes = {
+    children: PropTypes.node,
+    isVisible: PropTypes.bool,
+    onClick: PropTypes.func
+  };
+
+  state = {
+    enterAnimation: {
+      animation: { opacity: 1 },
+      duration: 200
+    },
+    leaveAnimation: {
+      animation: { opacity: 0 },
+      duration: 200
+    }
+  }
+
+  renderOverlay() {
+    if (this.props.isVisible) {
+      const baseClassName = classnames({
+        rui: true
+      });
+
+      return (
+        <div
+          className={baseClassName}
+          style={styles.base}
+          onClick={this.props.onClick}
+        />
+      );
+    }
+
+    return null;
+  }
+
+  render() {
+    return (
+      <VelocityTransitionGroup
+        enter={this.state.enterAnimation}
+        leave={this.state.leaveAnimation}
+      >
+        {this.renderOverlay()}
+      </VelocityTransitionGroup>
+    );
+  }
+}
+
+export default Radium(Overlay);

--- a/imports/plugins/core/ui/client/components/switch/switch.js
+++ b/imports/plugins/core/ui/client/components/switch/switch.js
@@ -14,7 +14,7 @@ class Switch extends Component {
     label: PropTypes.string,
     name: PropTypes.string,
     onChange: PropTypes.func,
-    onLabel: PropTypes.func
+    onLabel: PropTypes.string
   }
 
   constructor(props) {

--- a/imports/plugins/included/default-theme/client/styles/navbar.less
+++ b/imports/plugins/included/default-theme/client/styles/navbar.less
@@ -34,7 +34,7 @@
 .rui.navbar .showmenu button {
   background-color: transparent;
   border-color: transparent;
-  color: @white;
+  color: @text-color;
 }
 
 .rui.navbar .menu {

--- a/imports/plugins/included/default-theme/client/styles/tagGroup.less
+++ b/imports/plugins/included/default-theme/client/styles/tagGroup.less
@@ -55,26 +55,16 @@
 .rui.grouptag > .header .rui.tag.edit.create {
   text-transform: none;
 
-  @color: lighten(@btn-success-bg, 10%);
-  @color: @brand-secondary-color;
-  // @color: #238CC3;
-
-  input {
-    background-color: @color;
-    border-color: @color;
-    color: @white;
-  }
-
-  button {
-    background-color: @color;
-    border-color: @color;
-    color: @white;
+  input, button {
+    background-color: @tag-group-background-color;
+    border-color: @tag-group-border-color;
+    color: @tag-group-text-color;
   }
 }
 
 .rui.grouptag > .header .rui.tag.edit input,
 .rui.grouptag > .header .rui.tag.edit.create input {
-  .placeholder(@white);
+  .placeholder(@tag-group-text-color);
 }
 
 .rui.grouptag > .content .rui.tag.link {

--- a/imports/plugins/included/default-theme/client/styles/tagGroup.less
+++ b/imports/plugins/included/default-theme/client/styles/tagGroup.less
@@ -1,8 +1,14 @@
 
 .rui.grouptag {
   flex: 1 1 auto;
-  max-width: 20%;
+  // max-width: 20%;
+  max-width: 200px;
+  min-width: 150px;
   padding: 10px;
+
+  @media screen and (max-width: @screen-xs-max) {
+    max-width: 100%;
+  }
 }
 
 .rui.tagnav.vertical .rui.grouptag {

--- a/imports/plugins/included/default-theme/client/styles/tagNav.less
+++ b/imports/plugins/included/default-theme/client/styles/tagNav.less
@@ -95,7 +95,7 @@
   -webkit-overflow-scrolling: touch;
   z-index: @zindex-modal;
   box-shadow: 0 0 20px rgba(0,0,0,0.2);
-  transition: transform 250ms ease-in-out;
+  transition: transform 250ms ease-in-out, box-shadow  250ms;
   transform: translateX(-270px);
 }
 
@@ -105,6 +105,7 @@
 
 .rui.tagnav.fixed.closed {
   transform: translateX(-270px);
+  box-shadow: 0 0 20px rgba(0,0,0,0);
 }
 
 // Tag navigation tag list

--- a/imports/plugins/included/default-theme/client/styles/tagNav.less
+++ b/imports/plugins/included/default-theme/client/styles/tagNav.less
@@ -78,7 +78,6 @@
   .align-items(center);
 
   background-color: @navbar-inverse-bg;
-  position: relative;
   text-transform: uppercase;
   height: @navbar-height;
 }
@@ -300,7 +299,6 @@
 .rui.tagnav .navbar-item .dropdown-container {
   display: none;
   color: @text-color;
-  box-shadow: 0 0 20px rgba(0,0,0,.1);
 }
 
 .rui.tagnav .navbar-item .dropdown-container a {
@@ -330,7 +328,6 @@
   margin: 0;
 
   background-color: @white;
-  border: 1px solid @border-color;
 }
 
 .rui.tagnav.vertical .navbar-item.selected .dropdown-container,

--- a/imports/plugins/included/default-theme/client/styles/tagNav.less
+++ b/imports/plugins/included/default-theme/client/styles/tagNav.less
@@ -47,8 +47,6 @@
 .rui.tagnav .rui.tag.edit.create {
   @color: lighten(@btn-success-bg, 10%);
   @color: @brand-secondary-color;
-  // @color: #238CC3;
-  // @color: @white;
 
   input {
     // background-color: @color;
@@ -62,7 +60,7 @@
     // background-color: @color;
     // border-color: @color;
     background-color: @white;
-    color: @color;
+    color: @brand-primary-color;
   }
 }
 
@@ -95,16 +93,18 @@
   width: 270px;
   height: 100vh;
   -webkit-overflow-scrolling: touch;
-  z-index: @zindex-navbar;
+  z-index: @zindex-modal;
   box-shadow: 0 0 20px rgba(0,0,0,0.2);
+  transition: transform 250ms ease-in-out;
+  transform: translateX(-270px);
 }
 
 .rui.tagnav.fixed.open {
-  .display(flex);
+  transform: translateX(0);
 }
 
 .rui.tagnav.fixed.closed {
-  display: none;
+  transform: translateX(-270px);
 }
 
 // Tag navigation tag list
@@ -328,7 +328,7 @@
   position: absolute;
   top: @navbar-height;
   left: 0;
-  z-index: @zindex-navbar;
+  z-index: @zindex-modal;
   width: 100%;
   max-width: 100%;
   margin: 0;
@@ -364,4 +364,18 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+}
+
+.rui.tagnav-overlay.fixed {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: @zindex-modal-background;
+}
+
+.rui.tagnav-overlay.closed {
+  display: none;
 }

--- a/imports/plugins/included/default-theme/client/styles/tagNav.less
+++ b/imports/plugins/included/default-theme/client/styles/tagNav.less
@@ -326,10 +326,11 @@
   left: 0;
   z-index: @zindex-navbar;
   width: 100%;
+  max-width: 100%;
   margin: 0;
 
   background-color: @white;
-  border-bottom: 1px solid @border-color;
+  border: 1px solid @border-color;
 }
 
 .rui.tagnav.vertical .navbar-item.selected .dropdown-container,

--- a/imports/plugins/included/default-theme/client/styles/tagNav.less
+++ b/imports/plugins/included/default-theme/client/styles/tagNav.less
@@ -293,12 +293,18 @@
 }
 
 .rui.tagnav.vertical .navbar-item {
+  width: 100%;
   height: auto;
 }
 
 .rui.tagnav .navbar-item .dropdown-container {
   display: none;
   color: @text-color;
+  box-shadow: 0 5px 12px -3px rgba(0,0,0,0.2);
+  border-radius: 0;
+  border: 0;
+  border-top: 1px solid @border-color;
+  border-bottom: 1px solid @border-color;
 }
 
 .rui.tagnav .navbar-item .dropdown-container a {
@@ -326,7 +332,6 @@
   width: 100%;
   max-width: 100%;
   margin: 0;
-
   background-color: @white;
 }
 
@@ -334,6 +339,12 @@
 .rui.tagnav.vertical .navbar-item .dropdown-container {
   // display: block !important;
   position: static;
+}
+
+.rui.tagnav.vertical .navbar-item.edit-button {
+  display: flex;
+  justify-content: center;
+  padding: 10px 0;
 }
 
 .nav-dropbar-content {

--- a/imports/plugins/included/default-theme/client/styles/tags.less
+++ b/imports/plugins/included/default-theme/client/styles/tags.less
@@ -75,7 +75,7 @@ html.rtl .rui.tag.edit .btn:last-child {
 
 .rui.tag.edit.create {
   button {
-    color: @btn-success-bg;
+    color: @brand-primary-color;
   }
 }
 

--- a/imports/plugins/included/default-theme/client/styles/variables.less
+++ b/imports/plugins/included/default-theme/client/styles/variables.less
@@ -37,6 +37,8 @@
 // Brand
 @brand-primary-color: @reaction-brand;
 @brand-primary-dark: #23566D;
+@brand-primary-bg-light: #e4e9ec;
+@brand-primary-border-color: #afbac1;
 
 @brand-secondary-color: @brand-primary-dark; //lighten(@brand-primary-color, 20); // old @brand-secondary-color: #4aa5bd;
 @brand-accent-color: #94E8D1; //lighten(@brand-primary-color, 37); // old @brand-accent-color: #abe2e7;
@@ -50,6 +52,7 @@
 @brand-info-color:            #5bc0de;
 @brand-warning-color:         #EFC95F;
 @brand-danger-color:          #EB4D5C;
+
 
 //== Bootstrap colors
 //
@@ -1127,6 +1130,12 @@
 @navbar-secondary-bg: @white;
 @navbar-secondary-color: @black;
 @navbar-secondary-border: 1px solid @black10;
+
+
+// == Tag Groups
+@tag-group-text-color: @brand-primary-dark;
+@tag-group-border-color: @brand-primary-border-color;
+@tag-group-background-color: @brand-primary-bg-light;
 
 
 //== Dashboard navbar

--- a/imports/plugins/included/product-detail-simple/client/components/variantList.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variantList.js
@@ -52,6 +52,7 @@ class VariantList extends Component {
             <IconButton
               i18nKeyTooltip="variantList.createVariant"
               icon="fa fa-plus"
+              primary={true}
               tooltip="Create Variant"
               onClick={this.props.onCreateVariant}
             />

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/controls.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/controls.html
@@ -13,11 +13,15 @@
 
       {{#if product.isDeleted}}
         <div>
-        <span class="badge badge-danger" data-i18n="app.archived">
-          <span>Archived</span>
-        </span>
-      </div>
+          <span class="badge badge-danger" data-i18n="app.archived">
+            <span>Archived</span>
+          </span>
+        </div>
       {{/if}}
+
+      {{#unless isVisible}}
+        <div>{{> React VisibilityButton}}</div>
+      {{/unless}}
 
     </div>
   {{/if}}

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/controls.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/controls.js
@@ -7,10 +7,12 @@ Template.gridControls.onCreated(function () {
   this.state = new ReactiveDict();
 
   this.autorun(() => {
-    const selectedProducts = Session.get("productGrid/selectedProducts");
-    const isSelected = _.isArray(selectedProducts) ? selectedProducts.indexOf(this.data.product._id) >= 0 : false;
+    if (this.data.product) {
+      const selectedProducts = Session.get("productGrid/selectedProducts");
+      const isSelected = _.isArray(selectedProducts) ? selectedProducts.indexOf(this.data.product._id) >= 0 : false;
 
-    this.state.set("isSelected", isSelected);
+      this.state.set("isSelected", isSelected);
+    }
   });
 });
 
@@ -23,5 +25,19 @@ Template.gridControls.onRendered(function () {
 Template.gridControls.helpers({
   checked: function () {
     return Template.instance().state.equals("isSelected", true);
+  },
+
+  isVisible() {
+    const currentData = Template.currentData();
+    return currentData && currentData.product && currentData.product.isVisible;
+  },
+
+  VisibilityButton() {
+    return {
+      component: IconButton,
+      icon: "",
+      onIcon: "",
+      status: "info"
+    };
   }
 });


### PR DESCRIPTION
Resolves #1782 

- Updated edit button style to make it more visible
- Increased the size of the tagnav dropdown to full width of screen.
- Added min-width to tag group so prevent them from getting too small
- Added a max-width to tag group to prevent them from getting too big
- Modified the color of the show menu (hamburger) icon to be visible on light background
- Added app brand (title) component to header of vertical tag nav
- Centered edit button in vertical tag nav
- Fixed "close tag nav on click of link" action to no close if tag nav group is opened. Fixed it so it will close when sub items are clicked.
- Add indicator for unpublished product
- Variant list Add button primary status
- Fix prop type for switch onLabel