### PR TITLE
Fixed regex escape on searchQuery for Orders

### DIFF
--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -183,9 +183,9 @@ export function buildOrderSearchRecord(orderId) {
   ) || {};
 
   orderSearch.billingName = shopBilling.address && shopBilling.address.fullName;
-  orderSearch.billingPhone = shopBilling.address && shopBilling.address.phone.replace(/\D/g, "");
+  orderSearch.billingPhone = shopBilling.address && shopBilling.address.phone;
   orderSearch.shippingName = shopShipping.address && shopShipping.address.fullName;
-  orderSearch.shippingPhone = shopShipping.address && shopShipping.address.phone.replace(/\D/g, "");
+  orderSearch.shippingPhone = shopShipping.address && shopShipping.address.phone;
   orderSearch.billingAddress = {
     address: shopBilling.address && shopBilling.address.address1,
     postal: shopBilling.address && shopBilling.address.postal,

--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -1,9 +1,11 @@
 import _ from "lodash";
+import escapeStringRegex from "escape-string-regexp";
 import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { check, Match } from "meteor/check";
 import { Reaction, Logger } from "/server/api";
 import { ProductSearch, OrderSearch, AccountSearch } from "/lib/collections";
+
 
 const supportedCollections = ["products", "orders", "accounts"];
 
@@ -49,56 +51,57 @@ getResults.products = function (searchTerm, facets, maxResults, userId) {
 
 getResults.orders = function (searchTerm, facets, maxResults, userId) {
   let orderResults;
+  const regexSafeSearchTerm = escapeStringRegex(searchTerm);
   const shopId = Reaction.getShopId();
   const findTerm = {
     $and: [
       { shopId: shopId },
       { $or: [
         { _id: {
-          $regex: `^${searchTerm}`,
+          $regex: `^${regexSafeSearchTerm}`,
           $options: "i"
         } },
         { userEmails: {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } },
         { shippingName: {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } },
         { billingName: {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } },
         { billingCard: {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } },
         { billingPhone: {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } },
         { shippingPhone: {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } },
         { "product.title": {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } },
         { "variants.title": {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } },
         { "variants.optionTitle": {
-          $regex: searchTerm,
+          $regex: regexSafeSearchTerm,
           $options: "i"
         } }
       ] }
     ] };
   if (Reaction.hasPermission("orders", userId)) {
     orderResults = OrderSearch.find(findTerm, { limit: maxResults });
-    Logger.debug(`Found ${orderResults.count()} orders searching for ${searchTerm}`);
+    Logger.debug(`Found ${orderResults.count()} orders searching for ${regexSafeSearchTerm}`);
   }
   return orderResults;
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "css-annotation": "^0.6.2",
     "deep-diff": "^0.3.8",
     "dnd-core": "^2.4.0",
+    "escape-string-regexp": "^1.0.5",
     "faker": "^4.1.0",
     "fibers": "^2.0.0",
     "flatten-obj": "^3.1.0",


### PR DESCRIPTION
Resolves #2867 

Added a package `escape-string-regexp`, and also refactored the OrderSearch object to save phone numbers with `+` symbol

#### HOW TO TEST
- Create an account with an email containing `+` character. example `++john++@gmail.com` or in your shipping address use a phone number with a `+` character , example `+008165516536`
- Create an order or orders
- Go to order page and search for phone number or email

