### PR TITLE
Toggle Variant Visibility when Ancestor Product Visibility is Toggled

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/containers/publishContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/publishContainer.js
@@ -17,9 +17,13 @@ class ProductPublishContainer extends Component {
   handleVisibilityChange = (event, isProductVisible) => {
     // Update main product
     Meteor.call("products/updateProductField", this.props.product._id, "isVisible", isProductVisible);
+
     const variants = Products.find({
-      ancestors: this.props.product._id
+      ancestors: {
+        $in: [this.props.product._id]
+      }
     }).fetch();
+
     variants.map(variant => {
       // update variant
       Meteor.call("products/updateProductField", variant._id, "isVisible", isProductVisible);

--- a/imports/plugins/included/product-detail-simple/client/containers/publishContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/publishContainer.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from "react";
 import { composeWithTracker } from "/lib/api/compose";
 import { Router } from "/client/api";
 import { ReactionProduct } from "/lib/api";
-import { Tags, Media } from "/lib/collections";
+import { Tags, Media, Products } from "/lib/collections";
 import PublishContainer from "/imports/plugins/core/revisions/client/containers/publishContainer";
 
 class ProductPublishContainer extends Component {
@@ -15,7 +15,15 @@ class ProductPublishContainer extends Component {
   }
 
   handleVisibilityChange = (event, isProductVisible) => {
+    // Update main product
     Meteor.call("products/updateProductField", this.props.product._id, "isVisible", isProductVisible);
+    const variants = Products.find({
+      ancestors: this.props.product._id
+    }).fetch();
+    variants.map(variant => {
+      // update variant
+      Meteor.call("products/updateProductField", variant._id, "isVisible", isProductVisible);
+    });
   }
 
   handlePublishActions = (event, action, documentIds) => {

--- a/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
@@ -7,6 +7,12 @@ import { Media, Products } from "/lib/collections";
 import { isRevisionControlEnabled } from "/imports/plugins/core/revisions/lib/api";
 import { applyProductRevision } from "/lib/api/products";
 
+function updateVariantProductField(variants, field, value) {
+  return variants.map(variant => {
+    Meteor.call("products/updateProductField", variant._id, field, value);
+  });
+}
+
 Template.productSettings.onCreated(function () {
   this.state = new ReactiveDict();
   this.state.setDefault({
@@ -131,6 +137,13 @@ Template.productSettings.events({
         // visibility toggle. This is to ensure that all selected products will become visible or not visible
         // at the same time so it's not confusing.
         Meteor.call("products/updateProductField", product._id, "isVisible", !products[0].isVisible);
+        // update the variants visibility
+        const variants = Products.find({
+          ancestors: {
+            $in: [product._id]
+          }
+        });
+        updateVariantProductField(variants, "isVisible", !products[0].isVisible);
       }
     } else {
       // The legacy behavior will bulk toggle visibilty of each product seperatly.

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -15,6 +15,20 @@ import { Logger, Reaction } from "/server/api";
 /* eslint quotes: 0 */
 
 /**
+ * updateVariantProductField
+ * @summary updates the variant
+ * @param {Array} variants - the array of variants
+ * @param {String} field - the field to update
+ * @param {String} value - the value to add
+ * @return {Array} - return an array
+ */
+function updateVariantProductField(variants, field, value) {
+  return variants.map(variant => {
+    Meteor.call("products/updateProductField", variant._id, field, value);
+  });
+}
+
+/**
  * @array toDenormalize
  * @summary contains a list of fields, which should be denormalized
  * @type {string[]}
@@ -1234,7 +1248,8 @@ Meteor.methods({
           type: "simple"
         }
       });
-
+      // update product variants visibility
+      updateVariantProductField(variants, "isVisible", !product.isVisible);
       // if collection updated we return new `isVisible` state
       return res === 1 && !product.isVisible;
     }


### PR DESCRIPTION
**Resolves**
#2059 

**Testing**
1. Create a new product
1. Add variants.
1. Click the eye icon in the toolbar to make is visible.
1. Check in DB(Products) variants `isVisible` field is now set to true when ancestor product `isVisble` is true