### PR TITLE
Fix Top-Level Tags Menu Side-Bar Glitch

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/tagNav.less
+++ b/imports/plugins/included/default-theme/client/styles/tagNav.less
@@ -336,6 +336,12 @@
   background-color: @white;
 }
 
+@media screen and (max-width: @screen-sm-max) {
+  .navbar-item.selected .dropdown-container {
+    float: none;
+  }
+}
+
 .rui.tagnav.vertical .navbar-item.selected .dropdown-container,
 .rui.tagnav.vertical .navbar-item .dropdown-container {
   // display: block !important;


### PR DESCRIPTION
Resolves #1906.

**How to test:**
- Create multiple tags with children tags. (two or three of such is fine to test with)
- Change to mobile view, click icon to bring out menu bar and confirm that you can click on child tags within it's parent for all the tags with children.
- Switch back to desktop view, and confirm that the tags still behaves the way they do before.