### PR TITLE
Fixed guest checkout page showing 'Sign In' instead of 'Register'

### DIFF
--- a/imports/plugins/core/accounts/client/templates/inline/inline.html
+++ b/imports/plugins/core/accounts/client/templates/inline/inline.html
@@ -15,7 +15,7 @@
       {{/if}}
     {{/unless}}
     <div class="checkout-login">
-      {{> loginForm startView="loginFormSignUpView"}}
+      {{> loginForm loginFormCurrentView="loginFormSignUpView"}}
     </div>
   </div>
 </template>


### PR DESCRIPTION
Resolves #2944 

A wrong prop `startView` was provided to the login component on the guest checkout page, so I changed it to the appropriate which is `loginFormCurrentView`.

##### HOW TO TEST
- Add something to cart
- Go to checkout
- See that the sign in is  now defaulted register

