### PR TITLE
Fixes an issue with migration 8 - update registry provides

### DIFF
--- a/imports/plugins/core/versions/server/migrations/8_update_registry_provides_to_array.js
+++ b/imports/plugins/core/versions/server/migrations/8_update_registry_provides_to_array.js
@@ -5,24 +5,25 @@ Migrations.add({
   version: 8,
   up() {
     const packages = Packages.find();
-
     // Loop through all packages and update provides to use an array
     packages.forEach((pkg) => {
-      // Map the existing registry into an updated registry with the existing "provides" string wrapped in an array
-      // We use the term "app" to refer to individual registry entries
-      const updatedRegistry = pkg.registry.map((app) => {
-        if (typeof app.provides === "string") {
-          app.provides = [app.provides];
-        }
-        return app;
-      });
+      if (pkg.registry) {
+        // Map the existing registry into an updated registry with the existing "provides" string wrapped in an array
+        // We use the term "app" to refer to individual registry entries
+        const updatedRegistry = pkg.registry.map((app) => {
+          if (typeof app.provides === "string") {
+            app.provides = [app.provides];
+          }
+          return app;
+        });
 
-      // Update the package document with the new registry
-      Packages.update({ _id: pkg._id }, {
-        $set: {
-          registry: updatedRegistry
-        }
-      });
+        // Update the package document with the new registry
+        Packages.update({ _id: pkg._id }, {
+          $set: {
+            registry: updatedRegistry
+          }
+        });
+      }
     });
   },
 
@@ -31,23 +32,25 @@ Migrations.add({
 
     // Loop through all packages and update provides to use an array
     packages.forEach((pkg) => {
-      // Map the existing registry into an updated registry with any provides arrays changed to use the first element
-      // of the array. We discussed reducing the array and creating an entry for each provides here, but felt that
-      // since versions of the app before this would have only had one entry, it's safer to just take the first element
-      // of the array
-      const updatedRegistry = pkg.registry.map((entry) => {
-        if (Array.isArray(entry.provides)) {
-          entry.provides = entry.provides[0];
-        }
-        return entry;
-      });
+      if (pkg.registry) {
+        // Map the existing registry into an updated registry with any provides arrays changed to use the first element
+        // of the array. We discussed reducing the array and creating an entry for each provides here, but felt that
+        // since versions of the app before this would have only had one entry, it's safer to just take the first element
+        // of the array
+        const updatedRegistry = pkg.registry.map((entry) => {
+          if (Array.isArray(entry.provides)) {
+            entry.provides = entry.provides[0];
+          }
+          return entry;
+        });
 
-      // Update the package document with the new registry
-      Packages.update({ _id: pkg._id }, {
-        $set: {
-          registry: updatedRegistry
-        }
-      });
+        // Update the package document with the new registry
+        Packages.update({ _id: pkg._id }, {
+          $set: {
+            registry: updatedRegistry
+          }
+        });
+      }
     });
   }
 });


### PR DESCRIPTION
Fixes an undocumented issue that I came across migrating an older branch up where migration 8 would throw an error when it encountered a plugin that did not have a registry