### PR TITLE
Convert remainder of legacy registerComponent calls

### DIFF
--- a/imports/plugins/core/components/lib/components.js
+++ b/imports/plugins/core/components/lib/components.js
@@ -78,7 +78,7 @@ export function registerHOC(name, hocs = []) {
 /**
  * Get a component registered with registerComponent(name, component, ...hocs).
  * @param {String} name The name of the component to get.
- * @return {Function|React.Component} A (wrapped) React component
+ * @return {Function|React.Component|null} A (wrapped) React component
  */
 export function getComponent(name) {
   const component = ComponentsTable[name];

--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -13,7 +13,7 @@ import {
   Translation,
   Overlay
 } from "/imports/plugins/core/ui/client/components";
-import { getComponent } from "/imports/plugins/core/layout/lib/components";
+import { getComponent } from "@reactioncommerce/reaction-components";
 
 
 const getStyles = (props) => {
@@ -194,24 +194,24 @@ class ActionView extends Component {
   renderControlComponent() {
     if (this.props.actionView && typeof this.props.actionView.template === "string") {
       // Render a react component if one has been registered by name
-      const component = getComponent(this.props.actionView.template);
+      try {
+        const component = getComponent(this.props.actionView.template);
 
-      if (component) {
         return (
           <div style={this.styles.masterView} className="master">
             {React.createElement(component, this.props.actionView.data)}
           </div>
         );
+      } catch (e) {
+        return (
+          <div style={this.styles.masterView} className="master">
+            <Blaze
+              {...this.props.actionView.data}
+              template={this.props.actionView.template}
+            />
+          </div>
+        );
       }
-
-      return (
-        <div style={this.styles.masterView} className="master">
-          <Blaze
-            {...this.props.actionView.data}
-            template={this.props.actionView.template}
-          />
-        </div>
-      );
     }
 
     return null;

--- a/imports/plugins/core/dashboard/client/components/packageList.js
+++ b/imports/plugins/core/dashboard/client/components/packageList.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { map } from "lodash";
 import { Card, CardHeader, CardBody, CardGroup, ListItem } from "/imports/plugins/core/ui/client/components";
-import { getComponent } from "/imports/plugins/core/layout/lib/components";
+import { getComponent } from "@reactioncommerce/reaction-components";
 
 class PackageList extends Component {
   static propTypes = {
@@ -64,17 +64,24 @@ class PackageList extends Component {
             );
 
             // Look for a registered component_ActionDashboard component
-            const actionComponent = getComponent(`${packageData.template}_ActionDashboard`);
 
-            // If one exists, add it to the list of elements
-            if (actionComponent) {
-              elements.push(
-                <Card expandable={true} key={`action-${index}`}>
-                  <CardBody>
-                    {React.createElement(actionComponent)}
-                  </CardBody>
-                </Card>
-              );
+            let actionComponent;
+
+            try {
+              actionComponent = getComponent(`${packageData.template}_ActionDashboard`);
+            } catch (e) {
+              actionComponent = null;
+            } finally {
+              // If one exists, add it to the list of elements
+              if (actionComponent) {
+                elements.push(
+                  <Card expandable={true} key={`action-${index}`}>
+                    <CardBody>
+                      {React.createElement(actionComponent)}
+                    </CardBody>
+                  </Card>
+                );
+              }
             }
 
             return elements;

--- a/imports/plugins/core/i18n/client/index.js
+++ b/imports/plugins/core/i18n/client/index.js
@@ -1,7 +1,4 @@
 import LocalizationSettingsContainer from "./containers/localizationSettingsContainer";
-import { registerComponent } from "/imports/plugins/core/layout/lib/components";
+import { registerComponent } from "@reactioncommerce/reaction-components";
 
-registerComponent({
-  name: "i18nSettings",
-  component: LocalizationSettingsContainer
-});
+registerComponent("i18nSettings", LocalizationSettingsContainer);

--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -38,6 +38,7 @@ CoreLayout.propTypes = {
   structure: PropTypes.object
 };
 
-registerComponent("CoreLayout", CoreLayout);
+// lowercased to match the legacy blaze "coreLayout"
+registerComponent("coreLayout", CoreLayout);
 
 export default CoreLayout;

--- a/imports/plugins/core/layout/client/components/printLayout.js
+++ b/imports/plugins/core/layout/client/components/printLayout.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Blaze from "meteor/gadicc:blaze-react-component";
+import { registerComponent } from "@reactioncommerce/reaction-components";
 
 class PrintLayout extends Component {
   static propTypes = {
@@ -13,5 +14,8 @@ class PrintLayout extends Component {
     );
   }
 }
+
+// lowercased to match the legacy blaze "printLayout"
+registerComponent("printLayout", PrintLayout);
 
 export default PrintLayout;

--- a/imports/plugins/core/layout/client/index.js
+++ b/imports/plugins/core/layout/client/index.js
@@ -20,19 +20,5 @@ import "./templates/layout/notice/unauthorized.js";
 import "./templates/theme/theme.html";
 import "./templates/theme/theme.js";
 
-
-import CoreLayout from "./components/coreLayout";
-import PrintLayout from "./components/printLayout";
-import { registerComponent } from "../lib/components";
-
-
-registerComponent({
-  name: "coreLayout", // lowercased to match the legacy blaze "coreLayout"
-  component: CoreLayout
-});
-
-
-registerComponent({
-  name: "printLayout", // lowercased to match the legacy blaze "printLayout"
-  component: PrintLayout
-});
+export CoreLayout from "./components/coreLayout";
+export PrintLayout from "./components/printLayout";

--- a/imports/plugins/core/layout/lib/components.js
+++ b/imports/plugins/core/layout/lib/components.js
@@ -1,19 +1,33 @@
-import Immutable from "immutable";
+/* eslint-disable no-console */
+import {
+  Components,
+  getComponent as newGetComponent,
+  registerComponent as newRegisterComponent
+} from "@reactioncommerce/reaction-components/components";
 
-let registeredComponents = Immutable.Map();
 
 export function registerComponent(componentInfo) {
-  registeredComponents = registeredComponents.set(
-    componentInfo.name,
-    componentInfo
-  );
+  console.warn("DEPRECATED registerComponent(). Use new implementation. see: https://docs.reactioncommerce.com/reaction-docs/master/components-api");
+
+  newRegisterComponent(componentInfo.name, componentInfo.component);
 }
 
 export function getComponent(name) {
-  const componentInfo = registeredComponents.get(name);
-  return componentInfo && componentInfo.component || null;
+  console.warn("DEPRECATED getComponent(). Use new implementation. see: https://docs.reactioncommerce.com/reaction-docs/master/components-api");
+
+  let component = null;
+
+  try {
+    component = newGetComponent(name);
+  } catch (e) {
+    component = null;
+  } finally {
+    return component;
+  }
 }
 
 export function getAllComponents() {
-  return registeredComponents.toObject();
+  console.warn("DEPRECATED getAllComponents(). Use new implementation. see: https://docs.reactioncommerce.com/reaction-docs/master/components-api");
+
+  return Components;
 }

--- a/imports/plugins/core/layout/lib/reactionLayout.js
+++ b/imports/plugins/core/layout/lib/reactionLayout.js
@@ -6,7 +6,7 @@ import { registerComponent, composeWithTracker } from "@reactioncommerce/reactio
 import { Meteor } from "meteor/meteor";
 import { Reaction } from "/client/api";
 import classnames from "classnames";
-import { getComponent } from "/imports/plugins/core/layout/lib/components";
+import { getComponent } from "@reactioncommerce/reaction-components";
 import { Templates } from "/lib/collections";
 
 class ReactionLayout extends Component {
@@ -44,15 +44,19 @@ class ReactionLayout extends Component {
           if (this.checkElementPermissions(child)) {
             let component = child.component;
 
-            if (typeof child.component === "string") {
-              component = getComponent(child.component);
-            }
+            try {
+              if (typeof child.component === "string") {
+                component = getComponent(child.component);
+              }
 
-            return React.createElement(component, {
-              key: childIndex,
-              ...(child.props || {}),
-              ...this.props.layoutProps
-            });
+              return React.createElement(component, {
+                key: childIndex,
+                ...(child.props || {}),
+                ...this.props.layoutProps
+              });
+            } catch (e) {
+              return null;
+            }
           }
 
           return null;

--- a/imports/plugins/included/product-detail-simple/client/index.js
+++ b/imports/plugins/included/product-detail-simple/client/index.js
@@ -1,6 +1,6 @@
 import "./templates/productDetailSimple.html";
 import "./templates/productDetailSimple.js";
-import { registerComponent } from "/imports/plugins/core/layout/lib/components";
+import { registerComponent } from "@reactioncommerce/reaction-components";
 
 import {
   ProductField,
@@ -8,7 +8,8 @@ import {
   ProductMetadata,
   PriceRange,
   AddToCartButton,
-  ProductNotFound
+  ProductNotFound,
+  ProductDetail
 } from "./components";
 
 import {
@@ -27,57 +28,15 @@ import {
 
 
 // Register PDP components and some others
-registerComponent({
-  name: "ProductField",
-  component: ProductField
-});
-
-registerComponent({
-  name: "ProductTags",
-  component: ProductTags
-});
-
-registerComponent({
-  name: "ProductMetadata",
-  component: ProductMetadata
-});
-
-registerComponent({
-  name: "PriceRange",
-  component: PriceRange
-});
-
-registerComponent({
-  name: "AlertContainer",
-  component: Alerts
-});
-
-registerComponent({
-  name: "MediaGalleryContainer",
-  component: MediaGalleryContainer
-});
-
-registerComponent({
-  name: "SocialContainer",
-  component: SocialContainer
-});
-
-registerComponent({
-  name: "VariantListContainer",
-  component: VariantListContainer
-});
-
-registerComponent({
-  name: "AddToCartButton",
-  component: AddToCartButton
-});
-
-registerComponent({
-  name: "Divider",
-  component: Divider
-});
-
-registerComponent({
-  name: "ProductNotFound",
-  component: ProductNotFound
-});
+registerComponent("productDetail", ProductDetail);
+registerComponent("ProductField", ProductField);
+registerComponent("ProductTags", ProductTags);
+registerComponent("ProductMetadata", ProductMetadata);
+registerComponent("PriceRange", PriceRange);
+registerComponent("AlertContainer", Alerts);
+registerComponent("MediaGalleryContainer", MediaGalleryContainer);
+registerComponent("SocialContainer", SocialContainer);
+registerComponent("VariantListContainer", VariantListContainer);
+registerComponent("AddToCartButton", AddToCartButton);
+registerComponent("Divider", Divider);
+registerComponent("ProductNotFound", ProductNotFound);


### PR DESCRIPTION
- Deprecate legacy `registerComponent`.
- Forward all calls to legacy `registerComponent` to new registerComponent API.
- Convert all instances of components being registered with old API to new API.
- Convert all instances of components being fetched with the old API to new API.
