### PR TITLE
Fix Login dropdown not showing user account even when signed in

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -195,7 +195,10 @@ export default {
       } else {
         permissions = checkPermissions;
       }
-      // if the user has admin, owner permissions we'll always check if those roles are enough
+      // if the user has owner permissions we'll always check if those roles are enough
+      // By adding the "owner" role to the permissions list, we are making hasPermission always return
+      // true for "owners". This gives owners global access.
+      // TODO: Review this way of granting global access for owners
       permissions.push("owner");
       permissions = _.uniq(permissions);
 

--- a/imports/plugins/core/accounts/client/containers/mainDropdown.js
+++ b/imports/plugins/core/accounts/client/containers/mainDropdown.js
@@ -111,6 +111,7 @@ const composer = ({ currentAccount }, onData) => {
   const adminShortcuts = getAdminShortcutIcons();
 
   onData(null, {
+    currentAccount,
     adminShortcuts,
     userImage,
     userName

--- a/imports/plugins/core/accounts/client/containers/mainDropdown.js
+++ b/imports/plugins/core/accounts/client/containers/mainDropdown.js
@@ -111,7 +111,6 @@ const composer = ({ currentAccount }, onData) => {
   const adminShortcuts = getAdminShortcutIcons();
 
   onData(null, {
-    currentAccount,
     adminShortcuts,
     userImage,
     userName

--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -40,14 +40,16 @@ export function withCurrentAccount(component) {
       return null;
     }
 
-    // shoppers should always be guests
-    const isGuest = Roles.userIsInRole(user, "guest", shopId);
-    // but if a user has never logged in then they are anonymous
-    const isAnonymous = Roles.userIsInRole(user, "anonymous", shopId);
+    const accSub = Meteor.subscribe("Accounts", user._id);
+    if (accSub.ready()) {
+      // shoppers should always be guests
+      const isGuest = Roles.userIsInRole(user, "guest", shopId);
+      // but if a user has never logged in then they are anonymous
+      const isAnonymous = Roles.userIsInRole(user, "anonymous", shopId);
+      const account = Accounts.findOne(user._id);
 
-    const account = Accounts.findOne(user._id);
-
-    onData(null, { currentAccount: isGuest && !isAnonymous && account });
+      onData(null, { currentAccount: isGuest && !isAnonymous && account });
+    }
   })(component);
 }
 

--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -46,6 +46,7 @@ export function withCurrentAccount(component) {
       const isGuest = Roles.userIsInRole(user, "guest", shopId);
       // but if a user has never logged in then they are anonymous
       const isAnonymous = Roles.userIsInRole(user, "anonymous", shopId);
+
       const account = Accounts.findOne(user._id);
 
       onData(null, { currentAccount: isGuest && !isAnonymous && account });

--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -43,10 +43,12 @@ export function withCurrentAccount(component) {
     const accSub = Meteor.subscribe("Accounts", user._id);
     if (accSub.ready()) {
       // shoppers should always be guests
-      const isGuest = Roles.userIsInRole(user, "guest", shopId);
+      const isGuest = Reaction.hasPermission("guest");
       // but if a user has never logged in then they are anonymous
       const isAnonymous = Roles.userIsInRole(user, "anonymous", shopId);
-
+      // this check for "anonymous" uses userIsInRole instead of hasPermission because hasPermission
+      // always return `true` when logged in as the owner.
+      // But in this case, the anonymous check should be false when a user is logged in
       const account = Accounts.findOne(user._id);
 
       onData(null, { currentAccount: isGuest && !isAnonymous && account });


### PR DESCRIPTION
Resolves #2803.
Username and avatar should consistently be shown when a user is logged in, but this doesn't happen. Sometimes a user is logged in, and the dropdown still shows "Sign In".

## How To Test:
* Log In and confirm that the username and avatar is show in the account dropdown.
* Log out and log in again to confirm that the user details always get shown (Repeat this a few times).

The fix:
_ Check to ensure that Accounts is ready before doing Accounts.findOne

