### PR TITLE
Fix PayPal Express redirect issue with multiple shops enabled

### DIFF
--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -80,7 +80,8 @@ export function getShopPrefix(leading = "/") {
     }
 
     // If this is not the primary shop, use the shop slug in routes for this shop
-    return slug;
+    // TODO: "/shop" should be configurable in marketplace settings
+    return "/shop" + slug;
   }
 
   return "";

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -54,10 +54,36 @@ export function getShopName() {
  * @return {String} returns shop url prefix
  */
 export function getShopPrefix(leading = "/") {
-  if (Shops.find({}).count() === 1) {
-    return "";
+  const shopId = getShopId();
+
+  if (shopId) {
+    const shop = Shops.findOne({
+      _id: shopId
+    }, {
+      fields: {
+        _id: 1,
+        name: 1,
+        shopType: 1
+      }
+    });
+
+    const settings = Core.Reaction.getMarketplaceSettings();
+    const slug = leading + getSlug(shop.slug || getShopName().toLowerCase());
+
+    if (shop.shopType === "primary") {
+      // If naked routes is turned off, use the shop slug for our primary shop routes
+      if (settings && settings.marketplaceNakedRoutes === false) {
+        return slug;
+      }
+
+      return "";
+    }
+
+    // If this is not the primary shop, use the shop slug in routes for this shop
+    return slug;
   }
-  return leading + getSlug(getShopName().toLowerCase());
+
+  return "";
 }
 
 /**


### PR DESCRIPTION
Updated `getShopPrefix` to support prefix-less routes for the primary shop when `marketplaceNakedRoutes` is enabled.

**Issue solved:**
When there are multiple shops, `Reaction.getAbsoluteUrl()` is returning an absolute URL with a shop prefix, which is then used by the Paypal Express return URL, sending the user to a 404.

**To Test:**

**PASS on marketplace branch**
1. Enable a shipping rates provider
2. Enable PayPal Express
3. Checkout
4. Should get redirected to the checkout completed page

**FAIL on marketplace branch**
1. Invite a shop owner, now you should have two shops
2. Enable a shipping rates provider
3. Enable PayPal Express
4. Checkout
5. Gets redirected to a 404

**PASS with this branch**
1. Invite a shop owner
2. Enable a shipping rates provider
3. Enable PayPal Express
4. Checkout
5. Should get redirected to the checkout completed page
