### PR TITLE
Fix missing shop

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -59,7 +59,13 @@
     "mute": [
       "wdio-mocha-framework",
       "griddle-react",
-      "nodemailer"
+      "nodemailer",
+      "twilio",
+      "react-addons-create-fragment",
+      "react-addons-pure-render-mixin",
+      "react-dom",
+      "react",
+      "transliteration"
     ],
     "unused-ignores": [
       "jquery",

--- a/.bithoundrc
+++ b/.bithoundrc
@@ -63,6 +63,7 @@
       "twilio",
       "react-addons-create-fragment",
       "react-addons-pure-render-mixin",
+      "react-addons-test-utils",
       "react-dom",
       "react",
       "transliteration"

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetailContainer.js
@@ -118,7 +118,7 @@ class ProductDetailContainer extends Component {
         if (productId) {
           Meteor.call("cart/addToCart", productId, currentVariant._id, quantity, (error) => {
             if (error) {
-              Logger.error("Failed to add to cart.", error);
+              Logger.error(error, "Failed to add to cart.");
               return error;
             }
             // Reset cart quantity on success

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -388,11 +388,11 @@ export default {
       // or attempt to load reaction.json fixture data
       try {
         registryFixtureData = Assets.getText("settings/reaction.json");
+        Logger.info("Loaded \"/private/settings/reaction.json\" for registry fixture import");
       } catch (error) {
         Logger.warn("Skipped loading settings from reaction.json.");
         Logger.debug(error, "loadSettings reaction.json not loaded.");
       }
-      Logger.info("Loaded \"/private/settings/reaction.json\" for registry fixture import");
     }
 
     if (!!registryFixtureData) {

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -15,8 +15,15 @@ import { getMailUrl } from "./email/config";
 export default {
 
   init() {
+    // make sure the default shop has been created before going further
+    while (!this.getShopId()) {
+      Logger.warn("No shopId, waiting one second...");
+      Meteor._sleepForMs(1000);
+    }
+
     // run onCoreInit hooks
-    Hooks.Events.run("onCoreInit", this);
+    Hooks.Events.run("onCoreInit");
+
     // start job server
     Jobs.startJobServer(() => {
       Logger.info("JobServer started");
@@ -251,10 +258,6 @@ export default {
     let configureEnv = false;
     let accountId;
 
-    while (!this.getShopId()) {
-      Logger.debug("No shopId, waiting one second...");
-      Meteor._sleepForMs(1000);
-    }
     const shopId = this.getShopId();
 
     // if an admin user has already been created, we'll exit

--- a/server/api/core/setDomain.js
+++ b/server/api/core/setDomain.js
@@ -25,7 +25,7 @@ export function setDomain() {
   try {
     currentDomain = Shops.findOne().domains[0];
   } catch (_error) {
-    Logger.error("Failed to determine default shop.", _error);
+    Logger.error(_error, "Failed to determine default shop.");
   }
   // if the server domain changes, update shop
   const domain = getRegistryDomain();

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -48,7 +48,7 @@ Meteor.methods({
     try {
       Collections.Shops.insert(shop);
     } catch (error) {
-      return Logger.error("Failed to shop/createShop", sanitizedError);
+      return Logger.error(error, "Failed to shop/createShop");
     }
     // we should have created new shop, or errored
     Logger.info("Created shop: ", shop._id);

--- a/server/startup/index.js
+++ b/server/startup/index.js
@@ -1,6 +1,5 @@
 import Accounts from "./accounts";
 import i18n from "./i18n";
-import Load from "./load-data";
 import Packages from "./packages";
 import Registry from "./registry";
 import Init from "./init";
@@ -12,7 +11,6 @@ export default function () {
   Accounts();
   i18n();
   initTemplates();
-  Load();
   Packages();
   Registry();
   Init();

--- a/server/startup/init.js
+++ b/server/startup/init.js
@@ -1,10 +1,14 @@
 import { Reaction, Logger } from "/server/api";
+import LoadData from "./load-data";
 
 /*
  * Execute start up fixtures
  */
 
 export default function () {
+  // load fixture data
+  LoadData();
+  // initialize Reaction
   Reaction.init();
   // we've finished all reaction core initialization
   Logger.info("Reaction initialization finished.");

--- a/server/startup/load-data.js
+++ b/server/startup/load-data.js
@@ -1,43 +1,41 @@
 import { Shops } from "/lib/collections";
-import { Hooks, Logger, Reaction } from "/server/api";
+import { Logger, Reaction } from "/server/api";
 import { Fixture } from "/server/api/core/import";
 
 export default function () {
   /**
    * Hook to setup core additional imports during Reaction init (shops process first)
    */
-  Hooks.Events.add("onCoreInit", () => {
-    Logger.info("Load default data from /private/data/");
+  Logger.info("Load default data from /private/data/");
 
-    try {
-      Reaction.Import.process(Assets.getText("data/Shops.json"), ["name"], Reaction.Import.shop);
-      // ensure Shops are loaded first.
-      Reaction.Import.flush(Shops);
-    } catch (error) {
-      Logger.info("Bypassing loading Shop default data");
-    }
+  try {
+    Reaction.Import.process(Assets.getText("data/Shops.json"), ["name"], Reaction.Import.shop);
+    // ensure Shops are loaded first.
+    Reaction.Import.flush(Shops);
+  } catch (error) {
+    Logger.info("Bypassing loading Shop default data");
+  }
 
-    try {
-      Fixture.process(Assets.getText("data/Shipping.json"), ["name"], Reaction.Import.shipping);
-    } catch (error) {
-      Logger.info("Bypassing loading Shipping default data.");
-    }
+  try {
+    Fixture.process(Assets.getText("data/Shipping.json"), ["name"], Reaction.Import.shipping);
+  } catch (error) {
+    Logger.info("Bypassing loading Shipping default data.");
+  }
 
-    try {
-      Fixture.process(Assets.getText("data/Products.json"), ["title"], Reaction.Import.load);
-    } catch (error) {
-      Logger.info("Bypassing loading Products default data.");
-    }
+  try {
+    Fixture.process(Assets.getText("data/Products.json"), ["title"], Reaction.Import.load);
+  } catch (error) {
+    Logger.info("Bypassing loading Products default data.");
+  }
 
-    try {
-      Fixture.process(Assets.getText("data/Tags.json"), ["name"], Reaction.Import.load);
-    } catch (error) {
-      Logger.info("Bypassing loading Tags default data.");
-    }
-    //
-    // these will flush and import with the rest of the imports from core init.
-    // but Bulk.find.upsert() = false
-    //
-    Fixture.flush();
-  });
+  try {
+    Fixture.process(Assets.getText("data/Tags.json"), ["name"], Reaction.Import.load);
+  } catch (error) {
+    Logger.info("Bypassing loading Tags default data.");
+  }
+  //
+  // these will flush and import with the rest of the imports from core init.
+  // but Bulk.find.upsert() = false
+  //
+  Fixture.flush();
 }


### PR DESCRIPTION
This update ensures the default fixture data loading happens before `Reaction.init()` even runs.  It was previously running in the `onCoreInit` hook and that created a potential for race conditions because there's no simple way to guarantee the order that those hooks run in.  By default, they run in the order in which they're added to the queue and that is largely dictated by the Meteor load order and a bunch of imports across the app.

The original reason this was a problem (#1424) was because translations were _also_ loaded in the `onCoreInit` hook and this occasionally allowed it to run before the initial shopId was available and that prevents translations from loading properly on the client because of the translations pub/sub relies on using the current shopId as a filter.

Now all the fixture data loads before anything else and there's a `while` loop that checks for the default shopId to exist before allowing the rest of `Reaction.init()` to continue.

Unrelated, this also fixes a debug log that wasn't at the right scope and was returning an inconsistent result.  Essentially, it was saying `reaction.json` was not loaded and then immediately afterward it said it _was_ loaded (which it definitely wasn't).

While I was there, I also took the opportunity to fix a few `Logger.error()` instances that had the args in the wrong order.  For the Bunyan error object parsing to work, the error object needs to be the first argument, so it should always be: 

```js
Logger.error(errorObject, "Some human readable string");
```
