### PR TITLE
Don't create default admin user when running in app test mode

### DIFF
--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -30,8 +30,10 @@ export default {
     this.loadPackages();
     // process imports from packages and any hooked imports
     this.Import.flush();
-    // timing is important, packages are rqd for initilial permissions configuration.
-    this.createDefaultAdminUser();
+    // timing is important, packages are rqd for initial permissions configuration.
+    if (!Meteor.isAppTest) {
+      this.createDefaultAdminUser();
+    }
     this.setAppVersion();
     // hook after init finished
     Hooks.Events.run("afterCoreInit");


### PR DESCRIPTION
Apparently you can't run `Accounts.createUser` in test mode.

This feels a little bit terrible except that we probably shouldn't creating any users in startup when testing, and create whatever users you need in your tests.
