### PR TITLE
Get package data by shopId as well as package name

### DIFF
--- a/imports/plugins/included/payments-stripe/server/methods/stripeapi.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripeapi.js
@@ -1,10 +1,8 @@
 /* eslint camelcase: 0 */
-// meteor modules
 import { Meteor } from "meteor/meteor";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-// reaction modules
 import { Packages } from "/lib/collections";
-import { Logger } from "/server/api";
+import { Reaction, Logger } from "/server/api";
 
 export const StripeApi = {};
 StripeApi.methods = {};
@@ -48,7 +46,10 @@ StripeApi.methods.getApiKey = new ValidatedMethod({
   name: "StripeApi.methods.getApiKey",
   validate: null,
   run() {
-    const settings = Packages.findOne({ name: "reaction-stripe" }).settings;
+    const settings = Packages.findOne({
+      name: "reaction-stripe",
+      shopId: Reaction.getShopId()
+    }).settings;
     if (!settings.api_key) {
       throw new Meteor.Error("403", "Invalid Stripe Credentials");
     }


### PR DESCRIPTION
Resolves #1805 

A user was experiencing an issue where Stripe was not working with "Invalid Credentials". It turns out that the package config here was grabbing the "`<blank site>`" record because the query was not by `shopId`. This fixes that.

I was originally going to use this ticket to change all of our `Packages.findOne` to use the global helper but it quickly got messy and I wanted to get this bug fix out. So here's the PR.


### How to test this PR

Pretty much all operations involving Stripe should fail if there is a problem with the change.
