### PR TITLE
1994 Console Dropzone Warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-dnd": "^2.3.0",
     "react-dnd-html5-backend": "^2.3.0",
     "react-dom": "^15.4.2",
-    "react-dropzone": "^3.12.2",
+    "react-dropzone": "^3.12.3",
     "react-helmet": "^5.0.1",
     "react-komposer": "^2.0.0",
     "react-measure": "^1.4.6",

--- a/server/api/core/email/config.js
+++ b/server/api/core/email/config.js
@@ -88,7 +88,7 @@ export function getMailConfig() {
       host: parsedUrl.hostname,
       port: parsedUrl.port,
       // since the port is casted to number above
-      secure: parsedUrl.port === 465 || parsedUrl.port === 587,
+      secure: parsedUrl.port === 465,
       auth: {
         user: creds[0],
         pass: creds[1]
@@ -135,7 +135,7 @@ export function getMailConfig() {
     return {
       host,
       port,
-      secure: port === 465 || port === 587,
+      secure: port === 465,
       auth: { user, pass: password },
       logger: process.env.EMAIL_DEBUG === "true"
     };


### PR DESCRIPTION
Resolves [1994](https://github.com/reactioncommerce/reaction/issues/1994)

**Testing**
- Pull this branch to your local machine
- Run `npm install` to update `react-dropzone` version
- Note that there are no warnings in the console