### PR TITLE
Adding the license description with link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ Integration tests can be run at the command line with `reaction test`.
 We ensure that all releases are deployable as [Docker](https://www.docker.com/) containers.  While we don't regularly test other methods of deployment, our community has documented deployment strategies for AWS, [Digital Ocean](https://gist.github.com/jshimko/745ca66748846551692e24c267a56060), and Galaxy.
 
 For an introduction to Docker deployment, [the Reaction deployment guide](https://docs.reactioncommerce.com/reaction-docs/master/deploying) has detailed examples. Reaction Commerce also offers a managed deployment platform integrated with the Reaction command line.
+
+### License
+
+Copyright © [GNU General Public License v3.0](./LICENSE.md)


### PR DESCRIPTION
I've added the new topic at the bottom of the README file about GNU License and the respective link.