### PR TITLE
Fix git tagging on CircleCI 2.0

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -40,9 +40,9 @@ fi
 
 # Master branch deployment (only runs when a version git tag exists - syntax: "v1.2.3")
 if [[ "$CIRCLE_BRANCH" == "master" ]]; then
-  if git describe --tags | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+$"; then
-    VERSION=$(git describe --tags | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+$")
+  VERSION=$(git describe --tags | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+$")
 
+  if [[ "$VERSION" ]]; then
     DOCKER_NAMESPACE=${DOCKER_NAMESPACE:-"reactioncommerce/reaction"}
 
     docker tag $DOCKER_NAMESPACE:latest $DOCKER_NAMESPACE:$VERSION

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -39,16 +39,19 @@ fi
 
 
 # Master branch deployment (only runs when a version git tag exists - syntax: "v1.2.3")
-# The git tag is available in $CIRCLE_TAG
-VERSION_REGEX="/v[0-9]+(\.[0-9]+)*/"
+if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+  if git describe --tags | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+$"; then
+    VERSION=$(git describe --tags | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+$")
 
-if [[ "$CIRCLE_BRANCH" == "master" && "$CIRCLE_TAG" =~ $VERSION_REGEX ]]; then
-  DOCKER_NAMESPACE=${DOCKER_NAMESPACE:-"reactioncommerce/reaction"}
+    DOCKER_NAMESPACE=${DOCKER_NAMESPACE:-"reactioncommerce/reaction"}
 
-  docker tag $DOCKER_NAMESPACE:latest $DOCKER_NAMESPACE:$CIRCLE_TAG
+    docker tag $DOCKER_NAMESPACE:latest $DOCKER_NAMESPACE:$VERSION
 
-  docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 
-  docker push $DOCKER_NAMESPACE:$CIRCLE_TAG
-  docker push $DOCKER_NAMESPACE:latest
+    docker push $DOCKER_NAMESPACE:$VERSION
+    docker push $DOCKER_NAMESPACE:latest
+  else
+    echo "On the master branch, but no version tag was found. Skipping image deployment."
+  fi
 fi


### PR DESCRIPTION
CircleCI 2.0 doesn't support git tag triggered deploys yet, so we need to parse it ourselves manually with the git CLI.  This PR restores the previous behavior of master branch version tagged commits that trigger a Docker Hub deployment of the built image.

#betasoftwareisfun