### PR TITLE
Close any existing actionViewDetail before opening an actionView

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -559,6 +559,7 @@ export default {
   },
 
   setActionView(viewData) {
+    this.hideActionViewDetail();
     if (viewData) {
       let viewStack;
 


### PR DESCRIPTION
Resolves #2839.

This PR fixes a bug in which opening an `actionView` after an `actionViewDetail` showed a doubled up, confusing `actionView`. This PR solves that problem by always closing any existing `actionViewDetail` before opening a new `actionView`.

## Test Instructions
- Login as admin.
- Open the `Orders` modal. Then open the `order details` panel for any one of the displayed orders.
- Close the `Orders` modal.
- Navigate to another route.
- Open a new `actionView` e.g by editing some property of a product, clicking the shipping button in the admin menu etc.
- Observe that the `actionView` displays correctly and isn't doubled up as reported in #2839.

