### PR TITLE
update search results to use their own notice / badges template

### DIFF
--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -9,7 +9,7 @@ import { transformations } from "./transformations";
 
 
 const requiredFields = {};
-requiredFields.products = ["_id", "hashtags", "shopId", "handle", "price", "isVisible"];
+requiredFields.products = ["_id", "hashtags", "shopId", "handle", "price", "isVisible", "isSoldOut", "isLowQuantity", "isBackorder"];
 requiredFields.orders = ["_id", "shopId", "shippingName", "shippingPhone", "billingName", "userEmails",
   "shippingAddress", "billingAddress", "shippingStatus", "billingStatus", "orderTotal", "orderDate"];
 requiredFields.accounts = ["_id", "shopId", "emails", "profile"];

--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -34,7 +34,10 @@ getResults.products = function (searchTerm, facets, maxResults, userId) {
         hashtags: 1,
         description: 1,
         handle: 1,
-        price: 1
+        price: 1,
+        isSoldOut: 1,
+        isLowQuantity: 1,
+        isBackorder: 1
       },
       sort: { score: { $meta: "textScore" } },
       limit: maxResults

--- a/imports/plugins/included/ui-search/client/index.js
+++ b/imports/plugins/included/ui-search/client/index.js
@@ -13,6 +13,8 @@ import "./templates/productSearch/productItem.html";
 import "./templates/productSearch/productItem.js";
 import "./templates/productSearch/content.html";
 import "./templates/productSearch/content.js";
+import "./templates/productSearch/notice.html";
+import "./templates/productSearch/notice.js";
 
 // Order Search
 import "./templates/orderSearch/orderResults.html";

--- a/imports/plugins/included/ui-search/client/templates/productSearch/notice.html
+++ b/imports/plugins/included/ui-search/client/templates/productSearch/notice.html
@@ -1,4 +1,4 @@
-<template name="gridNotice">
+<template name="searchGridNotice">
   {{#if isSoldOut}}
     {{#if isBackorder}}
       <span class="variant-qty-sold-out badge" data-i18n="productDetail.backOrder">Backorder</span>

--- a/imports/plugins/included/ui-search/client/templates/productSearch/notice.js
+++ b/imports/plugins/included/ui-search/client/templates/productSearch/notice.js
@@ -1,7 +1,7 @@
 /**
- * gridNotice helpers
+ * searchGridNotice helpers
  */
-Template.gridNotice.helpers({
+Template.searchGridNotice.helpers({
   isLowQuantity: function () {
     return this.isLowQuantity;
   },

--- a/imports/plugins/included/ui-search/client/templates/productSearch/notice.js
+++ b/imports/plugins/included/ui-search/client/templates/productSearch/notice.js
@@ -1,53 +1,14 @@
-// /**
-//  * searchGridNotice helpers
-//  */
-// Template.searchGridNotice.helpers({
-//   isLowQuantity: function () {
-//     return this.isLowQuantity;
-//   },
-//   isSoldOut: function () {
-//     return this.isSoldOut;
-//   },
-//   isBackorder: function () {
-//     return this.isBackorder;
-//   }
-// });
-
-
-
-import { ReactionProduct } from "/lib/api";
-import { Catalog } from "/lib/api";
-
 /**
  * searchGridNotice helpers
  */
 Template.searchGridNotice.helpers({
   isLowQuantity: function () {
-    const topVariants = ReactionProduct.getTopVariants(this.product._id);
-
-    for (const topVariant of topVariants) {
-      const inventoryThreshold = topVariant.lowInventoryWarningThreshold;
-      const inventoryQuantity = ReactionProduct.getVariantQuantity(topVariant);
-
-      if (inventoryQuantity !== 0 && inventoryThreshold >= inventoryQuantity) {
-        return true;
-      }
-    }
-    return false;
+    return this.product.isLowQuantity;
   },
   isSoldOut: function () {
-    const topVariants = ReactionProduct.getTopVariants(this.product._id);
-
-    for (const topVariant of topVariants) {
-      const inventoryQuantity = ReactionProduct.getVariantQuantity(topVariant);
-
-      if (inventoryQuantity > 0) {
-        return false;
-      }
-    }
-    return true;
+    return this.product.isSoldOut;
   },
   isBackorder: function () {
-    return this.isBackorder;
+    return this.product.isBackorder;
   }
 });

--- a/imports/plugins/included/ui-search/client/templates/productSearch/notice.js
+++ b/imports/plugins/included/ui-search/client/templates/productSearch/notice.js
@@ -23,7 +23,7 @@ import { Catalog } from "/lib/api";
  */
 Template.searchGridNotice.helpers({
   isLowQuantity: function () {
-    const topVariants = ReactionProduct.getTopVariants(this._id);
+    const topVariants = ReactionProduct.getTopVariants(this.product._id);
 
     for (const topVariant of topVariants) {
       const inventoryThreshold = topVariant.lowInventoryWarningThreshold;
@@ -36,7 +36,7 @@ Template.searchGridNotice.helpers({
     return false;
   },
   isSoldOut: function () {
-    const topVariants = ReactionProduct.getTopVariants(this._id);
+    const topVariants = ReactionProduct.getTopVariants(this.product._id);
 
     for (const topVariant of topVariants) {
       const inventoryQuantity = ReactionProduct.getVariantQuantity(topVariant);

--- a/imports/plugins/included/ui-search/client/templates/productSearch/notice.js
+++ b/imports/plugins/included/ui-search/client/templates/productSearch/notice.js
@@ -1,12 +1,51 @@
+// /**
+//  * searchGridNotice helpers
+//  */
+// Template.searchGridNotice.helpers({
+//   isLowQuantity: function () {
+//     return this.isLowQuantity;
+//   },
+//   isSoldOut: function () {
+//     return this.isSoldOut;
+//   },
+//   isBackorder: function () {
+//     return this.isBackorder;
+//   }
+// });
+
+
+
+import { ReactionProduct } from "/lib/api";
+import { Catalog } from "/lib/api";
+
 /**
  * searchGridNotice helpers
  */
 Template.searchGridNotice.helpers({
   isLowQuantity: function () {
-    return this.isLowQuantity;
+    const topVariants = ReactionProduct.getTopVariants(this._id);
+
+    for (const topVariant of topVariants) {
+      const inventoryThreshold = topVariant.lowInventoryWarningThreshold;
+      const inventoryQuantity = ReactionProduct.getVariantQuantity(topVariant);
+
+      if (inventoryQuantity !== 0 && inventoryThreshold >= inventoryQuantity) {
+        return true;
+      }
+    }
+    return false;
   },
   isSoldOut: function () {
-    return this.isSoldOut;
+    const topVariants = ReactionProduct.getTopVariants(this._id);
+
+    for (const topVariant of topVariants) {
+      const inventoryQuantity = ReactionProduct.getVariantQuantity(topVariant);
+
+      if (inventoryQuantity > 0) {
+        return false;
+      }
+    }
+    return true;
   },
   isBackorder: function () {
     return this.isBackorder;

--- a/imports/plugins/included/ui-search/client/templates/productSearch/productItem.html
+++ b/imports/plugins/included/ui-search/client/templates/productSearch/productItem.html
@@ -1,7 +1,7 @@
 <template name="productItem">
   <li class="product-grid-item {{#if positions.pinned}}pinned{{/if}} {{weightClass}} {{isSelected}}" data-id="{{product._id}}" id="{{product._id}}">
     <div class="item-content">
-      {{> gridNotice}}
+      {{> searchGridNotice}}
       <span class="product-grid-item-alerts">
         {{> inlineAlerts placement="productGridItem" id=product._id}}
       </span>


### PR DESCRIPTION
Create a new `searchGridNotice` template to be used in our search results modal to display badges for low inventory and sold out products.

Currently, the search grid shares a template, `gridNotice`, with our main grid view. When navigating to a PDP page, we lose the publication data for all products, and only receive the current PDP product data, which was causing display issues in search.

This update creates a new template to be used only on the search results page, which uses new data output through the search publication.

This update will temporarily cause no badges to display in our search results, which will be remedied in `release-0.20.0` by denormalizing inventory data and attaching it to the top level product.