### PR TITLE
fix Docker memory issues in CircleCI build

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -11,7 +11,7 @@ if [[ "$CIRCLE_BRANCH" != "master" && "$CIRCLE_BRANCH" != "development" && "$CIR
 fi
 
 # build new image
-docker build -t reactioncommerce/reaction:latest .
+docker build --build-arg TOOL_NODE_FLAGS="--max-old-space-size=4096" -t reactioncommerce/reaction:latest .
 
 # run the container and wait for it to boot
 docker-compose -f .circleci/docker-compose.yml up -d


### PR DESCRIPTION
This adds `--build-arg TOOL_NODE_FLAGS="--max-old-space-size=4096"` to the Docker build command in the CircleCI build script.  This fixes an "insufficient memory" issue by allowing the Meteor build tool to have a little more RAM available for the build process.

Tested and confirmed working.