### PR TITLE
Update users when groups updated - Resolves 2195

### DIFF
--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -234,7 +234,7 @@ export function buildAccountSearchRecord(accountId) {
   check(accountId, String);
   const account = Accounts.findOne(accountId);
   // let's ignore anonymous accounts
-  if (account.emails.length) {
+  if (account && account.emails && account.emails.length) {
     const accountSearch = {};
     for (const field of requiredFields.accounts) {
       if (transformations.accounts[field]) {

--- a/server/api/core/addDefaultRoles.js
+++ b/server/api/core/addDefaultRoles.js
@@ -1,9 +1,54 @@
+import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Groups } from "/lib/collections";
+import { Groups, Shops, Accounts } from "/lib/collections";
 import { Logger } from "/server/api";
 
 /**
- * Add roles to the default groups for shops
+ * Private method which should only be called by addRolesToGroups to keep users in sync with updated groups
+ * @private
+ * @method addRolesToUsersInGroups
+ * @param  {object} options object that contains the query selector for groups and roles to add to users
+ * @returns {number} count of all update operations performed
+ */
+function addRolesToUsersInGroups(options) {
+  const { query, roles } = options;
+  const groupsToUpdate = Groups.find(query);
+
+  // We need a list of groups => shops to determine which users get which updates
+  const groupAndShopIds = groupsToUpdate.map((group) => {
+    return {
+      id: group._id,
+      shopId: group.shopId
+    };
+  });
+
+  // We perform one update for each groupId and return a count of the number of updates performed
+  return groupAndShopIds.reduce((updates, group) => {
+    // Find all accounts with this group
+    const accounts = Accounts.find({ groups: group.id });
+    // Get a list of all userIds in those accounts
+    const userIds = accounts.map((account) => account._id);
+    // We're going to update all users with an _id that matched
+    const selector = { _id: { $in: userIds } };
+
+    // Build our update operation - add new roles to set for the shop associated with this group.
+    const operation = {};
+    operation.$addToSet = {};
+    operation.$addToSet[group.shopId] = { $each: roles };
+
+    // Run the update and store the result
+    const countOfUpdatedUsers = Meteor.users.update(selector, operation, { multi: true });
+
+    // Sum with the running total of all updates performed
+    // Note that we're counting total updates, not unique users updated.
+    // Any user in multiple groups will get counted multiple times.
+    return updates + countOfUpdatedUsers;
+  }, 0);
+}
+
+/**
+ * Add roles to the default groups for shops and adds roles added to the default groups
+ * to any users who are in those groups for the appropriate shops.
  * Options:
  * allShops: add supplied roles to all shops, defaults to false
  * roles: Array of roles to add to default roles set
@@ -12,13 +57,15 @@ import { Logger } from "/server/api";
  * @param {Object} options - See above for details
  * @returns {Number} result of Shops.update method (number of documents updated)
  */
-export function addRolesToGroups(options = { allShops: false, roles: [], shops: [], groups: ["guest"] }) {
+export function addRolesToGroups(options = { allShops: false, roles: [], shopIds: [], groups: ["guest"] }) {
   check(options.roles, [String]);
   check(options.allShops, Match.Maybe(Boolean));
-  check(options.shops, Match.Maybe([String]));
+  check(options.shopsIds, Match.Maybe([String]));
   check(options.groups, Match.Maybe([String]));
 
-  const { allShops, roles, shops, groups } = options;
+  const { allShops, roles, groups } = options;
+
+  const { shopIds } = options; // we'll reassign shopIds if we are using all shops
   const query = {
     slug: {
       $in: groups
@@ -26,13 +73,20 @@ export function addRolesToGroups(options = { allShops: false, roles: [], shops: 
   };
   const multi = { multi: true };
 
+  // We need this for updating users roles
+
   if (!allShops) {
     // if we're not updating for all shops, we should only update for the shops passed in.
-    query.shopId = { $in: shops || [] };
-    Logger.debug(`Adding Roles: ${roles} to Groups: ${groups} for shops: ${shops}`);
+    query.shopId = { $in: shopIds || [] };
+
+    Logger.debug(`Adding Roles: ${roles} to Groups: ${groups} for shops: ${shopIds}`);
   } else {
     Logger.debug(`Adding Roles: ${roles} to Groups: ${groups} for all shops`);
   }
 
-  return Groups.update(query, { $addToSet: { permissions: { $each: roles } } }, multi);
+  const groupsUpdated = Groups.update(query, { $addToSet: { permissions: { $each: roles } } }, multi);
+  const usersUpdated = addRolesToUsersInGroups({ roles, query });
+
+  // Return the count of groups and users updated;
+  return { groupsUpdated, usersUpdated };
 }

--- a/server/api/core/addDefaultRoles.js
+++ b/server/api/core/addDefaultRoles.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Groups, Shops, Accounts } from "/lib/collections";
+import { Accounts, Groups, Shops } from "/lib/collections";
 import { Logger } from "/server/api";
 
 /**
@@ -8,12 +8,20 @@ import { Logger } from "/server/api";
  * @private
  * @method addRolesToUsersInGroups
  * @param  {object} options object that contains the query selector for groups and roles to add to users
- * @returns {number} count of all update operations performed
+ * @returns {void}
  */
 function addRolesToUsersInGroups(options) {
-  const { query, roles } = options;
-  const groupsToUpdate = Groups.find(query);
+  const { query, roles } = { ...options };
 
+  if (!query.shopId) {
+    const shops = Shops.find({}).fetch();
+    const shopIds = shops.map((shop) => shop._id);
+    query.shopId = {
+      $in: shopIds
+    };
+  }
+
+  const groupsToUpdate = Groups.find(query, { fields: { _id: 1, shopId: 1 } }).fetch();
   // We need a list of groups => shops to determine which users get which updates
   const groupAndShopIds = groupsToUpdate.map((group) => {
     return {
@@ -23,49 +31,46 @@ function addRolesToUsersInGroups(options) {
   });
 
   // We perform one update for each groupId and return a count of the number of updates performed
-  return groupAndShopIds.reduce((updates, group) => {
+  groupAndShopIds.forEach((group) => {
     // Find all accounts with this group
-    const accounts = Accounts.find({ groups: group.id });
+    const accounts = Accounts.find({ groups: group.id }, { fields: { _id: 1 } }).fetch();
     // Get a list of all userIds in those accounts
     const userIds = accounts.map((account) => account._id);
     // We're going to update all users with an _id that matched
     const selector = { _id: { $in: userIds } };
 
     // Build our update operation - add new roles to set for the shop associated with this group.
-    const operation = {};
-    operation.$addToSet = {};
-    operation.$addToSet[group.shopId] = { $each: roles };
+    const operation = {
+      $addToSet: {
+        [`roles.${group.shopId}`]: {
+          $each: roles
+        }
+      }
+    };
 
-    // Run the update and store the result
-    const countOfUpdatedUsers = Meteor.users.update(selector, operation, { multi: true });
-
-    // Sum with the running total of all updates performed
-    // Note that we're counting total updates, not unique users updated.
-    // Any user in multiple groups will get counted multiple times.
-    return updates + countOfUpdatedUsers;
-  }, 0);
+    // Update users
+    Meteor.users.update(selector, operation, { multi: true });
+  });
 }
 
 /**
- * Add roles to the default groups for shops and adds roles added to the default groups
- * to any users who are in those groups for the appropriate shops.
+ * Add roles to the default groups for shops and updates any users that are in
+ * those permission groups
  * Options:
  * allShops: add supplied roles to all shops, defaults to false
  * roles: Array of roles to add to default roles set
  * shops: Array of shopIds that should be added to set
  * groups: Groups to add roles to, Options: ["guest", "customer", "owner"]
  * @param {Object} options - See above for details
- * @returns {Number} result of Shops.update method (number of documents updated)
+ * @returns {Number} result of Groups.update method (number of documents updated)
  */
-export function addRolesToGroups(options = { allShops: false, roles: [], shopIds: [], groups: ["guest"] }) {
+export function addRolesToGroups(options = { allShops: false, roles: [], shops: [], groups: ["guest"] }) {
   check(options.roles, [String]);
   check(options.allShops, Match.Maybe(Boolean));
-  check(options.shopsIds, Match.Maybe([String]));
+  check(options.shops, Match.Maybe([String]));
   check(options.groups, Match.Maybe([String]));
 
-  const { allShops, roles, groups } = options;
-
-  const { shopIds } = options; // we'll reassign shopIds if we are using all shops
+  const { allShops, roles, shops, groups } = options;
   const query = {
     slug: {
       $in: groups
@@ -73,20 +78,15 @@ export function addRolesToGroups(options = { allShops: false, roles: [], shopIds
   };
   const multi = { multi: true };
 
-  // We need this for updating users roles
-
   if (!allShops) {
     // if we're not updating for all shops, we should only update for the shops passed in.
-    query.shopId = { $in: shopIds || [] };
-
-    Logger.debug(`Adding Roles: ${roles} to Groups: ${groups} for shops: ${shopIds}`);
+    query.shopId = { $in: shops || [] };
+    Logger.debug(`Adding Roles: ${roles} to Groups: ${groups} for shops: ${shops}`);
   } else {
     Logger.debug(`Adding Roles: ${roles} to Groups: ${groups} for all shops`);
   }
 
-  const groupsUpdated = Groups.update(query, { $addToSet: { permissions: { $each: roles } } }, multi);
-  const usersUpdated = addRolesToUsersInGroups({ roles, query });
+  addRolesToUsersInGroups({ query, roles });
 
-  // Return the count of groups and users updated;
-  return { groupsUpdated, usersUpdated };
+  return Groups.update(query, { $addToSet: { permissions: { $each: roles } } }, multi);
 }

--- a/server/methods/core/groups.app-test.js
+++ b/server/methods/core/groups.app-test.js
@@ -22,6 +22,7 @@ describe("Group test", function () {
 
   const sampleCustomerGroup = {
     name: "Customer",
+    slug: "customer",
     permissions: ["guest", "account/profile", "product", "tag", "index", "cart/checkout", "cart/completed"]
   };
 
@@ -171,5 +172,40 @@ describe("Group test", function () {
     Meteor.call("group/updateGroup", group._id, newGroupData, shop._id);
     updatedUser = Meteor.users.findOne({ _id: user._id });
     expect(updatedUser.roles[shop._id]).to.include.members(newGroupData.permissions);
+  });
+
+
+  it("should add permissions for users in a group when roles are added", function () {
+    this.timeout(10000);
+    sandbox.stub(Reaction, "hasPermission", () => true);
+    spyOnMethod("createGroup", shop._id);
+    spyOnMethod("addUser", shop._id);
+
+    Meteor.call("group/createGroup", sampleCustomerGroup, shop._id);
+    const group = Groups.findOne({ shopId: shop._id });
+    Meteor.call("group/addUser", user._id, group._id);
+    let updatedUser = Meteor.users.findOne({ _id: user._id });
+    expect(updatedUser.roles[shop._id]).to.include.members(sampleCustomerGroup.permissions);
+
+    Reaction.addRolesToGroups({ shops: [shop._id], roles: ["test-updated-role"], groups: ["customer"] });
+    updatedUser = Meteor.users.findOne({ _id: user._id });
+    expect(updatedUser.roles[shop._id]).to.contain("test-updated-role");
+  });
+
+  it("should add permissions for users in a group when roles are added to all shops", function () {
+    this.timeout(10000);
+    sandbox.stub(Reaction, "hasPermission", () => true);
+    spyOnMethod("createGroup", shop._id);
+    spyOnMethod("addUser", shop._id);
+
+    Meteor.call("group/createGroup", sampleCustomerGroup, shop._id);
+    const group = Groups.findOne({ shopId: shop._id });
+    Meteor.call("group/addUser", user._id, group._id);
+    let updatedUser = Meteor.users.findOne({ _id: user._id });
+    expect(updatedUser.roles[shop._id]).to.include.members(sampleCustomerGroup.permissions);
+
+    Reaction.addRolesToGroups({ allShops: true, shops: [], roles: ["test-updated-role"], groups: ["customer"] });
+    updatedUser = Meteor.users.findOne({ _id: user._id });
+    expect(updatedUser.roles[shop._id]).to.contain("test-updated-role");
   });
 });


### PR DESCRIPTION
Finishes #2195 

This was already the case when editing groups via the admin panel, but this PR extends that functionality to make sure that if new plugins add permissions to default groups that users in those groups have their permissions updated as well.

Adds some tests for this new functionality as well.