### PR TITLE
Remove random regex checks on names. Fixes #2461

### DIFF
--- a/imports/plugins/included/payments-authnet/lib/collections/schemas/authnet.js
+++ b/imports/plugins/included/payments-authnet/lib/collections/schemas/authnet.js
@@ -39,8 +39,7 @@ export const AuthNetPackageConfig = new SimpleSchema([
 export const AuthNetPayment = new SimpleSchema({
   payerName: {
     type: String,
-    label: "Cardholder name",
-    regEx: /[A-Z][a-zA-Z]*/
+    label: "Cardholder name"
   },
   cardNumber: {
     type: String,
@@ -63,8 +62,4 @@ export const AuthNetPayment = new SimpleSchema({
     label: "CVV",
     max: 4
   }
-});
-
-AuthNetPayment.messages({
-  "regEx payerName": "[label] must include both first and last name"
 });

--- a/imports/plugins/included/payments-authnet/lib/collections/schemas/index.js
+++ b/imports/plugins/included/payments-authnet/lib/collections/schemas/index.js
@@ -1,1 +1,1 @@
-export * from "./package";
+export * from "./authnet";

--- a/imports/plugins/included/payments-braintree/lib/collections/schemas/braintree.js
+++ b/imports/plugins/included/payments-braintree/lib/collections/schemas/braintree.js
@@ -46,8 +46,7 @@ export const BraintreePackageConfig = new SimpleSchema([
 export const BraintreePayment = new SimpleSchema({
   payerName: {
     type: String,
-    label: "Cardholder name",
-    regEx: /^\w+\s\w+$/
+    label: "Cardholder name"
   },
   cardNumber: {
     type: String,
@@ -72,6 +71,3 @@ export const BraintreePayment = new SimpleSchema({
   }
 });
 
-BraintreePayment.messages({
-  "regEx payerName": "[label] must include both first and last name"
-});

--- a/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
+++ b/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
@@ -74,8 +74,7 @@ export const PaypalPackageConfig = new SimpleSchema([
 export const PaypalPayment = new SimpleSchema({
   payerName: {
     type: String,
-    label: "Cardholder name",
-    regEx: /[A-Z][a-zA-Z]*/
+    label: "Cardholder name"
   },
   cardNumber: {
     type: String,
@@ -100,6 +99,3 @@ export const PaypalPayment = new SimpleSchema({
   }
 });
 
-PaypalPayment.messages({
-  "regEx payerName": "[label] must include both first and last name"
-});

--- a/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
+++ b/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
@@ -55,7 +55,3 @@ export const StripePayment = new SimpleSchema({
     label: "CVV"
   }
 });
-
-StripePayment.messages({
-  "regEx payerName": "[label] must include both first and last name"
-});


### PR DESCRIPTION
Resolves: #2461 

### To Test

1. Enable Authorize.net for payment (and everything else for checkout)
1. Enter a name that starts with a lowercase letter in the address (so it will flow into the "Cartholder name"
1. Complete checkout
1. Perform same test for Paypal and Braintree

