### PR TITLE
Make Edit Mode on by default

### DIFF
--- a/client/modules/accounts/templates/signIn/signIn.js
+++ b/client/modules/accounts/templates/signIn/signIn.js
@@ -70,12 +70,6 @@ Template.loginFormSignInView.events({
           alerts: [error]
         });
       } else {
-        // If you are an admin user logging in for the first time, enable admin / edit mode
-        if (Reaction.hasAdminAccess()) {
-          if (Reaction.getUserPreferences("reaction-dashboard", "viewAs") === undefined) {
-            Reaction.setUserPreferences("reaction-dashboard", "viewAs", "administrator");
-          }
-        }
         // Close dropdown or navigate to page
       }
     });

--- a/client/modules/accounts/templates/signIn/signIn.js
+++ b/client/modules/accounts/templates/signIn/signIn.js
@@ -1,7 +1,6 @@
 import { LoginFormSharedHelpers } from "/client/modules/accounts/helpers";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
-import { Reaction } from "/client/api";
 
 /**
  * onCreated: Login form sign in view

--- a/client/modules/accounts/templates/signIn/signIn.js
+++ b/client/modules/accounts/templates/signIn/signIn.js
@@ -1,6 +1,7 @@
 import { LoginFormSharedHelpers } from "/client/modules/accounts/helpers";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { Reaction } from "/client/api";
 
 /**
  * onCreated: Login form sign in view
@@ -69,6 +70,12 @@ Template.loginFormSignInView.events({
           alerts: [error]
         });
       } else {
+        // If you are an admin user logging in for the first time, enable admin / edit mode
+        if (Reaction.hasAdminAccess()) {
+          if (Reaction.getUserPreferences("reaction-dashboard", "viewAs") === undefined) {
+            Reaction.setUserPreferences("reaction-dashboard", "viewAs", "administrator");
+          }
+        }
         // Close dropdown or navigate to page
       }
     });

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -236,7 +236,7 @@ export default {
   },
 
   isPreview() {
-    const viewAs = this.getUserPreferences("reaction-dashboard", "viewAs", "customer");
+    const viewAs = this.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
     if (viewAs === "customer") {
       return true;


### PR DESCRIPTION
Fixes #1798 

Customer View / Edit Mode Off was the default setting when logging in as an admin.

This update switches this around to make Administrator View / Edit Mode the default setting for profiles which haven’t yet saved the setting to their preferences