### PR TITLE
Always grab shipping from primary shop regardless of current shop (Resolves #2732/#2713)

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -304,8 +304,19 @@ export default {
     return this.hasPermission(ownerPermissions);
   },
 
-  hasAdminAccess() {
+  /**
+   * Checks to see if the user has admin permissions. If a shopId is optionally
+   * passed in, we check for that shopId, otherwise we check against the default
+   * @method hasAdminAccess
+   * @param  {string} [shopId] Optional shopId to check access against
+   * @return {Boolean} true if the user has admin or owner permission,
+   *                   otherwise false
+   */
+  hasAdminAccess(shopId) {
     const adminPermissions = ["owner", "admin"];
+    if (shopId) {
+      return this.hasPermission(adminPermissions, Meteor.userId(), shopId);
+    }
     return this.hasPermission(adminPermissions);
   },
 

--- a/imports/plugins/core/shipping/client/templates/checkout/shipping.js
+++ b/imports/plugins/core/shipping/client/templates/checkout/shipping.js
@@ -46,7 +46,8 @@ function enabledShipping() {
   const enabledShippingArr = [];
   const apps = Reaction.Apps({
     provides: "shippingSettings",
-    enabled: true
+    enabled: true,
+    shopId: Reaction.getPrimaryShopId()
   });
   for (const app of apps) {
     if (app.enabled === true) enabledShippingArr.push(app);
@@ -65,7 +66,8 @@ Template.coreCheckoutShipping.onCreated(function () {
   const shippingOpts = {
     provides: "settings",
     name: "settings/shipping",
-    template: "shippingSettings"
+    template: "shippingSettings",
+    shopId: Reaction.getPrimaryShopId()
   };
 
   // If shipping not set, show shipping settings dashboard

--- a/imports/plugins/core/shipping/client/templates/checkout/shipping.js
+++ b/imports/plugins/core/shipping/client/templates/checkout/shipping.js
@@ -112,8 +112,19 @@ Template.coreCheckoutShipping.helpers({
     return false;
   },
 
+  /**
+   * Template helper that checks to see if the user has permissions for the shop
+   * responsible for shipping rates. This is the primary shop unless
+   * `merchantShippingRates` is enabled in marketplace
+   * @method isAdmin
+   * @return {Boolean} true if the user has admin access, otherwise false
+   */
   isAdmin() {
-    return Reaction.hasAdminAccess();
+    const marketplaceSettings = Reaction.marketplace;
+    if (marketplaceSettings && marketplaceSettings.merchantShippingRates) {
+      Reaction.hasAdminAccess();
+    }
+    return Reaction.hasAdminAccess(Reaction.getPrimaryShopId());
   }
 });
 

--- a/imports/plugins/core/shipping/client/templates/checkout/shipping.js
+++ b/imports/plugins/core/shipping/client/templates/checkout/shipping.js
@@ -66,8 +66,7 @@ Template.coreCheckoutShipping.onCreated(function () {
   const shippingOpts = {
     provides: "settings",
     name: "settings/shipping",
-    template: "shippingSettings",
-    shopId: Reaction.getPrimaryShopId()
+    template: "shippingSettings"
   };
 
   // If shipping not set, show shipping settings dashboard

--- a/imports/plugins/included/shipping-rates/server/hooks/hooks.js
+++ b/imports/plugins/included/shipping-rates/server/hooks/hooks.js
@@ -17,7 +17,7 @@ function getShippingRates(rates, cart) {
 
   const pkgData = Packages.findOne({
     name: "reaction-shipping-rates",
-    shopId: Reaction.getShopId()
+    shopId: Reaction.getPrimaryShopId()
   });
 
   if (!pkgData || !cart.items || pkgData.settings.flatRates.enabled !== true) {

--- a/imports/plugins/included/shipping-rates/server/hooks/hooks.js
+++ b/imports/plugins/included/shipping-rates/server/hooks/hooks.js
@@ -15,6 +15,7 @@ function getShippingRates(rates, cart) {
     merchantShippingRates = marketplaceSettings.public.merchantShippingRates;
   }
 
+  // TODO: Check to see if the merchantShippingRates flag is set in marketplace and get rates from the correct shop
   const pkgData = Packages.findOne({
     name: "reaction-shipping-rates",
     shopId: Reaction.getPrimaryShopId()


### PR DESCRIPTION
Resolves #2732 and #2713 

### Steps to Test
1. Full reset.
1. Set up a second shop and add a product as shop admin
1. Try to checkout as shop admin. Observe that shipping methods appear
1. As marketplace admin switch to the second shop
1. Place an item in your cart
1. Attempt to check out
1. Observe that the shipping methods appear

