### PR TITLE
Remove redundant risul:moment-timezone

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -70,7 +70,6 @@ meteorhacks:subs-manager
 natestrauser:select2
 ongoworks:security
 raix:ui-dropped-event
-risul:moment-timezone
 tmeasday:publish-counts
 vsivsi:job-collection@=1.4.0
 react-meteor-data@=0.2.9

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -142,7 +142,6 @@ reactive-dict@1.1.9
 reactive-var@1.0.11
 reload@1.1.11
 retry@1.0.9
-risul:moment-timezone@0.5.7
 routepolicy@1.0.12
 service-configuration@1.0.11
 session@1.1.7

--- a/client/modules/i18n/main.js
+++ b/client/modules/i18n/main.js
@@ -1,4 +1,5 @@
 import i18next from "i18next";
+import moment from "moment";
 import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";

--- a/imports/plugins/core/i18n/client/containers/localizationSettingsContainer.js
+++ b/imports/plugins/core/i18n/client/containers/localizationSettingsContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import moment from "moment-timezone";
 import { Meteor } from "meteor/meteor";
 import { Reaction, i18next } from "/client/api";
 import { composeWithTracker } from "/lib/api/compose";

--- a/imports/plugins/included/payments-braintree/server/methods/braintreeApi.js
+++ b/imports/plugins/included/payments-braintree/server/methods/braintreeApi.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import Braintree from "braintree";
 import accounting from "accounting-js";
+import moment from "moment";
 import Future from "fibers/future";
 import { Meteor } from "meteor/meteor";
 import { Packages } from "/lib/collections";

--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -1,5 +1,6 @@
 /* eslint camelcase: 0 */
 import _ from "lodash";
+import moment from "moment";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Reaction, Logger } from "/server/api";

--- a/server/api/core/accounts/password.js
+++ b/server/api/core/accounts/password.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import moment from "moment";
 import { Meteor } from "meteor/meteor";
 import { Accounts } from "meteor/accounts-base";
 import { SSR } from "meteor/meteorhacks:ssr";


### PR DESCRIPTION
- Removes the Meteor package risul:moment-timezone
- Implements missing imports for moment
