### PR TITLE
Restore dropdown template helper method

### DIFF
--- a/client/modules/accounts/templates/dropdown/dropdown.html
+++ b/client/modules/accounts/templates/dropdown/dropdown.html
@@ -35,7 +35,7 @@
   <ul class="user-accounts-dropdown-apps">
     {{> userAccountsDropdown}}
     <!--administrative shortcut icons -->
-    {{#each reactionApps provides="shortcut" enabled=true}}
+    {{#each reactionApps reactionAppsOptions}}
       <li class="dropdown-apps-icon">
         <a href={{pathFor name}} id="dropdown-apps-{{name}}" title="{{label}}">
           <i class="{{icon}}"></i>

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -72,3 +72,16 @@ Template.loginDropdown.events({
     template.$(".dropdown-toggle").dropdown("toggle");
   }
 });
+
+Template.accountsDropdownApps.helpers({
+  reactionAppsOptions() {
+    // get shortcuts with audience permissions based on user roles
+    const roles = Roles.getRolesForUser(Meteor.userId(), Reaction.getShopId());
+
+    return {
+      provides: "shortcut",
+      enabled: true,
+      audience: roles
+    };
+  }
+});


### PR DESCRIPTION
Resolves #2252 

This template helper method is needed. It provides the "audience" parameter for the Reaction.Apps call for the dropdown icons (for logged in users). It was moved when the plan was to have Reaction.Apps read audience internally.

Since we stepped back from doing that for now (in #2235), I should have added it back, but sadly missed it out in that PR.