### PR TITLE
update groups to allow invitations

### DIFF
--- a/imports/plugins/included/payments-stripe/server/startup/startup.js
+++ b/imports/plugins/included/payments-stripe/server/startup/startup.js
@@ -3,7 +3,7 @@ import { Reaction, Hooks } from "/server/api";
 Hooks.Events.add("afterCoreInit", () => {
   Reaction.addRolesToGroups({
     allShops: true,
-    groups: ["customer", "guest"],
+    groups: ["owner", "shop manager", "customer", "guest"],
     roles: ["stripe/connect/authorize"]
   });
 });


### PR DESCRIPTION
updating group roles for the `payments-stripe` package to fix / allow invitations using the dashboard accounts permissions forms.