### PR TITLE
Fix Errors importing exported product data 

### DIFF
--- a/server/api/core/import.js
+++ b/server/api/core/import.js
@@ -229,7 +229,9 @@ Import.product = function (key, product) {
   // If product has an _id, we use it to look up the product before
   // updating the product so as to avoid trying to change the _id
   // which is immutable.
-  if (product._id && !key._id) key._id = product._id;
+  if (product._id && !key._id) {
+    key._id = product._id;
+  }
   return this.object(Collections.Products, key, product);
 };
 

--- a/server/api/core/import.js
+++ b/server/api/core/import.js
@@ -360,7 +360,9 @@ Import.object = function (collection, key, object) {
   const updateObject = object;
 
   // enforce strings instead of Mongo.ObjectId
-  if (!collection.findOne(key) && !object._id) key._id = Random.id();
+  if (!collection.findOne(key) && !object._id) {
+    key._id = Random.id();
+  }
 
   // hooks for additional import manipulation.
   const importObject = Hooks.Events.run(`onImport${this._name(collection)}`, object);

--- a/server/api/core/import.js
+++ b/server/api/core/import.js
@@ -356,6 +356,12 @@ Import.object = function (collection, key, object) {
   // enforce strings instead of Mongo.ObjectId
   if (!collection.findOne(key) && !object._id) key._id = Random.id();
 
+  // remove _id fields from documents to be imported
+  // since they are automatically generated and "immutable"
+  if (object._id) {
+    delete object._id;
+  }
+
   // hooks for additional import manipulation.
   const importObject = Hooks.Events.run(`onImport${this._name(collection)}`, object);
 

--- a/server/api/core/import.js
+++ b/server/api/core/import.js
@@ -226,6 +226,10 @@ Import.buffer = function (collection) {
  * * Update the variant.
  */
 Import.product = function (key, product) {
+  // If product has an _id, we use it to look up the product before
+  // updating the product so as to avoid trying to change the _id
+  // which is immutable.
+  if (product._id && !key._id) key._id = product._id;
   return this.object(Collections.Products, key, product);
 };
 
@@ -355,12 +359,6 @@ Import.object = function (collection, key, object) {
 
   // enforce strings instead of Mongo.ObjectId
   if (!collection.findOne(key) && !object._id) key._id = Random.id();
-
-  // remove _id fields from documents to be imported
-  // since they are automatically generated and "immutable"
-  if (object._id) {
-    delete object._id;
-  }
 
   // hooks for additional import manipulation.
   const importObject = Hooks.Events.run(`onImport${this._name(collection)}`, object);


### PR DESCRIPTION
This resolves #2480 

### Steps to test
1. Sign in as admin
1. Add some products
1. Export the Products and Tags to a `Products.json` and `Tags.json` respectively
1. Replace the Products.json and `Tags.json` in `/private/data` with the exported files
1. Restart the application.
1. Observe that terminal throws no import errors as the application starts