### PR TITLE
Fix "Order table previous/next pagination buttons" bug #2885

### DIFF
--- a/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
@@ -114,7 +114,7 @@ class SortableTablePagination extends Component {
         <div className="-previous">
           <PreviousComponent
             onClick={(e) => { // eslint-disable-line no-unused-vars
-              if (!canPrevious) {
+              if (canPrevious) {
                 return this.changePage(page - 1);
               }
             }}
@@ -127,7 +127,7 @@ class SortableTablePagination extends Component {
         <div className="-next">
           <NextComponent
             onClick={(e) => { // eslint-disable-line no-unused-vars
-              if (!canNext) {
+              if (canNext) {
                 return this.changePage(page + 1);
               }
             }}


### PR DESCRIPTION
Resolves [#2885](https://github.com/reactioncommerce/reaction/issues/2885)
Previous/Next pagination button do not work

**canNext** and **canPrevious** are boolean values that control the click function of these pagination buttons. From previous implementation, they were negated.
```
if (!canPrevious) {
  return this.changePage(page - 1);
}

if (!canNext) {
  return this.changePage(page - 1);
}
```

###### Fix
- Remove negation from canNext and canPrevious
```
if (canPrevious) {
  return this.changePage(page - 1);
}

if (canNext) {
  return this.changePage(page - 1);
}
```

###### Test
```
Have 5+ orders
Set number of rows to 5
Click on the active Next button to navigate to the next page
Observe that change in items/list displayed
```

