### PR TITLE
fix a bug by adding a missing component import

### DIFF
--- a/imports/plugins/core/ui/client/components/table/index.js
+++ b/imports/plugins/core/ui/client/components/table/index.js
@@ -1,1 +1,2 @@
 export { default as SortableTable } from "./sortableTable";
+export { default as SortableTableLegacy } from "./sortableTableLegacy";


### PR DESCRIPTION
Resolves #2802.

This PR fixes a bug that stopped the search modal from functioning properly. In summary, the bug was due to an improper import/export of a certain component.

### Test Instructions
- Make sure that your instance of RC has multiple users and orders.
- Log in as admin.
- Open the search modal using the search icon in the navigation bar.
- Enter a simple search query and check its results in either the `ACCOUNTS` or `ORDERS` tabs of the search results section.
- Open your browser console. Observe that the errors reported in #2802 are no longer there.




