### PR TITLE
Fix LoadMoreProducts button not working as it should

### DIFF
--- a/imports/plugins/included/product-variant/components/products.js
+++ b/imports/plugins/included/product-variant/components/products.js
@@ -69,7 +69,7 @@ class ProductsComponent extends Component {
   render() {
     if (this.props.ready()) {
       return (
-        <div>
+        <div id="container-main">
           {this.renderProductGrid()}
           {this.renderLoadMoreProductsButton()}
           {this.renderSpinner()}

--- a/imports/plugins/included/product-variant/containers/productsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainer.js
@@ -20,16 +20,15 @@ import ProductsComponent from "../components/products";
 function loadMoreProducts() {
   let threshold;
   const target = document.querySelectorAll("#productScrollLimitLoader");
-  let scrollContainer = document.querySelectorAll("#reactionAppContainer");
-
+  let scrollContainer = document.querySelectorAll("#container-main");
   if (scrollContainer.length === 0) {
     scrollContainer = window;
   }
 
   if (target.length) {
-    threshold = scrollContainer[0].scrollTop + scrollContainer[0].offsetHeight - target[0].offsetHeight;
+    threshold = scrollContainer[0].scrollHeight - scrollContainer[0].scrollTop === scrollContainer[0].clientHeight;
 
-    if (target[0].offsetTop <= threshold) {
+    if (threshold) {
       if (!target[0].getAttribute("visible")) {
         target[0].setAttribute("productScrollLimit", true);
         Session.set("productScrollLimit", Session.get("productScrollLimit") + ITEMS_INCREMENT || 24);

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -262,9 +262,32 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
               ancestors: {
                 $in: productIds
               }
-            }, {
-              hashtags: {
-                $in: productFilters.tags
+            }, { $and: [
+              {
+                hashtags: {
+                  $in: productFilters.tags
+                }
+              }, {
+                _id: {
+                  $in: productIds
+                }
+              }
+            ]
+            }
+          ]
+        });
+      } else {
+        newSelector = _.omit(selector, ["hashtags"]);
+        _.extend(newSelector, {
+          $or: [
+            {
+              ancestors: {
+                $in: productIds
+              }
+            },
+            {
+              _id: {
+                $in: productIds
               }
             }
           ]

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -242,6 +242,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
       selector.isVisible = {
         $in: [true, false, undefined]
       };
+      selector.ancestors = [];
 
       // Get _ids of top-level products
       const productIds = Products.find(selector, {
@@ -253,7 +254,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
 
       // Remove hashtag filter from selector (hashtags are not applied to variants, we need to get variants)
       if (productFilters && productFilters.tags) {
-        newSelector = _.omit(selector, ["hashtags"]);
+        newSelector = _.omit(selector, ["hashtags", "ancestors"]);
 
         // Re-configure selector to pick either Variants of one of the top-level products, or the top-level products in the filter
         _.extend(newSelector, {
@@ -277,7 +278,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
           ]
         });
       } else {
-        newSelector = _.omit(selector, ["hashtags"]);
+        newSelector = _.omit(selector, ["hashtags", "ancestors"]);
         _.extend(newSelector, {
           $or: [
             {


### PR DESCRIPTION
This resolves #2525 

### Steps to test

1. Sign in to the app as admin.
1. Create 24+ products (like 30 or so).
1. Refresh the page
1. Observe that when you scroll, you can see only the first 24 products and the `loadMoreProducts` button.
1. Observe that when you click on the button, the remain products are loaded as expected and when you've loaded all the products, the `loadMoreProducts` is no longer displayed.