### PR TITLE
[WIP] Display correct price range in product grid when variants are archived

### DIFF
--- a/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
@@ -144,7 +144,7 @@ class ProductGridItemsContainer extends Component {
 
   displayPrice = () => {
     if (this.props.product.price && this.props.product.price.range) {
-      return this.props.product.price.range;
+      return ReactionProduct.getProductPriceRange(this.props.product._id).range;
     }
   }
 


### PR DESCRIPTION
This resolves #2521 

### Steps to test
1. Clone the "Basic Reaction Product"
1. Archive the "Red" option so the price just shows $12.99 in the PDP
1. Publish
1. Observe that the price range on the product grid has changed to $12.99