### PR TITLE
Don't subscribe to all media

### DIFF
--- a/server/publications/collections/media.js
+++ b/server/publications/collections/media.js
@@ -72,9 +72,7 @@ Meteor.publish("Media", function (shops) {
     });
   }
 
-  return Media.find(selector, {
-    sort: {
-      "metadata.priority": 1
-    }
+  return Media.find({
+    "metadata.type": "brandAsset"
   });
 });

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -1,4 +1,4 @@
-import { Products, Revisions } from "/lib/collections";
+import { Media, Products, Revisions } from "/lib/collections";
 import { Logger, Reaction } from "/server/api";
 import { RevisionApi } from "/imports/plugins/core/revisions/lib/api/revisions";
 
@@ -156,7 +156,17 @@ Meteor.publish("Product", function (productId) {
         handle2.stop();
       });
 
-      return this.ready();
+      const mediaCursor = Media.find({
+        "metadata.productId": _id
+      }, {
+        sort: {
+          "metadata.priority": 1
+        }
+      });
+
+      return [
+        mediaCursor
+      ];
     }
 
     // Revision control is disabled
@@ -164,5 +174,18 @@ Meteor.publish("Product", function (productId) {
   }
 
   // Everyone else gets the standard, visibile products and variants
-  return Products.find(selector);
+  const productCursor = Products.find(selector);
+
+  const mediaCursor = Media.find({
+    "metadata.productId": _id
+  }, {
+    sort: {
+      "metadata.priority": 1
+    }
+  });
+
+  return [
+    productCursor,
+    mediaCursor
+  ];
 });

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -22,16 +22,14 @@ export function findProductMedia(publicationInstance, productIds) {
     selector["metadata.shopId"] = shopId;
   }
 
+  // No one needs to see archived images on products
+  selector["metadata.workflow"] = {
+    $nin: ["archived"]
+  };
+
   // Product editors can see both published and unpublished images
   if (!Reaction.hasPermission(["createProduct"], publicationInstance.userId)) {
-    selector["metadata.workflow"] = {
-      $in: [null, "published"]
-    };
-  } else {
-    // but no one gets to see archived images
-    selector["metadata.workflow"] = {
-      $nin: ["archived"]
-    };
+    selector["metadata.workflow"].$in = [null, "published"];
   }
 
   return Media.find(selector, {

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -1,6 +1,7 @@
-import { Media, Products, Revisions } from "/lib/collections";
+import { Products, Revisions } from "/lib/collections";
 import { Reaction, Logger } from "/server/api";
 import { RevisionApi } from "/imports/plugins/core/revisions/lib/api/revisions";
+import { findProductMedia } from "./product";
 
 //
 // define search filters as a schema so we can validate
@@ -273,7 +274,8 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
       }
 
       if (RevisionApi.isRevisionControlEnabled()) {
-        const handle = Products.find(newSelector).observeChanges({
+        const productCursor = Products.find(newSelector);
+        const handle = productCursor.observeChanges({
           added: (id, fields) => {
             const revisions = Revisions.find({
               "$or": [
@@ -366,23 +368,20 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
           handle2.stop();
         });
 
-        return this.ready();
+        const mediaProductIds = productCursor.fetch().map((p) => p._id);
+        const mediaCursor = findProductMedia(this, mediaProductIds);
+
+        return [
+          mediaCursor
+        ];
       }
-      // Revision control is disabled
+      // Revision control is disabled, but is admin
       const productCursor = Products.find(newSelector, {
         sort: sort,
         limit: productScrollLimit
       });
-
-      const mediaCursor = Media.find({
-        "metadata.productId": {
-          $in: productCursor.fetch().map((p) => p._id)
-        }
-      }, {
-        sort: {
-          "metadata.priority": 1
-        }
-      });
+      const mediaProductIds = productCursor.fetch().map((p) => p._id);
+      const mediaCursor = findProductMedia(this, mediaProductIds);
 
       return [
         productCursor,
@@ -428,15 +427,8 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
       ]
     });
 
-    const mediaCursor = Media.find({
-      "metadata.productId": {
-        $in: productCursor.fetch().map((p) => p._id)
-      }
-    }, {
-      sort: {
-        "metadata.priority": 1
-      }
-    });
+    const mediaProductIds = productCursor.fetch().map((p) => p._id);
+    const mediaCursor = findProductMedia(this, mediaProductIds);
 
     return [
       productCursor,


### PR DESCRIPTION
Fixes #1815 

- Publish brand assets globally in media publication
- Publish product media in the `Products` and `Product` publications
- Limit media to only published products

After much back and forth with another branch, this is the solution I came up with. Simple yea?

Let’s call this a first step towards media performance. Everything else like CDN / S3 will be next.