### PR TITLE
Create reactive aggregate

### DIFF
--- a/imports/plugins/core/orders/client/containers/orderDashboardContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderDashboardContainer.js
@@ -232,7 +232,7 @@ class OrderDashboardContainer extends Component {
       Reaction.setUserPreferences(PACKAGE_NAME, ORDER_LIST_FILTERS_PREFERENCE_NAME, "processing");
     }
 
-    /* TODO: 
+    /* TODO:
     a) What other routes have a query parameter of _id=XXXXXXX ?
     b) What exactly are we using the order dashboard for? If it's search,
      well, clicking a search result doesn't CURRENTLY do anything. What's

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -1,6 +1,5 @@
 import accounting from "accounting-js";
 import _ from "lodash";
-import { Meteor } from "meteor/meteor";
 import { Shops } from "/lib/collections";
 
 

--- a/server/publications/collections/orders.js
+++ b/server/publications/collections/orders.js
@@ -12,8 +12,9 @@ import { Reaction } from "/server/api";
  * @param {Object} sort - An object containing a sort
  * @param {Number} limit - An optional limit of how many records to return
  * @returns {Array} An array of projection operators
+ * @private
  */
-export function createAggregate(shopId, sort = { createdAt: -1 }, limit = 0) {
+function createAggregate(shopId, sort = { createdAt: -1 }, limit = 0) {
   // NOTE: in Mongo 3.4 using the $in operator will be supported for projection filters
   const aggregate = [
     { $match: { "items.shopId": shopId } },

--- a/server/publications/collections/orders.js
+++ b/server/publications/collections/orders.js
@@ -2,8 +2,10 @@ import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Roles } from "meteor/alanning:roles";
 import { Counts } from "meteor/tmeasday:publish-counts";
+import { ReactiveAggregate } from "./reactiveAggregate";
 import { Orders } from "/lib/collections";
 import { Reaction } from "/server/api";
+
 
 /**
  * orders
@@ -63,10 +65,51 @@ Meteor.publish("CustomPaginatedOrders", function (query, options) {
   if (!shopId) {
     return this.ready();
   }
+
+  // return any order for which the shopId is attached to an item
+  const selector = {
+    "items.shopId": shopId
+  };
   if (Roles.userIsInRole(this.userId, ["admin", "owner", "orders"], shopId)) {
-    Counts.publish(this, "order-count", Orders.find({ shopId: shopId }), { noReady: true });
-    return Orders.find({ shopId: shopId });
+    ReactiveAggregate(this, Orders, [
+      {
+        $project: {
+          items: {
+            $filter: {
+              input: "$items",
+              as: "item",
+              cond: { $eq: ["$$item.shopId", "J8Bhq3uTtdgwZx3rz"] }
+            }
+          },
+          billing: {
+            $filter: {
+              input: "$billing",
+              as: "billing",
+              cond: { $eq: ["$$billing.shopId", "J8Bhq3uTtdgwZx3rz"] }
+            }
+          },
+          shipping: {
+            $filter: {
+              input: "$shipping",
+              as: "shipping",
+              cond: { $eq: ["$$shipping.shopId", "J8Bhq3uTtdgwZx3rz"] }
+            }
+          },
+          cartId: 1,
+          sessionId: 1,
+          shopId: 1,
+          workflow: 1,
+          discount: 1,
+          tax: 1,
+          email: 1,
+          createdAt: 1
+        }
+      }
+    ], selector);
   }
+
+  // TODO How to we return this order-count
+  //   Counts.publish(this, "order-count", Orders.find(selector), { noReady: true });
   return Orders.find({
     shopId: shopId,
     userId: this.userId

--- a/server/publications/collections/orders.js
+++ b/server/publications/collections/orders.js
@@ -7,6 +7,42 @@ import { Orders } from "/lib/collections";
 import { Reaction } from "/server/api";
 
 
+const filteredOrdersProjection = [
+  {
+    $project: {
+      items: {
+        $filter: {
+          input: "$items",
+          as: "item",
+          cond: { $eq: ["$$item.shopId", "J8Bhq3uTtdgwZx3rz"] }
+        }
+      },
+      billing: {
+        $filter: {
+          input: "$billing",
+          as: "billing",
+          cond: { $eq: ["$$billing.shopId", "J8Bhq3uTtdgwZx3rz"] }
+        }
+      },
+      shipping: {
+        $filter: {
+          input: "$shipping",
+          as: "shipping",
+          cond: { $eq: ["$$shipping.shopId", "J8Bhq3uTtdgwZx3rz"] }
+        }
+      },
+      cartId: 1,
+      sessionId: 1,
+      shopId: 1,
+      workflow: 1,
+      discount: 1,
+      tax: 1,
+      email: 1,
+      createdAt: 1
+    }
+  }
+];
+
 /**
  * orders
  */
@@ -67,45 +103,13 @@ Meteor.publish("CustomPaginatedOrders", function (query, options) {
   }
 
   // return any order for which the shopId is attached to an item
-  const selector = {
-    "items.shopId": shopId
+  const aggregateOptions = {
+    observeSelector: {
+      "items.shopId": shopId
+    }
   };
   if (Roles.userIsInRole(this.userId, ["admin", "owner", "orders"], shopId)) {
-    ReactiveAggregate(this, Orders, [
-      {
-        $project: {
-          items: {
-            $filter: {
-              input: "$items",
-              as: "item",
-              cond: { $eq: ["$$item.shopId", "J8Bhq3uTtdgwZx3rz"] }
-            }
-          },
-          billing: {
-            $filter: {
-              input: "$billing",
-              as: "billing",
-              cond: { $eq: ["$$billing.shopId", "J8Bhq3uTtdgwZx3rz"] }
-            }
-          },
-          shipping: {
-            $filter: {
-              input: "$shipping",
-              as: "shipping",
-              cond: { $eq: ["$$shipping.shopId", "J8Bhq3uTtdgwZx3rz"] }
-            }
-          },
-          cartId: 1,
-          sessionId: 1,
-          shopId: 1,
-          workflow: 1,
-          discount: 1,
-          tax: 1,
-          email: 1,
-          createdAt: 1
-        }
-      }
-    ], selector);
+    ReactiveAggregate(this, Orders, filteredOrdersProjection, aggregateOptions);
   }
 
   // TODO How to we return this order-count

--- a/server/publications/collections/orders.js
+++ b/server/publications/collections/orders.js
@@ -48,7 +48,7 @@ export function createAggregate(shopId, sort = { createdAt: -1 }, limit = 0) {
         tax: 1,
         email: 1,
         createdAt: 1
-      },
+      }
     },
     { $sort: sort }
   ];

--- a/server/publications/collections/reactiveAggregate.js
+++ b/server/publications/collections/reactiveAggregate.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { Mongo, MongoInternals } from "meteor/mongo";
 
@@ -86,12 +85,12 @@ export function ReactiveAggregate(sub, collection, pipeline, options) {
       sub._ids[doc._id] = sub._iteration;
     });
     // remove documents not in the result anymore
-    _.forEach(sub._ids, function (value, key) {
+    for (const [key, value] of Object.entries(sub._ids)) {
       if (value !== sub._iteration) {
         delete sub._ids[key];
         sub.removed(subOptions.clientCollection, key);
       }
-    });
+    }
     sub._iteration++;
   }
 

--- a/server/publications/collections/reactiveAggregate.js
+++ b/server/publications/collections/reactiveAggregate.js
@@ -1,0 +1,90 @@
+import _ from "lodash";
+import { Meteor } from "meteor/meteor";
+import { Mongo, MongoInternals } from "meteor/mongo";
+
+
+// Add the aggregate function available in tbe raw collection to normal collections
+Mongo.Collection.prototype.aggregate = function (pipelines, options) {
+  const coll = this._getCollection();
+  return Meteor.wrapAsync(coll.aggregate.bind(coll))(pipelines, options);
+};
+
+Mongo.Collection.prototype._getDb = function () {
+  if (typeof this._collection._getDb === "function") {
+    return this._collection._getDb();
+  }
+  const  mongoConn = MongoInternals.defaultRemoteCollectionDriver().mongo;
+  return wrapWithDb(mongoConn);
+};
+
+Mongo.Collection.prototype._getCollection = function () {
+  const db = this._getDb();
+  return db.collection(this._name);
+};
+
+function wrapWithDb(mongoConn) {
+  if (mongoConn.db) {
+    return mongoConn.db;
+  }
+}
+
+
+export function ReactiveAggregate(sub, collection, pipeline, options) {
+  const defaultOptions = {
+    observeSelector: {},
+    observeOptions: {},
+    clientCollection: collection._name
+  };
+  const subOptions = Object.assign({}, defaultOptions, options);
+
+  let initializing = true;
+  sub._ids = {};
+  sub._iteration = 1;
+
+  function update() {
+    if (initializing) {
+      return;
+    }
+
+    // add and update documents on the client
+    collection.aggregate(pipeline).forEach(function (doc) {
+      if (!sub._ids[doc._id]) {
+        sub.added(subOptions.clientCollection, doc._id, doc);
+      } else {
+        sub.changed(subOptions.clientCollection, doc._id, doc);
+      }
+      sub._ids[doc._id] = sub._iteration;
+    });
+    // remove documents not in the result anymore
+    _.forEach(sub._ids, function (value, key) {
+      if (value !== sub._iteration) {
+        delete sub._ids[key];
+        sub.removed(subOptions.clientCollection, key);
+      }
+    });
+    sub._iteration++;
+  }
+
+  // track any changes on the collection used for the aggregation
+  const query = collection.find(subOptions.observeSelector, subOptions.observeOptions);
+  const handle = query.observeChanges({
+    added: update,
+    changed: update,
+    removed: update,
+    error: function (error) {
+      throw new Meteor.Error(`Encountered an error while observing ${collection._name}`, error);
+    }
+  });
+  // observeChanges() will immediately fire an "added" event for each document in the query
+  // these are skipped using the initializing flag
+  initializing = false;
+  // send an initial result set to the client
+  update();
+  // mark the subscription as ready
+  sub.ready();
+
+  // stop observing the cursor when the client unsubscribes
+  sub.onStop(function () {
+    handle.stop();
+  });
+}

--- a/server/publications/collections/reactiveAggregate.js
+++ b/server/publications/collections/reactiveAggregate.js
@@ -2,13 +2,14 @@ import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { Mongo, MongoInternals } from "meteor/mongo";
 
-
+// This code taken from https://github.com/meteorhacks/meteor-aggregate
 // Add the aggregate function available in tbe raw collection to normal collections
 Mongo.Collection.prototype.aggregate = function (pipelines, options) {
   const coll = this._getCollection();
   return Meteor.wrapAsync(coll.aggregate.bind(coll))(pipelines, options);
 };
 
+// this group of methods were taken from https://github.com/meteorhacks/meteor-collection-utils
 Mongo.Collection.prototype._getDb = function () {
   if (typeof this._collection._getDb === "function") {
     return this._collection._getDb();
@@ -28,7 +29,36 @@ function wrapWithDb(mongoConn) {
   }
 }
 
-
+// this code taken from https://github.com/JcBernack/meteor-reactive-aggregate
+// ## Usage
+// ReactiveAggregate(sub, collection, pipeline, options)
+//
+// - `sub` should always be `this` in a publication.
+// - `collection` is the Mongo.Collection instance to query.
+// - `pipeline` is the aggregation pipeline to execute.
+// - `options` provides further options:
+//   - `observeSelector` can be given to improve efficiency. This selector is used for observing the collection.
+// (e.g. `{ authorId: { $exists: 1 } }`)
+// - `observeOptions` can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
+//   If none is given any change to the collection will cause the aggregation to be reevaluated.
+// (e.g. `{ limit: 10, sort: { createdAt: -1 } }`)
+// - `clientCollection` defaults to `collection._name` but can be overriden to sent the results
+// to a different client-side collection.
+//
+// ## Quick Example
+//
+// A publication for one of the
+//   [examples](https://docs.mongodb.org/v3.0/reference/operator/aggregation/group/#group-documents-by-author)
+// in the MongoDB docs would look like this:
+//
+// Meteor.publish("booksByAuthor", function () {
+//   ReactiveAggregate(this, Books, [{
+//     $group: {
+//       _id: "$author",
+//       books: { $push: "$$ROOT" }
+//     }
+//   }]);
+// });
 export function ReactiveAggregate(sub, collection, pipeline, options) {
   const defaultOptions = {
     observeSelector: {},


### PR DESCRIPTION
At Spencer's suggestion I am creating a separate PR for this.

This adds new class called `ReactiveAggregate` that allows you to use Mongo aggregates as a normal Meteor publication. The primary use case for this now is allowing us to filter things like Orders where we want to filter out items within an order rather than the whole order.

I'm including the Order filtering here so we can see an example of it in use (and because I think that's the primary use case right now). As a store admin you should only see the billing/shipping/items on orders attached to your store. So to a store admin, it will appear that only your parts of the order are the entire order.

