### PR TITLE
State feedback capture payment 1243

### DIFF
--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
@@ -116,7 +116,7 @@
           </a>
           <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment">
             <span id="btn-capture-payment" data-i18n="order.capturePayment">Capture Payment</span>
-            <i class="fa fa-spinner fa-spin {{#unless isLoading}}hidden{{/unless}}" id="btn-processing"></i>
+            <i class="fa fa-spinner fa-spin {{#unless isCapturing}}hidden{{/unless}}" id="btn-processing"></i>
           </button>
       {{/if}}
     </div>
@@ -166,7 +166,11 @@
           class="btn btn-success flex-item-fill"
           type="submit"
           data-event-action="applyRefund"
-          data-i18n="order.applyRefund" {{refundSubmitDisabled}}>Apply Refund</button>
+          {{refundSubmitDisabled}}
+        >
+          <span id="btn-refund-payment" data-i18n="order.applyRefund">Apply Refund</span>
+          <i class="fa fa-spinner fa-spin {{#unless isRefunding}}hidden{{/unless}}"></i>
+        </button>
       </div>
     </form>
   {{else}}

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
@@ -114,7 +114,7 @@
             data-i18n="app.print">
             Print
           </a>
-          <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment">
+          <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment" {{capturedDisabled}}>
             <span id="btn-capture-payment" data-i18n="order.capturePayment">Capture Payment</span>
             <i class="fa fa-spinner fa-spin {{#unless isCapturing}}hidden{{/unless}}" id="btn-processing"></i>
           </button>

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
@@ -115,16 +115,8 @@
             Print
           </a>
           <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment">
-            <span>Capturing</span>
-            <i class="fa fa-spinner fa-spin" id="btn-processing"></i>
-          </button>
-          <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment">
-            {{#if isLoading}}
-              <span>Capturing</span>
-              <i class="fa fa-spinner fa-spin" id="btn-processing"></i>
-            {{else}}
-              <span data-i18n="order.capturePayment">Capture Payment</span>
-            {{/if}}
+            <i class="fa fa-spinner fa-spin {{#unless isLoading}}hidden{{/unless}}" id="btn-processing"></i>
+            <span data-i18n="order.capturePayment">Capture Payment</span>
           </button>
       {{/if}}
     </div>

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
@@ -115,8 +115,8 @@
             Print
           </a>
           <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment">
+            <span id="btn-capture-payment" data-i18n="order.capturePayment">Capture Payment</span>
             <i class="fa fa-spinner fa-spin {{#unless isLoading}}hidden{{/unless}}" id="btn-processing"></i>
-            <span data-i18n="order.capturePayment">Capture Payment</span>
           </button>
       {{/if}}
     </div>

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
@@ -114,14 +114,21 @@
             data-i18n="app.print">
             Print
           </a>
-          <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment" data-i18n="order.capturePayment">Capture Payment</button>
+          <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment">
+            <span>Capturing</span>
+            <i class="fa fa-spinner fa-spin" id="btn-processing"></i>
+          </button>
+          <button class="btn btn-success flex-item-fill" type="button" data-event-action="capturePayment">
+            {{#if isLoading}}
+              <span>Capturing</span>
+              <i class="fa fa-spinner fa-spin" id="btn-processing"></i>
+            {{else}}
+              <span data-i18n="order.capturePayment">Capture Payment</span>
+            {{/if}}
+          </button>
       {{/if}}
-
-
     </div>
-
   </form>
-
 
   {{#if paymentCaptured}}
     <form name="refund">

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.html
@@ -131,11 +131,21 @@
         </div>
       </div>
 
-      {{#each refund in refunds}}
-        <div class="order-summary-form-group">
-          <span class="reason" data-i18n="cartSubTotals.refundAmount">Refunded on: {{dateFormat refund.created format="MMM D, YYYY"}}</span>
-          <div class="amount">-{{formatPrice refund.amount}}</div>
+      {{#if isFetching}}
+        <div class="form-group order-summary-form-group">
+          <span class="reason">
+            <i class="fa fa-info-circle text-info"></i>
+            <strong class="text-info">Loading Refunds</strong>
+            <i class="fa fa-spinner fa-spin"></i>
+          </span>
         </div>
+      {{/if}}
+
+      {{#each refund in refunds}}
+      <div class="order-summary-form-group">
+        <span class="reason" data-i18n="cartSubTotals.refundAmount">Refunded on: {{dateFormat refund.created format="MMM D, YYYY"}}</span>
+        <div class="amount">-{{formatPrice refund.amount}}</div>
+      </div>
       {{/each}}
 
       <div class="reason">

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -24,7 +24,8 @@ Template.coreOrderShippingInvoice.onCreated(function () {
   this.refundAmount = new ReactiveVar(0.00);
   this.state.setDefault({
     isCapturing: false,
-    isRefunding: false
+    isRefunding: false,
+    isFetching: true
   });
 
   this.autorun(() => {
@@ -39,6 +40,7 @@ Template.coreOrderShippingInvoice.onCreated(function () {
       Meteor.call("orders/refunds/list", order, (error, result) => {
         if (!error) {
           this.refunds.set(result);
+          this.state.set("isFetching", false);
         }
       });
     }
@@ -59,6 +61,13 @@ Template.coreOrderShippingInvoice.helpers({
     const instance = Template.instance();
     if (instance.state.get("isRefunding")) {
       instance.$("#btn-refund-payment").text("Refunding");
+      return true;
+    }
+    return false;
+  },
+  isFetching() {
+    const instance = Template.instance();
+    if (instance.state.get("isFetching")) {
       return true;
     }
     return false;

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -179,11 +179,10 @@ Template.coreOrderShippingInvoice.events({
 
   "click [data-event-action=capturePayment]": (event, instance) => {
     event.preventDefault();
-    const { state } = Template.instance();
-    console.log("before", instance.state);
+
     instance.state.set("isLoading", true);
+
     const order = instance.state.get("order");
-    console.log("after", instance.state);
     Meteor.call("orders/capturePayments", order._id);
 
     if (order.workflow.status === "new") {

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -23,12 +23,13 @@ Template.coreOrderShippingInvoice.onCreated(function () {
   this.state = new ReactiveDict();
   this.refunds = new ReactiveVar([]);
   this.refundAmount = new ReactiveVar(0.00);
+  this.state.setDefault("isLoading", false);
+
   this.autorun(() => {
     const currentData = Template.currentData();
     const order = Orders.findOne(currentData.orderId);
     const shop = Shops.findOne({});
 
-    this.state.set("isLoading", false);
     this.state.set("order", order);
     this.state.set("currency", shop.currencies[shop.currency]);
 
@@ -43,6 +44,15 @@ Template.coreOrderShippingInvoice.onCreated(function () {
 });
 
 Template.coreOrderShippingInvoice.helpers({
+  isLoading() {
+    const instance = Template.instance();
+    if (instance.state.get("isLoading")) {
+      instance.$("#btn-capture-payment").text("Capturing");
+      return true;
+    }
+    return false;
+  },
+
   DiscountList() {
     return DiscountList;
   },
@@ -192,7 +202,6 @@ Template.coreOrderShippingInvoice.events({
         filter: "processing",
         _id: order._id
       });
-      instance.state.set("isLoading", false);
     }
   },
 

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -50,6 +50,7 @@ Template.coreOrderShippingInvoice.helpers({
   isCapturing() {
     const instance = Template.instance();
     if (instance.state.get("isCapturing")) {
+      instance.$(":input").attr("disabled", true);
       instance.$("#btn-capture-payment").text("Capturing");
       return true;
     }
@@ -389,9 +390,18 @@ Template.coreOrderShippingInvoice.helpers({
     return Math.abs(paymentMethod.amount - refundTotal);
   },
 
+  capturedDisabled() {
+    const isLoading = Template.instance().state.get("isCapturing");
+    if (isLoading) {
+      return "disabled";
+    }
+    return null;
+  },
+
   refundSubmitDisabled() {
     const amount = Template.instance().state.get("field-refund") || 0;
-    if (amount === 0) {
+    const isLoading = Template.instance().state.get("isRefunding");
+    if (amount === 0 || isLoading) {
       return "disabled";
     }
 

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -7,6 +7,7 @@ import { i18next, Logger, formatNumber, Reaction } from "/client/api";
 import { NumericInput } from "/imports/plugins/core/ui/client/components";
 import { Media, Orders, Shops } from "/lib/collections";
 import DiscountList from "/imports/plugins/core/discounts/client/components/list";
+import "./shippingInvoice.html";
 
 // helper to return the order payment object
 // the first credit paymentMethod on the order
@@ -22,12 +23,12 @@ Template.coreOrderShippingInvoice.onCreated(function () {
   this.state = new ReactiveDict();
   this.refunds = new ReactiveVar([]);
   this.refundAmount = new ReactiveVar(0.00);
-
   this.autorun(() => {
     const currentData = Template.currentData();
     const order = Orders.findOne(currentData.orderId);
     const shop = Shops.findOne({});
 
+    this.state.set("isLoading", false);
     this.state.set("order", order);
     this.state.set("currency", shop.currencies[shop.currency]);
 
@@ -178,7 +179,11 @@ Template.coreOrderShippingInvoice.events({
 
   "click [data-event-action=capturePayment]": (event, instance) => {
     event.preventDefault();
+    const { state } = Template.instance();
+    console.log("before", instance.state);
+    instance.state.set("isLoading", true);
     const order = instance.state.get("order");
+    console.log("after", instance.state);
     Meteor.call("orders/capturePayments", order._id);
 
     if (order.workflow.status === "new") {
@@ -188,6 +193,7 @@ Template.coreOrderShippingInvoice.events({
         filter: "processing",
         _id: order._id
       });
+      instance.state.set("isLoading", false);
     }
   },
 

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -7,7 +7,6 @@ import { i18next, Logger, formatNumber, Reaction } from "/client/api";
 import { NumericInput } from "/imports/plugins/core/ui/client/components";
 import { Media, Orders, Shops } from "/lib/collections";
 import DiscountList from "/imports/plugins/core/discounts/client/components/list";
-import "./shippingInvoice.html";
 
 // helper to return the order payment object
 // the first credit paymentMethod on the order


### PR DESCRIPTION
Capture payment and apply refund in order fulfillment workflow doesn't give feedback when loading.

This update adds a spinner on the button when loading.

**Test**

1. Enable Stripe
2. Checkout an item
3. Approve and Capture payment
4. Apply refund

Fixes #1243 

