### PR TITLE
[Marketplace] Feature - getShopId server side

### DIFF
--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -76,7 +76,7 @@ Template.loginDropdown.events({
 Template.accountsDropdownApps.helpers({
   reactionAppsOptions() {
     // get shortcuts with audience permissions based on user roles
-    const roles = Roles.getRolesForUser(Meteor.userId(), Reaction.getSellerShopId());
+    const roles = Roles.getRolesForUser(Meteor.userId(), Reaction.getShopId());
 
     return {
       provides: "shortcut",

--- a/client/modules/core/helpers/permissions.js
+++ b/client/modules/core/helpers/permissions.js
@@ -19,7 +19,7 @@ import { Reaction } from "../";
 Template.registerHelper("hasPermission", function (permissions, options) {
   // default to checking this.userId
   let userId = Meteor.userId();
-  const shopId = Reaction.getSellerShopId(userId);
+  const shopId = Reaction.getShopId();
   // we don't necessarily need to check here
   // as these same checks and defaults are
   // also performed in Reaction.hasPermission

--- a/client/modules/core/helpers/permissions.js
+++ b/client/modules/core/helpers/permissions.js
@@ -59,6 +59,10 @@ Template.registerHelper("hasDashboardAccess", function () {
   return Reaction.hasDashboardAccess();
 });
 
+Template.registerHelper("hasDashboardAccessForAnyShop", function () {
+  return Reaction.hasPermissionsForAnyShop();
+});
+
 /**
  * allowGuestCheckout template helper
  * @summary check if guest users are allowed to checkout

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -33,9 +33,21 @@ export default {
 
       if (this.Subscriptions.Shops.ready()) {
         domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
-        shop = Shops.findOne({
-          domains: domain
-        });
+
+        // if we don't have an active shopId, try to retreive it from the userPreferences object
+        // and set the shop from the storedShopId
+        if (!this.shopId) {
+          const storedShopId = this.getUserPreferences("reaction", "activeShopId");
+          if (storedShopId) {
+            shop = Shops.findOne({
+              _id: storedShopId
+            });
+          } else {
+            shop = Shops.findOne({
+              domains: domain
+            });
+          }
+        }
 
         if (shop) {
           // Only set shopId if it hasn't been set yet
@@ -287,7 +299,7 @@ export default {
   },
 
   getShopId() {
-    return this.shopId;
+    return this.shopId || this.getUserPreferences("reaction", "activeShopId");
   },
 
   set shopId(id) {
@@ -297,6 +309,7 @@ export default {
   setShopId(id) {
     if (id) {
       this.shopId = id;
+      this.setUserPreferences("reaction", "activeShopId", id);
     }
   },
 

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -186,19 +186,33 @@ export default {
     return false;
   },
 
+
+  /**
+   * hasDashboardAccessForAnyShop - client
+   * client permission check for any "owner", "admin", or "dashboard" permissions for any shop.
+   *
+   * @todo This could be faster with a dedicated hasAdminDashboard boolean on the user object
+   * @param { Object } options - options object that can be passed a user and/or a set of permissions
+   * @return {Boolean} Boolean - true if has dashboard access for any shop
+   */
   hasDashboardAccessForAnyShop(options = { user: Meteor.user(), permissions: ["owner", "admin", "dashboard"] }) {
-    const user = options.user || Meteor.user();
-    const permissions = options.permissions || [""];
+    const user = options.user;
+    const permissions = options.permissions;
+
     if (!user || !user.roles) {
       return false;
     }
 
+    // Nested find that determines if a user has any of the permissions
+    // specified in the `permissions` array for any shop
     const hasPermissions = Object.keys(user.roles).find((shopId) => {
       return user.roles[shopId].find((role) => {
         return permissions.find(permission => permission === role);
       });
     });
 
+    // Find returns undefined if nothing is found.
+    // This will return true if permissions are found, false otherwise
     return typeof hasPermissions !== "undefined";
   },
 

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -244,7 +244,7 @@ export default {
   },
 
   hasShopSwitcherAccess() {
-    return this.hasPermissionsForAnyShop();
+    return this.hasDashboardAccessForAnyShop();
   },
 
   getSellerShopId: function (userId = Meteor.userId(), noFallback = false) {

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -30,12 +30,22 @@ export default {
     return Tracker.autorun(() => {
       let domain;
       let shop;
-
+      let route;
+      Router.watchPathChange();
       if (this.Subscriptions.Shops.ready()) {
-        domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
-        shop = Shops.findOne({
-          domains: domain
-        });
+        if (Router) {
+          route = Router.current();
+        }
+        if (route && route.params && route.params.shopId && route.params.shopId.length > 0) {
+          shop = Shops.findOne({
+            _id: route.params.shopId
+          });
+        } else {
+          domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
+          shop = Shops.findOne({
+            domains: domain
+          });
+        }
 
         if (shop) {
           this.shopId = shop._id;

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -38,8 +38,11 @@ export default {
         });
 
         if (shop) {
-          this.shopId = shop._id;
-          this.shopName = shop.name;
+          // Only set shopId if it hasn't been set yet
+          if (!this.shopId) {
+            this.shopId = shop._id;
+            this.shopName = shop.name;
+          }
           // initialize local client Countries collection
           if (!Countries.findOne()) {
             createCountryCollection(shop.locales.countries);
@@ -92,7 +95,7 @@ export default {
     if (checkGroup !== undefined && typeof checkGroup === "string") {
       group = checkGroup;
     } else {
-      group = this.getSellerShopId() || Roles.GLOBAL_GROUP;
+      group = this.getShopId() || Roles.GLOBAL_GROUP;
     }
 
     let permissions = ["owner"];

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -183,6 +183,22 @@ export default {
     return false;
   },
 
+  hasDashboardAccessForAnyShop(options = { user: Meteor.user(), permissions: ["owner", "admin", "dashboard"] }) {
+    const user = options.user || Meteor.user();
+    const permissions = options.permissions || [""];
+    if (!user || !user.roles) {
+      return false;
+    }
+
+    const hasPermissions = Object.keys(user.roles).find((shopId) => {
+      return user.roles[shopId].find((role) => {
+        return permissions.find(permission => permission === role);
+      });
+    });
+
+    return typeof hasPermissions !== "undefined";
+  },
+
   hasOwnerAccess() {
     const ownerPermissions = ["owner"];
     return this.hasPermission(ownerPermissions);

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -21,7 +21,7 @@ const reactionState = new ReactiveDict();
  * Global reaction shop permissions methods and shop initialization
  */
 export default {
-  shopId: null,
+  _shopId: new ReactiveVar(null),
 
   Locale: new ReactiveVar({}),
 
@@ -30,22 +30,12 @@ export default {
     return Tracker.autorun(() => {
       let domain;
       let shop;
-      let route;
-      Router.watchPathChange();
+
       if (this.Subscriptions.Shops.ready()) {
-        if (Router) {
-          route = Router.current();
-        }
-        if (route && route.params && route.params.shopId && route.params.shopId.length > 0) {
-          shop = Shops.findOne({
-            _id: route.params.shopId
-          });
-        } else {
-          domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
-          shop = Shops.findOne({
-            domains: domain
-          });
-        }
+        domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
+        shop = Shops.findOne({
+          domains: domain
+        });
 
         if (shop) {
           this.shopId = shop._id;
@@ -255,8 +245,16 @@ export default {
     });
   },
 
+  get shopId() {
+    return this._shopId.get();
+  },
+
   getShopId() {
     return this.shopId;
+  },
+
+  set shopId(id) {
+    this._shopId.set(id);
   },
 
   setShopId(id) {

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -259,6 +259,12 @@ export default {
     return this.shopId;
   },
 
+  setShopId(id) {
+    if (id) {
+      this.shopId = id;
+    }
+  },
+
   getShopName() {
     return this.shopName;
   },

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -231,6 +231,10 @@ export default {
     return this.hasPermission(dashboardPermissions);
   },
 
+  hasShopSwitcherAccess() {
+    return this.hasPermissionsForAnyShop();
+  },
+
   getSellerShopId: function (userId = Meteor.userId(), noFallback = false) {
     if (userId) {
       const group = Roles.getGroupsForUser(userId, "admin")[0];

--- a/client/modules/core/subscriptions.js
+++ b/client/modules/core/subscriptions.js
@@ -4,6 +4,8 @@ import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
 import { SubsManager } from "meteor/meteorhacks:subs-manager";
 
+import Reaction from "./main";
+
 export const Subscriptions = {};
 
 // Subscription Manager
@@ -30,9 +32,10 @@ Subscriptions.Account = Subscriptions.Manager.subscribe("Accounts", Meteor.userI
  */
 Subscriptions.Shops = Subscriptions.Manager.subscribe("Shops");
 
-Subscriptions.SellerShops = Subscriptions.Manager.subscribe("SellerShops");
+// Init Packages sub so we have a "ready" state
+Subscriptions.Packages = Subscriptions.Manager.subscribe("Packages", "");
 
-Subscriptions.Packages = Subscriptions.Manager.subscribe("Packages");
+Subscriptions.SellerShops = Subscriptions.Manager.subscribe("SellerShops");
 
 Subscriptions.Tags = Subscriptions.Manager.subscribe("Tags");
 
@@ -69,4 +72,11 @@ Tracker.autorun(() => {
   });
   Subscriptions.Cart = Meteor.subscribe("Cart", sessionId, Meteor.userId());
   Subscriptions.UserProfile = Meteor.subscribe("UserProfile", Meteor.userId());
+});
+
+Tracker.autorun(() => {
+  // Reload Packages sub if shopId changes
+  if (Reaction.getShopId()) {
+    Subscriptions.Packages = Subscriptions.Manager.subscribe("Packages", Reaction.getShopId());
+  }
 });

--- a/imports/plugins/core/dashboard/client/components/toolbar.js
+++ b/imports/plugins/core/dashboard/client/components/toolbar.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from "react";
 import Blaze from "meteor/gadicc:blaze-react-component";
 import {
+  DropDownMenu,
+  MenuItem,
   FlatButton,
   Toolbar,
   ToolbarGroup,
@@ -20,9 +22,12 @@ class PublishControls extends Component {
     isEnabled: PropTypes.bool,
     isPreview: PropTypes.bool,
     onAddProduct: PropTypes.func,
+    onShopSelectChange: PropTypes.func,
     onViewContextChange: PropTypes.func,
     onVisibilityChange: PropTypes.func,
     packageButtons: PropTypes.arrayOf(PropTypes.object),
+    shopId: PropTypes.string,
+    shops: PropTypes.arrayOf(PropTypes.object),
     showViewAsControls: PropTypes.bool,
     translation: PropTypes.shape({
       lang: PropTypes.string
@@ -36,6 +41,13 @@ class PublishControls extends Component {
   onViewContextChange = (event, isChecked) => {
     if (typeof this.props.onViewContextChange === "function") {
       this.props.onViewContextChange(event, isChecked ? "administrator" : "customer");
+    }
+  }
+
+  // Passthrough to shopSelectChange handler in container above
+  onShopSelectChange = (event, shopId) => {
+    if (typeof this.props.onShopSelectChange === "function") {
+      this.props.onShopSelectChange(event, shopId);
     }
   }
 
@@ -59,6 +71,32 @@ class PublishControls extends Component {
     }
 
     return null;
+  }
+
+  renderShopSelect() {
+    let menuItems;
+    if (Array.isArray(this.props.shops)) {
+      menuItems = this.props.shops.map((shop, index) => {
+        return (
+          <MenuItem
+            label={shop.name}
+            selectLabel={shop.name}
+            value={shop._id}
+            key={index}
+          />
+        );
+      });
+    }
+
+    return (
+      <DropDownMenu
+        onChange={this.onShopSelectChange}
+        value={this.props.shopId}
+        closeOnClick={true}
+      >
+        {menuItems}
+      </DropDownMenu>
+    );
   }
 
   renderVisibilitySwitch() {
@@ -146,6 +184,7 @@ class PublishControls extends Component {
       <Toolbar>
         <ToolbarGroup firstChild={true}>
           {this.renderVisibilitySwitch()}
+          {this.renderShopSelect()}
         </ToolbarGroup>
         <ToolbarGroup lastChild={true}>
           {this.renderAddButton()}

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Meteor } from "meteor/meteor";
 import { composeWithTracker } from "/lib/api/compose";
 import { Reaction, i18next } from "/client/api";
-import { Tags } from "/lib/collections";
+import { Tags, Shops } from "/lib/collections";
 import { TranslationProvider, AdminContextProvider } from "/imports/plugins/core/ui/client/providers";
 import { isRevisionControlEnabled } from "/imports/plugins/core/revisions/lib/api";
 
@@ -50,9 +50,28 @@ const handleViewContextChange = (event, value) => {
   }
 };
 
+/**
+* Handler that fires when the shop selector is changed
+* @param {Object} event - the `event` coming from the select change event
+* @param {String} shopId - The `value` coming from the select change event
+* @returns {undefined}
+*/
+const handleShopSelectChange = (event, shopId) => {
+  if (/^[A-Za-z0-9]{17}$/.test(shopId)) { // Make sure shopId is a valid ID
+    Reaction.setShopId(shopId);
+  }
+};
+
 function composer(props, onData) {
   // Reactive data sources
   const routeName = Reaction.Router.getRouteName();
+  const user = Meteor.user();
+  let shops;
+
+  if (user && user.roles) {
+    // Get all shops for which user has roles
+    shops = Shops.find({ _id: { $in: Object.keys(user.roles) } }).fetch();
+  }
 
   // Standard variables
   const packageButtons = [];
@@ -89,9 +108,12 @@ function composer(props, onData) {
     isActionViewAtRootView: Reaction.isActionViewAtRootView(),
     actionViewIsOpen: Reaction.isActionViewOpen(),
     hasCreateProductAccess: Reaction.hasPermission("createProduct", Meteor.userId(), Reaction.getShopId()),
+    shopId: Reaction.getShopId(),
+    shops: shops,
 
     // Callbacks
     onAddProduct: handleAddProduct,
+    onShopSelectChange: handleShopSelectChange,
     onViewContextChange: handleViewContextChange
   });
 }

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -88,7 +88,7 @@ function composer(props, onData) {
     isEnabled: isRevisionControlEnabled(),
     isActionViewAtRootView: Reaction.isActionViewAtRootView(),
     actionViewIsOpen: Reaction.isActionViewOpen(),
-    hasCreateProductAccess: Reaction.hasPermission("createProduct", Meteor.userId(), Reaction.getSellerShopId()),
+    hasCreateProductAccess: Reaction.hasPermission("createProduct", Meteor.userId(), Reaction.getShopId()),
 
     // Callbacks
     onAddProduct: handleAddProduct,

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -123,15 +123,20 @@ Template.shopSettings.helpers({
   },
 
   shop: function () {
-    return Shops.findOne();
+    return Shops.findOne({
+      _id: Reaction.getShopId()
+    });
   },
   packageData: function () {
     return Packages.findOne({
-      name: "core"
+      name: "core",
+      shopId: Reaction.getShopId()
     });
   },
   addressBook: function () {
-    const address = Shops.findOne().addressBook;
+    const address = Shops.findOne({
+      _id: Reaction.getShopId()
+    }).addressBook;
     return address[0];
   }
 });

--- a/imports/plugins/core/email/client/containers/emailConfig.js
+++ b/imports/plugins/core/email/client/containers/emailConfig.js
@@ -8,7 +8,7 @@ import EmailConfig from "../components/emailConfig";
 import { composeWithTracker, merge } from "/lib/api/compose";
 
 const composer = ({}, onData) => {
-  if (Meteor.subscribe("Packages").ready()) {
+  if (Meteor.subscribe("Packages", Reaction.getShopId()).ready()) {
     const shopSettings = Reaction.getShopSettings();
     const settings = shopSettings.mail || {};
 

--- a/imports/plugins/core/email/client/containers/emailSettings.js
+++ b/imports/plugins/core/email/client/containers/emailSettings.js
@@ -9,7 +9,7 @@ import { composeWithTracker, merge } from "/lib/api/compose";
 const providers = Object.keys(require("nodemailer-wellknown/services.json"));
 
 const composer = ({}, onData) => {
-  if (Meteor.subscribe("Packages").ready()) {
+  if (Meteor.subscribe("Packages", Reaction.getShopId()).ready()) {
     const settings = Reaction.getShopSettings().mail || {};
 
     const { service, host, port, user, password } = settings;

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -137,7 +137,7 @@ Template.coreOrderShippingInvoice.events({
     const invoiceTotal = order.billing[0].invoice.total;
     const currencySymbol = instance.state.get("currency").symbol;
 
-    Meteor.subscribe("Packages");
+    Meteor.subscribe("Packages", Reaction.getShopId());
     const packageId = order.billing[0].paymentMethod.paymentPackageId;
     const settingsKey = order.billing[0].paymentMethod.paymentSettingsKey;
     // check if payment provider supports de-authorize

--- a/imports/plugins/core/router/client/app.js
+++ b/imports/plugins/core/router/client/app.js
@@ -103,7 +103,7 @@ class App extends Component {
 function composer(props, onData) {
   onData(null, {
     isActionViewOpen: Reaction.isActionViewOpen(),
-    hasDashboardAccess: Reaction.hasDashboardAccess(),
+    hasDashboardAccess: Reaction.hasDashboardAccessForAnyShop(),
     currentRoute: Router.current()
   });
 }

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -3,11 +3,11 @@
   <div class="rui navbar">
     <div class="showmenu">{{> button icon="bars" onClick=onMenuButtonClick}}</div>
     {{> coreNavigationBrand}}
+    {{> shopSelect}}
 
-    {{#if isMarketplaceOwner}}
-      {{> shopSelect}}
-      <span>{{> React component=VerticalDivider}}</span>
-    {{/if}}
+    <span>
+      {{> React component=VerticalDivider}}
+    </span>
 
     <div class="menu">
       {{> tagNav tagNavProps}}

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -1,4 +1,3 @@
-
 <template name="CoreNavigationBar">
   <div class="rui navbar">
     <div class="showmenu">{{> button icon="bars" onClick=onMenuButtonClick}}</div>

--- a/imports/plugins/core/ui/client/components/menu/dropDownMenu.js
+++ b/imports/plugins/core/ui/client/components/menu/dropDownMenu.js
@@ -10,8 +10,25 @@ class DropDownMenu extends Component {
     super(props);
 
     this.state = {
-      label: undefined
+      label: undefined,
+      isOpen: false
     };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.isControlled) {
+      this.setState({
+        isOpen: nextProps.isOpen
+      });
+    }
+  }
+
+  get isOpen() {
+    return this.props.isOpen || this.state.isOpen;
+  }
+
+  get isControlled() {
+    return typeof this.props.isOpen === "boolean";
   }
 
   handleMenuItemChange = (event, value, menuItem) => {
@@ -19,8 +36,24 @@ class DropDownMenu extends Component {
       label: menuItem.props.label || value
     });
 
+    if (this.props.closeOnClick) {
+      this.handleOpen(false);
+    }
+
     if (this.props.onChange) {
       this.props.onChange(event, value);
+    }
+  }
+
+  handleOpen = (isOpen) => {
+    if (this.isControlled) {
+      if (this.props.onRequestOpen) {
+        this.props.onRequestOpen(isOpen);
+      }
+    } else {
+      this.setState({
+        isOpen: isOpen
+      });
     }
   }
 
@@ -53,6 +86,8 @@ class DropDownMenu extends Component {
             label={this.label}
           />
         }
+        isOpen={this.isOpen}
+        onRequestOpen={this.handleOpen}
       >
         <Menu value={this.props.value} onChange={this.handleMenuItemChange}>
           {this.props.children}
@@ -65,9 +100,12 @@ class DropDownMenu extends Component {
 DropDownMenu.propTypes = {
   buttonElement: PropTypes.node,
   children: PropTypes.node,
+  closeOnClick: PropTypes.bool,
   isEnabled: PropTypes.bool,
+  isOpen: PropTypes.bool,
   onChange: PropTypes.func,
   onPublishClick: PropTypes.func,
+  onRequestOpen: PropTypes.func,
   revisions: PropTypes.arrayOf(PropTypes.object),
   translation: PropTypes.shape({
     lang: PropTypes.string

--- a/imports/plugins/core/ui/client/components/popover/popover.js
+++ b/imports/plugins/core/ui/client/components/popover/popover.js
@@ -9,6 +9,22 @@ class Popover extends Component {
     isOpen: false
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.isControlled) {
+      this.setState({
+        isOpen: nextProps.isOpen
+      });
+    }
+  }
+
+  get isOpen() {
+    return this.props.isOpen || this.state.isOpen;
+  }
+
+  get isControlled() {
+    return typeof this.props.isOpen === "boolean";
+  }
+
   /**
    * attachment
    * @description Return the attachment for the tooltip or the default
@@ -25,19 +41,31 @@ class Popover extends Component {
   }
 
   handleOpen = () => {
-    this.setState({
-      isOpen: true
-    });
+    if (this.isControlled) {
+      if (this.props.onRequestOpen) {
+        this.props.onRequestOpen(true);
+      }
+    } else {
+      this.setState({
+        isOpen: true
+      });
+    }
   }
 
   handleClickOutside = () => {
-    this.setState({
-      isOpen: false
-    });
+    if (this.isControlled) {
+      if (this.props.onRequestOpen) {
+        this.props.onRequestOpen(false);
+      }
+    } else {
+      this.setState({
+        isOpen: false
+      });
+    }
   }
 
   renderPopoverChildren() {
-    if (this.state.isOpen) {
+    if (this.isOpen) {
       return  (
         <PopoverContent
           children={this.props.children}
@@ -96,7 +124,9 @@ Popover.propTypes = {
   attachment: PropTypes.string,
   buttonElement: PropTypes.node,
   children: PropTypes.node,
+  isOpen: PropTypes.bool,
   onDisplayButtonClick: PropTypes.func,
+  onRequestOpen: PropTypes.func,
   showArrow: PropTypes.bool,
   showDropdownButton: PropTypes.bool,
   targetAttachment: PropTypes.string,

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.html
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.html
@@ -8,16 +8,13 @@
            aria-haspopup="true"
            aria-expanded="false">
 
-          {{#if isOwnerShop}}
-            <span data-i18n="app.myShop">* {{currentShopName}}</span>
-          {{else}}
-            <span data-i18n="app.shops">{{currentShopName}}</span>
-          {{/if}}
+          <span>{{currentShopName}}</span>
+
           <span class="caret"></span>
         </div>
         <ul class="dropdown-menu" role="menu">
           {{#each shops}}
-            <li class="{{class}}">
+            <li class="{{isActiveShop _id}}">
               <a class="shop" role="menuitem">{{name}}</a>
             </li>
           {{/each}}

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.html
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.html
@@ -1,5 +1,5 @@
 <template name="shopSelect">
-  {{#if sellerShops}}
+  {{#if shops}}
     <div class="shops">
       <div class="dropdown" role="shops">
         <div class="dropdown-toggle"
@@ -8,17 +8,15 @@
            aria-haspopup="true"
            aria-expanded="false">
 
-          {{#if isChildShop}}
-            {{currentShopName}}
-          {{else if isOwnerShop}}
-            <span data-i18n="app.myShop">My Shop</span>
+          {{#if isOwnerShop}}
+            <span data-i18n="app.myShop">* {{currentShopName}}</span>
           {{else}}
-            <span data-i18n="app.shops">Shops</span>
+            <span data-i18n="app.shops">{{currentShopName}}</span>
           {{/if}}
           <span class="caret"></span>
         </div>
         <ul class="dropdown-menu" role="menu">
-          {{#each sellerShops}}
+          {{#each shops}}
             <li class="{{class}}">
               <a class="shop" role="menuitem">{{name}}</a>
             </li>

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
@@ -5,52 +5,35 @@ import { Shops } from "/lib/collections";
 
 Template.shopSelect.helpers({
   shops() {
-    const currentShopId = Router.getParam("shopId") || 0;
-    const selector = {
-    };
+    if (Reaction.Subscriptions.Shops.ready()) {
+      return Shops.find();
+    }
+  },
 
-    // active class
-    // TODO: Revise the way active is determined
-    const shops = Shops.find(selector).fetch().map((shop) => {
-      if (currentShopId && shop._id === currentShopId) {
-        shop.class = "active";
-      }
-      return shop;
-    });
-
-    return shops;
+  isActiveShop(shopId) {
+    return shopId === Router.getParam("shopId") ? "active" : "";
   },
 
   currentShopName() {
-    const _id = Reaction.Router.getParam("shopId") || 0;
+    const _id = Router.getParam("shopId") || Reaction.getShopId(); // or prime shop
     let shop;
 
     if (_id) {
       shop = Shops.findOne({
         _id
       });
-    } else {
-      shop = Shops.findOne({ _id: Reaction.getShopId() });
-    }
-
-    // always make sure we have a shop in case id was incorrect
-    if (shop) {
-      return shop.name;
+      if (shop) {
+        return shop.name;
+      }
     }
 
     return "Shop Name";
-  },
-
-  isOwnerShop() {
-    const currentShopId = Reaction.Router.getParam("shopId") || 0;
-    return (currentShopId === Reaction.getSellerShopId()); // TODO: Remove getSellerShopId
   }
 });
 
 Template.shopSelect.events({
   "click .shop"(event) {
     event.preventDefault();
-    Reaction.setShopId(this._id);
     Router.go("shop", {
       shopId: this._id
     });

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
@@ -50,7 +50,8 @@ Template.shopSelect.helpers({
 Template.shopSelect.events({
   "click .shop"(event) {
     event.preventDefault();
-    Reaction.Router.go("shop", {
+    Reaction.setShopId(this._id);
+    Router.go("shop", {
       shopId: this._id
     });
   }

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
@@ -1,27 +1,17 @@
 import { Template } from "meteor/templating";
 import { Reaction } from "/lib/api";
-import { SellerShops } from "/lib/collections";
-
-Template.shopSelect.onCreated(function () {
-  this.autorun(() => {
-    // watch path change to reset toggle
-    Reaction.Router.watchPathChange();
-  });
-});
+import { Router } from "/client/api";
+import { Shops } from "/lib/collections";
 
 Template.shopSelect.helpers({
-  sellerShops() {
-    const currentShopId = Reaction.Router.getParam("shopId") || 0;
+  shops() {
+    const currentShopId = Router.getParam("shopId") || 0;
     const selector = {
-      // ignore blank site
-      // TODO: Don't hardcode IDs to ignore
-      _id: {
-        $ne: "ddzuN2YPvgvx7rJS5"
-      }
     };
 
     // active class
-    const shops = SellerShops.find(selector).fetch().map((shop) => {
+    // TODO: Revise the way active is determined
+    const shops = Shops.find(selector).fetch().map((shop) => {
       if (currentShopId && shop._id === currentShopId) {
         shop.class = "active";
       }
@@ -33,27 +23,27 @@ Template.shopSelect.helpers({
 
   currentShopName() {
     const _id = Reaction.Router.getParam("shopId") || 0;
+    let shop;
 
-    if (_id && _id !== Reaction.getShopId()) {
-      const shop = SellerShops.findOne({
+    if (_id) {
+      shop = Shops.findOne({
         _id
       });
-
-      // always make sure we have a shop in case id was incorrect
-      if (shop) {
-        return shop.name;
-      }
+    } else {
+      shop = Shops.findOne({ _id: Reaction.getShopId() });
     }
-  },
 
-  isChildShop() {
-    const currentShopId = Reaction.Router.getParam("shopId") || 0;
-    return (currentShopId && Reaction.getSellerShopId() !== currentShopId);
+    // always make sure we have a shop in case id was incorrect
+    if (shop) {
+      return shop.name;
+    }
+
+    return "Shop Name";
   },
 
   isOwnerShop() {
     const currentShopId = Reaction.Router.getParam("shopId") || 0;
-    return (currentShopId === Reaction.getSellerShopId());
+    return (currentShopId === Reaction.getSellerShopId()); // TODO: Remove getSellerShopId
   }
 });
 

--- a/imports/plugins/included/payments-authnet/client/checkout/authnet.js
+++ b/imports/plugins/included/payments-authnet/client/checkout/authnet.js
@@ -81,7 +81,7 @@ AutoForm.addHooks("authnet-payment-form", {
         let normalizedStatus = "failed";
 
         const transId = transaction.transactionId[0].toString();
-        Meteor.subscribe("Packages");
+        Meteor.subscribe("Packages", Reaction.getShopId());
         const packageData = Packages.findOne({
           name: "reaction-auth-net",
           shopId: Reaction.getShopId()

--- a/imports/plugins/included/payments-braintree/client/checkout/braintree.js
+++ b/imports/plugins/included/payments-braintree/client/checkout/braintree.js
@@ -68,7 +68,7 @@ function submitToBrainTree(doc, template) {
       if (results.saved === true) {
         const normalizedStatus = normalizeState(results.response.transaction.status);
         const normalizedMode = normalizeMode(results.response.transaction.status);
-        Meteor.subscribe("Packages");
+        Meteor.subscribe("Packages", Reaction.getShopId());
         const packageData = Packages.findOne({
           name: "reaction-braintree",
           shopId: Reaction.getShopId()

--- a/imports/plugins/included/payments-example/client/checkout/example.js
+++ b/imports/plugins/included/payments-example/client/checkout/example.js
@@ -54,7 +54,7 @@ AutoForm.addHooks("example-payment-form", {
       type: Reaction.getCardType(doc.cardNumber)
     };
     const storedCard = form.type.charAt(0).toUpperCase() + form.type.slice(1) + " " + doc.cardNumber.slice(-4);
-    Meteor.subscribe("Packages");
+    Meteor.subscribe("Packages", Reaction.getShopId());
     const packageData = Packages.findOne({
       name: "example-paymentmethod",
       shopId: Reaction.getShopId()

--- a/imports/plugins/included/payments-example/client/settings/containers/exampleSettingsFormContainer.js
+++ b/imports/plugins/included/payments-example/client/settings/containers/exampleSettingsFormContainer.js
@@ -70,7 +70,7 @@ ExampleSettingsFormContainer.propTypes = {
 };
 
 const composer = ({}, onData) => {
-  const subscription = Meteor.subscribe("Packages");
+  const subscription = Meteor.subscribe("Packages", Reaction.getShopId());
   if (subscription.ready()) {
     const packageData = Packages.findOne({
       name: "example-paymentmethod",

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.js
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.js
@@ -130,7 +130,7 @@ AutoForm.addHooks("paypal-payment-form", {
           if (typeof transaction.response.transactions[0].related_resources[0] === "object") {
             authId = transaction.response.transactions[0].related_resources[0].authorization.id;
           }
-          Meteor.subscribe("Packages");
+          Meteor.subscribe("Packages", Reaction.getShopId());
           const packageData = Packages.findOne({
             name: "reaction-paypal",
             shopId: Reaction.getShopId()

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/return/done.js
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/return/done.js
@@ -21,7 +21,7 @@ function showError(error) {
 }
 
 function buildPaymentMethod(result, status, mode) {
-  Meteor.subscribe("Packages");
+  Meteor.subscribe("Packages", Reaction.getShopId());
   const packageData = Packages.findOne({
     name: "reaction-paypal",
     shopId: Reaction.getShopId()

--- a/imports/plugins/included/payments-stripe/client/checkout/stripe.js
+++ b/imports/plugins/included/payments-stripe/client/checkout/stripe.js
@@ -99,7 +99,7 @@ AutoForm.addHooks("stripe-payment-form", {
                 return "capture";
             }
           })();
-          Meteor.subscribe("Packages");
+          Meteor.subscribe("Packages", Reaction.getShopId());
           const packageData = Packages.findOne({
             name: "reaction-stripe",
             shopId: Reaction.getShopId()

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/controls.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/controls.js
@@ -40,7 +40,7 @@ Template.gridControls.helpers({
     }
 
     const instance = Template.instance();
-    const shopId = Reaction.getSellerShopId();
+    const shopId = Reaction.getShopId();
 
     return (
         Reaction.hasPermission("createProduct") &&

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -148,7 +148,7 @@ export default {
     const domain = this.getDomain();
     const cursor = Shops.find({
       domains: domain
-    }, { limit: 1 });
+    });
     if (!cursor.count()) {
       Logger.debug(domain, "Add a domain entry to shops for ");
     }

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -3,6 +3,7 @@ import packageJson from "/package.json";
 import { merge, uniqWith } from "lodash";
 import { Meteor } from "meteor/meteor";
 import { EJSON } from "meteor/ejson";
+import { check, Match } from "meteor/check";
 import { Jobs, Packages, Shops } from "/lib/collections";
 import { Hooks, Logger } from "/server/api";
 import ProcessJobs from "/server/jobs";
@@ -164,7 +165,18 @@ export default {
     return null;
   },
 
-  getShopId() {
+  getShopId(userId) {
+    check(userId, Match.Optional(String));
+
+    if (userId) {
+      const activeShopId = this.getUserPreferences({
+        userId,
+        packageName: "reaction",
+        preference: "activeShopId"
+      });
+      return activeShopId;
+    }
+
     const domain = this.getDomain();
     const shop = Shops.find({
       domains: domain
@@ -246,6 +258,28 @@ export default {
     }
 
     return Packages.findOne(query);
+  },
+
+  // {packageName, preference, defaultValue}
+  getUserPreferences(options) {
+    const userId = options.userId;
+    const packageName = options.packageName;
+    const preference = options.preference;
+    const defaultValue = options.defaultValue;
+    if (!userId) {
+      return undefined;
+    }
+
+    const user = Meteor.users.findOne({ _id: userId });
+
+    if (user) {
+      const profile = user.profile;
+      if (profile && profile.preferences && profile.preferences[packageName] && profile.preferences[packageName][preference]) {
+        return profile.preferences[packageName][preference];
+      }
+    }
+
+    return defaultValue || undefined;
   },
 
   /**

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -73,7 +73,7 @@ export default {
    * @param {String} checkGroup group - default to shopId
    * @return {Boolean} Boolean - true if has permission
    */
-  hasPermission(checkPermissions, userId = Meteor.userId(), checkGroup = this.getSellerShopId(userId)) {
+  hasPermission(checkPermissions, userId = Meteor.userId(), checkGroup = this.getShopId()) { // TODO: getSellerShop Conversion - pass in shop here
     // check(checkPermissions, Match.OneOf(String, Array)); check(userId, String); check(checkGroup,
     // Match.Optional(String));
 

--- a/server/publications/collections/packages.js
+++ b/server/publications/collections/packages.js
@@ -69,10 +69,13 @@ function transform(doc, userId) {
 //
 //  Packages Publication
 //
-Meteor.publish("Packages", function (shopCursor) {
-  check(shopCursor, Match.Optional(Object));
+Meteor.publish("Packages", function (shopId) {
+  check(shopId, String);
   const self = this;
-  const shop = shopCursor || Reaction.getCurrentShop();
+
+  if (!shopId) {
+    return self.ready();
+  }
 
   // user is required.
   if (self.userId) {
@@ -93,7 +96,7 @@ Meteor.publish("Packages", function (shopCursor) {
     };
 
     // we should always have a shop
-    if (shop) {
+    if (shopId) {
       // if admin user, return all shop properties
       if (Roles.userIsInRole(self.userId, [
         "dashboard", "owner", "admin"
@@ -104,7 +107,7 @@ Meteor.publish("Packages", function (shopCursor) {
       }
       // observe and transform Package registry adds i18n and other meta data
       const observer = Packages.find({
-        shopId: shop._id
+        shopId: shopId
       }, options).observe({
         added: function (doc) {
           self.added("Packages", doc._id, transform(doc, self.userId));


### PR DESCRIPTION
Please review and merge #2429 if it has not been merged yet first. Creating separate PRs and branches here even though they build off of each other to keep concerns separated.

This PR accomplishes the following
1. When an administrative user selects a shop, saves the selected shop as a user preference in the database as a user preference using `Reaction.setUserPreference`
2. Adds a server method `Reaction.getUserPreference` that permits us to retrieve user preferences on the server
3. Changes `Reaction.getShopId` on the server to accept a userId param and return the users activeShopId if it's set
4. Changes all Collection permit/deny security code to use the active shop
5. On the client, select the active shop on app load if it's available.

This PR should be reviewed in depth for security vulnerabilities 