### PR TITLE
Fix Multiple Refunds For Stripe

### DIFF
--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -831,7 +831,6 @@ export const methods = {
       shopId: Reaction.getShopId()
     }).settings[settingsKey].support;
 
-    const orderStatus = paymentMethod.status;
     const orderMode = paymentMethod.mode;
 
     let result;
@@ -849,7 +848,7 @@ export const methods = {
         Logger.fatal("Attempt for de-authorize transaction failed", order._id, paymentMethod.transactionId, result.error);
         throw new Meteor.Error("Attempt to de-authorize transaction failed", result.error);
       }
-    } else if (orderStatus === "completed" && orderMode === "capture") {
+    } else if (orderMode === "capture") {
       result = Meteor.call(`${processor}/refund/create`, paymentMethod, amount);
       query = {
         $push: {


### PR DESCRIPTION
*Resolves*
#2215 

*Testing*
1. Launch system and enable Stripe (the only payment method that allows immediate refunds from the Order Panel)
1. Create an order
1. Login as admin
1. Issue a refund for that order less than the total amount
1. Issue another refund
1. Observe that the second refund works.