### PR TITLE
Fix You may not observe cursor with fields _id: 0

### DIFF
--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -51,11 +51,7 @@ Meteor.startup(() => {
       //
       return Meteor.subscribe("Translations", language, () => {
         // fetch reaction translations
-        const translations = Translations.find({}, {
-          fields: {
-            _id: 0
-          }
-        }).fetch();
+        const translations = Translations.find({}).fetch();
 
         //
         // reduce and merge translations


### PR DESCRIPTION
Fixes console error
```
Error: You may not observe a cursor with {fields: {_id: 0}}
```
Not really sure when it got introduced, perhaps in Meteor `1.5.1rc5`?

@erik and I had both seen this issue intermittently

Not really sure why we're trying to suppress the `_id`s for Translations anyway, but if there's a good reason to do that, please let me know.