### PR TITLE
Fixes issues related to missing `shop` on sign in / sign out

### DIFF
--- a/client/modules/i18n/currency.js
+++ b/client/modules/i18n/currency.js
@@ -20,7 +20,7 @@ function findCurrency(defaultCurrency, useDefaultShopCurrency) {
     }
   });
 
-  const shopCurrency = shop.currency;
+  const shopCurrency = shop && shop.currency || "USD";
   const localStorageCurrencyName = localStorage.getItem("currency");
   if (typeof shop === "object" && shop.currencies && localStorageCurrencyName) {
     let localStorageCurrency = {};

--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -69,7 +69,9 @@ Meteor.startup(() => {
       const shop = Shops.findOne({
         _id: shopId
       });
-      let language = shop.language;
+
+      let language = shop && shop.language || "en";
+
       if (Meteor.user() && Meteor.user().profile && Meteor.user().profile.lang) {
         language = Meteor.user().profile.lang;
       }

--- a/imports/plugins/core/accounts/client/containers/mainDropdown.js
+++ b/imports/plugins/core/accounts/client/containers/mainDropdown.js
@@ -128,11 +128,11 @@ const handlers = {
 registerComponent("MainDropdown", MainDropdown, [
   withCurrentAccount,
   withProps(handlers),
-  composeWithTracker(composer)
+  composeWithTracker(composer, false)
 ]);
 
 export default compose(
   withCurrentAccount,
   withProps(handlers),
-  composeWithTracker(composer)
+  composeWithTracker(composer, false)
 )(MainDropdown);

--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -53,7 +53,7 @@ export function withCurrentAccount(component) {
 
       onData(null, { currentAccount: isGuest && !isAnonymous && account });
     }
-  })(component);
+  }, false)(component);
 }
 
 

--- a/imports/plugins/core/layout/client/templates/theme/theme.js
+++ b/imports/plugins/core/layout/client/templates/theme/theme.js
@@ -26,7 +26,7 @@ function getRouteLayout(context) {
       }
 
       const shop = Shops.findOne(Reaction.getShopId());
-      const currentLayout = shop.layout.find((x) => {
+      const currentLayout = shop && shop.layout.find((x) => {
         if (x.layout === registryRoute.layout && x.workflow === registryRoute.workflow && x.enabled === true) {
           return true;
         }

--- a/imports/plugins/core/router/client/startup.js
+++ b/imports/plugins/core/router/client/startup.js
@@ -10,7 +10,7 @@ Meteor.startup(function () {
   loadRegisteredComponents();
 
   // Subscribe to router required publications
-  // Note: Although these are subscribed to by the subscription mamager in "/modules/client/core/subscriptions",
+  // Note: Although these are subscribed to by the subscription manager in "/modules/client/core/subscriptions",
   // using the subscriptions manager sometimes causes issues when signing in/out where you may seee a grey screen
   // or missing shop data throughout the app.
   // TODO: Revisit subscriptions manager usage and waiting for shops to exist client side before rendering.

--- a/imports/plugins/core/router/client/startup.js
+++ b/imports/plugins/core/router/client/startup.js
@@ -2,25 +2,34 @@ import { loadRegisteredComponents } from "@reactioncommerce/reaction-components"
 import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
 import { Accounts } from "meteor/accounts-base";
-import { Reaction } from "/client/api";
+import { Shops } from "/lib/collections";
 import { initBrowserRouter } from "./browserRouter";
 import { Router } from "../lib";
 
 Meteor.startup(function () {
   loadRegisteredComponents();
 
+  // Subscribe to router required publications
+  // Note: Although these are subscribed to by the subscription mamager in "/modules/client/core/subscriptions",
+  // using the subscriptions manager sometimes causes issues when signing in/out where you may seee a grey screen
+  // or missing shop data throughout the app.
+  // TODO: Revisit subscriptions manager usage and waiting for shops to exist client side before rendering.
+  const primaryShopSub = Meteor.subscribe("PrimaryShop");
+  const merchantShopSub = Meteor.subscribe("MerchantShops");
+  const packageSub = Meteor.subscribe("Packages");
+
   Tracker.autorun(function () {
     // initialize client routing
-    if (Reaction.Subscriptions.Packages.ready() &&
-        Reaction.Subscriptions.PrimaryShop.ready() &&
-        Reaction.Subscriptions.MerchantShops.ready()) {
+    if (primaryShopSub.ready() && merchantShopSub.ready() && packageSub.ready()) {
+      const shops = Shops.find({}).fetch();
       //  initBrowserRouter calls Router.initPackageRoutes which calls shopSub.ready which is reactive,
       //  So we have to call initBrowserRouter in a non reactive context.
-      //  Otherwise initBrowserRouter is called twice each time a Reaction.Subscriptions.Packages.ready() and
-      //  Reaction.Subscriptions.PrimaryShop.ready() are true
-
+      //  Otherwise initBrowserRouter is called twice each time a subscription becomes "ready"
       Tracker.nonreactive(()=> {
-        initBrowserRouter();
+        // Make sure we have shops before we try to make routes for them
+        if (Array.isArray(shops) && shops.length)  {
+          initBrowserRouter();
+        }
       });
     }
   });
@@ -33,8 +42,12 @@ Meteor.startup(function () {
   // has already been generated (existing user)
   //
   Accounts.onLogin(() => {
+    const shops = Shops.find({}).fetch();
+
     if (Meteor.loggingIn() === false && Router._routes.length > 0) {
-      initBrowserRouter();
+      if (Array.isArray(shops) && shops.length)  {
+        initBrowserRouter();
+      }
     }
   });
 });

--- a/imports/plugins/core/ui-navbar/client/components/brand.js
+++ b/imports/plugins/core/ui-navbar/client/components/brand.js
@@ -1,10 +1,13 @@
 import React, { Component } from "react";
-import _ from "lodash";
+import PropTypes from "prop-types";
 import { registerComponent } from "@reactioncommerce/reaction-components";
 import { Reaction } from "/client/api";
-import { Media, Shops } from "/lib/collections";
 
 class Brand extends Component {
+  static propTypes = {
+    logo: PropTypes.string,
+    title: PropTypes.string
+  }
   constructor(props) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
@@ -15,27 +18,15 @@ class Brand extends Component {
     Reaction.Router.go("/");
   }
 
-  getShop() {
-    return Shops.findOne(Reaction.getShopId());
-  }
-
-  getLogo() {
-    if (Array.isArray(this.getShop().brandAssets)) {
-      const brandAsset = _.find(this.getShop().brandAssets, (asset) => asset.type === "navbarBrandImage");
-      return Media.findOne(brandAsset.mediaId);
-    }
-    return false;
-  }
-
   render() {
     return (
       <a className="brand" onClick={this.handleClick}>
-        {this.getLogo() &&
+        {this.props.logo &&
           <div className="logo">
-            <img src={this.getLogo().url()} />
+            <img src={this.props.logo} />
           </div>
         }
-        <span className="title">{this.getShop().name}</span>
+        <span className="title">{this.props.title}</span>
       </a>
     );
   }

--- a/imports/plugins/core/ui-navbar/client/components/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/components/navbar.js
@@ -21,8 +21,10 @@ async function openSearchModalLegacy(props) {
 
 class NavBar extends Component {
   static propTypes = {
+    brandMedia: PropTypes.object,
     hasProperPermission: PropTypes.bool,
-    searchEnabled: PropTypes.bool
+    searchEnabled: PropTypes.bool,
+    shop: PropTypes.object
   }
 
   state = {
@@ -59,8 +61,14 @@ class NavBar extends Component {
   }
 
   renderBrand() {
+    const shop = this.props.shop || { name: "" };
+    const logo = this.props.brandMedia && this.props.brandMedia.url();
+
     return (
-      <Components.Brand />
+      <Components.Brand
+        logo={logo}
+        title={shop.name}
+      />
     );
   }
 

--- a/imports/plugins/core/ui-navbar/client/containers/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/containers/navbar.js
@@ -1,11 +1,15 @@
+import _ from "lodash";
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Reaction } from "/client/api";
 import NavBar from "../components/navbar";
+import { Media, Shops } from "/lib/collections";
 
 function composer(props, onData) {
+  const shop = Shops.findOne(Reaction.getShopId());
   const searchPackage = Reaction.Apps({ provides: "ui-search" });
   let searchEnabled;
   let searchTemplate;
+  let bandMedia;
 
   if (searchPackage.length) {
     searchEnabled = true;
@@ -14,9 +18,16 @@ function composer(props, onData) {
     searchEnabled = false;
   }
 
+  if (shop && Array.isArray(shop.brandAssets)) {
+    const brandAsset = _.find(this.getShop().brandAssets, (asset) => asset.type === "navbarBrandImage");
+    bandMedia = Media.findOne(brandAsset.mediaId);
+  }
+
   const hasProperPermission = Reaction.hasPermission("account/profile");
 
   onData(null, {
+    shop,
+    bandMedia,
     searchEnabled,
     searchTemplate,
     hasProperPermission

--- a/imports/plugins/core/ui-navbar/client/containers/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/containers/navbar.js
@@ -9,7 +9,7 @@ function composer(props, onData) {
   const searchPackage = Reaction.Apps({ provides: "ui-search" });
   let searchEnabled;
   let searchTemplate;
-  let bandMedia;
+  let brandMedia;
 
   if (searchPackage.length) {
     searchEnabled = true;
@@ -20,14 +20,14 @@ function composer(props, onData) {
 
   if (shop && Array.isArray(shop.brandAssets)) {
     const brandAsset = _.find(this.getShop().brandAssets, (asset) => asset.type === "navbarBrandImage");
-    bandMedia = Media.findOne(brandAsset.mediaId);
+    brandMedia = Media.findOne(brandAsset.mediaId);
   }
 
   const hasProperPermission = Reaction.hasPermission("account/profile");
 
   onData(null, {
     shop,
-    bandMedia,
+    brandMedia,
     searchEnabled,
     searchTemplate,
     hasProperPermission

--- a/imports/plugins/core/ui/client/components/app/app.js
+++ b/imports/plugins/core/ui/client/components/app/app.js
@@ -55,7 +55,7 @@ class App extends Component {
 
     const currentRoute = this.props.currentRoute;
     const routeOptions = currentRoute.route && currentRoute.route.options || {};
-    const routeData = routeOptions && currentRoute.route.options.structure || {};
+    const routeData = routeOptions && routeOptions.structure || {};
 
     return (
       <div

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -36,7 +36,7 @@ export function getShopName() {
     shop = Shops.findOne({
       _id: shopId
     });
-    return shop && shop.name;
+    return shop && shop.name || "";
   }
 
   const domain = url.parse(Meteor.absoluteUrl()).hostname;
@@ -45,7 +45,7 @@ export function getShopName() {
     limit: 1
   }).fetch()[0];
 
-  return !!shop ? shop.name : null;
+  return !!shop ? shop.name : "";
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/reactioncommerce/reaction/issues/2931 https://github.com/reactioncommerce/reaction/issues/2750

What was happening...

Signing in and out of the app sometimes causes the screen to be blank or causing with some components to not render at all due to errors. This is because shop data is no longer available on the client and many components that assumed shop would always be available. 

This PR, add guards around the initial set of components that were complaining about missing `shop`. It further guards against the shop not being available at the router level and replaces subscription manager with local subscriptions.

For some reason, using the subscription manager in the router `startup.js` was causing issues with sign in and sign out. Perhaps this is due to how it caches subscriptions or otherwise. By switching to local subscriptions, it appears this problem is resolved or at least lessened its frequency.

I added a `TODO` to revisit with subscription manager. This is a really good case for using `Redux` or something more transparent for debugging purposes. :)