### PR TITLE
update Docker base to reactioncommerce/base:v1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM reactioncommerce/base:v1.0.3
+FROM reactioncommerce/base:v1.2.0
 
 # Default environment variables
 ENV ROOT_URL "http://localhost"


### PR DESCRIPTION
Update to v1.2.0 of `reactioncommerce/base`.

Release notes for the base image:

- Meteor is preinstalled, but we now set the version (currently `1.4.2.7` and can be changed via `$METEOR_VERSION` env var)
- Node 4.7.3
- MongoDB 3.4.2
- Quiet down internal MongoDB logs (if used)

