### PR TITLE
Add in-app notification for newly promoted accounts

### DIFF
--- a/imports/plugins/included/notifications/client/components/notificationDropdown.js
+++ b/imports/plugins/included/notifications/client/components/notificationDropdown.js
@@ -36,6 +36,12 @@ class NotificationDropdown extends Component {
         provides: "dashboard"
       });
       Reaction.showActionView(actionViewData);
+    } else if (notify.url === "newshopmembernotification") {
+      Reaction.showActionView({
+        i18nKeyTitle: "dashboard.coreTitle",
+        title: "Dashboard",
+        template: "dashboardPackages"
+      });
     } else {
       Reaction.Router.go(notify.url);
     }


### PR DESCRIPTION
Related To [#2661](https://github.com/reactioncommerce/reaction/issues/2661)

**NB:**  This PR sends in-app  notification to newly promoted accounts.
When the user clicks on the notification, it triggers the sidebar action view to open.

**How to test:**

- As an admin, promote a user by adding them as shop manager or shop owner.

- When the user logs in, he/she gets in-app notification.


