### PR TITLE
update Docker base to v2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM reactioncommerce/base:v2.0.0
+FROM reactioncommerce/base:v2.0.2
 
 # Default environment variables
 ENV ROOT_URL "http://localhost"


### PR DESCRIPTION
This update doesn't actually change any functionality of the container.  It only adds a new environment variable (`REACTION_DOCKER_BUILD=true`) so that you can test for when you're inside of an official Reaction Docker build (now used by `reaction-cli`).