### PR TITLE
Revert minifier to abernix fork

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -15,7 +15,6 @@ ecmascript@0.8.0              # Enable ECMAScript2015+ syntax in app code
 audit-argument-checks@1.0.7   # ensure meteor method argument validation
 browser-policy@1.1.0          # security-related policies enforced by newer browsers
 juliancwirko:postcss          # CSS post-processing plugin (replaces standard-minifier-css)
-standard-minifier-js          # a minifier plugin used for Meteor apps by default
 session@1.1.7                 # ReactiveDict whose contents are preserved across Hot Code Push
 tracker@1.1.3                 # Meteor transparent reactive programming library
 mongo@1.1.18
@@ -95,3 +94,4 @@ johanbrook:publication-collector
 # meteorhacks:sikka                         # additional ddp, login security
 
 # Custom Packages
+abernix:standard-minifier-js@2.1.0-beta.0

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -19,7 +19,7 @@ allow-deny@1.0.5
 amplify@1.0.0
 audit-argument-checks@1.0.7
 autoupdate@1.3.12
-babel-compiler@6.19.2
+babel-compiler@6.19.3
 babel-runtime@1.0.1
 base64@1.0.10
 binary-heap@1.0.10
@@ -55,7 +55,7 @@ cfs:ui@0.1.3
 cfs:upload-http@0.0.20
 cfs:worker@0.1.4
 check@1.2.5
-coffeescript@1.12.3_1
+coffeescript@1.12.6_1
 dburles:factory@1.1.0
 ddp@1.2.5
 ddp-client@1.3.4
@@ -67,7 +67,7 @@ diff-sequence@1.0.7
 dispatch:mocha@0.4.1
 dispatch:run-as-user@1.1.1
 dynamic-import@0.1.1
-ecmascript@0.8.0
+ecmascript@0.8.1
 ecmascript-runtime@0.4.1
 ecmascript-runtime-client@0.4.2
 ecmascript-runtime-server@0.4.1
@@ -86,7 +86,7 @@ html-tools@1.0.11
 htmljs@1.0.11
 http@1.2.12
 id-map@1.0.9
-johanbrook:publication-collector@1.0.7
+johanbrook:publication-collector@1.0.8
 jparker:crypto-core@0.1.0
 jparker:crypto-md5@0.1.1
 jparker:gravatar@0.5.1
@@ -111,7 +111,7 @@ minifier-css@1.2.16
 minimongo@1.2.1
 mobile-experience@1.0.4
 mobile-status-bar@1.0.14
-modules@0.9.1
+modules@0.9.2
 modules-runtime@0.8.0
 momentjs:moment@2.18.1
 mongo@1.1.18

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,3 +1,5 @@
+abernix:minifier-js@2.1.0-beta.0
+abernix:standard-minifier-js@2.1.0-beta.0
 accounts-base@1.3.0
 accounts-facebook@1.2.0
 accounts-google@1.2.0
@@ -106,7 +108,6 @@ meteor-base@1.1.0
 meteorhacks:ssr@2.2.0
 meteorhacks:subs-manager@1.6.4
 minifier-css@1.2.16
-minifier-js@2.1.0
 minimongo@1.2.1
 mobile-experience@1.0.4
 mobile-status-bar@1.0.14
@@ -150,7 +151,6 @@ shell-server@0.2.3
 spacebars@1.0.15
 spacebars-compiler@1.1.2
 srp@1.0.10
-standard-minifier-js@2.1.0
 templating@1.3.2
 templating-compiler@1.3.2
 templating-runtime@1.3.2


### PR DESCRIPTION
I've confirmed reverting this fixes the failing Docker builds that were reporting memory issues.  Specifically #2475.