### PR TITLE
Reduce Inventory records subscribed to by admin

### DIFF
--- a/client/modules/core/subscriptions.js
+++ b/client/modules/core/subscriptions.js
@@ -36,10 +36,6 @@ Subscriptions.Tags = Subscriptions.Manager.subscribe("Tags");
 
 Subscriptions.Media = Subscriptions.Manager.subscribe("Media");
 
-// admin only
-// todo should we put this inside autorun and detect user changes
-Subscriptions.Inventory = Subscriptions.Manager.subscribe("Inventory");
-
 /**
  * Subscriptions that need to reload on new sessions
  */


### PR DESCRIPTION
Resolves #1370 

I went through the app and realized that the Inventory subscription wasn't being used (client-side), and it was affecting app performance. This resolves that issue.

### How to test

Add quantity of products. This should not affect the app's performance.
