### PR TITLE
Add `requirements` subsection and `my-reaction-app` param for quick test

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install -g reaction-cli
 
 For more information on installation check out the [installation](https://docs.reactioncommerce.com/reaction-docs/development/installation) doc.
 
-### reaction-cli usage
+### reaction-cli init usage
 
 Into your workspace:
 
@@ -47,6 +47,8 @@ reaction init my-reaction-app
 cd my-reaction-app
 reaction
 ```
+
+Go on the url provided and log you with your login/password information also provided.
 
 For more information on configuration check out the [configuration](https://docs.reactioncommerce.com/reaction-docs/development/configuration) doc.
 

--- a/README.md
+++ b/README.md
@@ -21,25 +21,32 @@ Reaction’s out-of-the-box core features include:
 
 And, since anything in our codebase can be extended, overwritten, or installed as a package, you may also develop, scale, and customize anything on our platform.
 
-## Installation
+## Get Started
 
-**_requirements_**
+### reaction-cli requirements ###
 
 - Node.js (v4 or higher)
 - Meteor
 
-For more information on requirements check out the [requirements](https://docs.reactioncommerce.com/reaction-docs/master/requirements).
+For more information on requirements check out the [requirements](https://docs.reactioncommerce.com/reaction-docs/master/requirements) docs.
 
-**_reaction-cli installation_**
+### reaction-cli installation ###
 
 ```bash
 npm install -g reaction-cli
+```
+
+For more information on requirements check out the [installation](https://docs.reactioncommerce.com/reaction-docs/development/installation) docs.
+
+### reaction-cli usage ###
+
+Into your workspace
+
+```bash
 reaction init my-reaction-app
 cd my-reaction-app
 reaction
 ```
-
-For more information on setup and configuration, check out the [installation](https://docs.reactioncommerce.com/reaction-docs/development/installation) and [configuration](https://docs.reactioncommerce.com/reaction-docs/development/configuration) docs.
 
 ## Participation
 

--- a/README.md
+++ b/README.md
@@ -23,30 +23,32 @@ And, since anything in our codebase can be extended, overwritten, or installed a
 
 ## Get Started
 
-### reaction-cli requirements ###
+### reaction-cli requirements
 
 - Node.js (v4 or higher)
 - Meteor
 
-For more information on requirements check out the [requirements](https://docs.reactioncommerce.com/reaction-docs/master/requirements) docs.
+For more information on requirements check out the [requirements](https://docs.reactioncommerce.com/reaction-docs/master/requirements) doc.
 
-### reaction-cli installation ###
+### reaction-cli installation
 
 ```bash
 npm install -g reaction-cli
 ```
 
-For more information on requirements check out the [installation](https://docs.reactioncommerce.com/reaction-docs/development/installation) docs.
+For more information on requirements check out the [installation](https://docs.reactioncommerce.com/reaction-docs/development/installation) doc.
 
-### reaction-cli usage ###
+### reaction-cli usage
 
-Into your workspace
+Into your workspace:
 
 ```bash
 reaction init my-reaction-app
 cd my-reaction-app
 reaction
 ```
+
+For more information on requirements check out the [configuration](https://docs.reactioncommerce.com/reaction-docs/development/configuration) doc.
 
 ## Participation
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For more information on requirements check out the [requirements](https://docs.r
 npm install -g reaction-cli
 ```
 
-For more information on requirements check out the [installation](https://docs.reactioncommerce.com/reaction-docs/development/installation) doc.
+For more information on installation check out the [installation](https://docs.reactioncommerce.com/reaction-docs/development/installation) doc.
 
 ### reaction-cli usage
 
@@ -48,7 +48,7 @@ cd my-reaction-app
 reaction
 ```
 
-For more information on requirements check out the [configuration](https://docs.reactioncommerce.com/reaction-docs/development/configuration) doc.
+For more information on configuration check out the [configuration](https://docs.reactioncommerce.com/reaction-docs/development/configuration) doc.
 
 ## Participation
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,19 @@ And, since anything in our codebase can be extended, overwritten, or installed a
 
 ## Installation
 
+**_requirements_**
+
+- Node.js (v4 or higher)
+- Meteor
+
+For more information on requirements check out the [requirements](https://docs.reactioncommerce.com/reaction-docs/master/requirements).
+
 **_reaction-cli installation_**
 
 ```bash
 npm install -g reaction-cli
-reaction init
-cd reaction
+reaction init my-reaction-app
+cd my-reaction-app
 reaction
 ```
 


### PR DESCRIPTION
## What is the problem this PR should resolved

**Trying to quickly test the solution to see if it fit it my needs I follows this steps**

**Step**

```bash
git clone https://github.com/reactioncommerce/reaction.git
cd reaction
npm install -g reaction-cli
reaction init
```

produce

```bash
Directory 'reaction' already exists.
Use 'reaction init somename' to install in a different directory.
```

**Screen**

![Example](https://files.gitter.im/reactioncommerce/reaction/Yd6F/blob)

**Config**

Windows : 10
Node.js : 3.10.9
Meteor : 1.4.3.2
NPM : 3.10.9

**And I think that**

There is no way for Windows OS to knows the difference between a `reaction` directory or a `reaction` file. So use the command `reaction init` will always result on error saying `reaction directory already exist`. So if you're smarter you will find the CLI documentation and add a param after `init` command BUT in my case, Meteor was not mentioned as a dependency and my message was `you have not Meteor`. After installing Meteor, when I have use another time `reaction init` command I get `reaction directory already exist` and I have thinking « Ok, first time all was installed, and it's just because Meteor was not installed ». After that I have been a lot of dependencies problems, etc. I have past 2 hours just for `test` application and I use Node.js ecosystem really often so I imagine a beginner want just try « out-of-the-box ».

## Why this modifications

So just run your project on Windows system without understand `git clone` is not useful, and you will always have `reaction directory already exist` message when you will use `reaction init`.

In order to avoid this problem for futur beginners I propose:

- first: propose to install node.js and meteor before starting.
- second: place installation command in dedicated subsection to understand this command not require any `git clone` usage and is self-suffisant.
- three: encourage usage of this command with a param. It's why in the README.md now I say `reaction init my-reaction-app`
