### PR TITLE
allow loading of registry data with REACTION_REGISTRY

### DIFF
--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -347,22 +347,33 @@ export default {
   loadPackages() {
     const packages = Packages.find().fetch();
 
-    let settingsFromJSON;
+    let registryFixtureData;
 
-    // Attempt to load reaction.json fixture data
-    try {
-      const settingsJSONAsset = Assets.getText("settings/reaction.json");
-      const validatedJson = EJSON.parse(settingsJSONAsset);
-
-      if (!_.isArray(validatedJson[0])) {
-        Logger.warn("Load Settings is not an array. Failed to load settings.");
-      } else {
-        settingsFromJSON = validatedJson;
+    if (process.env.REACTION_REGISTRY) {
+      // check the environment for the registry fixture data first
+      registryFixtureData = process.env.REACTION_REGISTRY;
+      Logger.info("Loaded REACTION_REGISTRY environment variable for registry fixture import");
+    } else {
+      // or attempt to load reaction.json fixture data
+      try {
+        registryFixtureData = Assets.getText("settings/reaction.json");
+      } catch (error) {
+        Logger.warn("Skipped loading settings from reaction.json.");
+        Logger.debug(error, "loadSettings reaction.json not loaded.");
       }
-    } catch (error) {
-      Logger.warn("Skipped loading settings from reaction.json.");
-      Logger.debug(error, "loadSettings reaction.json not loaded.");
+      Logger.info("Loaded \"/private/settings/reaction.json\" for registry fixture import");
     }
+
+    if (!!registryFixtureData) {
+      const validatedJson = EJSON.parse(registryFixtureData);
+
+      if (!Array.isArray(validatedJson[0])) {
+        Logger.warn("Registry fixture data is not an array. Failed to load.");
+      } else {
+        registryFixtureData = validatedJson;
+      }
+    }
+
     const layouts = [];
     // for each shop, we're loading packages in a unique registry
     _.each(this.Packages, (config, pkgName) => {
@@ -385,8 +396,8 @@ export default {
 
         // Setting from a fixture file, most likely reaction.json
         let settingsFromFixture;
-        if (settingsFromJSON) {
-          settingsFromFixture = _.find(settingsFromJSON[0], (packageSetting) => {
+        if (registryFixtureData) {
+          settingsFromFixture = _.find(registryFixtureData[0], (packageSetting) => {
             return config.name === packageSetting.name;
           });
         }


### PR DESCRIPTION
This adds the option to load the registry fixture data with the `REACTION_REGISTRY` environment variable.  The original file location still works the same way it always did, so this is totally opt-in.  Just note that setting the environment variable takes precedence over the default file location (`/private/settings/reaction.json`).

Aside from supporting any method of setting environment variables, this can also now be used with a new `--registry` flag in `reaction-cli` that was just released in `v0.7.4`.  

To test that flag and this PR:

```sh
reaction init -b registry-env-var
cd reaction

reaction --registry path/to/reaction.json
```

You should see the fixture data load the same way it did with the file.
