### PR TITLE
fix #2278 Router tables (Router.routes) not re-initializing

### DIFF
--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -371,6 +371,7 @@ export function ReactionLayout(options = {}) {
  */
 Router.initPackageRoutes = (options) => {
   Router.Reaction = options.reactionContext;
+  Router.routes = [];
 
   const pkgs = Packages.find().fetch();
   const prefix = Router.Reaction.getShopPrefix();
@@ -509,6 +510,7 @@ Router.initPackageRoutes = (options) => {
 
     Router._initialized = true;
     Router.reactComponents = reactRouterRoutes;
+    Router._routes = Router.routes;
 
     routerReadyDependency.changed();
   }


### PR DESCRIPTION
- [ ] Clearly explain what your PR is trying to accomplish. A link to an issue is best
 Router Table (Router.routes) keeps on growing in single browser session. see issue #2278
- [ ] Provide us detailed instructions on how we can test your PR
   Please follow the steps as per #2278 

