### PR TITLE
Invoice Currency Formatting

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/pdf.html
+++ b/imports/plugins/core/orders/client/templates/list/pdf.html
@@ -101,7 +101,7 @@
         <tr>
           <td>{{quantity}}</td>
           <td>{{variants.title}}</td>
-          <td>{{variants.price}}</td>
+          <td>{{formatPrice variants.price}}</td>
         </tr>
       {{/each}}
     </table>
@@ -111,23 +111,23 @@
       <div class="container">
         <div class="row">
           <div class="col-md-3"><span data-i18n='cartSubTotals.subtotal'>Sub total</span>:</div>
-          <div class="col-md-2 col-md-offset-1">{{subtotal}}</div>
+          <div class="col-md-2 col-md-offset-1">{{formatPrice subtotal}}</div>
         </div>
         <div class="row">
           <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.shipping'>Shipping</span>:</div>
-          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{shipping}}</div>
+          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{formatPrice shipping}}</div>
         </div>
         <div class="row">
           <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.tax'>Tax</span>:</div>
-          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{taxes}}</div>
+          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{formatPrice taxes}}</div>
         </div>
         <div class="row">
           <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.discount'>Discount</span>:</div>
-          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{discounts}}</div>
+          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1">{{formatPrice discounts}}</div>
         </div>
         <div class="row">
           <div class="col-md-3 col-xs-3"><span data-i18n='cartSubTotals.total'>Total</span>:</div>
-          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1"><strong>{{total}}</strong></div>
+          <div class="col-md-2 col-xs-2 col-md-offset-1 col-xs-offset-1"><strong>{{formatPrice total}}</strong></div>
         </div>
       </div>
     {{/with}}


### PR DESCRIPTION
Resolves [2133](https://github.com/reactioncommerce/reaction/issues/2133)

**Testing**
- Place an order
- Go to the Dashboard and select orders
- Select the order and approve it
- Click on "Print"
- Observe totals are formatted as currency.

**Screenshot**
<img width="1167" alt="screen shot 2017-04-21 at 12 22 12 pm" src="https://cloud.githubusercontent.com/assets/10584060/25275601/0cbd39aa-268e-11e7-91a4-0b73bd5d1f0b.png">
