### PR TITLE
[WIP] Broken Formatting for Non-USD currencies

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/summary.html
+++ b/imports/plugins/core/orders/client/templates/list/summary.html
@@ -20,7 +20,7 @@
                   <div class="col-xs-7 text-right">
                     <span data-i18n='cartSubTotals.shipping'>Shipping</span>
                   </div>
-                  <div class="col-xs-4 col-xs-offset-1">
+                  <div class="col-xs-4 col-xs-offset-1" style="white-space: nowrap">
                     {{formatPrice shipping}}
                   </div>
                 </div>
@@ -31,7 +31,7 @@
                   <div class="col-xs-7 text-right">
                     <span data-i18n='cartSubTotals.tax'>Tax</span>
                   </div>
-                  <div class="col-xs-4 col-xs-offset-1">
+                  <div class="col-xs-4 col-xs-offset-1" style="white-space: nowrap">
                     {{formatPrice taxes}}
                   </div>
                 </div>
@@ -42,7 +42,7 @@
                   <div class="col-xs-7 text-right">
                     <span data-i18n='cartSubTotals.discount'>Discount</span>
                   </div>
-                  <div class="col-xs-4 col-xs-offset-1">
+                  <div class="col-xs-4 col-xs-offset-1" style="white-space: nowrap">
                     {{formatPrice discounts}}
                   </div>
                 </div>

--- a/imports/plugins/core/orders/client/templates/list/summary.html
+++ b/imports/plugins/core/orders/client/templates/list/summary.html
@@ -10,7 +10,7 @@
                   <div class="col-xs-7 text-right">
                     <span data-i18n='cartSubTotals.subtotal'>Sub total</span>
                   </div>
-                  <div class="col-xs-4 col-xs-offset-1">
+                  <div class="col-xs-4 col-xs-offset-1" style="white-space: nowrap">
                     {{formatPrice subtotal}}
                   </div>
                 </div>
@@ -52,7 +52,7 @@
                   <div class="col-xs-7 text-right">
                     <span data-i18n='cartSubTotals.total'>Total</span>
                   </div>
-                  <div class="col-xs-4 col-xs-offset-1">
+                  <div class="col-xs-4 col-xs-offset-1" style="white-space: nowrap">
                     {{formatPrice total}}
                   </div>
                 </div>


### PR DESCRIPTION
Resolves [1960](https://github.com/reactioncommerce/reaction/issues/1960)

**Test**
- Clone this branch and run the application
- Change your currency to a non-USD currency
- Add a product to your cart and checkout
- Notice that `Sub Total` and `Total` values are on the same line with the currency

