### PR TITLE
fork Nodemailer and add to Reaction

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -59,7 +59,6 @@
     "mute": [
       "wdio-mocha-framework",
       "griddle-react",
-      "nodemailer",
       "twilio",
       "react-addons-create-fragment",
       "react-addons-pure-render-mixin",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@reactioncommerce/authorize-net": "^1.0.8",
+    "@reactioncommerce/nodemailer": "^5.0.4",
     "accounting-js": "^1.1.1",
     "autoprefixer": "^6.7.7",
     "autosize": "^3.0.20",
@@ -58,7 +59,6 @@
     "moment-timezone": "^0.5.11",
     "nexmo": "^1.2.0",
     "node-geocoder": "^3.16.0",
-    "nodemailer": "2.7.2",
     "nodemailer-wellknown": "^0.2.1",
     "nouislider-algolia-fork": "^10.0.0",
     "npm-shrinkwrap": "^6.0.2",

--- a/server/api/core/email/config.js
+++ b/server/api/core/email/config.js
@@ -1,4 +1,4 @@
-import nodemailer from "nodemailer";
+import nodemailer from "@reactioncommerce/nodemailer";
 import getServiceConfig from "nodemailer-wellknown";
 import url from "url";
 import { Meteor } from "meteor/meteor";

--- a/server/jobs/email.js
+++ b/server/jobs/email.js
@@ -1,4 +1,4 @@
-import nodemailer from "nodemailer";
+import nodemailer from "@reactioncommerce/nodemailer";
 import { Emails, Jobs } from "/lib/collections";
 import { Reaction, Logger } from "/server/api";
 


### PR DESCRIPTION
Nodemailer has been [officially forked to the Reaction org](https://github.com/reactioncommerce/nodemailer) and [published to npm](https://www.npmjs.com/package/@reactioncommerce/nodemailer) as `@reactioncommerce/nodemailer`.  I replaced the original Grunt build tools with npm scripts and a Babel build.  This solved the Node >=6 requirement that has had us stuck on Nodemailer 2.x for months.  

The entire suite of 332 tests are [consistently passing](https://circleci.com/gh/reactioncommerce/nodemailer/tree/master) on the Babel-compiled code and CircleCI has been configured to publish passing builds that have a version tag in the format `v1.2.3` (same as Reaction).

All email methods have been manually tested with the new package and everything appears to be good to go.

