### PR TITLE
Fix #2243 paypal express

### DIFF
--- a/imports/plugins/included/payments-paypal/server/index.js
+++ b/imports/plugins/included/payments-paypal/server/index.js
@@ -2,3 +2,4 @@ import "./i18n";
 import "./methods/express";
 import "./methods/payflow";
 import "./security/paypal";
+import "./startup/startup";

--- a/imports/plugins/included/payments-paypal/server/startup/startup.js
+++ b/imports/plugins/included/payments-paypal/server/startup/startup.js
@@ -1,0 +1,9 @@
+import { Reaction, Hooks } from "/server/api";
+
+Hooks.Events.add("afterCoreInit", () => {
+  Reaction.addRolesToDefaultRoleSet({
+    allShops: true,
+    roleSets: ["defaultRoles", "defaultVisitorRole"],
+    roles: ["reaction-paypal/paypalDone", "reaction-paypal/paypalCancel"]
+  });
+});


### PR DESCRIPTION
Fixes #2243 by adding paypal roles that are required for accessing the redirect templates within the Paypal Express payment package.

Video:
http://recordit.co/hGX73J8t2J