### PR TITLE
sync inventory policy toggle between top-level variants and child variants

### DIFF
--- a/imports/plugins/core/ui/client/components/switch/switch.js
+++ b/imports/plugins/core/ui/client/components/switch/switch.js
@@ -10,6 +10,9 @@ class Switch extends Component {
 
   static propTypes = {
     checked: PropTypes.bool,
+    disabled: PropTypes.bool,
+    helpText: PropTypes.string,
+    i18nKeyHelpText: PropTypes.string,
     i18nKeyLabel: PropTypes.string,
     i18nKeyOnLabel: PropTypes.string,
     label: PropTypes.string,
@@ -24,6 +27,16 @@ class Switch extends Component {
     this.state = {
       checked: false
     };
+  }
+
+  get isHelpMode() {
+    // TODO: add functionality to toggle helpMode on / off.
+    // When on, helpText will always show.
+    // When off, only validation messages will show.
+    // For now, all helpText will show, meaning this doesn't affect how the app currently works.
+    // This is here just to lay the foundation for when we add the toggle.
+
+    return true;
   }
 
   handleChange = (event) => {
@@ -61,6 +74,27 @@ class Switch extends Component {
     return null;
   }
 
+  /**
+   * Render help text or validation message
+   * @return {ReactNode|null} react node or null
+   */
+  renderHelpText() {
+    const helpMode = this.isHelpMode;
+    const helpText = this.props.helpText;
+    const i18nKey = this.props.i18nKeyHelpText;
+
+    // Show if helpMode is true
+    if (helpText && helpMode) {
+      return (
+        <span className="help-block">
+          <Components.Translation defaultValue={helpText} i18nKey={i18nKey} />
+        </span>
+      );
+    }
+
+    return null;
+  }
+
   checkboxRef = (ref) => {
     this._checkbox = ref;
   }
@@ -68,7 +102,8 @@ class Switch extends Component {
   render() {
     const baseClassName = classnames({
       rui: true,
-      switch: true
+      switch: true,
+      disabled: this.props.disabled
     });
 
     const switchControlClassName = classnames({
@@ -77,16 +112,19 @@ class Switch extends Component {
     });
 
     return (
-      <label className={baseClassName}>
-        <input
-          checked={this.props.checked}
-          onChange={this.handleChange}
-          ref={this.checkboxRef}
-          type="checkbox"
-        />
-        <div className={switchControlClassName} />
-        {this.renderLabel()}
-      </label>
+      <span>
+        <label className={baseClassName}>
+          <input
+            checked={this.props.checked}
+            onChange={this.handleChange}
+            ref={this.checkboxRef}
+            type="checkbox"
+          />
+          <div className={switchControlClassName} />
+          {this.renderLabel()}
+        </label>
+        {this.renderHelpText()}
+      </span>
     );
   }
 }

--- a/imports/plugins/included/default-theme/client/styles/forms.less
+++ b/imports/plugins/included/default-theme/client/styles/forms.less
@@ -72,6 +72,12 @@
   input, label {
     display: none;
   }
+
+  &.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 }
 
 .rui.switch .switch-control {
@@ -135,6 +141,11 @@
 
 .rui.list-item-action .rui.switch {
   padding: 0;
+}
+
+// Original style is inherited from Bootstrap
+.rui.switch .help-block {
+  color: @black30;
 }
 
 .checkbox-large {

--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -6,6 +6,7 @@ import Velocity from "velocity-animate";
 import "velocity-animate/velocity.ui";
 import { Components } from "@reactioncommerce/reaction-components";
 import { formatPriceString } from "/client/api";
+import { Reaction } from "/lib/api";
 
 const fieldNames = [
   "title",
@@ -129,6 +130,7 @@ class VariantForm extends Component {
   }
 
   handleFieldBlur = (event, value, field) => {
+    console.log("field", field);
     if (this.props.onVariantFieldSave) {
       this.props.onVariantFieldSave(this.variant._id, field, value, this.state.variant);
     }
@@ -259,6 +261,44 @@ class VariantForm extends Component {
         </div>
       );
     }
+  }
+
+  renderInventoryPolicyField() {
+    if (this.props.hasChildVariants(this.variant)) {
+      return (
+        <div className="col-sm-12">
+          <Components.Switch
+            i18nKeyLabel="productVariant.inventoryPolicy"
+            i18nKeyOnLabel="productVariant.inventoryPolicy"
+            name="inventoryPolicy"
+            label={"Allow backorder"}
+            onLabel={"Allow backorder"}
+            checked={!this.state.inventoryPolicy}
+            onChange={this.handleInventoryPolicyChange}
+            validation={this.props.validation}
+            disabled={true}
+            helpText={"Backorder allowance is now controlled by options"}
+            i18nKeyHelpText={"admin.helpText.variantBackorderToggle"}
+            style={{ backgroundColor: "lightgrey", cursor: "not-allowed" }}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div className="col-sm-12">
+        <Components.Switch
+          i18nKeyLabel="productVariant.inventoryPolicy"
+          i18nKeyOnLabel="productVariant.inventoryPolicy"
+          name="inventoryPolicy"
+          label={"Allow backorder"}
+          onLabel={"Allow backorder"}
+          checked={!this.state.inventoryPolicy}
+          onChange={this.handleInventoryPolicyChange}
+          validation={this.props.validation}
+        />
+      </div>
+    );
   }
 
   renderQuantityField() {
@@ -526,18 +566,7 @@ class VariantForm extends Component {
             </div>
           </div>
           <div className="row">
-            <div className="col-sm-6">
-              <Components.Switch
-                i18nKeyLabel="productVariant.inventoryPolicy"
-                i18nKeyOnLabel="productVariant.inventoryPolicy"
-                name="inventoryPolicy"
-                label={"Allow backorder"}
-                onLabel={"Allow backorder"}
-                checked={!this.state.inventoryPolicy}
-                onChange={this.handleInventoryPolicyChange}
-                validation={this.props.validation}
-              />
-            </div>
+            {this.renderInventoryPolicyField()}
           </div>
         </Components.SettingsCard>
       </Components.CardGroup>
@@ -654,6 +683,7 @@ class VariantForm extends Component {
 
             <div className="row">
               {this.renderQuantityField()}
+              {this.renderInventoryPolicyField()}
             </div>
           </Components.CardBody>
         </Components.Card>

--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -6,7 +6,6 @@ import Velocity from "velocity-animate";
 import "velocity-animate/velocity.ui";
 import { Components } from "@reactioncommerce/reaction-components";
 import { formatPriceString } from "/client/api";
-import { Reaction } from "/lib/api";
 
 const fieldNames = [
   "title",

--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -130,7 +130,6 @@ class VariantForm extends Component {
   }
 
   handleFieldBlur = (event, value, field) => {
-    console.log("field", field);
     if (this.props.onVariantFieldSave) {
       this.props.onVariantFieldSave(this.variant._id, field, value, this.state.variant);
     }

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -206,33 +206,37 @@ const wrapComponent = (Comp) => (
      * @return {undefined} return nothing
      */
     updateInventoryPolicyIfChildVariants = (variant) => {
-      // Get parent of variant
-      const parentId = variant.ancestors[1];
-
-      // Get all of parents children
+      // Get all siblings, including current variant
       // Check to see if their inventory policy is true / false
-      if (parentId) {
-        const options = ReactionProduct.getVariants(parentId);
-        if (options && options.length) {
-          const inventoryPolicy = options.filter((option) => {
-            return option.inventoryPolicy === false;
-          });
+      const options = ReactionProduct.getSiblings(variant);
 
-          // If all inventory policies on children are true, update parent to be true
-          if (inventoryPolicy.length === 0) {
-            return Meteor.call("products/updateProductField", parentId, "inventoryPolicy", true, (error) => {
-              if (error) {
-                Alerts.toast(error.message, "error");
-              }
-            });
-          }
-          // If any child has a false inventoryPolicy, update parent to be false
-          return Meteor.call("products/updateProductField", parentId, "inventoryPolicy", false, (error) => {
-            if (error) {
-              Alerts.toast(error.message, "error");
-            }
-          });
-        }
+      console.log("getParent", ReactionProduct.getParent(variant));
+
+      console.log("variant", variant);
+      console.log("options", options);
+
+      console.log("getSiblings", ReactionProduct.getSiblings(variant));
+      if (options && options.length) {
+        const inventoryPolicy = options.filter((option) => {
+          return option.inventoryPolicy === false;
+        });
+
+        console.log("getParent", ReactionProduct.getParent(variant));
+
+        // // If all inventory policies on children are true, update parent to be true
+        // if (inventoryPolicy.length === 0) {
+        //   return Meteor.call("products/updateProductField", parentId, "inventoryPolicy", true, (error) => {
+        //     if (error) {
+        //       Alerts.toast(error.message, "error");
+        //     }
+        //   });
+        // }
+        // // If any child has a false inventoryPolicy, update parent to be false
+        // return Meteor.call("products/updateProductField", parentId, "inventoryPolicy", false, (error) => {
+        //   if (error) {
+        //     Alerts.toast(error.message, "error");
+        //   }
+        // });
       }
     }
 

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -178,9 +178,6 @@ const wrapComponent = (Comp) => (
     handleVariantFieldSave = (variantId, fieldName, value, variant) => {
       const validationStatus = this.runVariantValidation(variant);
 
-      console.log("fieldName", fieldName);
-
-
       if (validationStatus.isFieldValid(fieldName)) {
         Meteor.call("products/updateProductField", variantId, fieldName, value, (error) => {
           if (error) {

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -209,7 +209,7 @@ const wrapComponent = (Comp) => (
       // Get all siblings, including current variant
       const options = ReactionProduct.getSiblings(variant);
       // Get parent
-      const parent = ReactionProduct.getParent(variant);
+      const parent = ReactionProduct.getVariantParent(variant);
 
       // If this is not a top-level variant, update top-level inventory policy as well
       if (parent) {

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -207,36 +207,33 @@ const wrapComponent = (Comp) => (
      */
     updateInventoryPolicyIfChildVariants = (variant) => {
       // Get all siblings, including current variant
-      // Check to see if their inventory policy is true / false
       const options = ReactionProduct.getSiblings(variant);
+      // Get parent
+      const parent = ReactionProduct.getParent(variant);
 
-      console.log("getParent", ReactionProduct.getParent(variant));
+      // If this is not a top-level variant, update top-level inventory policy as well
+      if (parent) {
+        if (options && options.length) {
+          // Check to see if every variant option inventory policy is true
+          const inventoryPolicy = options.every((option) => {
+            return option.inventoryPolicy === true;
+          });
 
-      console.log("variant", variant);
-      console.log("options", options);
-
-      console.log("getSiblings", ReactionProduct.getSiblings(variant));
-      if (options && options.length) {
-        const inventoryPolicy = options.filter((option) => {
-          return option.inventoryPolicy === false;
-        });
-
-        console.log("getParent", ReactionProduct.getParent(variant));
-
-        // // If all inventory policies on children are true, update parent to be true
-        // if (inventoryPolicy.length === 0) {
-        //   return Meteor.call("products/updateProductField", parentId, "inventoryPolicy", true, (error) => {
-        //     if (error) {
-        //       Alerts.toast(error.message, "error");
-        //     }
-        //   });
-        // }
-        // // If any child has a false inventoryPolicy, update parent to be false
-        // return Meteor.call("products/updateProductField", parentId, "inventoryPolicy", false, (error) => {
-        //   if (error) {
-        //     Alerts.toast(error.message, "error");
-        //   }
-        // });
+          // If all inventory policies on children are true, update parent to be true
+          if (inventoryPolicy === true) {
+            return Meteor.call("products/updateProductField", parent._id, "inventoryPolicy", true, (error) => {
+              if (error) {
+                Alerts.toast(error.message, "error");
+              }
+            });
+          }
+          // If any child has a false inventoryPolicy, update parent to be false
+          return Meteor.call("products/updateProductField", parent._id, "inventoryPolicy", false, (error) => {
+            if (error) {
+              Alerts.toast(error.message, "error");
+            }
+          });
+        }
       }
     }
 

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -201,7 +201,7 @@ const wrapComponent = (Comp) => (
 
     /**
      * @method updateInventoryPolicyIfChildVariants
-     * @description update parent inventory policy if variant has children children
+     * @description update parent inventory policy if variant has children
      * @param {Object} variant product or variant document
      * @return {undefined} return nothing
      */
@@ -212,28 +212,26 @@ const wrapComponent = (Comp) => (
       const parent = ReactionProduct.getVariantParent(variant);
 
       // If this is not a top-level variant, update top-level inventory policy as well
-      if (parent) {
-        if (options && options.length) {
-          // Check to see if every variant option inventory policy is true
-          const inventoryPolicy = options.every((option) => {
-            return option.inventoryPolicy === true;
-          });
+      if (parent && options && options.length) {
+        // Check to see if every variant option inventory policy is true
+        const inventoryPolicy = options.every((option) => {
+          return option.inventoryPolicy === true;
+        });
 
-          // If all inventory policies on children are true, update parent to be true
-          if (inventoryPolicy === true) {
-            return Meteor.call("products/updateProductField", parent._id, "inventoryPolicy", true, (error) => {
-              if (error) {
-                Alerts.toast(error.message, "error");
-              }
-            });
-          }
-          // If any child has a false inventoryPolicy, update parent to be false
-          return Meteor.call("products/updateProductField", parent._id, "inventoryPolicy", false, (error) => {
+        // If all inventory policies on children are true, update parent to be true
+        if (inventoryPolicy === true) {
+          return Meteor.call("products/updateProductField", parent._id, "inventoryPolicy", true, (error) => {
             if (error) {
               Alerts.toast(error.message, "error");
             }
           });
         }
+        // If any child has a false inventoryPolicy, update parent to be false
+        return Meteor.call("products/updateProductField", parent._id, "inventoryPolicy", false, (error) => {
+          if (error) {
+            Alerts.toast(error.message, "error");
+          }
+        });
       }
     }
 

--- a/imports/plugins/included/product-variant/server/i18n/en.json
+++ b/imports/plugins/included/product-variant/server/i18n/en.json
@@ -10,6 +10,7 @@
           "optionTitle": "Displayed on Product Detail Page",
           "price": "Purchase price",
           "title": "Displayed in cart, checkout, and orders",
+          "variantBackorderToggle": "Backorder allowance is now controlled by options",
           "variantInventoryQuantity": "Variant inventory is now controlled by options"
         },
         "tooltip": {

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -163,6 +163,36 @@ export default {
   },
 
   /**
+   * @method getParent
+   * @description Get direct parent variant
+   * @summary could be useful for lower level variants to get direct parents
+   * @param {Object} [variant] - product / variant object
+   * @return {Array} Parent variant or empty
+   */
+  getParent(variant) {
+    return Products.find({
+      _id: { $in: variant.ancestors },
+      type: "variant"
+    }).map(this.getPublishedOrRevision);
+  },
+
+  /**
+   * @method getSiblings
+   * @description Get all sibling variants - variants with the same ancestor tree
+   * @summary could be useful for child variants relationships with top-level variants
+   * @param {Object} [variant] - product / variant object
+   * @param {String} [type] - type of variant
+   * @param {Boolean} [includeSelf] - include current variant in results
+   * @return {Array} Sibling variants or empty array
+   */
+  getSiblings(variant, type) {
+    return Products.find({
+      ancestors: [variant.ancestors],
+      type: type || "variant"
+    }).map(this.getPublishedOrRevision);
+  },
+
+  /**
    * @method getTopVariants
    * @description Get only product top level variants
    * @param {String} [id] - product _id

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -170,10 +170,11 @@ export default {
    * @return {Array} Parent variant or empty
    */
   getParent(variant) {
-    return Products.find({
+    const parent = Products.findOne({
       _id: { $in: variant.ancestors },
       type: "variant"
-    }).map(this.getPublishedOrRevision);
+    });
+    return this.getPublishedOrRevision(parent);
   },
 
   /**
@@ -187,7 +188,7 @@ export default {
    */
   getSiblings(variant, type) {
     return Products.find({
-      ancestors: [variant.ancestors],
+      ancestors: variant.ancestors,
       type: type || "variant"
     }).map(this.getPublishedOrRevision);
   },

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -163,13 +163,13 @@ export default {
   },
 
   /**
-   * @method getParent
+   * @method getVariantParent
    * @description Get direct parent variant
    * @summary could be useful for lower level variants to get direct parents
    * @param {Object} [variant] - product / variant object
    * @return {Array} Parent variant or empty
    */
-  getParent(variant) {
+  getVariantParent(variant) {
     const parent = Products.findOne({
       _id: { $in: variant.ancestors },
       type: "variant"

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -293,14 +293,14 @@ ReactionProduct.getSiblings = (variant, type) => {
 };
 
 /**
- * @method getParent
+ * @method getVariantParent
  * @description Get direct parent variant
  * @summary could be useful for lower level variants to get direct parents
  * @param {Object} [variant] - product / variant object
  * @return {Array} Parent variant or empty
  */
-ReactionProduct.getParent = (variant) => {
-  return Catalog.getParent(variant);
+ReactionProduct.getVariantParent = (variant) => {
+  return Catalog.getVariantParent(variant);
 };
 
 /**

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -280,6 +280,30 @@ ReactionProduct.getVariants = (id, type) => {
 };
 
 /**
+ * @method getSiblings
+ * @description Get all sibling variants - variants with the same ancestor tree
+ * @summary could be useful for child variants relationships with top-level variants
+ * @param {Object} [variant] - product / variant object
+ * @param {String} [type] - type of variant
+ * @param {Boolean} [includeSelf] - include current variant in results
+ * @return {Array} Sibling variants or empty array
+ */
+ReactionProduct.getSiblings = (variant, type) => {
+  return Catalog.getSiblings(variant, type);
+};
+
+/**
+ * @method getParent
+ * @description Get direct parent variant
+ * @summary could be useful for lower level variants to get direct parents
+ * @param {Object} [variant] - product / variant object
+ * @return {Array} Parent variant or empty
+ */
+ReactionProduct.getParent = (variant) => {
+  return Catalog.getParent(variant);
+};
+
+/**
  * @method getTopVariants
  * @description Get only product top level variants
  * @param {String} [id] - product _id


### PR DESCRIPTION
Resolves #2911 

- Introduce `ReactionProduct.getSiblings()` to get documents of a variants `siblings`, who have the same ancestor tree
- Introduce `ReactionProduct.getParent()` to get document of a variants direct parent
- Updates the way the inventory policy toggle updates.

If a variant has no child variants, the toggle functionality is unchanged.

If a variant has child variants, the toggle is disabled on the top-level variant, and inherits the following value, based on it's children:

1. If **_any_** of the children are set to `inventoryPolicy === false`, meaning backorders are allowed, then the top-level variant will also be set to `inventoryPolicy === false`
2. If _**all**_ of the children are set to `inventoryPolicy === true`, then the top-level variant will also be set to `inventoryPolicy === true`