### PR TITLE
2067 Improper Product Title Wrap

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/products/productGrid.less
+++ b/imports/plugins/included/default-theme/client/styles/products/productGrid.less
@@ -33,6 +33,7 @@
   font-size: @font-size-base;
   font-weight: 400;
   text-align: center;
+  word-break: break-word;
 }
 
 

--- a/imports/plugins/included/default-theme/client/styles/products/productGrid.less
+++ b/imports/plugins/included/default-theme/client/styles/products/productGrid.less
@@ -34,6 +34,7 @@
   font-weight: 400;
   text-align: center;
   word-break: break-word;
+  word-break: initial;
 }
 
 


### PR DESCRIPTION
Resolves [2067](https://github.com/reactioncommerce/reaction/issues/2067)

**Steps to Test**

- Create a product with a longer title e.g. "Van's Authentic Black Canvas Women's Trainers"
- Adjust browser width so that title needs to wrap
- Observe that the title does not break mid-word

**Screenshot**
<img width="382" alt="screen shot 2017-04-11 at 6 22 15 pm" src="https://cloud.githubusercontent.com/assets/10584060/24922042/ce8346e4-1ee4-11e7-972f-d937257628e1.png">


