### PR TITLE
Fix for variant option not updating when edited

### DIFF
--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/childVariant.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/childVariant.html
@@ -73,23 +73,6 @@
               </div>
 
             <div class="rui item half">
-              <div class="rui textfield form-group {{hasErrorClassName 'optionTitle'}}">
-                <label for="option-{{childVariantFormId}}" data-i18n="productVariant.optionTitle">Option Title</label>
-                <input
-                  id="option-{{childVariantFormId}}"
-                  type="text"
-                  class="form-control input-sm child-variant-input"
-                  value="{{optionTitle}}"
-                  name="optionTitle"
-                  placeholder="Add option title"
-                  />
-                {{#with hasValidationMessage 'optionTitle'}}
-                  <span class="help-block">{{message}}</span>
-                {{/with}}
-              </div>
-            </div>
-
-            <div class="rui item half">
               <div class="rui textfield form-group {{hasErrorClassName 'title'}}">
                 <label for="label-{{childVariantFormId}}" data-i18n="productVariant.title">Cart / Checkout Label</label>
                 <input
@@ -101,6 +84,23 @@
                   placeholder="Add cart label"
                   />
                 {{#with hasValidationMessage 'title'}}
+                  <span class="help-block">{{message}}</span>
+                {{/with}}
+              </div>
+            </div>
+
+            <div class="rui item half">
+              <div class="rui textfield form-group {{hasErrorClassName 'optionTitle'}}">
+                <label for="option-{{childVariantFormId}}" data-i18n="productVariant.optionTitle">Option Title</label>
+                <input
+                  id="option-{{childVariantFormId}}"
+                  type="text"
+                  class="form-control input-sm child-variant-input"
+                  value="{{optionTitle}}"
+                  name="optionTitle"
+                  placeholder="Add option title"
+                  />
+                {{#with hasValidationMessage 'optionTitle'}}
                   <span class="help-block">{{message}}</span>
                 {{/with}}
               </div>

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/childVariant.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/childVariant.js
@@ -49,9 +49,11 @@ Template.childVariantForm.helpers({
   Icon() {
     return Components.Icon;
   },
+
   childVariantFormId: function () {
     return "child-variant-form-" + this._id;
   },
+
   media: function () {
     const media = Media.find({
       "metadata.variantId": this._id
@@ -63,6 +65,7 @@ Template.childVariantForm.helpers({
 
     return media;
   },
+
   featuredMedia: function () {
     const media = Media.findOne({
       "metadata.variantId": this._id
@@ -78,6 +81,7 @@ Template.childVariantForm.helpers({
 
     return false;
   },
+
   handleFileUpload() {
     const ownerId = Meteor.userId();
     const productId = ReactionProduct.selectedProductId();
@@ -98,6 +102,7 @@ Template.childVariantForm.helpers({
       }
     };
   },
+
   active() {
     const variantId = ReactionProduct.selectedVariantId();
 
@@ -107,6 +112,7 @@ Template.childVariantForm.helpers({
 
     return "panel-default";
   },
+
   hasValidationMessage(fieldName)  {
     const instance = Template.instance();
     const validationStatus = instance.state.get("validationStatus");
@@ -117,6 +123,7 @@ Template.childVariantForm.helpers({
 
     return false;
   },
+
   hasErrorClassName(fieldName)  {
     const instance = Template.instance();
     const validationStatus = instance.state.get("validationStatus");
@@ -144,6 +151,7 @@ Template.childVariantForm.events({
 
     return ReactionProduct.setCurrentVariant(template.data._id);
   },
+
   "change .child-variant-input": function (event, template) {
     const variant = template.data;
     const value = Template.instance().$(event.currentTarget).val();
@@ -159,17 +167,17 @@ Template.childVariantForm.events({
     template.state.set("validationStatus", validationStatus);
     template.state.set("variant", updated);
 
-    if (validationStatus.isValid === true) {
-      Meteor.call("products/updateProductField", variant._id, field, value,
-        error => {
-          if (error) {
-            Alerts.toast(error.message, "error");
-          }
-        });
-    }
+    Meteor.call("products/updateProductField", variant._id, field, value,
+      error => {
+        if (error) {
+          Alerts.toast(error.message, "error");
+        }
+      }
+    );
 
     return ReactionProduct.setCurrentVariant(variant._id);
   },
+
   "click .js-child-variant-heading": function (event, instance) {
     const variantId = instance.data._id;
 


### PR DESCRIPTION
Resolves #2582 

This PR fixes a bug with creating product variant options. Previously, editing a product did not update parts of UI. This bug fixes that.

### Testing steps
* Log in as admin.
* Open the panel for editing a product.
* Create a new variant option and try to edit its `option` or `price` form field. Immediately you hit `Enter`, click elsewhere on the page or hit `Tab`, the UI is updated with the text you added to the form field.


