### PR TITLE
move packageNameSpace into startup file (marketplace)

### DIFF
--- a/client/modules/i18n/main.js
+++ b/client/modules/i18n/main.js
@@ -4,7 +4,7 @@ import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
 import { Reaction } from "/client/api";
-import { Shops, Packages } from "/lib/collections";
+import { Shops } from "/lib/collections";
 
 //
 // Reaction i18n Translations, RTL and Currency Exchange Support
@@ -84,7 +84,6 @@ export function getMessagesFor() {
 export const i18nextDep = new Tracker.Dependency();
 export const localeDep = new Tracker.Dependency();
 export const currencyDep = new Tracker.Dependency();
-export const packageNamespaces = [];
 
 Meteor.startup(() => {
   Tracker.autorun(function (c) {
@@ -104,16 +103,6 @@ Meteor.startup(() => {
       // every package gets a namespace, fetch them and export
       // get packages from primaryShopId as merchant shops
       // may not have all packages
-      const packages = Packages.find({
-        shopId: primaryShopId
-      }, {
-        fields: {
-          name: 1
-        }
-      }).fetch();
-      for (const pkg of packages) {
-        packageNamespaces.push(pkg.name);
-      }
 
       // By default, use the primaryShopId to get locale
       // If markteplace is enabled and set to use merchant currencies,

--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -8,9 +8,9 @@ import { Template } from "meteor/templating";
 import { $ } from "meteor/jquery";
 import { Tracker } from "meteor/tracker";
 import { Reaction } from "/client/api";
-import { Shops, Translations } from "/lib/collections";
+import { Shops, Translations, Packages } from "/lib/collections";
 import * as Schemas from "/lib/collections/schemas";
-import i18next, { packageNamespaces, getLabelsFor, getMessagesFor, i18nextDep, currencyDep } from "./main";
+import i18next, { getLabelsFor, getMessagesFor, i18nextDep, currencyDep } from "./main";
 import { mergeDeep } from "/lib/api";
 
 //
@@ -51,6 +51,20 @@ Meteor.startup(() => {
       } else {
         shopId = Reaction.getPrimaryShopId();
       }
+
+      const packageNamespaces = [];
+
+      const packages = Packages.find({
+        shopId: shopId
+      }, {
+        fields: {
+          name: 1
+        }
+      }).fetch();
+      for (const pkg of packages) {
+        packageNamespaces.push(pkg.name);
+      }
+
 
       const shop = Shops.findOne({
         _id: shopId


### PR DESCRIPTION
Fix translations that were not working correctly in React components.

Resolves #2593 

PR #2637  is the same PR, just into the `development` branch.

I get the glory of the PR, but @mikemurray did most of the work...

We figured out that namespaces were not being loaded in conjunction with i18n. 

The reasoning seems to be that the namespace object was being created in one file, and loaded in another. 

The default namespacing was never loaded into i18n (it was set as `undefined`), and React didn't know to refresh once the namespace object was available. 

The solution was to move the namespacing object creation into the same file as the i18n tree creation, so that they were created in conjucntion and not imported as undefined.