### PR TITLE
Migrations for package registry

### DIFF
--- a/imports/plugins/core/versions/server/migrations/3_reset_package_registry.js
+++ b/imports/plugins/core/versions/server/migrations/3_reset_package_registry.js
@@ -1,0 +1,19 @@
+import { Migrations } from "/imports/plugins/core/versions";
+import { Packages } from "/lib/collections";
+import { Reaction } from "/server/api/";
+// Add keys to search so that stock search is enabled by default
+Migrations.add({
+  version: 3,
+  up() {
+    Packages.update({},
+      {
+        $set: {
+          registry: []
+        }
+      },
+      { multi: true }
+    );
+    Reaction.loadPackages();
+    Reaction.Import.flush();
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -1,2 +1,3 @@
 import "./1_rebuild_account_and_order_search_collections";
 import "./2_add_key_to_search_ui";
+import "./3_reset_package_registry";


### PR DESCRIPTION
- deletes, then re-adds registry entries for version 0.19
- does not update settings

To test: 
checkout master, reaction reset, check settings. git checkout development, do not reset.  `reaction update`, then `reaction` . Migrations should run, and revised registry entries should be used. This should also work for all custom packages.
![reaction](https://cloud.githubusercontent.com/assets/439959/23200983/425568c4-f88c-11e6-829c-96df82d647af.png)
