### PR TITLE
Default to using shop country code or GeoIP result for new addresses

### DIFF
--- a/client/modules/accounts/templates/addressBook/add/add.js
+++ b/client/modules/accounts/templates/addressBook/add/add.js
@@ -3,12 +3,13 @@ import { Session } from "meteor/session";
 import { Meteor } from "meteor/meteor";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { Template } from "meteor/templating";
-import { i18next } from "/client/api";
+import { Reaction, i18next } from "/client/api";
 import * as Collections from "/lib/collections";
 
 Template.addressBookAdd.helpers({
   thisAddress: function () {
     const thisAddress = {};
+    const shop = Collections.Shops.findOne({ _id: Reaction.getShopId() });
     // admin should receive his account
     const account = Collections.Accounts.findOne({
       userId: Meteor.userId()
@@ -26,6 +27,15 @@ Template.addressBookAdd.helpers({
             thisAddress.isBillingDefault = true;
           }
         }
+      }
+    }
+
+    // Set default country code based on shop's shipping address
+    if (shop && Array.isArray(shop.addressBook) && shop.addressBook.length > 0) {
+      const defaultAddress = shop.addressBook.find(address => address.isShippingDefault);
+      const defaultCountryCode = defaultAddress.country;
+      if (defaultCountryCode) {
+        thisAddress.country = defaultCountryCode;
       }
     }
 

--- a/client/modules/accounts/templates/addressBook/add/add.js
+++ b/client/modules/accounts/templates/addressBook/add/add.js
@@ -1,34 +1,47 @@
 import { $ } from "meteor/jquery";
 import { Session } from "meteor/session";
 import { Meteor } from "meteor/meteor";
+import { HTTP } from "meteor/http";
+import { ReactiveVar } from "meteor/reactive-var";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { Template } from "meteor/templating";
 import { Reaction, i18next } from "/client/api";
 import * as Collections from "/lib/collections";
 
+Template.addressBookAdd.onCreated(function () {
+  this.currentCountry = new ReactiveVar(null);
+  // hit Reaction's GeoIP server and try to determine the user's country
+  HTTP.get("https://geo.getreaction.io/json/", (err, res) => {
+    if (!err) {
+      this.currentCountry.set(res.data.country_code);
+    }
+  });
+});
+
 Template.addressBookAdd.helpers({
-  thisAddress: function () {
+  thisAddress() {
     const thisAddress = {};
-    const shop = Collections.Shops.findOne({ _id: Reaction.getShopId() });
-    // admin should receive his account
+
+    // admin should receive their account
     const account = Collections.Accounts.findOne({
       userId: Meteor.userId()
     });
-    if (account) {
-      if (account.profile) {
-        if (account.profile.name) {
-          thisAddress.fullName = account.profile.name;
-        }
-        // if this will be the first address we set defaults here and not display
-        // them inside form
-        if (account.profile.addressBook) {
-          if (account.profile.addressBook.length === 0) {
-            thisAddress.isShippingDefault = true;
-            thisAddress.isBillingDefault = true;
-          }
+
+    if (account && account.profile) {
+      if (account.profile.name) {
+        thisAddress.fullName = account.profile.name;
+      }
+      // if this will be the first address we set defaults here and not display
+      // them inside form
+      if (account.profile.addressBook) {
+        if (account.profile.addressBook.length === 0) {
+          thisAddress.isShippingDefault = true;
+          thisAddress.isBillingDefault = true;
         }
       }
     }
+
+    const shop = Collections.Shops.findOne(Reaction.getShopId());
 
     // Set default country code based on shop's shipping address
     if (shop && Array.isArray(shop.addressBook) && shop.addressBook.length > 0) {
@@ -45,6 +58,9 @@ Template.addressBookAdd.helpers({
       thisAddress.city = Session.get("address").city;
       thisAddress.region = Session.get("address").state;
     }
+
+    // update the reactive country code from the GeoIP lookup (if found)
+    thisAddress.country = Template.instance().currentCountry.get() || thisAddress.country;
 
     return thisAddress;
   },


### PR DESCRIPTION
For the address add template, default the country dropdown to use the active shop's country if it exists instead of defaulting to unselected.

To test: 
1. Make sure your shop has an address set.
2. Go through the checkout process as a new / logged out user (incognito works).
3. Observe that the country for your new address is set by default to the shops country.