### PR TITLE
Pin vsivsi:job-collection meteor package to 1.4.0 as a workaround to issue #2210

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -74,7 +74,7 @@ ongoworks:security
 raix:ui-dropped-event
 risul:moment-timezone
 tmeasday:publish-counts
-vsivsi:job-collection
+vsivsi:job-collection@1.4.0
 react-meteor-data
 percolate:migrations
 gadicc:blaze-react-component

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -168,6 +168,6 @@ twitter-oauth@1.2.0
 ui@1.0.13
 underscore@1.0.10
 url@1.1.0
-vsivsi:job-collection@1.5.1
+vsivsi:job-collection@1.4.0
 webapp@1.3.15
 webapp-hashing@1.0.9


### PR DESCRIPTION
- [ ] Clearly explain what your PR is trying to accomplish. A link to an issue is best
On windows 10, RC installation, off  `development` branch is stuck in `reaction run` due to  vsivsi:job-collection 's latest version is not getting installed. Therefore it is suggested to pin it to version 1.4.0 instead of 1.5.1.  Workaround for #2210 
- [ ] Provide us detailed instructions on how we can test your PR
Fresh RC Build using this PR branch.
Test  some key flows like, Create/Publish Product, Order, Invite new user.

 
