### PR TITLE
Remove broken check for bulk write support

### DIFF
--- a/imports/plugins/included/inventory/server/methods/statusChanges.js
+++ b/imports/plugins/included/inventory/server/methods/statusChanges.js
@@ -269,10 +269,12 @@ Meteor.methods({
       }
 
       const execute = Meteor.wrapAsync(batch.execute, batch);
-      const inventoryBackorder = execute();
-      const inserted = inventoryBackorder.nInserted;
-      Logger.debug(`created ${inserted} backorder records for product ${newReservation.productId}, variant ${newReservation.variantId}`);
-      return inserted;
+      if (batch.length) {
+        const inventoryBackorder = execute();
+        const inserted = inventoryBackorder.nInserted;
+        Logger.debug(`created ${inserted} backorder records for product ${newReservation.productId}, variant ${newReservation.variantId}`);
+        return inserted;
+      }
     }
     //
     // TODO implement a backup inventory/backorder method if bulk operations fail.

--- a/imports/plugins/included/inventory/server/methods/statusChanges.js
+++ b/imports/plugins/included/inventory/server/methods/statusChanges.js
@@ -260,25 +260,19 @@ Meteor.methods({
 
     // insert backorder
     let i = 0;
-
-    // check if we support bulk operations
-    const currentBatch = Inventory._collection.rawCollection().currentBatch;
-
-    if (currentBatch && currentBatch.operations && currentBatch.operations.length > 0) {
-      const batch = Inventory._collection.rawCollection().initializeUnorderedBulkOp();
-      if (batch) {
-        while (i < backOrderQty) {
-          const id = Inventory._makeNewID();
-          batch.insert(Object.assign({ _id: id }, newReservation));
-          i++;
-        }
-
-        const execute = Meteor.wrapAsync(batch.execute, batch);
-        const inventoryBackorder = execute();
-        const inserted = inventoryBackorder.nInserted;
-        Logger.debug(`created ${inserted} backorder records for product ${newReservation.productId}, variant ${newReservation.variantId}`);
-        return inserted;
+    const batch = Inventory.rawCollection().initializeUnorderedBulkOp();
+    if (batch) {
+      while (i < backOrderQty) {
+        const id = Inventory._makeNewID();
+        batch.insert(Object.assign({ _id: id }, newReservation));
+        i++;
       }
+
+      const execute = Meteor.wrapAsync(batch.execute, batch);
+      const inventoryBackorder = execute();
+      const inserted = inventoryBackorder.nInserted;
+      Logger.debug(`created ${inserted} backorder records for product ${newReservation.productId}, variant ${newReservation.variantId}`);
+      return inserted;
     }
     //
     // TODO implement a backup inventory/backorder method if bulk operations fail.


### PR DESCRIPTION
Resolves #1288

I actually was never able to replicate the `Invalid Operation, No operations in bulk` error. But I was seeing `skipped bulk operations backorder updates` which was caused by a check for BulkOrder support that always failed. All versions of Mongo > 2.6 support bulk operations and we only support Mongo > 2.6 so there is no reason to check for this support any longer. Additionally if the bulk operation support was there, we shouldn't just silently not perform the inventory operation, but fall back to iterating over individual records.

Also verified that this check does not exist elsewhere.

We do do this check in Import which I think is fine:

```
  if (!MongoInternals.NpmModule.Collection.prototype.initializeUnorderedBulkOp) {
    throw Error("Couldn't detect the MongoDB bulk API, are you using MongoDB 2.6 or above?");
  }
```

To Test:

1. Run tests and verify that the error message is gone.
1. Put something in backorder (add more to cart than is in stock and Deny Stock is turned off) and confirm that there is no error and that things are in backorder. (inventory records marked `workflow.status: backorder`)

**Edit update: Erik got the error once so I added what I believe is the fix for that (not trying to execute an empty bulk request).**