### PR TITLE
Don't reload when the main product is not in the modified products

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/containers/publishContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/publishContainer.js
@@ -28,7 +28,7 @@ class ProductPublishContainer extends Component {
     if (result && result.status === "success" && this.props.product) {
       const productDocument = result.previousDocuments.find((product) => this.props.product._id === product._id);
 
-      if (this.props.product.handle !== productDocument.handle) {
+      if (productDocument && this.props.product.handle !== productDocument.handle) {
         const newProductPath = Router.pathFor("product", {
           hash: {
             handle: this.props.product.handle


### PR DESCRIPTION
Resolves issue #2004 

Here `productDocument` would be `undefined` when the modified documents did not include the top level product (like happens when you reorder variants). But when we have only modified child products we also do not need to refresh so we can just bail when `productDocument` is `undefined`

### To Test

Follow the instructions for replicating #2004 and ensure that the error no longer appears.
