### PR TITLE
Docker base v1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM reactioncommerce/base:v1.2.2
+FROM reactioncommerce/base:v1.3.0
 
 # Default environment variables
 ENV ROOT_URL "http://localhost"


### PR DESCRIPTION
Docker base v1.3.0 includes updates to Meteor 1.4.4.1 and Node 4.8.1.  This update is currently needed for the realease-1.1.1 branch to build correctly.

