### PR TITLE
added adjustments for navbar causing overflow in admin view using default theme

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/layout/layout.less
+++ b/imports/plugins/included/default-theme/client/styles/layout/layout.less
@@ -14,7 +14,6 @@ body.admin {
   .flex-direction(column);
   .flex(1 1 auto);
   height: 100vh;
-  overflow-x: hidden;
 }
 
 .page #main {
@@ -23,7 +22,6 @@ body.admin {
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }
-
 
 .page.show-settings {
   min-width: 0;

--- a/imports/plugins/included/default-theme/client/styles/navbar.less
+++ b/imports/plugins/included/default-theme/client/styles/navbar.less
@@ -68,7 +68,6 @@
   .flex(0 0 auto);
   position: relative;
   cursor: pointer;
-  right: -1px;
 }
 
 .rtl .rui.navbar .cart {


### PR DESCRIPTION
### Disclaimer
This is very minor but thought I'd contribute if I could. This is related to the default client theme. I'm open for correction if this is my slight of knowledge of _reaction_.

### Problem
When logged in as __admin__ and viewing a product there is a __double scroll-bar__. Please disregard if there is a similar fix.

![screen shot 2017-08-22 at 10 15 28 pm](https://user-images.githubusercontent.com/95763/29596660-2181d634-878c-11e7-89dd-f275af47cc71.png)

### Proposed Fix
This appears to be caused by the styles and removing them solves it in my isolated case:
- `/imports/plugins/included/default-theme/client/styles/navbar.less` => `.navbar .cart` with `right: -1px`
- `/imports/plugins/included/default-theme/client/styles/layouts/layout.less` => `.page` with `overflow-x: hidden`

#### References
- [navbar.less history](https://github.com/reactioncommerce/reaction/blob/bd61902943977e3470057d970c97c22f1dce8af5/imports/plugins/included/default-theme/client/styles/navbar.less)
- [layout.less history](https://github.com/reactioncommerce/reaction/blob/db4e8d2aa500a9da59f994e64df4f8999ebe6965/imports/plugins/included/default-theme/client/styles/layout/layout.less)


Cheers,
