### PR TITLE
Fix issue with i18n helper

### DIFF
--- a/client/modules/i18n/helpers.js
+++ b/client/modules/i18n/helpers.js
@@ -24,10 +24,8 @@ Template.registerHelper("i18n", function (i18nKey, i18nMessage) {
 
   i18nextDep.depend();
 
-  const message = new Spacebars.SafeString(i18nMessage);
-
   // returning translated key
-  return i18next.t(i18nKey, { defaultValue: message });
+  return i18next.t(i18nKey, { defaultValue: i18nMessage });
 });
 
 /**


### PR DESCRIPTION
Resolves #1811 

Removed Spacebars sanitization helper for default i18n message.
Sanitization helper returns an object, and in some cases when used with
subexpressions with autoforms, causes an error which prevents template
from rendering.

```
const message = new Spacebars.SafeString(i18nMessage); 
// console.log(message) yields  _.SafeString {string: "Label"}

return i18next.t(i18nKey, { defaultValue: message });
```

Which is fine for most uses of this template helper in Blaze, but doesn't like being used in handlebars/spacebars subexpression in relation to autoforms.
