### PR TITLE
Fix on tag menu-sidebar glitch

### DIFF
--- a/imports/plugins/core/ui-tagnav/client/components/tagGroup.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagGroup.js
@@ -123,7 +123,7 @@ class TagGroup extends Component {
       <div className="rui tagtree">
         <div className="header">
           <span className="title">{this.state.parentTag.name}</span>
-          <a href="#">View All <i className="fa fa-angle-right" /></a>
+          <a href={this.state.parentTag.slug}>View All <i className="fa fa-angle-right" /></a>
         </div>
         <div className="content">
           {this.renderTree(this.tags)}

--- a/imports/plugins/core/ui-tagnav/client/components/tagGroup.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagGroup.js
@@ -6,6 +6,7 @@ import TagGroupHeader from "./tagGroupHeader";
 import { TagItem } from "/imports/plugins/core/ui/client/components/tags/";
 import { TagHelpers } from "/imports/plugins/core/ui-tagnav/client/helpers";
 import { getTagIds } from "/lib/selectors/tags";
+import { Router } from "/client/api";
 
 class TagGroup extends Component {
   constructor(props) {
@@ -119,11 +120,17 @@ class TagGroup extends Component {
   }
 
   render() {
+    const slug = this.state.parentTag.slug;
+    const url = Router.pathFor("tag", {
+      hash: {
+        slug: slug
+      }
+    });
     return (
       <div className="rui tagtree">
         <div className="header">
           <span className="title">{this.state.parentTag.name}</span>
-          <a href={this.state.parentTag.slug}>View All <i className="fa fa-angle-right" /></a>
+          <a href={url}>View All <i className="fa fa-angle-right" /></a>
         </div>
         <div className="content">
           {this.renderTree(this.tags)}


### PR DESCRIPTION
Resolves #2356 
**Testing**
- Start the app and open in either mobile view or full screen mode
- Hover on any tag on the tags menu and notice a dropdown pops out with child tags
- Click on `View all` and observe that it routes to the required page
