### PR TITLE
2141 Create Product Should Flip into Edit Mode

### DIFF
--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -7,6 +7,7 @@ import { TranslationProvider, AdminContextProvider } from "/imports/plugins/core
 import { isRevisionControlEnabled } from "/imports/plugins/core/revisions/lib/api";
 
 const handleAddProduct = () => {
+  Reaction.setUserPreferences("reaction-dashboard", "viewAs", "administrator");
   Meteor.call("products/createProduct", (error, productId) => {
     if (Meteor.isClient) {
       let currentTag;


### PR DESCRIPTION
Resolves [2141](https://github.com/reactioncommerce/reaction/issues/2141)

**Testing**
- Clone Branch and run on your local machine
- Turn off `Edit Mode`
- Click the `+` button to add a product
- Observe that `Edit Mode` button flips on