### PR TITLE
standardize price field location && update panel casing

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/panels.less
+++ b/imports/plugins/included/default-theme/client/styles/panels.less
@@ -15,10 +15,6 @@
   }
 }
 
-.panel-heading {
-  text-transform: capitalize;
-}
-
 .flex-item > .panel {
   margin-bottom: 0;
   min-height: 220px;

--- a/imports/plugins/included/product-variant/components/variantEdit.js
+++ b/imports/plugins/included/product-variant/components/variantEdit.js
@@ -38,7 +38,7 @@ class VariantEdit extends Component {
           name={"variantOptions"}
         >
           <Components.CardHeader
-            i18nKeyTitle="productDetailEdit.variantsDetails"
+            i18nKeyTitle="productDetailEdit.variantsOptions"
             title="Variant Options"
           >
             <Components.Button

--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -369,21 +369,6 @@ class VariantForm extends Component {
             <div className="row">
               <div className="col-sm-6">
                 <Components.TextField
-                  i18nKeyLabel="productVariant.compareAtPrice"
-                  i18nKeyPlaceholder={formatPriceString("0.00")}
-                  placeholder={formatPriceString("0.00")}
-                  label="Compare At Price"
-                  name="compareAtPrice"
-                  ref="compareAtPriceInput"
-                  value={this.variant.compareAtPrice}
-                  onBlur={this.handleFieldBlur}
-                  onChange={this.handleFieldChange}
-                  onReturnKeyDown={this.handleFieldBlur}
-                  validation={this.props.validation}
-                />
-              </div>
-              <div className="col-sm-6">
-                <Components.TextField
                   i18nKeyLabel="productVariant.price"
                   i18nKeyPlaceholder={formatPriceString("0.00")}
                   placeholder={formatPriceString("0.00")}
@@ -393,6 +378,21 @@ class VariantForm extends Component {
                   value={this.variant.price}
                   style={this.props.greyDisabledFields(this.variant)}
                   disabled={this.props.hasChildVariants(this.variant)}
+                  onBlur={this.handleFieldBlur}
+                  onChange={this.handleFieldChange}
+                  onReturnKeyDown={this.handleFieldBlur}
+                  validation={this.props.validation}
+                />
+              </div>
+              <div className="col-sm-6">
+                <Components.TextField
+                  i18nKeyLabel="productVariant.compareAtPrice"
+                  i18nKeyPlaceholder={formatPriceString("0.00")}
+                  placeholder={formatPriceString("0.00")}
+                  label="Compare At Price"
+                  name="compareAtPrice"
+                  ref="compareAtPriceInput"
+                  value={this.variant.compareAtPrice}
                   onBlur={this.handleFieldBlur}
                   onChange={this.handleFieldChange}
                   onReturnKeyDown={this.handleFieldBlur}

--- a/private/data/i18n/en.json
+++ b/private/data/i18n/en.json
@@ -105,7 +105,8 @@
         "makeVisible": "Make visible",
         "hideProduct": "Hide product",
         "productIsVisible": "Product is visible",
-        "productIsNotVisible": "Product is not visible"
+        "productIsNotVisible": "Product is not visible",
+        "variantOptions": "Variant options"
       },
       "productVariant": {
         "addVariantOptions": "Add options to enable 'Add to Cart' button",

--- a/private/data/i18n/en.json
+++ b/private/data/i18n/en.json
@@ -15,6 +15,7 @@
         }
       },
       "app": {
+        "auto": "Auto",
         "save": "Save",
         "saveAndContinue": "Save and continue",
         "cancel": "Cancel",

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -455,7 +455,7 @@ Meteor.methods({
 
     if (!newVariant) {
       Object.assign(assembledVariant, {
-        title: product.title + " - Untitled Option",
+        title: product.title + " - Untitled option",
         price: 0.00
       });
     }


### PR DESCRIPTION
1) update price fields locations to be standard across variant and variant options ( Fixes #2997 )
2) Update LESS on Panel Headers to be raw incoming text instead of `text-transform: capitalize;` ( Fixes #2998 )