### PR TITLE
Fix overlapping product grid alerts

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/products/productGrid.less
+++ b/imports/plugins/included/default-theme/client/styles/products/productGrid.less
@@ -322,6 +322,10 @@
   .more-options-container {
     position: relative;
   }
+
+  .rui.btn {
+    margin-left: 5px;
+  }
 }
 
 .product-grid-badges {

--- a/imports/plugins/included/default-theme/client/styles/products/productGrid.less
+++ b/imports/plugins/included/default-theme/client/styles/products/productGrid.less
@@ -300,13 +300,12 @@
 
 // ----------------------------------------------------------------------------
 
-  // position: absolute;
-  // top: 10px;
-  // right: 10px;
-  // border: none;
-  // background-color: rgb(239, 102, 198);
-  // color: white;
-  // padding: 10px 15px;
+.grid-alerts {
+  display: flex;
+  position: absolute;
+  top: 0;
+  right: 0;
+}
 
 
 .product-grid-controls {
@@ -314,66 +313,25 @@
   .flex(0 1 auto);
   .align-items(center);
   .justify-content(center);
+  .margin-left(5px);
 
   width: auto;
   padding: 0;
   overflow: hidden;
 
-  position: absolute;
-  top: 0;
-  right: 0;
-
-
-  // button, .rui.button {
-  //   border: none;
-  //   border-radius: 0;
-  //   background-color: @black60;
-  //   width: 32px;
-  //   height: 32px;
-  //
-  //   color: @white;
-  //
-  //   border-right: 1px solid @controlbar-seperator;
-  //
-  //   &:last-child {
-  //     border: none;
-  //   }
-  //
-  //   // TODO: Make make this more like bootstrap / like a framework
-  //   &:hover, &.active {
-  //     color: @controlbar-fg-hover;
-  //     background-color: @controlbar-hover;
-  //   }
-  // }
-
   .more-options-container {
     position: relative;
   }
-
-
-  // background-color: @controlbar-bg;
-
-  // border-radius: 5px;
-  // box-shadow: 0 3px 6px rgba(0,0,0,0.2);
 }
 
 .product-grid-badges {
-  .badge {
-    position: absolute;
-    top: 0px;
-    right: 0px;
-  }
-}
+  .display(flex);
+  .flex(0 1 auto);
+  .align-items(center);
+  .justify-content(center);
+  .margin-left(5px);
 
-.product-grid-item-images .not-visible {
-  position: relative;
-}
-
-.prodcut-grid-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0,0,0,0.2);
+  width: auto;
+  padding: 0;
+  overflow: hidden;
 }

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/controls.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/controls.html
@@ -12,11 +12,9 @@
       </label>
 
       {{#if product.isDeleted}}
-        <div>
-          <span class="badge badge-danger" data-i18n="app.archived">
-            <span>Archived</span>
-          </span>
-        </div>
+        <span class="badge badge-danger" data-i18n="app.archived">
+          <span>Archived</span>
+        </span>
       {{/if}}
 
       {{#if hasChanges}}

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/item.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/item.html
@@ -1,6 +1,5 @@
 <template name="productGridItems">
   <li class="product-grid-item {{#if positions.pinned}}pinned{{/if}} {{weightClass}} {{isSelected}}" data-id="{{_id}}" id="{{_id}}">
-    {{> gridNotice}}
     <span class="product-grid-item-alerts">
       {{> inlineAlerts placement="productGridItem" id=_id}}
     </span>
@@ -40,7 +39,11 @@
 
     </a>
 
-    {{> gridControls controlProps}}
+    <div class="grid-alerts">
+      {{> gridNotice}}
+      {{> gridControls controlProps}}
+    </div>
+
     {{> gridContent}}
   </li>
 </template>


### PR DESCRIPTION
Fixes #1820 

Product Grid alerts were overlapping. This puts them in the correct containers so they are all visible.

<img width="417" alt="screen shot 2017-02-14 at 10 19 46 pm" src="https://cloud.githubusercontent.com/assets/4482263/22962750/e0cf2ea6-f303-11e6-854e-a87678941644.png">
 