### PR TITLE
Added inventoryPolicy check and min removed from Schema

### DIFF
--- a/imports/plugins/included/inventory/server/methods/statusChanges.js
+++ b/imports/plugins/included/inventory/server/methods/statusChanges.js
@@ -235,9 +235,9 @@ Meteor.methods({
     check(backOrderQty, Number);
     this.unblock();
 
-    // this use case could happen then mergeCart is fires. We don't add anything
+    // this use case could happen when mergeCart is fired. We don't add anything
     // or remove, just item owner changed. We need to add this check here
-    // because of bulk operation. It thows exception if nothing to operate.
+    // because of bulk operation. It throws exception if nothing to operate.
     if (backOrderQty === 0) {
       return 0;
     }

--- a/lib/collections/schemas/products.js
+++ b/lib/collections/schemas/products.js
@@ -205,7 +205,6 @@ export const ProductVariant = new SimpleSchema({
     label: "Quantity",
     optional: true,
     defaultValue: 0,
-    min: 0,
     custom: function () {
       if (Meteor.isClient) {
         if (this.siblingField("type").value !== "inventory") {

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -274,7 +274,7 @@ function isLowQuantity(variants) {
  * @description Is products variants is still available to be ordered after
  * summary variants quantity is zero
  * @param {Array} variants - array with variant objects
- * @return {boolean} is backorder allowed or now for a product
+ * @return {boolean} is backorder allowed or not for a product
  */
 function isBackorder(variants) {
   return variants.every(variant => {

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -21,7 +21,7 @@ function quantityProcessing(product, variant, itemQty = 1) {
   const MIN = variant.minOrderQuantity || 1;
   const MAX = variant.inventoryQuantity || Infinity;
 
-  if (MIN > MAX) {
+  if (variant.inventoryPolicy && MIN > MAX) {
     Logger.debug(`productId: ${product._id}, variantId ${variant._id
     }: inventoryQuantity lower then minimum order`);
     throw new Meteor.Error(`productId: ${product._id}, variantId ${variant._id


### PR DESCRIPTION
Fix for #2743 

1. Removed that `min: 0` check from `Product` schema.
2. Added a condition to check for the inventoryPolicy before rejecting a order.

But this would cause the inventoryQuantity to be as negative as the no. of backorders on that variant. Is this the required behaviour?