### PR TITLE
Fix FireFox Admin search modal display

### DIFF
--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.js
@@ -32,7 +32,7 @@ Template.CoreNavigationBar.events({
     const searchTemplateName = instance.state.get("searchTemplate");
     const searchTemplate = Template[searchTemplateName];
     Blaze.renderWithData(searchTemplate, {
-    }, $("body").get(0));
+    }, $("html").get(0));
     $("body").css("overflow", "hidden");
     $("#search-input").focus();
   },

--- a/imports/plugins/included/default-theme/client/styles/search/results.less
+++ b/imports/plugins/included/default-theme/client/styles/search/results.less
@@ -16,7 +16,7 @@
   position: absolute;
   top: 10px;
   .right(10px);
-  z-index: calc(@zindex-modal + 1)
+  z-index: 1051; //calc(@zindex-modal + 1); // calc() doesn't work for z-index in FireFox
 }
 
 /* -------------------------- Modal Header -------------------------- */


### PR DESCRIPTION
Fixes #1552 
Fixes #1827 

Search Modal close button was not displaying on FireFox.

Search Modal was not displaying on FireFox - and un-ticketed, was also not displaying correctly in Safari - when logged in as an admin.

This change should fix those issues