### PR TITLE
Don't break out orders with quantities

### DIFF
--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -42,7 +42,7 @@ class LineItems extends Component {
           </div>
 
           <div className="order-detail-quantity">
-           {quantity}
+           {quantity || uniqueItem.quantity}
           </div>
 
           <div className="order-detail-price">
@@ -56,7 +56,7 @@ class LineItems extends Component {
     );
   }
 
-  renderLineItemInvoice(uniqueItem, shippingRate, quantity) {
+  renderLineItemInvoice(uniqueItem) {
     return (
       <div>
         <div className="order-summary-form-group">
@@ -69,14 +69,14 @@ class LineItems extends Component {
         <div className="order-summary-form-group">
           <strong><Translation defaultValue="Shipping" i18nKey="cartSubTotals.shipping"/></strong>
           <div className="invoice-details">
-            {formatPriceString(shippingRate)}
+            {formatPriceString(uniqueItem.shipping.rate)}
           </div>
         </div>
 
         <div className="order-summary-form-group">
           <strong>Item tax</strong>
           <div className="invoice-details">
-            {uniqueItem.taxDetail ? formatPriceString(uniqueItem.taxDetail.tax / quantity) : formatPriceString(0)}
+            {uniqueItem.taxDetail ? formatPriceString(uniqueItem.taxDetail.tax / uniqueItem.quantity) : formatPriceString(0)}
           </div>
         </div>
 
@@ -92,10 +92,10 @@ class LineItems extends Component {
           <div className="invoice-details">
             {uniqueItem.taxDetail ?
               <strong>
-                {this.calculateTotal(uniqueItem.variants.price, shippingRate, uniqueItem.taxDetail.tax)}
+                {this.calculateTotal(uniqueItem.variants.price, uniqueItem.shipping.rate, uniqueItem.taxDetail.tax)}
               </strong> :
                <strong>
-                {this.calculateTotal(uniqueItem.variants.price, shippingRate, 0)}
+                {this.calculateTotal(uniqueItem.variants.price, uniqueItem.shipping.rate, 0)}
               </strong>
             }
           </div>
@@ -112,7 +112,7 @@ class LineItems extends Component {
         {uniqueItems.map((uniqueItem) => {
           if (!isExpanded(uniqueItem._id)) {
             return (
-              <div key={uniqueItem._id}> { this.renderLineItem(uniqueItem.items[0], uniqueItem.items[0].quantity) } </div>
+              <div key={uniqueItem._id}> { this.renderLineItem(uniqueItem) } </div>
             );
           }
 
@@ -130,12 +130,12 @@ class LineItems extends Component {
 
                 <br/><br/>
 
-                {uniqueItem.items.map((item) => (
-                  <div key={item._id}>
-                    { this.renderLineItem(item) }
-                    { this.renderLineItemInvoice(item, uniqueItem.shippingRate, uniqueItem.items.length) }
+                {[...Array(uniqueItem.quantity)].map((v, i) =>
+                  <div key={i}>
+                    { this.renderLineItem(uniqueItem, 1) }
+                    { this.renderLineItemInvoice(uniqueItem) }
                   </div>
-                ))}
+                )}
 
               </div>
           </div>

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -42,7 +42,7 @@ class LineItems extends Component {
           </div>
 
           <div className="order-detail-quantity">
-            {quantity || 1}
+           {quantity}
           </div>
 
           <div className="order-detail-price">
@@ -107,13 +107,12 @@ class LineItems extends Component {
 
   render() {
     const { uniqueItems, isExpanded, onClose } = this.props;
-
     return (
       <div>
         {uniqueItems.map((uniqueItem) => {
-          if (!isExpanded(uniqueItem.cartItemId)) {
+          if (!isExpanded(uniqueItem._id)) {
             return (
-              <div key={uniqueItem.cartItemId}> { this.renderLineItem(uniqueItem.items[0], uniqueItem.items.length) } </div>
+              <div key={uniqueItem._id}> { this.renderLineItem(uniqueItem.items[0], uniqueItem.items[0].quantity) } </div>
             );
           }
 

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -22,7 +22,7 @@ class LineItems extends Component {
       <div className="order-items">
         <div
           className="invoice order-item form-group order-summary-form-group"
-          onClick={() => handleClick(uniqueItem.cartItemId)}
+          onClick={() => handleClick(uniqueItem._id)}
           style={{ height: 70 }}
         >
 
@@ -117,11 +117,11 @@ class LineItems extends Component {
           }
 
           return (
-            <div className="roll-up-invoice-list" key={uniqueItem.cartItemId}>
+            <div className="roll-up-invoice-list" key={uniqueItem._id}>
               <div className="roll-up-content">
 
                 <div style={{ float: "right" }}>
-                  <button className="rui btn btn-default flat icon-only" onClick={() => onClose(uniqueItem.cartItemId)}>
+                  <button className="rui btn btn-default flat icon-only" onClick={() => onClose(uniqueItem._id)}>
                     <i
                       className="rui font-icon fa-lg fa fa-times"
                     />

--- a/imports/plugins/core/orders/client/containers/lineItemsContainer.js
+++ b/imports/plugins/core/orders/client/containers/lineItemsContainer.js
@@ -90,7 +90,6 @@ class LineItemsContainer extends Component {
 }
 
 const composer = (props, onData) => {
-  console.log("props", props.items);
   const subscription = Meteor.subscribe("Media");
   if (subscription.ready()) {
     onData(null, {

--- a/imports/plugins/core/orders/client/containers/lineItemsContainer.js
+++ b/imports/plugins/core/orders/client/containers/lineItemsContainer.js
@@ -73,7 +73,6 @@ class LineItemsContainer extends Component {
 
   render() {
     const { invoice, uniqueItems } = this.props;
-
     return (
       <TranslationProvider>
         <LineItems

--- a/imports/plugins/core/orders/client/containers/lineItemsContainer.js
+++ b/imports/plugins/core/orders/client/containers/lineItemsContainer.js
@@ -90,6 +90,7 @@ class LineItemsContainer extends Component {
 }
 
 const composer = (props, onData) => {
+  console.log("props", props.items);
   const subscription = Meteor.subscribe("Media");
   if (subscription.ready()) {
     onData(null, {

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -515,7 +515,7 @@ Template.coreOrderShippingInvoice.helpers({
         });
       } else {
         cart = {
-          cartItemId: item._id,
+          _id: item._id,
           productId: item.productId,
           shippingRate: shipment.shipmentMethod.rate,
           items: [item]

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -309,16 +309,13 @@ Template.coreOrderShippingInvoice.helpers({
   refundAmount() {
     return Template.instance().refundAmount;
   },
-  /**
-   * Discount
-   * @return {Number} current discount amount
-   */
+
   invoice() {
     const instance = Template.instance();
     const order = instance.state.get("order");
 
     const invoice = Object.assign({}, order.billing[0].invoice, {
-      totalItems: order.items.length
+      totalItems: _.sumBy(order.items, function(o) { return o.quantity; })
     });
     return invoice;
   },

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -476,12 +476,10 @@ Template.coreOrderShippingInvoice.helpers({
     const currentData = Template.currentData();
     const shipment = currentData.fulfillment;
 
-    // returns array of individual items that have been checked out
-    const returnItems = _.map(shipment.items, (item) => {
-      const originalItem = _.find(order.items, {
-        _id: item._id
-      });
-      return _.extend(originalItem, item);
+    // returns order items with shipping detail
+    const returnItems = _.map(order.items, (item) => {
+      const shipping = shipment.shipmentMethod;
+      return _.extend(item, { shipping });
     });
 
     let items;
@@ -499,36 +497,6 @@ Template.coreOrderShippingInvoice.helpers({
     } else {
       items = returnItems;
     }
-
-    /**
-     * It goes through individual items and groups similar items using the cartItemId.
-     * The output is an object whose keys are cartItemId and every item with the same
-     * cartItemId is added as a value
-     */
-    let uniqueItems = items.reduce((carts, item) => {
-      let cart;
-
-      if (carts[item._id]) {
-        cart = carts[item._id];
-        cart = Object.assign({}, cart, {
-          items: [...cart.items, item]
-        });
-      } else {
-        cart = {
-          _id: item._id,
-          productId: item.productId,
-          shippingRate: shipment.shipmentMethod.rate,
-          items: [item]
-        };
-      }
-
-      carts[item._id] = cart;
-      return carts;
-    }, {});
-
-    // Converts the uniqueItems object to an array
-    uniqueItems = Object.keys(uniqueItems).map(k => uniqueItems[k]);
-
-    return uniqueItems;
+    return items;
   }
 });

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -315,7 +315,7 @@ Template.coreOrderShippingInvoice.helpers({
     const order = instance.state.get("order");
 
     const invoice = Object.assign({}, order.billing[0].invoice, {
-      totalItems: _.sumBy(order.items, function(o) { return o.quantity; })
+      totalItems: _.sumBy(order.items, (o) => o.quantity)
     });
     return invoice;
   },
@@ -492,7 +492,7 @@ Template.coreOrderShippingInvoice.helpers({
 
       items = _.map(returnItems, (item) => {
         const taxDetail = _.find(taxes, {
-          lineNumber: item.cartItemId
+          lineNumber: item._id
         });
         return _.extend(item, { taxDetail });
       });
@@ -508,21 +508,21 @@ Template.coreOrderShippingInvoice.helpers({
     let uniqueItems = items.reduce((carts, item) => {
       let cart;
 
-      if (carts[item.cartItemId]) {
-        cart = carts[item.cartItemId];
+      if (carts[item._id]) {
+        cart = carts[item._id];
         cart = Object.assign({}, cart, {
           items: [...cart.items, item]
         });
       } else {
         cart = {
-          cartItemId: item.cartItemId,
+          cartItemId: item._id,
           productId: item.productId,
           shippingRate: shipment.shipmentMethod.rate,
           items: [item]
         };
       }
 
-      carts[item.cartItemId] = cart;
+      carts[item._id] = cart;
       return carts;
     }, {});
 

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -97,7 +97,7 @@ function markInventoryShipped(doc) {
   const cartItems = [];
   for (const orderItem of orderItems) {
     const cartItem = {
-      _id: orderItem._id,
+      _id: orderItem.cartItemId || orderItem._id,
       shopId: orderItem.shopId,
       quantity: orderItem.quantity,
       productId: orderItem.productId,
@@ -112,9 +112,10 @@ function markInventoryShipped(doc) {
 function markInventorySold(doc) {
   const orderItems = doc.items;
   const cartItems = [];
+  // If a cartItemId exists it's a legacy order and we use that
   for (const orderItem of orderItems) {
     const cartItem = {
-      _id: orderItem._id,
+      _id: orderItem.cartItemId || orderItem._id,
       shopId: orderItem.shopId,
       quantity: orderItem.quantity,
       productId: orderItem.productId,

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -97,7 +97,7 @@ function markInventoryShipped(doc) {
   const cartItems = [];
   for (const orderItem of orderItems) {
     const cartItem = {
-      _id: orderItem.cartItemId,
+      _id: orderItem._id,
       shopId: orderItem.shopId,
       quantity: orderItem.quantity,
       productId: orderItem.productId,

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -114,7 +114,7 @@ function markInventorySold(doc) {
   const cartItems = [];
   for (const orderItem of orderItems) {
     const cartItem = {
-      _id: orderItem.cartItemId,
+      _id: orderItem._id,
       shopId: orderItem.shopId,
       quantity: orderItem.quantity,
       productId: orderItem.productId,

--- a/imports/plugins/included/payments-stripe/server/methods/stripeapi.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripeapi.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: 0 */
+import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
 import { Packages } from "/lib/collections";

--- a/server/methods/core/cart-create.app-test.js
+++ b/server/methods/core/cart-create.app-test.js
@@ -185,7 +185,7 @@ describe("Add/Create cart methods", function () {
       return done();
     });
 
-    it("should throw an error if order creation has failed", function (done) {
+    it("should throw an error if order creation has failed", function () {
       const cart = Factory.create("cartToOrder");
       spyOnMethod("copyCartToOrder", cart.userId);
       // The main moment of test. We are spy on `insert` operation but do not
@@ -196,7 +196,6 @@ describe("Add/Create cart methods", function () {
       }
       expect(copyCartFunc).to.throw(Meteor.Error, /Invalid request/);
       expect(insertStub).to.have.been.called;
-      return done();
     });
 
     it("should create an order", function (done) {

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -515,6 +515,12 @@ Meteor.methods({
     const order = Object.assign({}, cart);
     const sessionId = cart.sessionId;
 
+    if (!order.items || order.items.length === 0) {
+      const msg = "An error occurred saving the order. Missing cart items.";
+      Logger.error(msg);
+      throw new Meteor.Error("no-cart-items", msg);
+    }
+
     Logger.debug("cart/copyCartToOrder", cartId);
     // reassign the id, we'll get a new orderId
     order.cartId = cart._id;

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -590,17 +590,20 @@ Meteor.methods({
       };
     }
 
-    // _.each(order.items, (item) => {
-    //   if (order.shipping[0].items) {
-    //     order.shipping[0].items.push({
-    //       _id: item._id,
-    //       productId: item.productId,
-    //       shopId: item.shopId,
-    //       variantId: item.variants._id
-    //     });
-    //   }
-    // });
+    _.each(order.items, (item) => {
+      if (order.shipping[0].items) {
+        order.shipping[0].items.push({
+          _id: item._id,
+          productId: item.productId,
+          shopId: item.shopId,
+          variantId: item.variants._id
+        });
+      }
+    });
 
+    order.shipping[0].items.packed = false;
+    order.shipping[0].items.shipped = false;
+    order.shipping[0].items.delivered = false;
 
     order.billing[0].currency.exchangeRate = exchangeRate;
     order.workflow.status = "new";


### PR DESCRIPTION
Closes #2102 and resolves blocker with Avalara

Changes the behavior `copyCartToOrder` to not break out lines with quantities into individual lines

### To Test

This change should have no visibility to the user except for seeing new orders not broken out. The most important thing to test is that nothing is broken. With the exception for adding in some conditionals for Inventory hooks I didn't see any compatibility issues with moving forward from old versions.
