### PR TITLE
wrap component in translations

### DIFF
--- a/client/modules/accounts/containers/passwordReset/passwordOverlayContainer.js
+++ b/client/modules/accounts/containers/passwordReset/passwordOverlayContainer.js
@@ -5,7 +5,7 @@ import { Accounts } from "meteor/accounts-base";
 import { composeWithTracker } from "/lib/api/compose";
 import { UpdatePasswordOverlay } from "/client/modules/accounts/components";
 import { MessagesContainer } from "/client/modules/accounts/containers/helpers";
-import { LoginFormValidation } from "/lib/api";
+import { TranslationProvider } from "/imports/plugins/core/ui/client/providers";
 
 class UpdatePasswordOverlayContainer extends Component {
   static propTypes = {
@@ -101,16 +101,18 @@ class UpdatePasswordOverlayContainer extends Component {
 
   render() {
     return (
-      <UpdatePasswordOverlay
-        uniqueId={this.props.uniqueId}
-        loginFormMessages={this.formMessages}
-        onError={this.hasError}
-        messages={this.state.formMessages}
-        onFormSubmit={this.handleFormSubmit}
-        onCancel={this.handleFormCancel}
-        isOpen={this.state.isOpen}
-        isDisabled={this.state.isDisabled}
-      />
+      <TranslationProvider>
+        <UpdatePasswordOverlay
+          uniqueId={this.props.uniqueId}
+          loginFormMessages={this.formMessages}
+          onError={this.hasError}
+          messages={this.state.formMessages}
+          onFormSubmit={this.handleFormSubmit}
+          onCancel={this.handleFormCancel}
+          isOpen={this.state.isOpen}
+          isDisabled={this.state.isDisabled}
+        />
+      </TranslationProvider>
     );
   }
 }


### PR DESCRIPTION
It seems that because this component is outside of the regular react flow, by using the blaze template in this way, the overall Translation provider that wraps the entire app wasn't getting applied.

This change adds the TranslationProvider locally.

Test by:

1) removing your timeouts
2) changing the shop language (Spanish works)
3) following the directions in the original ticket