### PR TITLE
1907 PDP template switcher

### DIFF
--- a/imports/plugins/core/ui/client/components/index.js
+++ b/imports/plugins/core/ui/client/components/index.js
@@ -32,3 +32,4 @@ export { default as Slider } from "./slider/slider";
 export { default as MultiSelect } from "./multiselect/multiselect";
 export { Overlay } from "./modal";
 export * from "./tabs";
+export { default as Select } from "./select/select.react";

--- a/imports/plugins/core/ui/client/components/multiselect/multiselect.js
+++ b/imports/plugins/core/ui/client/components/multiselect/multiselect.js
@@ -1,22 +1,61 @@
 import React, { Component, PropTypes } from "react";
+import classnames from "classnames";
 import Select from "react-select";
+import { Translation } from "../translation";
 
 class MultiSelect extends Component {
+  static defaultProps = {
+    multi: true,
+    simpleValue: true
+  }
+
+  renderLabel() {
+    if (this.props.label) {
+      return (
+        <label>
+          <Translation defaultValue={this.props.label} i18nKey={this.props.i18nKeyLabel} />
+        </label>
+      );
+    }
+
+    return null;
+  }
+
+  handleChange = (value) => {
+    if (typeof this.props.onChange === "function") {
+      this.props.onChange(value, this.props.name);
+    }
+  }
+
   render() {
+    const {
+      label, i18nKeyLabel, // eslint-disable-line no-unused-vars
+      ...selectProps
+    } = this.props;
+
+    const classes = classnames({
+      // Base
+      "rui": true,
+      "multiselect": true,
+      "form-group": true
+    });
+
     return (
-      <Select
-        multi
-        simpleValue
-        value={this.props.value}
-        placeholder={this.props.placeholder}
-        options={this.props.options}
-        onChange={this.props.onChange}
-      />
+      <div className={classes}>
+        {this.renderLabel()}
+        <Select
+          {...selectProps}
+          onChange={this.handleChange}
+        />
+      </div>
     );
   }
 }
 
 MultiSelect.propTypes = {
+  i18nKeyLabel: PropTypes.string,
+  label: PropTypes.string,
+  name: PropTypes.string,
   onChange: PropTypes.func,
   options: PropTypes.array,
   placeholder: PropTypes.string,

--- a/imports/plugins/core/ui/client/components/multiselect/multiselect.js
+++ b/imports/plugins/core/ui/client/components/multiselect/multiselect.js
@@ -2,11 +2,23 @@ import React, { Component, PropTypes } from "react";
 import classnames from "classnames";
 import Select from "react-select";
 import { Translation } from "../translation";
+import { i18next } from "/client/api";
 
 class MultiSelect extends Component {
   static defaultProps = {
     multi: true,
     simpleValue: true
+  }
+
+  static propTypes = {
+    i18nKeyLabel: PropTypes.string,
+    i18nKeyPlaceholder: PropTypes.string,
+    label: PropTypes.string,
+    name: PropTypes.string,
+    onChange: PropTypes.func,
+    options: PropTypes.array,
+    placeholder: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
   }
 
   renderLabel() {
@@ -30,6 +42,7 @@ class MultiSelect extends Component {
   render() {
     const {
       label, i18nKeyLabel, // eslint-disable-line no-unused-vars
+      placeholder, i18nKeyPlaceholder,
       ...selectProps
     } = this.props;
 
@@ -40,26 +53,19 @@ class MultiSelect extends Component {
       "form-group": true
     });
 
+    const translatedPlaceholder = i18next.t(i18nKeyPlaceholder, { defaultValue: placeholder });
+
     return (
       <div className={classes}>
         {this.renderLabel()}
         <Select
           {...selectProps}
+          placeholder={translatedPlaceholder}
           onChange={this.handleChange}
         />
       </div>
     );
   }
 }
-
-MultiSelect.propTypes = {
-  i18nKeyLabel: PropTypes.string,
-  label: PropTypes.string,
-  name: PropTypes.string,
-  onChange: PropTypes.func,
-  options: PropTypes.array,
-  placeholder: PropTypes.string,
-  value: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
-};
 
 export default MultiSelect;

--- a/imports/plugins/core/ui/client/components/select/select.react.js
+++ b/imports/plugins/core/ui/client/components/select/select.react.js
@@ -1,0 +1,13 @@
+import React from "react";
+import MultiSelect from "../multiselect/multiselect";
+
+function Select(props) {
+  return (
+    <MultiSelect
+      multi={false}
+      {...props}
+    />
+  );
+}
+
+export default Select;

--- a/imports/plugins/included/default-theme/client/styles/dashboard/console.less
+++ b/imports/plugins/included/default-theme/client/styles/dashboard/console.less
@@ -221,13 +221,6 @@ body.admin-vertical .admin-controls {
 .admin-controls-content label {
   font-weight: lighter;
 }
-.admin-controls-content .form-group input:not([type=checkbox]) {
-  .form-control;
-}
-// .admin-controls-content .form-group select {
-//   .form-control;
-// }
-
 
 
 .rui.admin.action-view {

--- a/imports/plugins/included/product-admin/client/components/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/components/productAdmin.js
@@ -8,7 +8,8 @@ import {
   CardGroup,
   Metadata,
   TextField,
-  Translation
+  Translation,
+  Select
 } from "/imports/plugins/core/ui/client/components";
 import { Router } from "/client/api";
 import { TagListContainer } from "/imports/plugins/core/ui/client/containers";
@@ -132,6 +133,7 @@ class ProductAdmin extends Component {
 
 
   handleFieldChange = (event, value, field) => {
+    console.log(field, value);
     const newState = update(this.state, {
       product: {
         $merge: {
@@ -145,6 +147,12 @@ class ProductAdmin extends Component {
         this.props.onFieldChange(field, value);
       }
     });
+  }
+
+  handleTemplateChange = (value, field) => {
+    if (this.props.onProductFieldSave) {
+      this.props.onProductFieldSave(this.product._id, field, value);
+    }
   }
 
   handleToggleVisibility = () => {
@@ -224,8 +232,17 @@ class ProductAdmin extends Component {
             actAsExpander={true}
             i18nKeyTitle="productDetailEdit.productSettings"
             title="Product Settings"
+            onChange={this.handleFieldChange}
           />
           <CardBody expandable={true}>
+            <Select
+              clearable={false}
+              label="Template"
+              name="template"
+              onChange={this.handleTemplateChange}
+              options={this.props.templates}
+              value={this.product.template}
+            />
             <TextField
               i18nKeyLabel="productDetailEdit.title"
               i18nKeyPlaceholder="productDetailEdit.title"
@@ -402,6 +419,10 @@ ProductAdmin.propTypes = {
   onRestoreProduct: PropTypes.func,
   product: PropTypes.object,
   revisonDocumentIds: PropTypes.arrayOf(PropTypes.string),
+  templates: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.any
+  })),
   viewProps: PropTypes.object
 };
 

--- a/imports/plugins/included/product-admin/client/components/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/components/productAdmin.js
@@ -133,7 +133,6 @@ class ProductAdmin extends Component {
 
 
   handleFieldChange = (event, value, field) => {
-    console.log(field, value);
     const newState = update(this.state, {
       product: {
         $merge: {

--- a/imports/plugins/included/product-admin/client/components/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/components/productAdmin.js
@@ -236,10 +236,13 @@ class ProductAdmin extends Component {
           <CardBody expandable={true}>
             <Select
               clearable={false}
+              i18nKeyLabel="productDetailEdit.template"
+              i18nKeyPlaceholder="productDetailEdit.templateSelectPlaceholder"
               label="Template"
               name="template"
               onChange={this.handleTemplateChange}
               options={this.props.templates}
+              placeholder="Select a template"
               value={this.product.template}
             />
             <TextField

--- a/imports/plugins/included/product-admin/client/containers/productAdminContainer.js
+++ b/imports/plugins/included/product-admin/client/containers/productAdminContainer.js
@@ -130,6 +130,7 @@ function composer(props, onData) {
     const templates = Templates.find({
       parser: "react",
       provides: "template",
+      templateFor: { $in: ["pdp"] },
       enabled: true
     }).map((template) => {
       return {

--- a/imports/plugins/included/product-admin/client/containers/productAdminContainer.js
+++ b/imports/plugins/included/product-admin/client/containers/productAdminContainer.js
@@ -3,7 +3,7 @@ import update from "react/lib/update";
 import { Reaction } from "/client/api";
 import { composeWithTracker } from "/lib/api/compose";
 import { ReactionProduct } from "/lib/api";
-import { Tags, Media } from "/lib/collections";
+import { Tags, Media, Templates } from "/lib/collections";
 import { ProductAdmin } from "../components";
 
 class ProductAdminContainer extends Component {
@@ -127,12 +127,24 @@ function composer(props, onData) {
 
     revisonDocumentIds = [product._id];
 
+    const templates = Templates.find({
+      parser: "react",
+      provides: "template",
+      enabled: true
+    }).map((template) => {
+      return {
+        label: template.title,
+        value: template.name
+      };
+    });
+
     onData(null, {
       editFocus: Reaction.state.get("edit/focus"),
       product: product,
       media,
       tags,
-      revisonDocumentIds
+      revisonDocumentIds,
+      templates
     });
   } else {
     onData(null, {});

--- a/imports/plugins/included/product-admin/server/i18n/en.json
+++ b/imports/plugins/included/product-admin/server/i18n/en.json
@@ -8,6 +8,10 @@
           "productSettingsLabel": "Product Settings",
           "productDetailsLabel": "Product Details"
         }
+      },
+      "productDetailEdit": {
+        "template": "Template",
+        "templateSelectPlaceholder": "Select a template"
       }
     }
   }

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
@@ -279,7 +279,7 @@ function composer(props, onData) {
 
       onData(null, {
         variants: topVariants,
-        layout: "productDetailSimple",
+        layout: product.template || "productDetailSimple",
         product: productRevision || product,
         priceRange,
         tags,

--- a/imports/plugins/included/product-detail-simple/lib/layout/twoColumn.js
+++ b/imports/plugins/included/product-detail-simple/lib/layout/twoColumn.js
@@ -3,7 +3,7 @@ export default function twoColumn() {
   return [
     // Media block
     // Contains
-    // - Medai Gallery
+    // - Media Gallery
     // - Tags
     // - Details
     {
@@ -30,11 +30,23 @@ export default function twoColumn() {
       ]
     },
 
-    // Variant block
+    // Product Details Block
+    // Contains
+    // - Title
+    // - Sibtitle
+    // - Price
+    // - Social
+    // - Vendor
+    // - Description
+    // - Variants
+    // - Add to Cart button
     {
       type: "block",
       columns: 6,
       size: "half",
+      style: {
+        display: "block"
+      },
       permissions: ["admin"],
       audience: ["guest", "anonymous"],
       children: [

--- a/imports/plugins/included/product-detail-simple/server/index.js
+++ b/imports/plugins/included/product-detail-simple/server/index.js
@@ -7,6 +7,7 @@ Reaction.registerTemplate({
   name: "productDetailSimple",
   title: "Product Detail Simple Layout",
   type: "react",
+  templateFor: ["pdp"],
   permissions: ["admin", "owner"],
   audience: ["anonymous", "guest"],
   template: SimpleLayout()
@@ -16,6 +17,7 @@ Reaction.registerTemplate({
   name: "productDetailTwoColumn",
   title: "Product Detail Two Column Layout",
   type: "react",
+  templateFor: ["pdp"],
   permissions: ["admin", "owner"],
   audience: ["anonymous", "guest"],
   template: TwoColumnLayout()

--- a/lib/collections/schemas/products.js
+++ b/lib/collections/schemas/products.js
@@ -444,9 +444,10 @@ export const Product = new SimpleSchema({
     index: 1,
     defaultValue: false
   },
-  templateSuffix: {
+  template: {
+    label: "Template",
     type: String,
-    optional: true
+    defaultValue: "productDetailSimple"
   },
   createdAt: {
     type: Date,

--- a/lib/collections/schemas/templates.js
+++ b/lib/collections/schemas/templates.js
@@ -36,6 +36,7 @@ const sharedFields = {
     type: String,
     defaultValue: "template"
   },
+
   provides: {
     type: String,
     defaultValue: "template"
@@ -65,14 +66,10 @@ const sharedFields = {
 
 export const ReactLayout = new SimpleSchema({
   ...sharedFields,
-  // permissions: {
-  //   type: [String],
-  //   optional: true
-  // },
-  // audience: {
-  //   type: [String],
-  //   optional: true
-  // },
+  templateFor: {
+    type: [String],
+    optional: true
+  },
   template: {
     type: [Object],
     optional: true,
@@ -82,14 +79,6 @@ export const ReactLayout = new SimpleSchema({
 
 export const Template = new SimpleSchema({
   ...sharedFields,
-  // permissions: {
-  //   type: [String],
-  //   optional: true
-  // },
-  // audience: {
-  //   type: [String],
-  //   optional: true
-  // },
   template: {
     type: String,
     optional: true

--- a/server/api/core/templates.js
+++ b/server/api/core/templates.js
@@ -112,7 +112,8 @@ export function processTemplateInfoForDatabase(templateInfo) {
     name: templateInfo.name,
     title: templateInfo.title,
     type: templateInfo.type,
-    subject: templateInfo.subject
+    subject: templateInfo.subject,
+    templateFor: templateInfo.templateFor
   };
 
 


### PR DESCRIPTION
Resolves #1907 

Add the ability to select a different template for the PDP page.

Docs: https://github.com/reactioncommerce/reaction-docs/pull/161


![basic_reaction_product](https://cloud.githubusercontent.com/assets/42217/23384830/573f17a2-fd01-11e6-9520-d7571151eafc.png)


![basic_reaction_product](https://cloud.githubusercontent.com/assets/42217/23384887/9fc329f0-fd01-11e6-9098-f41b8d33025c.png)

