### PR TITLE
Use valid cursor property on .rui.switch

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/forms.less
+++ b/imports/plugins/included/default-theme/client/styles/forms.less
@@ -65,7 +65,7 @@
 .rui.switch {
   display: flex;
   align-items: center;
-  cursor: hand;
+  cursor: pointer;
   padding: 10px 0;
   margin-bottom: 0;
 


### PR DESCRIPTION
Quick fix for the switch component CSS. Fixes issue where cursor would not change to the "pointer" when hovering on a switch such as the "edit mode" switch.

Change cursor property value from invalid `hand` to valid `pointer`.