### PR TITLE
Fix product rearrangement at load time

### DIFF
--- a/imports/plugins/included/product-variant/containers/productsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainer.js
@@ -116,24 +116,24 @@ function composer(props, onData) {
   if (!tag && slug) {
     return;
   }
+  const currentTag = ReactionProduct.getTag();
+
+  const sort = {
+    [`positions.${currentTag}.position`]: 1,
+    [`positions.${currentTag}.createdAt`]: 1,
+    createdAt: 1
+  };
 
   const queryParams = Object.assign({}, tags, Reaction.Router.current().queryParams);
-  const productsSubscription = Meteor.subscribe("Products", scrollLimit, queryParams);
+  const productsSubscription = Meteor.subscribe("Products", scrollLimit, queryParams, sort);
 
   if (productsSubscription.ready()) {
     window.prerenderReady = true;
   }
 
-  const currentTag = ReactionProduct.getTag();
   const productCursor = Products.find({
     ancestors: [],
     type: { $in: ["simple"] }
-  }, {
-    sort: {
-      [`positions.${currentTag}.position`]: 1,
-      [`positions.${currentTag}.createdAt`]: 1,
-      createdAt: 1
-    }
   });
 
   const products = productCursor.map((product) => {


### PR DESCRIPTION
This resolves #1443 

### Steps to Reproduce the Behavior

1. Load more products (e.g. 30+).
1. Rearrange products as administrator (e.g. put last added product in the beginning of the page).
1. Log out/log in as non-admin, refresh the page so that only the first 24 products are loaded and the "load more products" button shows at the bottom.
1. Notice that the first product is the one that you moved there, and the first set of products are in the order you arranged them.
1. Click on "load more products", and see that all the new products are added to the lower part of the page only, and not mixed with the already presented products.
