### PR TITLE
add a more flexible case insensitive match to CI branch checks

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -4,9 +4,12 @@ set -e
 
 DOCKER_NAMESPACE=${DOCKER_NAMESPACE:-"reactioncommerce/reaction"}
 
-# if we're not on a deployment branch or a Docker related PR branch, skip the Docker build/test
-if [[ "$CIRCLE_BRANCH" != "master" && "$CIRCLE_BRANCH" != "development" && "$CIRCLE_BRANCH" != *"docker"* ]]; then
-  echo "Not running a deployment branch. Skipping the Docker build test."
+shopt -s nocasematch
+
+# if we're not on a deployment branch or a Docker/Release related PR branch, skip the Docker build/test
+if ! [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" == "development" ||
+        "$CIRCLE_BRANCH" =~ "docker" || "$CIRCLE_BRANCH" =~ "release" ]]; then
+  echo "Not running a Docker build test branch. Skipping the build."
   exit 0
 fi
 


### PR DESCRIPTION
This adds a slightly more flexible check for branch names in the CI Docker build script.  It will now trigger a Docker build/test on the following branches:

```
- master
- development
- *docker* (case insensitive regex)
- *release* (case insensitive regex)
```

The motivation for this update was to include "release" branches since they get merged straight to master and could potentially not have a recent Docker build test.