### PR TITLE
Notifications "Mark all as read" should mark all as read

### DIFF
--- a/imports/plugins/included/notifications/client/styles/dropdown.css
+++ b/imports/plugins/included/notifications/client/styles/dropdown.css
@@ -270,7 +270,10 @@ small.dropmenu-item-content {
   text-decoration: none;
 }
 .unread {
-  background-color:#f9f9f9 !important;
+  background-color: #F4F4FF !important;
+}
+.read {
+  background-color: #ffffff !important;
 }
 .notification:last-child {
   border-bottom: 0;


### PR DESCRIPTION
This resolves #2440 

### Steps to Reproduce the Behavior
1. Place orders so that you have notifications
1. Click on "Mark all as read" in the notification area
1. Observer that all are marked as read