### PR TITLE
Remove code which uses no longer defined event

### DIFF
--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
@@ -11,7 +11,7 @@ import Sortable from "sortablejs";
  */
 
 Template.productGrid.onCreated(function () {
-  let selectedProducts = Reaction.getUserPreferences("reaction-product-variant", "selectedGridItems");
+  const selectedProducts = Reaction.getUserPreferences("reaction-product-variant", "selectedGridItems");
 
   if (_.isEmpty(selectedProducts)) {
     Reaction.hideActionView();

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.js
@@ -16,12 +16,6 @@ Template.productGrid.onCreated(function () {
   if (_.isEmpty(selectedProducts)) {
     Reaction.hideActionView();
   } else {
-    if (event.target.checked) {
-      selectedProducts.push(event.target.value);
-    } else {
-      selectedProducts = _.without(selectedProducts, event.target.value);
-    }
-
     // Save the selected items to the Session
     Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
 


### PR DESCRIPTION
Fixes #1845 

Remove an old reference to an event which is never used anymore, and breaks firefox