### PR TITLE
Fix Tags not defined error

### DIFF
--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { composeWithTracker } from "/lib/api/compose";
 import { Meteor } from "meteor/meteor";
+import { Tags } from "/lib/collections";
+import { composeWithTracker } from "/lib/api/compose";
 import { Reaction, i18next } from "/client/api";
 
 import { TranslationProvider, AdminContextProvider } from "/imports/plugins/core/ui/client/providers";


### PR DESCRIPTION
When creating a product I get this error
`Exception in delivering result of invoking 'products/createProduct': ReferenceError: Tags is not defined`

This fixes that.
