### PR TITLE
Fix release 1.1.1 lint error

### DIFF
--- a/imports/plugins/included/payments-stripe/server/methods/stripeapi-methods-charge.app-test.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripeapi-methods-charge.app-test.js
@@ -126,8 +126,6 @@ describe("Stripe.authorize", function () {
       });
       done();
     });
-
-
   });
 });
 


### PR DESCRIPTION
I blame BH not running on non-development branches. Also, society.
