### PR TITLE
Added switch component to list item

### DIFF
--- a/imports/plugins/core/ui/client/components/list/listItem.js
+++ b/imports/plugins/core/ui/client/components/list/listItem.js
@@ -12,7 +12,6 @@ class ListItem extends Component {
     label: PropTypes.string,
     onClick: PropTypes.func,
     onSwitchChange: PropTypes.func,
-    packageData: PropTypes.object,
     switchName: PropTypes.string,
     switchOn: PropTypes.bool,
     value: PropTypes.any

--- a/imports/plugins/core/ui/client/components/list/listItem.js
+++ b/imports/plugins/core/ui/client/components/list/listItem.js
@@ -1,23 +1,38 @@
 import React, { Component, PropTypes } from "react";
 import classnames from "classnames";
-import { Icon, Translation } from "/imports/plugins/core/ui/client/components";
+import { Icon, Switch, Translation } from "/imports/plugins/core/ui/client/components";
 
 class ListItem extends Component {
   static propTypes = {
-    actionType: PropTypes.oneOf(["arrow"]),
+    actionType: PropTypes.oneOf(["arrow", "switch"]),
     children: PropTypes.node,
     i18nKeyLabel: PropTypes.string,
     icon: PropTypes.string,
     isAdmin: PropTypes.bool,
     label: PropTypes.string,
     onClick: PropTypes.func,
+    onSwitchChange: PropTypes.func,
     packageData: PropTypes.object,
+    switchName: PropTypes.string,
+    switchOn: PropTypes.bool,
     value: PropTypes.any
   }
 
   handleClick = (event) => {
-    if (typeof this.props.onClick === "function") {
+    if (this.props.actionType === "switch") {
+      const isChecked = typeof this.props.switchOn === "boolean" ? !this.props.switchOn : true;
+      this.handleSwitchChange(event, isChecked, this.props.switchName);
+    } else if (typeof this.props.onClick === "function") {
       this.props.onClick(event, this.data);
+    }
+  }
+
+  handleSwitchChange = (event, isChecked, name) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (typeof this.props.onSwitchChange === "function") {
+      this.props.onSwitchChange(event, isChecked, name);
     }
   }
 
@@ -49,6 +64,18 @@ class ListItem extends Component {
       "admin": this.props.isAdmin,
       "list-item-action": true
     });
+
+    if (this.props.actionType === "switch") {
+      return (
+        <div className={actionClassName}>
+          <Switch
+            checked={this.props.switchOn}
+            name={this.props.switchName}
+            onChange={this.handleSwitchChange}
+          />
+        </div>
+      );
+    }
 
     if (this.props.actionType) {
       return (

--- a/imports/plugins/included/default-theme/client/styles/forms.less
+++ b/imports/plugins/included/default-theme/client/styles/forms.less
@@ -132,3 +132,7 @@
 .rui.switch .control-label {
   margin-left: 10px;
 }
+
+.rui.list-item-action .rui.switch {
+  padding: 0;
+}


### PR DESCRIPTION
Related to: #1835 
Related to: #1797 

Adds a new `actionType` to the list item that ads a switch component.

Docs: https://github.com/reactioncommerce/reaction-docs/pull/164