### PR TITLE
Marketplace shop switcher

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -30,12 +30,22 @@ export default {
     return Tracker.autorun(() => {
       let domain;
       let shop;
-
+      let route;
+      Router.watchPathChange();
       if (this.Subscriptions.Shops.ready()) {
-        domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
-        shop = Shops.findOne({
-          domains: domain
-        });
+        if (Router) {
+          route = Router.current();
+        }
+        if (route && route.params && route.params.shopId && route.params.shopId.length > 0) {
+          shop = Shops.findOne({
+            _id: route.params.shopId
+          });
+        } else {
+          domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
+          shop = Shops.findOne({
+            domains: domain
+          });
+        }
 
         if (shop) {
           this.shopId = shop._id;

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -21,7 +21,7 @@ const reactionState = new ReactiveDict();
  * Global reaction shop permissions methods and shop initialization
  */
 export default {
-  shopId: null,
+  _shopId: new ReactiveVar(null),
 
   Locale: new ReactiveVar({}),
 
@@ -30,22 +30,12 @@ export default {
     return Tracker.autorun(() => {
       let domain;
       let shop;
-      let route;
-      Router.watchPathChange();
+
       if (this.Subscriptions.Shops.ready()) {
-        if (Router) {
-          route = Router.current();
-        }
-        if (route && route.params && route.params.shopId && route.params.shopId.length > 0) {
-          shop = Shops.findOne({
-            _id: route.params.shopId
-          });
-        } else {
-          domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
-          shop = Shops.findOne({
-            domains: domain
-          });
-        }
+        domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
+        shop = Shops.findOne({
+          domains: domain
+        });
 
         if (shop) {
           this.shopId = shop._id;
@@ -255,8 +245,16 @@ export default {
     });
   },
 
+  get shopId() {
+    return this._shopId.get();
+  },
+
   getShopId() {
     return this.shopId;
+  },
+
+  set shopId(id) {
+    this._shopId.set(id);
   },
 
   setShopId(id) {

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -259,6 +259,12 @@ export default {
     return this.shopId;
   },
 
+  setShopId(id) {
+    if (id) {
+      this.shopId = id;
+    }
+  },
+
   getShopName() {
     return this.shopName;
   },

--- a/imports/plugins/core/dashboard/client/components/toolbar.js
+++ b/imports/plugins/core/dashboard/client/components/toolbar.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from "react";
 import Blaze from "meteor/gadicc:blaze-react-component";
 import {
+  DropDownMenu,
+  MenuItem,
   FlatButton,
   Toolbar,
   ToolbarGroup,
@@ -20,9 +22,12 @@ class PublishControls extends Component {
     isEnabled: PropTypes.bool,
     isPreview: PropTypes.bool,
     onAddProduct: PropTypes.func,
+    onShopSelectChange: PropTypes.func,
     onViewContextChange: PropTypes.func,
     onVisibilityChange: PropTypes.func,
     packageButtons: PropTypes.arrayOf(PropTypes.object),
+    shopId: PropTypes.string,
+    shops: PropTypes.arrayOf(PropTypes.object),
     showViewAsControls: PropTypes.bool,
     translation: PropTypes.shape({
       lang: PropTypes.string
@@ -36,6 +41,13 @@ class PublishControls extends Component {
   onViewContextChange = (event, isChecked) => {
     if (typeof this.props.onViewContextChange === "function") {
       this.props.onViewContextChange(event, isChecked ? "administrator" : "customer");
+    }
+  }
+
+  // Passthrough to shopSelectChange handler in container above
+  onShopSelectChange = (event, shopId) => {
+    if (typeof this.props.onShopSelectChange === "function") {
+      this.props.onShopSelectChange(event, shopId);
     }
   }
 
@@ -59,6 +71,32 @@ class PublishControls extends Component {
     }
 
     return null;
+  }
+
+  renderShopSelect() {
+    let menuItems;
+    if (Array.isArray(this.props.shops)) {
+      menuItems = this.props.shops.map((shop, index) => {
+        return (
+          <MenuItem
+            label={shop.name}
+            selectLabel={shop.name}
+            value={shop._id}
+            key={index}
+          />
+        );
+      });
+    }
+
+    return (
+      <DropDownMenu
+        onChange={this.onShopSelectChange}
+        value={this.props.shopId}
+        closeOnClick={true}
+      >
+        {menuItems}
+      </DropDownMenu>
+    );
   }
 
   renderVisibilitySwitch() {
@@ -146,6 +184,7 @@ class PublishControls extends Component {
       <Toolbar>
         <ToolbarGroup firstChild={true}>
           {this.renderVisibilitySwitch()}
+          {this.renderShopSelect()}
         </ToolbarGroup>
         <ToolbarGroup lastChild={true}>
           {this.renderAddButton()}

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Meteor } from "meteor/meteor";
 import { composeWithTracker } from "/lib/api/compose";
 import { Reaction, i18next } from "/client/api";
-import { Tags } from "/lib/collections";
+import { Tags, Shops } from "/lib/collections";
 import { TranslationProvider, AdminContextProvider } from "/imports/plugins/core/ui/client/providers";
 import { isRevisionControlEnabled } from "/imports/plugins/core/revisions/lib/api";
 
@@ -50,9 +50,28 @@ const handleViewContextChange = (event, value) => {
   }
 };
 
+/**
+* Handler that fires when the shop selector is changed
+* @param {Object} event - the `event` coming from the select change event
+* @param {String} shopId - The `value` coming from the select change event
+* @returns {undefined}
+*/
+const handleShopSelectChange = (event, shopId) => {
+  if (/^[A-Za-z0-9]{17}$/.test(shopId)) { // Make sure shopId is a valid ID
+    Reaction.setShopId(shopId);
+  }
+};
+
 function composer(props, onData) {
   // Reactive data sources
   const routeName = Reaction.Router.getRouteName();
+  const user = Meteor.user();
+  let shops;
+
+  if (user && user.roles) {
+    // Get all shops for which user has roles
+    shops = Shops.find({ _id: { $in: Object.keys(user.roles) } }).fetch();
+  }
 
   // Standard variables
   const packageButtons = [];
@@ -89,9 +108,12 @@ function composer(props, onData) {
     isActionViewAtRootView: Reaction.isActionViewAtRootView(),
     actionViewIsOpen: Reaction.isActionViewOpen(),
     hasCreateProductAccess: Reaction.hasPermission("createProduct", Meteor.userId(), Reaction.getShopId()),
+    shopId: Reaction.getShopId(),
+    shops: shops,
 
     // Callbacks
     onAddProduct: handleAddProduct,
+    onShopSelectChange: handleShopSelectChange,
     onViewContextChange: handleViewContextChange
   });
 }

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -88,7 +88,7 @@ function composer(props, onData) {
     isEnabled: isRevisionControlEnabled(),
     isActionViewAtRootView: Reaction.isActionViewAtRootView(),
     actionViewIsOpen: Reaction.isActionViewOpen(),
-    hasCreateProductAccess: Reaction.hasPermission("createProduct", Meteor.userId(), Reaction.getSellerShopId()),
+    hasCreateProductAccess: Reaction.hasPermission("createProduct", Meteor.userId(), Reaction.getShopId()),
 
     // Callbacks
     onAddProduct: handleAddProduct,

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -3,11 +3,11 @@
   <div class="rui navbar">
     <div class="showmenu">{{> button icon="bars" onClick=onMenuButtonClick}}</div>
     {{> coreNavigationBrand}}
+    {{> shopSelect}}
 
-    {{#if isMarketplaceOwner}}
-      {{> shopSelect}}
-      <span>{{> React component=VerticalDivider}}</span>
-    {{/if}}
+    <span>
+      {{> React component=VerticalDivider}}
+    </span>
 
     <div class="menu">
       {{> tagNav tagNavProps}}

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -1,4 +1,3 @@
-
 <template name="CoreNavigationBar">
   <div class="rui navbar">
     <div class="showmenu">{{> button icon="bars" onClick=onMenuButtonClick}}</div>

--- a/imports/plugins/core/ui/client/components/menu/dropDownMenu.js
+++ b/imports/plugins/core/ui/client/components/menu/dropDownMenu.js
@@ -10,8 +10,25 @@ class DropDownMenu extends Component {
     super(props);
 
     this.state = {
-      label: undefined
+      label: undefined,
+      isOpen: false
     };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.isControlled) {
+      this.setState({
+        isOpen: nextProps.isOpen
+      });
+    }
+  }
+
+  get isOpen() {
+    return this.props.isOpen || this.state.isOpen;
+  }
+
+  get isControlled() {
+    return typeof this.props.isOpen === "boolean";
   }
 
   handleMenuItemChange = (event, value, menuItem) => {
@@ -19,8 +36,24 @@ class DropDownMenu extends Component {
       label: menuItem.props.label || value
     });
 
+    if (this.props.closeOnClick) {
+      this.handleOpen(false);
+    }
+
     if (this.props.onChange) {
       this.props.onChange(event, value);
+    }
+  }
+
+  handleOpen = (isOpen) => {
+    if (this.isControlled) {
+      if (this.props.onRequestOpen) {
+        this.props.onRequestOpen(isOpen);
+      }
+    } else {
+      this.setState({
+        isOpen: isOpen
+      });
     }
   }
 
@@ -53,6 +86,8 @@ class DropDownMenu extends Component {
             label={this.label}
           />
         }
+        isOpen={this.isOpen}
+        onRequestOpen={this.handleOpen}
       >
         <Menu value={this.props.value} onChange={this.handleMenuItemChange}>
           {this.props.children}
@@ -65,9 +100,12 @@ class DropDownMenu extends Component {
 DropDownMenu.propTypes = {
   buttonElement: PropTypes.node,
   children: PropTypes.node,
+  closeOnClick: PropTypes.bool,
   isEnabled: PropTypes.bool,
+  isOpen: PropTypes.bool,
   onChange: PropTypes.func,
   onPublishClick: PropTypes.func,
+  onRequestOpen: PropTypes.func,
   revisions: PropTypes.arrayOf(PropTypes.object),
   translation: PropTypes.shape({
     lang: PropTypes.string

--- a/imports/plugins/core/ui/client/components/popover/popover.js
+++ b/imports/plugins/core/ui/client/components/popover/popover.js
@@ -9,6 +9,22 @@ class Popover extends Component {
     isOpen: false
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.isControlled) {
+      this.setState({
+        isOpen: nextProps.isOpen
+      });
+    }
+  }
+
+  get isOpen() {
+    return this.props.isOpen || this.state.isOpen;
+  }
+
+  get isControlled() {
+    return typeof this.props.isOpen === "boolean";
+  }
+
   /**
    * attachment
    * @description Return the attachment for the tooltip or the default
@@ -25,19 +41,31 @@ class Popover extends Component {
   }
 
   handleOpen = () => {
-    this.setState({
-      isOpen: true
-    });
+    if (this.isControlled) {
+      if (this.props.onRequestOpen) {
+        this.props.onRequestOpen(true);
+      }
+    } else {
+      this.setState({
+        isOpen: true
+      });
+    }
   }
 
   handleClickOutside = () => {
-    this.setState({
-      isOpen: false
-    });
+    if (this.isControlled) {
+      if (this.props.onRequestOpen) {
+        this.props.onRequestOpen(false);
+      }
+    } else {
+      this.setState({
+        isOpen: false
+      });
+    }
   }
 
   renderPopoverChildren() {
-    if (this.state.isOpen) {
+    if (this.isOpen) {
       return  (
         <PopoverContent
           children={this.props.children}
@@ -96,7 +124,9 @@ Popover.propTypes = {
   attachment: PropTypes.string,
   buttonElement: PropTypes.node,
   children: PropTypes.node,
+  isOpen: PropTypes.bool,
   onDisplayButtonClick: PropTypes.func,
+  onRequestOpen: PropTypes.func,
   showArrow: PropTypes.bool,
   showDropdownButton: PropTypes.bool,
   targetAttachment: PropTypes.string,

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.html
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.html
@@ -8,16 +8,13 @@
            aria-haspopup="true"
            aria-expanded="false">
 
-          {{#if isOwnerShop}}
-            <span data-i18n="app.myShop">* {{currentShopName}}</span>
-          {{else}}
-            <span data-i18n="app.shops">{{currentShopName}}</span>
-          {{/if}}
+          <span>{{currentShopName}}</span>
+
           <span class="caret"></span>
         </div>
         <ul class="dropdown-menu" role="menu">
           {{#each shops}}
-            <li class="{{class}}">
+            <li class="{{isActiveShop _id}}">
               <a class="shop" role="menuitem">{{name}}</a>
             </li>
           {{/each}}

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.html
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.html
@@ -1,5 +1,5 @@
 <template name="shopSelect">
-  {{#if sellerShops}}
+  {{#if shops}}
     <div class="shops">
       <div class="dropdown" role="shops">
         <div class="dropdown-toggle"
@@ -8,17 +8,15 @@
            aria-haspopup="true"
            aria-expanded="false">
 
-          {{#if isChildShop}}
-            {{currentShopName}}
-          {{else if isOwnerShop}}
-            <span data-i18n="app.myShop">My Shop</span>
+          {{#if isOwnerShop}}
+            <span data-i18n="app.myShop">* {{currentShopName}}</span>
           {{else}}
-            <span data-i18n="app.shops">Shops</span>
+            <span data-i18n="app.shops">{{currentShopName}}</span>
           {{/if}}
           <span class="caret"></span>
         </div>
         <ul class="dropdown-menu" role="menu">
-          {{#each sellerShops}}
+          {{#each shops}}
             <li class="{{class}}">
               <a class="shop" role="menuitem">{{name}}</a>
             </li>

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
@@ -5,52 +5,35 @@ import { Shops } from "/lib/collections";
 
 Template.shopSelect.helpers({
   shops() {
-    const currentShopId = Router.getParam("shopId") || 0;
-    const selector = {
-    };
+    if (Reaction.Subscriptions.Shops.ready()) {
+      return Shops.find();
+    }
+  },
 
-    // active class
-    // TODO: Revise the way active is determined
-    const shops = Shops.find(selector).fetch().map((shop) => {
-      if (currentShopId && shop._id === currentShopId) {
-        shop.class = "active";
-      }
-      return shop;
-    });
-
-    return shops;
+  isActiveShop(shopId) {
+    return shopId === Router.getParam("shopId") ? "active" : "";
   },
 
   currentShopName() {
-    const _id = Reaction.Router.getParam("shopId") || 0;
+    const _id = Router.getParam("shopId") || Reaction.getShopId(); // or prime shop
     let shop;
 
     if (_id) {
       shop = Shops.findOne({
         _id
       });
-    } else {
-      shop = Shops.findOne({ _id: Reaction.getShopId() });
-    }
-
-    // always make sure we have a shop in case id was incorrect
-    if (shop) {
-      return shop.name;
+      if (shop) {
+        return shop.name;
+      }
     }
 
     return "Shop Name";
-  },
-
-  isOwnerShop() {
-    const currentShopId = Reaction.Router.getParam("shopId") || 0;
-    return (currentShopId === Reaction.getSellerShopId()); // TODO: Remove getSellerShopId
   }
 });
 
 Template.shopSelect.events({
   "click .shop"(event) {
     event.preventDefault();
-    Reaction.setShopId(this._id);
     Router.go("shop", {
       shopId: this._id
     });

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
@@ -50,7 +50,8 @@ Template.shopSelect.helpers({
 Template.shopSelect.events({
   "click .shop"(event) {
     event.preventDefault();
-    Reaction.Router.go("shop", {
+    Reaction.setShopId(this._id);
+    Router.go("shop", {
       shopId: this._id
     });
   }

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
@@ -1,27 +1,17 @@
 import { Template } from "meteor/templating";
 import { Reaction } from "/lib/api";
-import { SellerShops } from "/lib/collections";
-
-Template.shopSelect.onCreated(function () {
-  this.autorun(() => {
-    // watch path change to reset toggle
-    Reaction.Router.watchPathChange();
-  });
-});
+import { Router } from "/client/api";
+import { Shops } from "/lib/collections";
 
 Template.shopSelect.helpers({
-  sellerShops() {
-    const currentShopId = Reaction.Router.getParam("shopId") || 0;
+  shops() {
+    const currentShopId = Router.getParam("shopId") || 0;
     const selector = {
-      // ignore blank site
-      // TODO: Don't hardcode IDs to ignore
-      _id: {
-        $ne: "ddzuN2YPvgvx7rJS5"
-      }
     };
 
     // active class
-    const shops = SellerShops.find(selector).fetch().map((shop) => {
+    // TODO: Revise the way active is determined
+    const shops = Shops.find(selector).fetch().map((shop) => {
       if (currentShopId && shop._id === currentShopId) {
         shop.class = "active";
       }
@@ -33,27 +23,27 @@ Template.shopSelect.helpers({
 
   currentShopName() {
     const _id = Reaction.Router.getParam("shopId") || 0;
+    let shop;
 
-    if (_id && _id !== Reaction.getShopId()) {
-      const shop = SellerShops.findOne({
+    if (_id) {
+      shop = Shops.findOne({
         _id
       });
-
-      // always make sure we have a shop in case id was incorrect
-      if (shop) {
-        return shop.name;
-      }
+    } else {
+      shop = Shops.findOne({ _id: Reaction.getShopId() });
     }
-  },
 
-  isChildShop() {
-    const currentShopId = Reaction.Router.getParam("shopId") || 0;
-    return (currentShopId && Reaction.getSellerShopId() !== currentShopId);
+    // always make sure we have a shop in case id was incorrect
+    if (shop) {
+      return shop.name;
+    }
+
+    return "Shop Name";
   },
 
   isOwnerShop() {
     const currentShopId = Reaction.Router.getParam("shopId") || 0;
-    return (currentShopId === Reaction.getSellerShopId());
+    return (currentShopId === Reaction.getSellerShopId()); // TODO: Remove getSellerShopId
   }
 });
 

--- a/imports/plugins/included/product-detail-simple/client/containers/publishContainer.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/publishContainer.js
@@ -3,7 +3,7 @@ import { Meteor } from "meteor/meteor";
 import { composeWithTracker } from "/lib/api/compose";
 import { Router } from "/client/api";
 import { ReactionProduct } from "/lib/api";
-import { Tags, Media, Products } from "/lib/collections";
+import { Products } from "/lib/collections";
 import PublishContainer from "/imports/plugins/core/revisions/client/containers/publishContainer";
 
 class ProductPublishContainer extends Component {
@@ -71,24 +71,6 @@ function composer(props, onData) {
   let revisonDocumentIds;
 
   if (product) {
-    if (_.isArray(product.hashtags)) {
-      tags = _.map(product.hashtags, function (id) {
-        return Tags.findOne(id);
-      });
-    }
-
-    const selectedVariant = ReactionProduct.selectedVariant();
-
-    if (selectedVariant) {
-      media = Media.find({
-        "metadata.variantId": selectedVariant._id
-      }, {
-        sort: {
-          "metadata.priority": 1
-        }
-      });
-    }
-
     revisonDocumentIds = [product._id];
 
     onData(null, {

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -148,7 +148,7 @@ export default {
     const domain = this.getDomain();
     const cursor = Shops.find({
       domains: domain
-    }, { limit: 1 });
+    });
     if (!cursor.count()) {
       Logger.debug(domain, "Add a domain entry to shops for ");
     }


### PR DESCRIPTION
* Adds a marketplace shop switcher to the admin toolbar. 
* Admins can see and switch between any shops for which they have any permissions.
* Makes the product grid shop switcher work for changing between shops product grids for all users.
* Switching shops changes the `Reaction.shopId`
* Change `Reaction.shopId` into a ReactiveVar.
* Add getter and setter for `Reaction.shopId`
* Add `closeOnClick` option to `DropDownMenu` component