### PR TITLE
Docker/CI build updates

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -15,7 +15,10 @@ then
 fi
 
 # build new image
-docker build --build-arg TOOL_NODE_FLAGS="--max-old-space-size=4096" -t reactioncommerce/reaction:latest .
+docker build \
+  --build-arg TOOL_NODE_FLAGS="--max-old-space-size=4096" \
+  --build-arg INSTALL_MONGO=true \
+  -t reactioncommerce/reaction:latest .
 
 # run the container and wait for it to boot
 docker-compose -f .circleci/docker-compose.yml up -d

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -5,7 +5,11 @@ set -e
 DOCKER_NAMESPACE=${DOCKER_NAMESPACE:-"reactioncommerce/reaction"}
 
 # if we're not on a deployment branch or a Docker related PR branch, skip the Docker build/test
-if [[ "$CIRCLE_BRANCH" != "master" && "$CIRCLE_BRANCH" != "development" && "$CIRCLE_BRANCH" != *"docker"* ]]; then
+if [[ "$CIRCLE_BRANCH" != "master" && \
+      "$CIRCLE_BRANCH" != "development" && \
+      "$CIRCLE_BRANCH" != *"docker"* && \
+      "$CIRCLE_BRANCH" != "marketplace" ]]; # TODO: remove this once marketplace is merged
+then
   echo "Not running a deployment branch. Skipping the Docker build test."
   exit 0
 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ jobs:
     working_directory: /home/reaction
 
     docker:
-      - image: node:7
+      - image: node:8
 
     environment:
-      - DOCKER_VERSION: 17.03.1-ce
-      - DOCKER_COMPOSE_VERSION: 1.13.0
+      - DOCKER_VERSION: 17.06.0-ce
+      - DOCKER_COMPOSE_VERSION: 1.15.0
       - METEOR_ALLOW_SUPERUSER: true
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - image: node:8
 
     environment:
-      - DOCKER_VERSION: 17.06.0-ce
+      - DOCKER_VERSION: 17.05.0-ce
       - DOCKER_COMPOSE_VERSION: 1.15.0
       - METEOR_ALLOW_SUPERUSER: true
 

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -31,7 +31,7 @@ if [[ "$CIRCLE_BRANCH" == "development" ]]; then
   docker tag $DOCKER_NAMESPACE:latest $DOCKER_NAMESPACE_DEV:latest
   docker tag $DOCKER_NAMESPACE_DEV:latest $DOCKER_NAMESPACE_DEV:$CIRCLE_BUILD_NUM
 
-  docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+  docker login -u $DOCKER_USER -p $DOCKER_PASS
 
   docker push $DOCKER_NAMESPACE_DEV:$CIRCLE_BUILD_NUM
   docker push $DOCKER_NAMESPACE_DEV:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM reactioncommerce/base:v2.0.2
+FROM reactioncommerce/base:v2.1.3
 
 # Default environment variables
 ENV ROOT_URL "http://localhost"


### PR DESCRIPTION
- install Mongo by default in the official release build (fixes #2654)
- update build dependencies on CircleCI (Docker Compose 1.15.0, Node 8)
- update [Docker base image](https://github.com/reactioncommerce/base) to [v2.1.3](https://github.com/reactioncommerce/base/blob/master/HISTORY.md)
- do CI test builds on `marketplace` branch too so that we're testing Docker builds on every PR merge

FYI... after merging this PR, it should probably also be cherry picked and merged to master because all of these updates are relevant/important there as well.