### PR TITLE
Fix issue #2026 changed price not displayed for prod on grid page

### DIFF
--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -154,6 +154,14 @@ export const ProductRevision = {
       }
     });
     return variants;
+  },
+  getVariantQuantity(variant) {
+    const options = this.getVariants(variant._id);
+    if (options && options.length) {
+      return options.reduce((sum, option) =>
+      sum + option.inventoryQuantity || 0, 0);
+    }
+    return variant.inventoryQuantity || 0;
   }
 };
 

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -18,7 +18,7 @@ function convertMetadata(modifierObject) {
   return metadata;
 }
 
-const ProductRevision = {
+export const ProductRevision = {
   getProductPriceRange(productId) {
     const product = Products.findOne(productId);
     if (!product) {

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -2,7 +2,8 @@ import _ from  "lodash";
 import { EJSON } from "meteor/ejson";
 import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
-import { Catalog, copyFile, ReactionProduct } from "/lib/api";
+import { copyFile, ReactionProduct } from "/lib/api";
+import { ProductRevision as Catalog } from "/imports/plugins/core/revisions/server/hooks";
 import { Media, Products, Revisions, Tags } from "/lib/collections";
 import { Logger, Reaction } from "/server/api";
 


### PR DESCRIPTION
- [ ] Clearly explain what your PR is trying to accomplish. A link to an issue is best
To fix issue #2026 
This is happening because Product Revision is not available on server. This API is supposed to work on client where expected Revision is embeded in Published data.
https://github.com/reactioncommerce/reaction/blob/development/server/methods/catalog.js#L185
https://github.com/reactioncommerce/reaction/blob/development/server/methods/catalog.js#L187
https://github.com/reactioncommerce/reaction/blob/development/server/methods/catalog.js#L207

What we are doing in here:
https://github.com/reactioncommerce/reaction/blob/development/imports/plugins/core/revisions/server/hooks.js#L21
needs to be done in denormalize() method.
- [ ] Provide us detailed instructions on how we can test your PR
   1.  Can  change the price of  any variant loaded by default. Go to index page, it should show the updated one.
   2.  If wanna try new product then make sure to create, make it visible, publish and then update  `isVisible=true` for variant in db. (because of issue #2059)
