### PR TITLE
Fix MultiSelect prop type "value"

### DIFF
--- a/imports/plugins/core/ui/client/components/multiselect/multiselect.js
+++ b/imports/plugins/core/ui/client/components/multiselect/multiselect.js
@@ -19,7 +19,7 @@ class MultiSelect extends Component {
     onChange: PropTypes.func,
     options: PropTypes.array,
     placeholder: PropTypes.string,
-    value: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
+    value: PropTypes.any
   }
 
   renderLabel() {


### PR DESCRIPTION
react-select expects `value` to be of type `any`. Updated prop type to match that case.

My greatest achievement yet.