### PR TITLE
fix #2547: UI Safari bug fix for navbar 

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/tagNav.less
+++ b/imports/plugins/included/default-theme/client/styles/tagNav.less
@@ -294,7 +294,7 @@
 }
 
 .rui.tagnav .navbar-item {
-  height: 100%;
+  height: @navbar-height;
 }
 
 .rui.tagnav.vertical .navbar-item {


### PR DESCRIPTION
- Resolves https://github.com/reactioncommerce/reaction/issues/2547
- Sets `.navbar-item` height to the height of the navbar with the `@navbar-height` variable instead of the percentage. Percentage height breaks in Safari.

## Steps to Reproduce & Test:
- open http://localhost:3000 in Safari and Chrome on desktop
- compare the navbar on both browsers:

![screen shot 2017-07-11 at 2 44 12 pm](https://user-images.githubusercontent.com/3673236/28092375-f9abbee6-6647-11e7-8635-70b760f2f0e3.png)

![screen shot 2017-07-11 at 2 48 51 pm](https://user-images.githubusercontent.com/3673236/28092399-138958e6-6648-11e7-8eb6-4fbedce914ba.png)


