### PR TITLE
Marketplace - Allow Seller to View and Edit their products from the homepage grid and product detail page

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -87,7 +87,14 @@ export default {
    * @return {Boolean} Boolean - true if has permission
    */
   hasPermission(checkPermissions, checkUserId, checkGroup) {
-    let group = this.getSellerShopId();
+    let group;
+    // default group to the shop or global if shop isn't defined for some reason.
+    if (checkGroup !== undefined && typeof checkGroup === "string") {
+      group = checkGroup;
+    } else {
+      group = this.getSellerShopId() || Roles.GLOBAL_GROUP;
+    }
+
     let permissions = ["owner"];
     let id = "";
     const userId = checkUserId || this.userId || Meteor.userId();
@@ -116,7 +123,7 @@ export default {
       if (Roles.userIsInRole(userId, permissions, group)) {
         return true;
       }
-      // global roles check
+      /*// global roles check
       const sellerShopPermissions = Roles.getGroupsForUser(userId, "admin");
       // we're looking for seller permissions.
       if (sellerShopPermissions) {
@@ -129,7 +136,7 @@ export default {
             }
           }
         }
-      }
+      }*/
       // no specific permissions found returning false
       return false;
     }
@@ -166,15 +173,6 @@ export default {
         id = Meteor.setTimeout(validateUserId, 5000);
       } else {
         return roleCheck();
-      }
-
-      // default group to the shop or global if shop
-      // isn't defined for some reason.
-      if (checkGroup !== undefined && typeof checkGroup === "string") {
-        group = checkGroup;
-      }
-      if (!group) {
-        group = Roles.GLOBAL_GROUP;
       }
     }
     // return false to be safe

--- a/imports/plugins/core/ui/client/containers/editContainer.js
+++ b/imports/plugins/core/ui/client/containers/editContainer.js
@@ -180,7 +180,7 @@ function composer(props, onData) {
   if (props.disabled === true || viewAs === "customer") {
     hasPermission = false;
   } else {
-    hasPermission = Reaction.hasPermission(props.permissions);
+    hasPermission = Reaction.hasPermission(props.permissions, Meteor.userId(), props.data.shopId);
   }
 
   onData(null, {

--- a/imports/plugins/included/marketplace/client/templates/settings/sellerShopSettings.js
+++ b/imports/plugins/included/marketplace/client/templates/settings/sellerShopSettings.js
@@ -3,8 +3,7 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Reaction } from "/lib/api";
 import { i18next } from "/client/api";
-import { Media } from "/lib/collections";
-import { SellerShops } from "../../../lib/collections";
+import { SellerShops, Media } from "/lib/collections";
 
 Template.sellerShopSettings.onCreated(function () {
   this.autorun(() => {

--- a/imports/plugins/included/marketplace/lib/collections/collections.js
+++ b/imports/plugins/included/marketplace/lib/collections/collections.js
@@ -1,8 +1,0 @@
-import * as Schemas from "/lib/collections/schemas";
-
-/**
- * SellerShops Collection
- */
-export const SellerShops = new Mongo.Collection("SellerShops");
-
-SellerShops.attachSchema(Schemas.Shop);

--- a/imports/plugins/included/marketplace/lib/collections/index.js
+++ b/imports/plugins/included/marketplace/lib/collections/index.js
@@ -1,1 +1,0 @@
-export * from "./collections";

--- a/imports/plugins/included/marketplace/server/publications.js
+++ b/imports/plugins/included/marketplace/server/publications.js
@@ -1,8 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Security } from "meteor/ongoworks:security";
 import { Reaction } from "/lib/api";
-import { Shops, Media } from "/lib/collections";
-import { SellerShops } from "../lib/collections";
+import { Shops, SellerShops } from "/lib/collections";
 
 Meteor.publish("SellerShops", function () {
   const _id = Reaction.getSellerShopId(this.userId);

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
@@ -181,12 +181,13 @@ ProductDetailContainer.propTypes = {
 };
 
 function composer(props, onData) {
+  const userId = Meteor.userId();
   const tagSub = Meteor.subscribe("Tags");
   const productId = Reaction.Router.getParam("handle");
   const variantId = Reaction.Router.getParam("variantId");
   const revisionType = Reaction.Router.getQueryParam("revision");
-  const viewProductAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
+  let viewProductAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
   let productSub;
 
   if (productId) {
@@ -272,7 +273,11 @@ function composer(props, onData) {
       if (viewProductAs === "customer") {
         editable = false;
       } else {
-        editable = Reaction.hasPermission(["createProduct"]);
+        editable = Reaction.hasPermission(["createProduct"], userId, product.shopId);
+
+        if (!editable) {
+          viewProductAs = "customer";
+        }
       }
 
       const topVariants = ReactionProduct.getTopVariants();
@@ -286,7 +291,7 @@ function composer(props, onData) {
         media: mediaArray,
         editable,
         viewAs: viewProductAs,
-        hasAdminPermission: Reaction.hasPermission(["createProduct"])
+        hasAdminPermission: editable
       });
     } else {
       // onData must be called with composeWithTracker, or else the loading icon will show forever.

--- a/imports/plugins/included/product-variant/client/templates/products/products.js
+++ b/imports/plugins/included/product-variant/client/templates/products/products.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/client/api";
+import { Reaction } from "/lib/api";
 import { ReactionProduct } from "/lib/api";
 import { applyProductRevision } from "/lib/api/products";
 import { Products, Tags } from "/lib/collections";
@@ -51,21 +51,29 @@ Template.products.onCreated(function () {
   // We're not ready to serve prerendered page until products have loaded
   window.prerenderReady = false;
 
-
   // Update product subscription
   this.autorun(() => {
     const slug = Reaction.Router.getParam("slug");
     const tag = Tags.findOne({ slug: slug }) || Tags.findOne(slug);
     const scrollLimit = Session.get("productScrollLimit");
-    let tags = {}; // this could be shop default implementation needed
+    let options = {}; // this could be shop default implementation needed
 
     if (tag) {
-      tags = { tags: [tag._id] };
+      _.extend(options, { tags: [tag._id] });
     }
 
     // if we get an invalid slug, don't return all products
     if (!tag && slug) {
       return;
+    }
+
+    // allow published content from all sellers
+    if(Reaction.isPackageEnabled("reaction-marketplace")) {
+      const packageSettings = Reaction.getPackageSettings("reaction-marketplace");
+      if(packageSettings.settings.public.allowGuestSellers === true) {
+        // show all shops
+        _.extend(options, { marketplace: true });
+      }
     }
 
     if (this.state.equals("slug", slug) === false && this.state.equals("initialLoad", false)) {
@@ -74,7 +82,7 @@ Template.products.onCreated(function () {
 
     this.state.set("slug", slug);
 
-    const queryParams = Object.assign({}, tags, Reaction.Router.current().queryParams);
+    const queryParams = Object.assign({}, options, Reaction.Router.current().queryParams);
     const productsSubscription = this.subscribe("Products", scrollLimit, queryParams);
 
     // Once our products subscription is ready, we are ready to render

--- a/imports/plugins/included/product-variant/client/templates/products/products.js
+++ b/imports/plugins/included/product-variant/client/templates/products/products.js
@@ -1,3 +1,4 @@
+import _ from  "lodash";
 import { Reaction } from "/lib/api";
 import { ReactionProduct } from "/lib/api";
 import { applyProductRevision } from "/lib/api/products";

--- a/imports/plugins/included/product-variant/client/templates/products/products.js
+++ b/imports/plugins/included/product-variant/client/templates/products/products.js
@@ -56,7 +56,7 @@ Template.products.onCreated(function () {
     const slug = Reaction.Router.getParam("slug");
     const tag = Tags.findOne({ slug: slug }) || Tags.findOne(slug);
     const scrollLimit = Session.get("productScrollLimit");
-    let options = {}; // this could be shop default implementation needed
+    const options = {}; // this could be shop default implementation needed
 
     if (tag) {
       _.extend(options, { tags: [tag._id] });
@@ -68,9 +68,9 @@ Template.products.onCreated(function () {
     }
 
     // allow published content from all sellers
-    if(Reaction.isPackageEnabled("reaction-marketplace")) {
+    if (Reaction.isPackageEnabled("reaction-marketplace")) {
       const packageSettings = Reaction.getPackageSettings("reaction-marketplace");
-      if(packageSettings.settings.public.allowGuestSellers === true) {
+      if (packageSettings.settings.public.allowGuestSellers === true) {
         // show all shops
         _.extend(options, { marketplace: true });
       }

--- a/lib/api/core.js
+++ b/lib/api/core.js
@@ -1,6 +1,5 @@
 import { Meteor } from "meteor/meteor";
 import { Shops } from "/lib/collections";
-import { SellerShops } from "/imports/plugins/included/marketplace/lib/collections";
 
 // Export Reaction using commonJS style for common libraries to use Reaction easily
 // https://docs.meteor.com/packages/modules.html#CommonJS
@@ -10,6 +9,17 @@ if (Meteor.isServer) {
   Core = require("/server/api");
 } else {
   Core = require("/client/api");
+}
+
+/**
+ * Check if package is enabled
+ * @param  {String}  name - Package name
+ * @return {Boolean}      True if the package is enabled
+ */
+function isPackageEnabled(name) {
+  const settings = this.getPackageSettings(name);
+
+  return !!settings.enabled;
 }
 
 /**
@@ -35,6 +45,12 @@ function getSellerShopId(userId) {
   return Reaction.getShopId();
 }
 
+/**
+ * getSellerShop
+ * @summary Get a seller's shop or default to parent shop
+ * @param {userId} userId - An optional userId to find a shop for
+ * @returns {String} - The shop hash belonging to userId, or loggedIn seller, or the parent shop
+ */
 function getSellerShop(userId) {
   const _id = getSellerShopId(userId);
 
@@ -66,6 +82,7 @@ function hasMarketplaceGuestAccess() {
 }
 
 const Reaction = Object.assign(Core.Reaction, {
+  isPackageEnabled,
   getSellerShopId,
   getSellerShop,
   hasMarketplaceGuestAccess

--- a/lib/api/core.js
+++ b/lib/api/core.js
@@ -1,5 +1,5 @@
 import { Meteor } from "meteor/meteor";
-import { Shops } from "/lib/collections";
+import { Shops, SellerShops } from "/lib/collections";
 
 // Export Reaction using commonJS style for common libraries to use Reaction easily
 // https://docs.meteor.com/packages/modules.html#CommonJS

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -126,6 +126,12 @@ export const Shops = new Mongo.Collection("Shops");
 
 Shops.attachSchema(Schemas.Shop);
 
+/**
+ * SellerShops Collection (client-only)
+ */
+export const SellerShops = new Mongo.Collection("SellerShops");
+
+SellerShops.attachSchema(Schemas.Shop);
 
 /**
 * Tags Collection

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -129,7 +129,7 @@ Shops.attachSchema(Schemas.Shop);
 /**
  * SellerShops Collection (client-only)
  */
-if(Meteor.isClient) {
+if (Meteor.isClient) {
   export const SellerShops = new Mongo.Collection("SellerShops");
 
   SellerShops.attachSchema(Schemas.Shop);

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -129,9 +129,11 @@ Shops.attachSchema(Schemas.Shop);
 /**
  * SellerShops Collection (client-only)
  */
-export const SellerShops = new Mongo.Collection("SellerShops");
+if(Meteor.isClient) {
+  export const SellerShops = new Mongo.Collection("SellerShops");
 
-SellerShops.attachSchema(Schemas.Shop);
+  SellerShops.attachSchema(Schemas.Shop);
+}
 
 /**
 * Tags Collection

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -66,6 +66,7 @@ export default {
     // Match.Optional(String));
 
     let permissions;
+    let group;
     // default group to the shop or global if shop isn't defined for some reason.
     if (checkGroup !== undefined && typeof checkGroup === "string") {
       group = checkGroup;
@@ -92,7 +93,7 @@ export default {
     }
 
     // global roles check
-    const sellerShopPermissions = Roles.getGroupsForUser(userId, "admin");
+    /*const sellerShopPermissions = Roles.getGroupsForUser(userId, "admin");
 
     // we're looking for seller permissions.
     if (sellerShopPermissions) {
@@ -105,7 +106,7 @@ export default {
           }
         }
       }
-    }
+    }*/
     // no specific permissions found returning false
     return false;
   },
@@ -211,17 +212,6 @@ export default {
     }
 
     return Packages.findOne(query);
-  },
-
-  /**
-   * Check if package is enabled
-   * @param  {String}  name - Package name
-   * @return {Boolean}      True if the package is enabled
-   */
-  isPackageEnabled(name) {
-    const settings = this.getPackageSettings(name);
-
-    return !!settings.enabled;
   },
 
   /**

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -313,7 +313,7 @@ Meteor.methods({
     check(productId, String);
     check(variantId, String);
     // user needs createProduct permission to clone
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -400,7 +400,7 @@ Meteor.methods({
     check(parentId, String);
     check(newVariant, Match.Optional(Object));
     // must have createProduct permissions
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -457,7 +457,7 @@ Meteor.methods({
   "products/updateVariant": function (variant) {
     check(variant, Object);
     // must have createProduct permissions
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -500,7 +500,7 @@ Meteor.methods({
   "products/deleteVariant": function (variantId) {
     check(variantId, String);
     // must have createProduct permissions
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -538,7 +538,7 @@ Meteor.methods({
   "products/cloneProduct": function (productOrArray) {
     check(productOrArray, Match.OneOf(Array, Object));
     // must have createProduct permissions
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
     // this.unblock();
@@ -653,7 +653,7 @@ Meteor.methods({
   "products/createProduct": function (product) {
     check(product, Match.Optional(Object));
     // must have createProduct permission
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -688,7 +688,7 @@ Meteor.methods({
   "products/deleteProduct": function (productId) {
     check(productId, Match.OneOf(Array, String));
     // must have admin permission to delete
-    if (!Reaction.hasPermission("createProduct") && !Reaction.hasAdminAccess()) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId)) && !Reaction.hasAdminAccess()) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -770,7 +770,7 @@ Meteor.methods({
     check(field, String);
     check(value, Match.OneOf(String, Object, Array, Boolean));
     // must have createProduct permission
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -815,7 +815,7 @@ Meteor.methods({
     check(tagName, String);
     check(tagId, Match.OneOf(String, null));
     // must have createProduct permission
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
     this.unblock();
@@ -882,7 +882,7 @@ Meteor.methods({
   "products/removeProductTag": function (productId, tagId) {
     check(productId, String);
     check(tagId, String);
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -906,7 +906,7 @@ Meteor.methods({
   "products/setHandle": function (productId) {
     check(productId, String);
     // must have createProduct permission
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -934,7 +934,7 @@ Meteor.methods({
     check(productId, String);
     check(tagId, String);
     // must have createProduct permission
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -988,7 +988,7 @@ Meteor.methods({
     check(productId, String);
     check(positionData, Object);
     check(tag, String);
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
     this.unblock();
@@ -1052,7 +1052,7 @@ Meteor.methods({
     //   sortedVariantIds: { type: [String] }
     // }).validate({ sortedVariantIds });
 
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -1089,7 +1089,7 @@ Meteor.methods({
     check(updatedMeta, Object);
     check(meta, Match.OneOf(Object, Number, undefined, null));
     // must have createProduct permission
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -1149,7 +1149,7 @@ Meteor.methods({
     check(type, String);
 
     // must have createProduct permission
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -1172,7 +1172,7 @@ Meteor.methods({
    */
   "products/publishProduct": function (productId) {
     check(productId, String);
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
@@ -1243,7 +1243,7 @@ Meteor.methods({
    */
   "products/toggleVisibility": function (productId) {
     check(productId, String);
-    if (!Reaction.hasPermission("createProduct")) {
+    if (!Reaction.hasPermission("createProduct", this.userId, Reaction.getSellerShopId(this.userId))) {
       throw new Meteor.Error(403, "Access Denied");
     }
 

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -68,7 +68,7 @@ const filters = new SimpleSchema({
 /**
  * products publication
  * @param {Number} productScrollLimit - optional, defaults to 24
- * @param {Array} shops - array of shopId to retrieve product from or a mongodb $in regEx
+ * @param {Array} shops - array of shopId to retrieve product from.
  * @return {Object} return product cursor
  */
 Meteor.publish("Products", function (productScrollLimit = 24, productFilters, sort = {}) {


### PR DESCRIPTION
Product Grid updated so that sellers can display and edit their products from the homepage grid.
Also fixed permissions so that new ProductDetailPage works for sellers as well.

You will notice `Reaction.hasPermission` has the "sellers" check commented. 
This is TBD, but in essence the code always returns true for sellers, even when the product does not belong to the seller, which is an issue. With the new fix in place, now `hasPermission` needs to be called explicitly with the `userId` and `group` as arguments so that a seller's group is also in the checks.

Regarding cross-importing between included and core - To avoid having to import the `SellerShops` client-only collection from Marketplace directly, we have put it along with the core collections, and initialised only on Meteor.isClient.

To test, simply do:
1. Register as guest
2. Become a seller
3. Change your shop settings
4. Add a product
5. Edit product from the homepage grid
6. Edit product from PDP

We have tested the cart/payment/order flow for the owner (logged in buying his own product) and guest (on owner's product) and it works as expected, with Shippo and Stripe. 

A few general things to iron out especially on how the "Edit mode" toggle works. But as soon as the new UI is in place, these should be quick to fix. 

Any changes let us know.
