### PR TITLE
Add Community pages

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Reaction Commerce Code of Conduct
+
+All Community Guidelines content is licensed under a [Creative Commons Attribution](https://creativecommons.org/licenses/by/3.0/) license.
+
+Like the technical community as a whole, the Reaction team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
+
+Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to founders, mentors, and those seeking help and guidance.
+
+This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the broader communities in which we participate.
+
+This code of conduct applies to all spaces managed by Reaction Commerce. This includes our [development chat room](https://gitter.im/reactioncommerce/reaction), [forums](https://forums.reactioncommerce.com), [blog](https://blog.reactioncommerce.com), mailing lists, [issue tracker](https://github.com/reactioncommerce/reaction/issues), [project board](https://waffle.io/reactioncommerce/reaction), Reaction events and meetups, and any other forums or service created by the core project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+
+If you believe someone is violating the code of conduct, we ask that you report it by emailing [conduct@reactioncommerce.com](mailto:conduct@reactioncommerce.com). For more details, please see our [Reporting Guidelines](https://docs.reactioncommerce.com/reaction-docs/master/reporting-guide).
+
+- **Be friendly and patient.**
+
+- **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+
+- **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
+
+- **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Reaction community should be respectful when dealing with other members as well as with people outside the Reaction community.
+
+- **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
+
+  - Violent threats or language directed against another person.
+  - Discriminatory jokes and language.
+  - Posting sexually explicit or violent material.
+  - Posting (or threatening to post) other people's personally identifying information ("doxing").
+  - Personal insults, especially those using racist or sexist terms.
+  - Unwelcome sexual attention.
+  - Advocating for, or encouraging, any of the above behavior.
+  - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+
+- **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and Reaction is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of Reaction comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+
+## Questions?
+
+If you have questions, please see the [FAQs](https://docs.reactioncommerce.com/reaction-docs/master/guideline-faqs). If that doesn't answer your questions, feel free to [contact us](mailto:hello@reactioncommerce.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+At Reaction Commerce, we're dedicated to the open source community. In fact, we've designed our entire platform and business to grow from the passion and creativity that an open source community ignites. We've already attracted a small, dedicated team of open source contributors, and there's always room for more. If you'd like to join us, here's how to get started:
+
+**Step 1:**  If you haven't already, get Reaction running locally:
+
+```sh
+curl https://install.meteor.com | /bin/sh
+git clone https://github.com/reactioncommerce/reaction.git
+cd reaction
+reaction
+```
+
+**Step 2:**
+
+Explore the interface and the code to give you a good overview of the product and a sense for what's already built. Keep an eye out for bugs and interface issues, as well as features you'd like to see created.
+
+**Step 3:**
+
+Explore the [GitHub issues already open on our main repo](https://waffle.io/reactioncommerce/reaction). If you find something you want to work on, let us know right there in the comments. If you are interested in a specific aspect of the project but aren't sure where to begin, feel free to ask. Start small and open up a dialogue with us. This will help to get your contributions accepted easily.
+
+**Step 4:**
+
+Let us know how we can make the contribution process easier. We want to find the best ways to support you.
+
+## Pull Requests
+
+[Create a pull request](https://help.github.com/articles/creating-a-pull-request/) to propose and collaborate on changes to Reaction. These changes are proposed in a PR branch, and are reviewed before merge acceptance into `development` for release.
+
+- Should reference an issue if one exists, or provide detailed information on the goal of the PR.
+- Should pass CI / Tests. New functionality should include new tests.
+- Should passing a linter code review and follow Reaction style guidelines.
+- Contributors should review the CLA.
+- Code reviewed before merge acceptance.


### PR DESCRIPTION
- Adds `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` text from [Docs](docs.reactioncommerce.com) to adhere to GitHub's Open Source Guide.

- As a result, the Contributing guide will be linked on all incoming Pull Request pages:

![image](https://user-images.githubusercontent.com/3673236/28384062-234f254a-6c78-11e7-85b2-2fedb4ead065.png)

- And Reaction will be at 💯  on this checklist:

![screen shot 2017-07-19 at 11 51 10 am](https://user-images.githubusercontent.com/3673236/28384178-965b5964-6c78-11e7-8406-49d68a2a9f8c.png)

