### PR TITLE
[WIP] Internationalization of products and categories content

### DIFF
--- a/imports/plugins/core/i18n/server/i18n/index.js
+++ b/imports/plugins/core/i18n/server/i18n/index.js
@@ -2,6 +2,7 @@ import { loadTranslations } from "/server/startup/i18n";
 
 // import ar from "./ar.json";
 // import bg from "./bg.json";
+// import cs from "./cs.json";
 // import de from "./de.json";
 // import el from "./el.json";
 import en from "./en.json";
@@ -9,6 +10,7 @@ import en from "./en.json";
 // import fr from "./fr.json";
 // import he from "./he.json";
 // import hr from "./hr.json";
+// import hu from "./hu.json";
 // import it from "./it.json";
 // import my from "./my.json";
 // import nb from "./nb.json";
@@ -29,4 +31,4 @@ import en from "./en.json";
 // automated translation software
 //
 loadTranslations([en]);
-// loadTranslations([ar, bg, de, el, en, es, fr, he, hr, it, my, nb, nl, pl, pt, ro, ru, sl, sv, tr, vi, zh]);
+// loadTranslations([ar, bg, cs, de, el, en, es, fr, he, hr, hu, it, my, nb, nl, pl, pt, ro, ru, sl, sv, tr, vi, zh]);

--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -11,6 +11,7 @@ class TextField extends Component {
    * @return {String} value for text input
    */
   get value() {
+    // TODO intl
     return this.props.value || "";
   }
 
@@ -48,6 +49,7 @@ class TextField extends Component {
    */
   onChange = (event) => {
     if (this.props.onChange) {
+      // TODO intl
       this.props.onChange(event, event.target.value, this.props.name);
     }
   }

--- a/lib/collections/schemas/intlfield.js
+++ b/lib/collections/schemas/intlfield.js
@@ -1,0 +1,64 @@
+import { SimpleSchema } from "meteor/aldeed:simple-schema";
+
+/**
+* Reaction Schemas Intlfield
+*/
+
+const defaultAttributeOptions = {
+  type: String,
+  optional: true,
+  defaultValue: ""
+}
+
+const langs = [
+  'ar', 'bg', 'cs', 'de', 'el', 'en', 'es', 'fr', 'he', 'hr', 'hu', 'it', 'my',
+  'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sl', 'sv', 'tr', 'vi', 'zh',
+]
+
+function createI18nObject ( string = "" ) {
+  const obj = {}
+
+  for ( let lang of langs ) {
+    obj[lang] = string
+  }
+
+  return obj
+}
+
+function autoValue () {
+  const baseLang = 'en'
+
+  const { value } = this
+
+  if ( value && typeof value == 'object' ) {
+    return value
+  }
+
+  if ( value && typeof value == 'string' ) {
+    this.value = {
+      [baseLang]: createI18nObject(value)
+    }
+  }
+
+  return createI18nObject()
+}
+
+export function schemaBuilder ( i18nAttributeOptions = {}, extraAttributes = {} ) {
+  const attributes = {}
+
+  for ( let lang of langs ) {
+    attributes[lang] = { ...defaultAttributeOptions, ...i18nAttributeOptions }
+  }
+
+  return new SimpleSchema({ ...attributes, ...extraAttributes })
+}
+
+export const Intlfield = schemaBuilder()
+
+export function i18nify ( extraOptions = {}, i18nAttributeOptions, extraAttributes ) {
+  return {
+    type: schemaBuilder( i18nAttributeOptions, extraAttributes ),
+    autoValue,
+    ...extraOptions,
+  }
+}

--- a/lib/collections/schemas/products.js
+++ b/lib/collections/schemas/products.js
@@ -3,6 +3,7 @@ import { Random } from "meteor/random";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
 import { ReactionProduct, getSlug } from "/lib/api";
 import { shopIdAutoValue } from "./helpers";
+import { Intlfield } from "./intlfield";
 import { Metafield } from "./metafield";
 import { ShippingParcel } from "./shipping";
 import { Workflow } from "./workflow";
@@ -270,22 +271,24 @@ export const ProductVariant = new SimpleSchema({
     optional: true
   },
   taxDescription: {
-    type: String,
+    type: Intlfield,
     optional: true,
     label: "Tax Description"
   },
   // Label for customers
   title: {
     label: "Label",
-    type: String,
+    type: Intlfield,
     defaultValue: ""
   },
   // Option internal name
   optionTitle: {
     label: "Option",
-    type: String,
+    type: Intlfield,
     optional: true,
-    defaultValue: "Untitled Option"
+    defaultValue: {
+      en: "Untitled Option"
+    }
   },
   metafields: {
     type: [Metafield],
@@ -349,16 +352,16 @@ export const Product = new SimpleSchema({
     label: "Product ShopId"
   },
   title: {
-    type: String,
-    defaultValue: "",
+    type: Intlfield,
+    // defaultValue: "",
     label: "Product Title"
   },
   pageTitle: {
-    type: String,
+    type: Intlfield,
     optional: true
   },
   description: {
-    type: String,
+    type: Intlfield,
     optional: true
   },
   originCountry: {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "autoprefixer": "^7.1.1",
     "autosize": "^3.0.20",
     "babel-runtime": "^6.23.0",
+    "bcrypt": "^1.0.3",
     "bootstrap": "^3.3.7",
     "braintree": "^2.0.2",
     "bunyan": "^2.0.0",
@@ -150,7 +151,8 @@
   },
   "babel": {
     "plugins": [
-      "lodash", [
+      "lodash",
+      [
         "module-resolver",
         {
           "root": [


### PR DESCRIPTION
Directly related with #2514

**This PR is a Work-In-Progress**

I believe the first stage to include i18n over the product's and category's content is to let the admin change it manually. Then we can accomplish automatic i18n by using a plugin for that effect.

@aaronjudd I would like to hear from you where do you think we should implement the `value => intl object` at the frontend side. Should we apply at the textfield or somewhere into the data schema? If you prefer the last option can you please point where?

Thanks in advance.