### PR TITLE
Patrick customizable app container

### DIFF
--- a/imports/plugins/core/router/client/browserRouter.js
+++ b/imports/plugins/core/router/client/browserRouter.js
@@ -9,10 +9,10 @@ import { isEqual } from "lodash";
 import queryParse from "query-parse";
 import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
-import App from "/imports/plugins/core/router/client/app";
 import { Router } from "../lib";
 import { MetaData } from "/lib/api/router/metadata";
 import { TranslationProvider } from "/imports/plugins/core/ui/client/providers";
+import { Components } from "@reactioncommerce/reaction-components";
 
 const history = Router.history;
 
@@ -152,7 +152,7 @@ export function initBrowserRouter() {
       ReactDOM.render((
         <BrowserRouter history={history}>
           <TranslationProvider>
-            <App children={Router.reactComponents} />
+            <Components.App children={Router.reactComponents} />
           </TranslationProvider>
         </BrowserRouter>
       ), getRootNode());

--- a/imports/plugins/core/ui/client/components/app/app.js
+++ b/imports/plugins/core/ui/client/components/app/app.js
@@ -1,9 +1,7 @@
+import { Switch } from "react-router-dom";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { Switch } from "react-router-dom";
-import { composeWithTracker } from "@reactioncommerce/reaction-components";
-import { Reaction, Router } from "/client/api";
 import ToolbarContainer from "/imports/plugins/core/dashboard/client/containers/toolbarContainer";
 import Toolbar from "/imports/plugins/core/dashboard/client/components/toolbar";
 import { ActionViewContainer, PackageListContainer } from "/imports/plugins/core/dashboard/client/containers";
@@ -105,12 +103,4 @@ class App extends Component {
   }
 }
 
-function composer(props, onData) {
-  onData(null, {
-    isActionViewOpen: Reaction.isActionViewOpen(),
-    hasDashboardAccess: Reaction.hasDashboardAccessForAnyShop(),
-    currentRoute: Router.current()
-  });
-}
-
-export default composeWithTracker(composer)(App);
+export default App;

--- a/imports/plugins/core/ui/client/components/app/index.js
+++ b/imports/plugins/core/ui/client/components/app/index.js
@@ -1,0 +1,1 @@
+export { default as App } from "./app";

--- a/imports/plugins/core/ui/client/components/index.js
+++ b/imports/plugins/core/ui/client/components/index.js
@@ -1,6 +1,7 @@
 // export ButtonGroup from "./buttonGroup/buttonGroup";
 
 export { Alerts, Alert } from "./alerts";
+export { App } from "./app";
 export { default as Icon } from "./icon/icon";
 export { default as CircularProgress } from "./progress/circularProgress";
 export { default as Divider } from "./divider/divider";

--- a/imports/plugins/core/ui/client/containers/appContainer.js
+++ b/imports/plugins/core/ui/client/containers/appContainer.js
@@ -1,0 +1,20 @@
+import { compose } from "recompose";
+import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
+import { Reaction, Router } from "/client/api";
+import { App } from "../components";
+
+function composer(props, onData) {
+  onData(null, {
+    isActionViewOpen: Reaction.isActionViewOpen(),
+    hasDashboardAccess: Reaction.hasDashboardAccessForAnyShop(),
+    currentRoute: Router.current()
+  });
+}
+
+registerComponent("App", App, [
+  composeWithTracker(composer)
+]);
+
+export default compose(
+  composeWithTracker(composer),
+)(App);

--- a/imports/plugins/core/ui/client/containers/index.js
+++ b/imports/plugins/core/ui/client/containers/index.js
@@ -1,5 +1,6 @@
 export { default as EditContainer } from "./edit";
 export { default as Alerts } from "./alerts";
+export { default as App } from "./appContainer";
 export { default as ReactionAvatar } from "./avatar";
 export { default as SortableItem } from "./sortableItem";
 export { default as MediaGalleryContainer } from "./mediaGallery";


### PR DESCRIPTION
This PR addresses the new functionality requested in issue #2874.

Ultimately the core <App> component building code was moved out from imports/plugins/core/router/client/app.js into a registerable component in imports/plugins/core/ui/clients/components/apps and imports/plugins/core/ui/clients/containers (though I am open to guidance if there is a better place for this to live). In addition, defaults.js is used to specify what the overriding AppContainer should be.

