### PR TITLE
[WIP] fix #2811: Cart's Limited Supply status should not hide item title/quantity info

### DIFF
--- a/imports/plugins/core/checkout/client/components/cartItems.js
+++ b/imports/plugins/core/checkout/client/components/cartItems.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { i18next } from "/client/api";
 import { registerComponent } from "@reactioncommerce/reaction-components";
 
 class CartItems extends Component {
@@ -30,7 +31,16 @@ class CartItems extends Component {
     } = this.props;
 
     return (
-      <div className="cart-items" key={item._id} style={{ display: "inline-block" }}>
+      <div
+        className="cart-items"
+        key={item._id}
+        style={{ display: "inline-block" }}
+      >
+        {handleLowInventory(item) &&
+          <div className="badge secondary-badge badge-low-inv-warning">
+            { i18next.t("cartDrawerItems.amountRemaining", { amount: item.variants.inventoryQuantity }) }
+          </div>
+        }
         <i className="remove-cart-item fa fa-times fa-lg"
           id={item._id}
           onClick={handleRemoveItem}
@@ -50,20 +60,14 @@ class CartItems extends Component {
           }
         </a>
         <div className="cart-labels">
-          {handleLowInventory(item) ?
-            <div className="badge badge-low-inv-warning"
-              title={item.variants.inventoryQuantity}
-              data-i18n="cartDrawerItems.left"
-            >!</div> :
-            <div>
-              <span className="badge" style={{ marginRight: "3px" }}>{item.quantity}</span>
-              <span className="cart-item-title">
-                {item.title}
-                <br />
-                <small>{item.variants.title}</small>
-              </span>
-            </div>
-          }
+          <div>
+            <span className="badge" style={{ marginRight: "3px" }}>{item.quantity}</span>
+            <span className="cart-item-title">
+              {item.title}
+              <br />
+              <small>{item.variants.title}</small>
+            </span>
+          </div>
         </div>
       </div>
     );

--- a/imports/plugins/core/checkout/server/i18n/en.json
+++ b/imports/plugins/core/checkout/server/i18n/en.json
@@ -8,6 +8,9 @@
         "dashboard": {},
         "settings": {}
       },
+      "cartDrawerItems": {
+        "amountRemaining": "{{amount}} left"
+      },
       "cartCompleted": {
         "yourCart": "Your Cart",
         "discountTotal": "Discount Total",

--- a/imports/plugins/included/default-theme/client/styles/badge.less
+++ b/imports/plugins/included/default-theme/client/styles/badge.less
@@ -66,6 +66,11 @@
   .label-variant(@label-warning-bg);
 }
 
+.top-left.badge-low-inv-warning {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+}
 
 /* Badge Colors
 // Contextual variations of badges

--- a/imports/plugins/included/default-theme/client/styles/badge.less
+++ b/imports/plugins/included/default-theme/client/styles/badge.less
@@ -66,7 +66,7 @@
   .label-variant(@label-warning-bg);
 }
 
-.top-left.badge-low-inv-warning {
+.secondary-badge.badge-low-inv-warning {
   position: absolute;
   top: -8px;
   left: -8px;

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -1,6 +1,5 @@
 import accounting from "accounting-js";
 import _ from "lodash";
-import { Meteor } from "meteor/meteor";
 import { Shops } from "/lib/collections";
 
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] Closes part 1 of https://github.com/reactioncommerce/reaction/issues/2811
- [x] Provide us detailed instructions on how we can test your PR:

1. Created a product with limited supply
2. Add that product to cart
3. Open cart
4. Confirm the item's title, variant title and quantity appears below the image
- [x] Design

before
<img width="1379" alt="labels don t match up with limited supply" src="https://user-images.githubusercontent.com/20409254/30227078-2e8099a2-948d-11e7-8555-60f7dd8b193b.png">
