### PR TITLE
Enable product images on order complete and admin pages

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/items.js
+++ b/imports/plugins/core/orders/client/templates/list/items.js
@@ -7,20 +7,24 @@ import { Media } from "/lib/collections";
  */
 Template.ordersListItems.helpers({
   media: function () {
-    const variantImage = Media.findOne({
-      "metadata.productId": this.productId,
-      "metadata.variantId": this.variants._id
-    });
-    // variant image
-    if (variantImage) {
-      return variantImage;
-    }
-    // find a default image
-    const productImage = Media.findOne({
-      "metadata.productId": this.productId
-    });
-    if (productImage) {
-      return productImage;
+    const cartImagesSub = Meteor.subscribe("CartItemImage", this);
+    if (cartImagesSub.ready()) {
+      const variantImage = Media.findOne({
+        "metadata.productId": this.productId,
+        "metadata.variantId": this.variants._id
+      });
+      // variant image
+      if (variantImage) {
+        return variantImage;
+      }
+      // find a default image
+      const productImage = Media.findOne({
+        "metadata.productId": this.productId
+      });
+      if (productImage) {
+        return productImage;
+      }
+      return false;
     }
     return false;
   },


### PR DESCRIPTION
This resolve #2439 

### Steps to test
1. Sign in as admin
1. Add images to a product/variant
1. Complete an order
1. Observe that the product image is shown anywhere