### PR TITLE
Avalara error handling

### DIFF
--- a/imports/plugins/core/logging/server/index.js
+++ b/imports/plugins/core/logging/server/index.js
@@ -1,1 +1,2 @@
 import "./publications";
+import "./methods";

--- a/imports/plugins/core/logging/server/methods.js
+++ b/imports/plugins/core/logging/server/methods.js
@@ -1,0 +1,39 @@
+import { Meteor } from "meteor/meteor";
+import { Logs } from "/lib/collections";
+import { Reaction } from "/server/api";
+
+export function writeToLog(logType, logLevel, logData, source = "client") {
+  check(logType, String);
+  check(logLevel, String);
+  check(logData, Object);
+
+  const logEntry = {
+    logType: logType,
+    shopId: Reaction.getShopId(),
+    data: logData,
+    level: logLevel,
+    source: source
+  };
+  Logs.insert(logEntry);
+}
+
+function logError(logType, logData) {
+  check(logType, String);
+  check(logData, Object);
+  if (Roles.userIsInRole(this.userId, ["admin", "owner"])) {
+    writeToLog(logType, "error", logData);
+  }
+}
+
+function logWarning(logType, logData) {
+  check(logType, String);
+  check(logData, Object);
+  if (Roles.userIsInRole(this.userId, ["admin", "owner"])) {
+    writeToLog(logType, "warn", logData);
+  }
+}
+
+Meteor.methods({
+  "logging/logError": logError,
+  "logging/logWarning": logWarning
+});

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/variantForm.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/variantForm.js
@@ -206,7 +206,7 @@ Template.variantForm.helpers({
     return instance.state.get("taxCodes");
   },
   displayCode: function () {
-    if (this.taxCode && this.taxCode !== "00000") {
+    if (this.taxCode && this.taxCode !== "0000") {
       return this.taxCode;
     }
     return i18next.t("productVariant.selectTaxCode");

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/variantForm.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/variantForm.js
@@ -159,7 +159,7 @@ Template.variantForm.helpers({
       "shopId": shopId,
       "registry.provides": "taxCodes",
       "$where": function () {
-        const providerName = this.name.split("-")[1];
+        const providerName = _.filter(this.registry, (o) => o.provides === "taxCodes")[0].name.split("/")[2];
         return this.settings[providerName].enabled;
       }
     });

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/variantForm.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/variantForm.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { ReactiveDict } from "meteor/reactive-dict";
 import { Session } from "meteor/session";

--- a/imports/plugins/included/product-variant/server/methods/populateTaxCodes.js
+++ b/imports/plugins/included/product-variant/server/methods/populateTaxCodes.js
@@ -20,11 +20,13 @@ taxCodes.populateTaxCodes = function (shopId, code, providerName) {
     TaxCodes.insert({
       id: code.id,
       shopId: shopId,
-      taxCode: code.taxCode,
+      taxCode: code.taxCode || code.id,
       taxCodeProvider: providerName,
       ssuta: code.isSSTCertified,
-      label: code.description,
-      parent: code.parentTaxCode
+      title: code.title || "",
+      label: code.description || code.label,
+      parent: code.parentTaxCode || code.parent,
+      children: code.children || []
     });
   } catch (err) {
     throw new Meteor.Error("Error populating TaxCodes collection", err);

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -51,7 +51,7 @@ function checkConfiguration(packageData = taxCalc.getPackageData()) {
   for (const field of requiredFields) {
     if (!settings[field]) {
       const msg = `The Avalara package cannot function unless ${field} is configured`;
-      Logger.fatal(msg);
+      Logger.warn(msg);
       Avalogger.error({ error: msg });
       isValid = false;
     }

--- a/imports/plugins/included/taxes-taxcloud/register.js
+++ b/imports/plugins/included/taxes-taxcloud/register.js
@@ -12,6 +12,9 @@ Reaction.registerPackage({
       apiKey: "",
       refreshPeriod: "every 7 days",
       taxCodeUrl: "https://taxcloud.net/tic/?format=json"
+    },
+    taxCodes: {
+      getTaxCodeMethod: "taxcloud/getTaxCodes"
     }
   },
   registry: [
@@ -20,6 +23,11 @@ Reaction.registerPackage({
       name: "taxes/settings/taxcloud",
       provides: "taxSettings",
       template: "taxCloudSettings"
+    },
+    {
+      label: "TaxCloud Tax Codes",
+      provides: "taxCodes",
+      name: "taxes/taxcodes/taxcloud"
     }
   ]
 });

--- a/imports/plugins/included/taxes-taxcloud/register.js
+++ b/imports/plugins/included/taxes-taxcloud/register.js
@@ -12,9 +12,6 @@ Reaction.registerPackage({
       apiKey: "",
       refreshPeriod: "every 7 days",
       taxCodeUrl: "https://taxcloud.net/tic/?format=json"
-    },
-    taxCodes: {
-      getTaxCodeMethod: "taxcloud/getTaxCodes"
     }
   },
   registry: [

--- a/imports/plugins/included/taxes-taxcloud/register.js
+++ b/imports/plugins/included/taxes-taxcloud/register.js
@@ -20,11 +20,6 @@ Reaction.registerPackage({
       name: "taxes/settings/taxcloud",
       provides: "taxSettings",
       template: "taxCloudSettings"
-    },
-    {
-      label: "TaxCloud Tax Codes",
-      provides: "taxCodes",
-      name: "taxes/taxcodes/taxcloud"
     }
   ]
 });

--- a/imports/plugins/included/taxes-taxcloud/server/index.js
+++ b/imports/plugins/included/taxes-taxcloud/server/index.js
@@ -4,5 +4,5 @@ import "./i18n";
 // TODO decide if we want to use tax codes
 // these imports was start a job to import TaxCloud taxCodes
 
-// import "./methods";
+import "./methods";
 // import "./jobs";

--- a/imports/plugins/included/taxes-taxcloud/server/methods/index.js
+++ b/imports/plugins/included/taxes-taxcloud/server/methods/index.js
@@ -1,0 +1,1 @@
+import "./methods";

--- a/imports/plugins/included/taxes-taxcloud/server/methods/methods.js
+++ b/imports/plugins/included/taxes-taxcloud/server/methods/methods.js
@@ -1,58 +1,26 @@
 import { Meteor } from "meteor/meteor";
-import { Match, check } from "meteor/check";
 import { HTTP } from "meteor/http";
-import { EJSON } from "meteor/ejson";
-import { Logger } from "/server/api";
-import Reaction from "../../core/taxes/server/api";
-
 
 Meteor.methods({
   /**
-   * taxes/fetchTIC
-   * Tax Code fixture data.
    * We're using https://taxcloud.net
    * just to get an intial import data set
    * this service doesn't require taxcloud id
    * but other services need authorization
    * use TAXCODE_SRC  to override source url
-   * @param  {String} url alternate url to fetch TaxCodes from
-   * @return {undefined}
+   * @returns {Array} An array of Tax code objects
    */
-  "taxcloud/getTaxCodes": function (url) {
-    check(url, Match.Optional(String));
-    // check(url, Match.Optional(SimpleSchema.RegEx.Url));
-
-    // pretty info
-    if (url) {
-      Logger.debug("Fetching TaxCodes from source: ", url);
-    }
-    // allow for custom taxCodes from alternate sources
-    const TAXCODE_SRC = url || "https://taxcloud.net/tic/?format=json";
+  "taxcloud/getTaxCodes": function () {
+    const taxCodeArray = [];
+    const TAXCODE_SRC = "https://taxcloud.net/tic/?format=json";
     const taxCodes = HTTP.get(TAXCODE_SRC);
 
-    if (taxCodes.data && Reaction.Import.taxCode) {
-      for (json of taxCodes.data.tic_list) {
-        // transform children and flatten
-        // first level of tax children
-        // TODO: is there a need to go further
-        if (json.tic.children) {
-          const children = json.tic.children;
-          delete json.tic.children; // remove child levels for now
-          // process chilren
-          for (json of children) {
-            delete json.tic.children; // remove child levels for now
-            const taxCode = EJSON.stringify([json.tic]);
-            Reaction.Import.process(taxCode, ["id", "label"], Reaction.Import.taxCode);
-          }
-        }
-        // parent code process
-        const taxCode = EJSON.stringify([json.tic]);
-        Reaction.Import.process(taxCode, ["id", "label"], Reaction.Import.taxCode);
-      }
-      // commit tax records
-      Reaction.Import.flush();
-    } else {
-      throw new Meteor.error("unable to load taxcodes.");
+    if (taxCodes) {
+      taxCodes.data.tic_list.forEach(function (code) {
+        taxCodeArray.push(code.tic);
+      });
+      return taxCodeArray;
     }
+    throw new Meteor.Error("Error getting tax codes");
   }
 });

--- a/imports/plugins/included/taxes-taxcloud/server/methods/methods.js
+++ b/imports/plugins/included/taxes-taxcloud/server/methods/methods.js
@@ -17,6 +17,11 @@ Meteor.methods({
 
     if (taxCodes) {
       taxCodes.data.tic_list.forEach(function (code) {
+        if (code.tic.children) {
+          code.tic.children.forEach(function (child) {
+            taxCodeArray.push(child.tic);
+          });
+        }
         taxCodeArray.push(code.tic);
       });
       return taxCodeArray;

--- a/lib/collections/schemas/logs.js
+++ b/lib/collections/schemas/logs.js
@@ -13,6 +13,15 @@ export const Logs = new SimpleSchema({
     defaultValue: "info",
     allowedValues: ["trace", "debug", "info", "warn", "error", "fatal"]
   },
+  source: {
+    type: String,
+    defaultValue: "server",
+    allowedValues: ["client", "server"],
+  },
+  handled: {
+    type: Boolean,
+    defaultValue: false
+  },
   data: {
     type: Object,
     blackbox: true

--- a/lib/collections/schemas/products.js
+++ b/lib/collections/schemas/products.js
@@ -268,7 +268,7 @@ export const ProductVariant = new SimpleSchema({
   taxCode: {
     label: "Tax Code",
     type: String,
-    defaultValue: "00000",
+    defaultValue: "0000",
     optional: true
   },
   taxDescription: {


### PR DESCRIPTION
Resolves #1955 

Log errors to `Logs` collection instead of throwing `Meteor.Error`
