### PR TITLE
fix #2801 Label is overlapping with the status indicator on product grid

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/products/productGrid.less
+++ b/imports/plugins/included/default-theme/client/styles/products/productGrid.less
@@ -340,19 +340,3 @@
   padding: 0;
   overflow: hidden;
 }
-
-.product-grid-badges {
-  .badge {
-    position: absolute;
-    top: 0px;
-    right: 0px;
-  }
-}
-
-.product-grid-badges {
-  .badge {
-    position: absolute;
-    top: 0px;
-    right: 0px;
-  }
-}


### PR DESCRIPTION
- [x] Resolves https://github.com/reactioncommerce/reaction/issues/2801
- [x] Steps to reproduce: 

1. Get the `Sold Out` or `Limited Supply` label: Create a product with 0 inventory or inventory that matches the `Warn at` number.
2. Get the change status indicator circle: Make a change to that product, so the teal round indicator appears. Or, make a product that doesn't validate, like leave a required Label out, to get the red round indicator.
3. Navigate back to the Grid to see both labels.

- [x] Screenshots: 

before: 
<img width="423" alt="status-indicator-overlap" src="https://user-images.githubusercontent.com/20409254/30139543-6604fa0a-9323-11e7-920a-c8125acaf58e.png">


after:

![screen shot 2017-09-18 at 3 48 11 pm](https://user-images.githubusercontent.com/3673236/30568336-70d4054c-9c89-11e7-86fd-cfc2e68b3fa5.png)


