### PR TITLE
Tax code field styling in PDP 

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/products/variantForm.less
+++ b/imports/plugins/included/default-theme/client/styles/products/variantForm.less
@@ -29,3 +29,17 @@
 .select2-container {
   width: 370px;
 }
+.select2-container--default .select2-selection--single {
+  border-radius: 2px;
+  border: 1px solid #cccccc;
+  box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.select2-container .select2-selection--single {
+  height: 34px;
+}
+#select2-taxCode-container {
+font-size: 14px;
+line-height:30px;
+color: #555555;
+letter-spacing: 0.5px;
+}

--- a/imports/plugins/included/default-theme/client/styles/products/variantForm.less
+++ b/imports/plugins/included/default-theme/client/styles/products/variantForm.less
@@ -30,16 +30,24 @@
   width: 370px;
 }
 .select2-container--default .select2-selection--single {
-  border-radius: 2px;
+  border-radius: 4px;
   border: 1px solid #cccccc;
   box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
 .select2-container .select2-selection--single {
+  height: 36px;
+}
+.select2-container--default .select2-selection--single .select2-selection__arrow {
   height: 34px;
+  b {
+    border-color:#999999 transparent transparent;
+    border-width: 5px 5px 2.5px;
+    margin-left: -9px;
+  }
 }
 #select2-taxCode-container {
 font-size: 14px;
-line-height:30px;
+line-height:34px;
 color: #555555;
 letter-spacing: 0.5px;
 }


### PR DESCRIPTION
Fixes #1988 

Copied over CSS attributes for the other fields into the tax codes field for consistency purposes.

### How to test
1. Enable tax provider that supplies tax codes (Avalara or TaxCloud)
2. Head over to PDP
3. Observe that the fields are consistently styled

