### PR TITLE
Remove duplicate babel packages from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,6 @@
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.22.0",
-    "babel-preset-es2015": "^6.22.0",
-    "babel-preset-react": "^6.24.1",
     "browserstack-local": "^1.3.0",
     "chai": "^3.5.0",
     "enzyme": "^2.8.2",


### PR DESCRIPTION
[This commit](https://github.com/reactioncommerce/reaction/commit/bcd7d1d8402c4e1bc0bf2b44118c97bba93e739b#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) last night added babel plugin packages that already existed in the package.json.  This PR removes them.