### PR TITLE
Allow settings of "parcel" object from PDP Options and store on cart

### DIFF
--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -655,6 +655,71 @@ class VariantForm extends Component {
             <div className="row">
               {this.renderQuantityField()}
             </div>
+            <div className="row">
+              <div className="col-sm-6">
+                <Components.TextField
+                  i18nKeyLabel="productVariant.width"
+                  i18nKeyPlaceholder="0"
+                  placeholder="0"
+                  label="Width"
+                  name="width"
+                  ref="widthInput"
+                  value={this.variant.width}
+                  onBlur={this.handleFieldBlur}
+                  onChange={this.handleFieldChange}
+                  onReturnKeyDown={this.handleFieldBlur}
+                  validation={this.props.validation}
+                />
+              </div>
+              <div className="col-sm-6">
+                <Components.TextField
+                  i18nKeyLabel="productVariant.length"
+                  i18nKeyPlaceholder="0"
+                  placeholder="0"
+                  label="Length"
+                  name="length"
+                  ref="lengthInput"
+                  value={this.variant.length}
+                  onBlur={this.handleFieldBlur}
+                  onChange={this.handleFieldChange}
+                  onReturnKeyDown={this.handleFieldBlur}
+                  validation={this.props.validation}
+                />
+              </div>
+            </div>
+
+            <div className="row">
+              <div className="col-sm-6">
+                <Components.TextField
+                  i18nKeyLabel="productVariant.height"
+                  i18nKeyPlaceholder="0"
+                  placeholder="0"
+                  label="Height"
+                  name="height"
+                  ref="heightInput"
+                  value={this.variant.height}
+                  onBlur={this.handleFieldBlur}
+                  onChange={this.handleFieldChange}
+                  onReturnKeyDown={this.handleFieldBlur}
+                  validation={this.props.validation}
+                />
+              </div>
+              <div className="col-sm-6">
+                <Components.TextField
+                  i18nKeyLabel="productVariant.weight"
+                  i18nKeyPlaceholder="0"
+                  placeholder="0"
+                  label="Weight"
+                  name="weight"
+                  ref="weightInput"
+                  value={this.variant.weight}
+                  onBlur={this.handleFieldBlur}
+                  onChange={this.handleFieldChange}
+                  onReturnKeyDown={this.handleFieldBlur}
+                  validation={this.props.validation}
+                />
+              </div>
+            </div>
           </Components.CardBody>
         </Components.Card>
       </Components.CardGroup>

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -415,6 +415,10 @@ Meteor.methods({
       });
     }
 
+    let parcel = null;
+    if (variant.weight || variant.height || variant.width || variant.length) {
+      parcel = { weight: variant.weight, height: variant.height, width: variant.width, length: variant.length };
+    }
     // cart variant doesn't exist
     return Collections.Cart.update({
       _id: cart._id
@@ -430,7 +434,7 @@ Meteor.methods({
           metafields: options.metafields,
           title: product.title,
           type: product.type,
-          parcel: product.parcel || null
+          parcel
         }
       }
     }, function (error, result) {

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -415,7 +415,14 @@ Meteor.methods({
       });
     }
 
+    // we need to get the parent of the option to check if parcel info is stored there
+    const immediateAncestors = variant.ancestors.filter((ancestor) => ancestor !== product._id);
+    const immediateAncestor = Collections.Products.findOne({ _id: immediateAncestors[0] });
     let parcel = null;
+    if (immediateAncestor.weight || immediateAncestor.height || immediateAncestor.width || immediateAncestor.length) {
+      parcel = { weight: immediateAncestor.weight, height: immediateAncestor.height, width: immediateAncestor.width, length: immediateAncestor.length };
+    }
+    // if it's set at the option level then that overrides
     if (variant.weight || variant.height || variant.width || variant.length) {
       parcel = { weight: variant.weight, height: variant.height, width: variant.width, length: variant.length };
     }

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -419,8 +419,10 @@ Meteor.methods({
     const immediateAncestors = variant.ancestors.filter((ancestor) => ancestor !== product._id);
     const immediateAncestor = Collections.Products.findOne({ _id: immediateAncestors[0] });
     let parcel = null;
-    if (immediateAncestor.weight || immediateAncestor.height || immediateAncestor.width || immediateAncestor.length) {
-      parcel = { weight: immediateAncestor.weight, height: immediateAncestor.height, width: immediateAncestor.width, length: immediateAncestor.length };
+    if (immediateAncestor) {
+      if (immediateAncestor.weight || immediateAncestor.height || immediateAncestor.width || immediateAncestor.length) {
+        parcel = { weight: immediateAncestor.weight, height: immediateAncestor.height, width: immediateAncestor.width, length: immediateAncestor.length };
+      }
     }
     // if it's set at the option level then that overrides
     if (variant.weight || variant.height || variant.width || variant.length) {

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -415,6 +415,7 @@ Meteor.methods({
       });
     }
 
+    // TODO: Handle more than 2 levels of variant hierarchy for determining parcel dimensions
     // we need to get the parent of the option to check if parcel info is stored there
     const immediateAncestors = variant.ancestors.filter((ancestor) => ancestor !== product._id);
     const immediateAncestor = Collections.Products.findOne({ _id: immediateAncestors[0] });


### PR DESCRIPTION
This closes https://github.com/reactioncommerce/reaction/issues/2958

I debated just **moving** these dimensions from the variant to the option but tried to make it backwards compatible.



### To Test 
### Steps to Reproduce the Behavior
1. Login as administrator
1. Enable Shippo and enable carriers
1. Create a product (don't use the built-in product) and set weight and dimensions
1. Add **only** the newly created product to cart
1. Attempt to checkout
1. Observe that shipping methods are displayed