### PR TITLE
Allow loader passed in to composeWithTracker to render

### DIFF
--- a/lib/api/compose.js
+++ b/lib/api/compose.js
@@ -38,7 +38,7 @@ function getTrackerLoader(reactiveMapper) {
 export function composeWithTracker(reactiveMapper, LoadingComponent) {
   const options = {};
 
-  if (typeof LoadingComponent === "undefined") {
+  if (typeof LoadingComponent !== "undefined") {
     options.loadingHandler = () => { // eslint-disable-line react/display-name
       return (
         <LoadingComponent />


### PR DESCRIPTION
No custom `LoadingComponent` would appear when passed to `composeWithTracker` due to reversed logic statement. #2304

_Currently on releases/development on an individual product page:_ 
- No custom loading component appears when passed to `composeWithTracker` (as render is never reached.)

_With this PR on an individual product page:_
- A custom loading component that was passed to `composeWithTracker` should appear before the product fully loads.
