### PR TITLE
fix className variable

### DIFF
--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -91,7 +91,7 @@ class TextField extends Component {
 
     return (
       <TextareaAutosize
-        className="{this.props.name}-edit-input"
+        className={`${this.props.name}-edit-input`}
         onBlur={this.onBlur}
         onChange={this.onChange}
         placeholder={placeholder}


### PR DESCRIPTION
fix className to allow variable from props, prior to this change it was literally displaying `{this.props.name}-edit-input` as class