### PR TITLE
Update group invitation check to always allow owner

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -522,7 +522,11 @@ export default {
    * @return {Boolean} -
    */
   canInviteToGroup(options) {
-    const { group, user } = options;
+    const { group } = options;
+    let { user } = options;
+    if (!user) {
+      user = Meteor.user();
+    }
     const userPermissions = user.roles[group.shopId];
     const groupPermissions = group.permissions;
 
@@ -532,6 +536,7 @@ export default {
     }
 
     // checks that userPermissions includes all elements from groupPermissions
+    // we are not using Reaction.hasPermission here because it returns true if the user has at least one
     return _.difference(groupPermissions, userPermissions).length === 0;
   },
   /**

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -513,7 +513,27 @@ export default {
     }
     return allowGuest;
   },
+  /**
+   * canInviteToGroup
+   * @summary checks if the user making the request is allowed to make invitation to that group
+   * @param {Object} options -
+   * @param {Object} options.group - group to invite to
+   * @param {Object} options.user - user object  making the invite (Meteor.user())
+   * @return {Boolean} -
+   */
+  canInviteToGroup(options) {
+    const { group, user } = options;
+    const userPermissions = user.roles[group.shopId];
+    const groupPermissions = group.permissions;
 
+    if (this.hasPermission(["owner", "admin"], Meteor.userId(), group.shopId)) {
+      console.log("has these roles [owner, admin]", "allow invitation");
+      return true;
+    }
+
+    // checks that userPermissions includes all elements from groupPermissions
+    return _.difference(groupPermissions, userPermissions).length === 0;
+  },
   /**
    * @description showActionView
    *

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -527,7 +527,6 @@ export default {
     const groupPermissions = group.permissions;
 
     if (this.hasPermission(["owner", "admin"], Meteor.userId(), group.shopId)) {
-      console.log("has these roles [owner, admin]", "allow invitation");
       return true;
     }
 

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -514,7 +514,7 @@ export default {
     return allowGuest;
   },
   /**
-   * canInviteToGroup
+   * canInviteToGroup - client (similar to server/api canInviteToGroup)
    * @summary checks if the user making the request is allowed to make invitation to that group
    * @param {Object} options -
    * @param {Object} options.group - group to invite to
@@ -526,7 +526,8 @@ export default {
     const userPermissions = user.roles[group.shopId];
     const groupPermissions = group.permissions;
 
-    if (this.hasPermission(["owner", "admin"], Meteor.userId(), group.shopId)) {
+    // granting invitation right for user with `owner` role in a shop
+    if (this.hasPermission(["owner"], Meteor.userId(), group.shopId)) {
       return true;
     }
 

--- a/imports/plugins/core/accounts/client/components/groupsTableCell.js
+++ b/imports/plugins/core/accounts/client/components/groupsTableCell.js
@@ -68,7 +68,7 @@ const GroupsTableCell = ({ account, columnName, group, adminGroups, handleRemove
     // Also remove groups user does not have roles to manage. This is also checked on the server
     const dropOptions = groups
       .filter(grp => (grp.slug === "owner" && !hasOwnerAccess) ? false : true)
-      .filter(grp => props.canInviteToGroup({ group: grp, user: Meteor.user() })) || [];
+      .filter(grp => Reaction.canInviteToGroup({ group: grp, user: Meteor.user() })) || [];
 
     if (dropOptions.length < 2) { return dropDownButton(); } // do not use dropdown if only one option
 
@@ -105,7 +105,6 @@ const GroupsTableCell = ({ account, columnName, group, adminGroups, handleRemove
 GroupsTableCell.propTypes = {
   account: PropTypes.object,
   adminGroups: PropTypes.array, // all admin groups
-  canInviteToGroup: PropTypes.func,
   columnName: PropTypes.string,
   group: PropTypes.object, // current group in interation
   handleRemoveUserFromGroup: PropTypes.func,

--- a/imports/plugins/core/accounts/client/components/groupsTableCell.js
+++ b/imports/plugins/core/accounts/client/components/groupsTableCell.js
@@ -68,7 +68,7 @@ const GroupsTableCell = ({ account, columnName, group, adminGroups, handleRemove
     // Also remove groups user does not have roles to manage. This is also checked on the server
     const dropOptions = groups
       .filter(grp => (grp.slug === "owner" && !hasOwnerAccess) ? false : true)
-      .filter(grp => Reaction.canInviteToGroup({ group: grp, user: Meteor.user() })) || [];
+      .filter(grp => Reaction.canInviteToGroup({ group: grp })) || [];
 
     if (dropOptions.length < 2) { return dropDownButton(); } // do not use dropdown if only one option
 

--- a/imports/plugins/core/accounts/client/components/manageGroups.js
+++ b/imports/plugins/core/accounts/client/components/manageGroups.js
@@ -30,6 +30,7 @@ class ManageGroups extends Component {
 
   render() {
     // this gets a list of groups the user can invite to, we show only those in the dropdown
+    // see doc for getInvitableGroups in helpers/accountsHelper.js
     const groupsInvitable = getInvitableGroups(this.state.adminGroups);
 
     return (

--- a/imports/plugins/core/accounts/client/components/manageGroups.js
+++ b/imports/plugins/core/accounts/client/components/manageGroups.js
@@ -7,7 +7,6 @@ class ManageGroups extends Component {
   static propTypes = {
     accounts: PropTypes.array,
     adminGroups: PropTypes.array,
-    canInviteToGroup: PropTypes.func,
     group: PropTypes.object,
     groups: PropTypes.array,
     onChangeGroup: PropTypes.func
@@ -30,7 +29,8 @@ class ManageGroups extends Component {
   }
 
   render() {
-    const groupsInvitable = getInvitableGroups(this.state.adminGroups, this.props.canInviteToGroup);
+    // this gets a list of groups the user can invite to, we show only those in the dropdown
+    const groupsInvitable = getInvitableGroups(this.state.adminGroups);
 
     return (
       <div className="groups-form">

--- a/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
+++ b/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
@@ -1,5 +1,4 @@
 import { compose, withProps } from "recompose";
-import _ from "lodash";
 import Alert from "sweetalert2";
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Meteor } from "meteor/meteor";
@@ -81,18 +80,6 @@ const handlers = {
         confirmButtonText: i18next.t("admin.settings.continue")
       });
     }
-  },
-  canInviteToGroup(options) {
-    const { group, user } = options;
-    const userPermissions = user.roles[group.shopId];
-    const groupPermissions = group.permissions;
-
-    if (Reaction.hasPermission("owner", Meteor.userId(), group.shopId)) {
-      return true;
-    }
-
-    // checks that userPermissions includes all elements from groupPermissions
-    return _.difference(groupPermissions, userPermissions).length === 0;
   }
 };
 

--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -44,7 +44,7 @@ export function sortGroups(groups) {
 export function getInvitableGroups(groups) {
   return groups
     .filter(grp => grp.slug !== "owner")
-    .filter(grp => Reaction.canInviteToGroup({ group: grp, user: Meteor.user() }));
+    .filter(grp => Reaction.canInviteToGroup({ group: grp }));
 }
 
 // user's default invite groups is the group they belong

--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -34,19 +34,17 @@ export function sortGroups(groups) {
 
 /**
  * getInvitableGroups - helper - client
- * @summary puts each full user object into an array on the group they belong
- * This generates a list of groups the user can invite to.
+ * @summary This generates a list of groups the user can invite to.
  * It filters out the owner group (because you cannot invite directly to an existing shop as owner)
  * It also filters out groups that the user does not have needed permissions to invite to.
  * All these are also checked by the Meteor method, so this is done to prevent trying to invite and getting error
  * @param {Array} groups - list of user account objects
- * @param {Func} canInviteToGroup - func determining user group rights
  * @return {Array} - array of groups or empty object
  */
-export function getInvitableGroups(groups, canInviteToGroup) {
+export function getInvitableGroups(groups) {
   return groups
     .filter(grp => grp.slug !== "owner")
-    .filter(grp => canInviteToGroup({ group: grp, user: Meteor.user() }));
+    .filter(grp => Reaction.canInviteToGroup({ group: grp, user: Meteor.user() }));
 }
 
 // user's default invite groups is the group they belong

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -132,6 +132,11 @@ export default {
     const userPermissions = user.roles[group.shopId];
     const groupPermissions = group.permissions;
 
+    if (this.hasPermission(["owner", "admin"], Meteor.userId(), group.shopId)) {
+      console.log("has these roles [owner, admin]", "allow invitation");
+      return true;
+    }
+
     // checks that userPermissions includes all elements from groupPermissions
     return _.difference(groupPermissions, userPermissions).length === 0;
   },

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -128,15 +128,21 @@ export default {
    * @return {Boolean} -
    */
   canInviteToGroup(options) {
-    const { group, user } = options;
+    const { group } = options;
+    let { user } = options;
+    if (!user) {
+      user = Meteor.user();
+    }
     const userPermissions = user.roles[group.shopId];
     const groupPermissions = group.permissions;
 
-    if (this.hasPermission(["owner", "admin"], Meteor.userId(), group.shopId)) {
+    // granting invitation right for user with `owner` role in a shop
+    if (this.hasPermission(["owner"], Meteor.userId(), group.shopId)) {
       return true;
     }
 
     // checks that userPermissions includes all elements from groupPermissions
+    // we are not using Reaction.hasPermission here because it returns true if the user has at least one
     return _.difference(groupPermissions, userPermissions).length === 0;
   },
   /**

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -133,7 +133,6 @@ export default {
     const groupPermissions = group.permissions;
 
     if (this.hasPermission(["owner", "admin"], Meteor.userId(), group.shopId)) {
-      console.log("has these roles [owner, admin]", "allow invitation");
       return true;
     }
 

--- a/server/methods/core/groups.js
+++ b/server/methods/core/groups.js
@@ -30,7 +30,7 @@ Meteor.methods({
     let _id;
 
     // we are limiting group method actions to only users with admin roles
-    // this also include shop owners, since they have the global roles
+    // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }
@@ -80,7 +80,7 @@ Meteor.methods({
     check(shopId, String);
 
     // we are limiting group method actions to only users with admin roles
-    // this also include shop owners, since they have the global roles
+    // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }
@@ -131,7 +131,7 @@ Meteor.methods({
     const canInvite = Reaction.canInviteToGroup({ group, user: Meteor.user() });
 
     // we are limiting group method actions to only users with admin roles
-    // this also include shop owners, since they have the global roles
+    // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
     if (!Reaction.hasPermission("admin", loggedInUserId, shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }
@@ -201,7 +201,7 @@ Meteor.methods({
     const defaultCustomerGroupForShop = Groups.findOne({ slug: "customer", shopId }) || {};
 
     // we are limiting group method actions to only users with admin roles
-    // this also include shop owners, since they have the global roles
+    // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }

--- a/server/methods/core/groups.js
+++ b/server/methods/core/groups.js
@@ -128,7 +128,7 @@ Meteor.methods({
     const group = Groups.findOne({ _id: groupId }) || {};
     const { permissions, shopId, slug } = group;
     const loggedInUserId = Meteor.userId();
-    const canInvite = Reaction.canInviteToGroup({ group, user: Meteor.user() });
+    const canInvite = Reaction.canInviteToGroup({ group });
 
     // we are limiting group method actions to only users with admin roles
     // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP

--- a/server/methods/core/groups.js
+++ b/server/methods/core/groups.js
@@ -30,6 +30,7 @@ Meteor.methods({
     let _id;
 
     // we are limiting group method actions to only users with admin roles
+    // this also include shop owners, since they have the global roles
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }
@@ -79,6 +80,7 @@ Meteor.methods({
     check(shopId, String);
 
     // we are limiting group method actions to only users with admin roles
+    // this also include shop owners, since they have the global roles
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }
@@ -129,11 +131,12 @@ Meteor.methods({
     const canInvite = Reaction.canInviteToGroup({ group, user: Meteor.user() });
 
     // we are limiting group method actions to only users with admin roles
+    // this also include shop owners, since they have the global roles
     if (!Reaction.hasPermission("admin", loggedInUserId, shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }
 
-    // Users with `owner` and/or `admin` roles can invite to any group.
+    // Users with `owner` and/or `admin` roles can invite to any group
     // Also a user with `admin` can invite to only groups they have permissions that are a superset of
     // See details of canInvite method in core (i.e Reaction.canInviteToGroup)
     if (!canInvite) {
@@ -198,6 +201,7 @@ Meteor.methods({
     const defaultCustomerGroupForShop = Groups.findOne({ slug: "customer", shopId }) || {};
 
     // we are limiting group method actions to only users with admin roles
+    // this also include shop owners, since they have the global roles
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }

--- a/server/methods/core/groups.js
+++ b/server/methods/core/groups.js
@@ -29,6 +29,7 @@ Meteor.methods({
     check(shopId, String);
     let _id;
 
+    // we are limiting group method actions to only users with admin roles
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }
@@ -77,6 +78,7 @@ Meteor.methods({
     check(newGroupData, Object);
     check(shopId, String);
 
+    // we are limiting group method actions to only users with admin roles
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }
@@ -126,12 +128,16 @@ Meteor.methods({
     const loggedInUserId = Meteor.userId();
     const canInvite = Reaction.canInviteToGroup({ group, user: Meteor.user() });
 
-    // Owners can invite to any group.
-    if (!Reaction.hasPermission("owner", loggedInUserId, shopId)) {
-      // Admins can invite to only groups they belong
-      if (!canInvite) {
-        throw new Meteor.Error(403, "Access Denied");
-      }
+    // we are limiting group method actions to only users with admin roles
+    if (!Reaction.hasPermission("admin", loggedInUserId, shopId)) {
+      throw new Meteor.Error(403, "Access Denied");
+    }
+
+    // Users with `owner` and/or `admin` roles can invite to any group.
+    // Also a user with `admin` can invite to only groups they have permissions that are a superset of
+    // See details of canInvite method in core (i.e Reaction.canInviteToGroup)
+    if (!canInvite) {
+      throw new Meteor.Error(403, "Access Denied");
     }
 
     if (slug === "owner") {
@@ -191,6 +197,7 @@ Meteor.methods({
     const { shopId } = Groups.findOne({ _id: groupId }) || {};
     const defaultCustomerGroupForShop = Groups.findOne({ slug: "customer", shopId }) || {};
 
+    // we are limiting group method actions to only users with admin roles
     if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
       throw new Meteor.Error(403, "Access Denied");
     }


### PR DESCRIPTION
Update after #2662 Scoped invitation.

**What Happened Earlier:**
* In #2189 we added check so that group invitation is scoped to the permissions that a user has. That means that when a user belongs to a group with role set `[a,b,c,d]`, she can only invite a user to groups with those permissions or a subset of them. We set up `Reaction.canInviteToGroup` method to do this check. 
* But, there is a case such as where an installed package adds a new role and the author didn't push the role to the owner group using `addRolesToGroups`. This will leave the owner inadvertently cut out by `canInviteToGroup`

**Changes in this PR:**
* To resolve the above, I added a check to grant access for a user with `owner` role
* I also added/copied `canInviteToGroup` to client Reaction, so it's possible to do Reaction.canInviteToGroup client side. This is useful when deciding dropdown options.
* I added more comments in the code around all the above

**How To test**
* Try multiple scenarios of trying to invite to group as an owner of a shop, either by:
** Adding a user to an existing group
** Adding a user to a new group created via the Accounts UI
** Adding a user to a new group created by Groups.insert(groupData) like in the case of a custom package
Confirm that an owner can invite, in all those cases.

**Confirm that previous functionality stays intact by:**
* Create a group with all Account roles toggled on. Add a user to that group. 
* Login as that user, go to the Accounts dashboard, confirm in the `Invite Form` that the user doesn't have dropdown for higher groups e.g "Shop Manager"

You can also test all these with a new shop other than the primary shop