### PR TITLE
Fixes #2116 failure to send email

### DIFF
--- a/server/api/core/email/config.js
+++ b/server/api/core/email/config.js
@@ -88,7 +88,7 @@ export function getMailConfig() {
       host: parsedUrl.hostname,
       port: parsedUrl.port,
       // since the port is casted to number above
-      secure: parsedUrl.port === 465 || parsedUrl.port === 587,
+      secure: parsedUrl.port === 465,
       auth: {
         user: creds[0],
         pass: creds[1]
@@ -135,7 +135,7 @@ export function getMailConfig() {
     return {
       host,
       port,
-      secure: port === 465 || port === 587,
+      secure: port === 465,
       auth: { user, pass: password },
       logger: process.env.EMAIL_DEBUG === "true"
     };

--- a/server/methods/email.js
+++ b/server/methods/email.js
@@ -39,7 +39,7 @@ Meteor.methods({
     const { Email } = Reaction;
 
     try {
-      return Meteor.wrapAsync(Email.verifyConfig(config || Email.getMailConfig()));
+      return Meteor.wrapAsync(Email.verifyConfig)(config || Email.getMailConfig());
     } catch (e) {
       Logger.error(e);
       throw new Meteor.Error(e.responseCode, e.response);

--- a/server/methods/email.js
+++ b/server/methods/email.js
@@ -39,7 +39,7 @@ Meteor.methods({
     const { Email } = Reaction;
 
     try {
-      return Meteor.wrapAsync(Email.verifyConfig)(config || Email.getMailConfig());
+      return Meteor.wrapAsync(Email.verifyConfig(config || Email.getMailConfig()));
     } catch (e) {
       Logger.error(e);
       throw new Meteor.Error(e.responseCode, e.response);


### PR DESCRIPTION
Fixes #2116 

We were setting `secureConnection: true` for port 587 for nodemailer.
Port 587 connects via plaintext first and then upgrades the connection via STARTTLS. Because of this secure connection should be set to false for port 587

https://nodemailer.com/smtp/#tls-options