### PR TITLE
Fix "No confirmation message or validation when saving settings for Paypal Express" bug

### DIFF
--- a/imports/plugins/included/payments-paypal/client/templates/settings/express.js
+++ b/imports/plugins/included/payments-paypal/client/templates/settings/express.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { Template } from "meteor/templating";
 import { AutoForm } from "meteor/aldeed:autoform";
+import { i18next } from "/client/api";
 import { Packages } from "/lib/collections";
 import { PaypalPackageConfig } from "../../../lib/collections/schemas";
 import "./express.html";
@@ -17,16 +18,12 @@ Template.paypalExpressSettings.helpers({
 });
 
 AutoForm.hooks({
-  "paypal-update-form": {
+  "paypal-update-form-express": {
     onSuccess: function () {
-      Alerts.removeSeen();
-      return Alerts.add("Paypal settings saved.", "success", {
-        autoHide: true
-      });
+      return Alerts.toast(i18next.t("admin.settings.saveSuccess"), "success");
     },
     onError: function (operation, error) {
-      Alerts.removeSeen();
-      return Alerts.add("Paypal settings update failed. " + error, "danger");
+      return Alerts.toast(`${i18next.t("admin.settings.saveFailed")} ${error}`, "error");
     }
   }
 });

--- a/imports/plugins/included/payments-paypal/client/templates/settings/payflow.js
+++ b/imports/plugins/included/payments-paypal/client/templates/settings/payflow.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { AutoForm } from "meteor/aldeed:autoform";
 import { Template } from "meteor/templating";
+import { i18next } from "/client/api";
 import { Packages } from "/lib/collections";
 import { PaypalPackageConfig } from "../../../lib/collections/schemas";
 import "./payflow.html";
@@ -17,16 +18,12 @@ Template.paypalPayFlowSettings.helpers({
 });
 
 AutoForm.hooks({
-  "paypal-update-form": {
+  "paypal-update-form-payflow": {
     onSuccess: function () {
-      Alerts.removeSeen();
-      return Alerts.add("Paypal settings saved.", "success", {
-        autoHide: true
-      });
+      return Alerts.toast(i18next.t("admin.settings.saveSuccess"), "success");
     },
     onError: function (operation, error) {
-      Alerts.removeSeen();
-      return Alerts.add("Paypal settings update failed. " + error, "danger");
+      return Alerts.toast(`${i18next.t("admin.settings.saveFailed")} ${error}`, "error");
     }
   }
 });


### PR DESCRIPTION
Resolves [#2135](https://github.com/reactioncommerce/reaction/issues/2135)
No toast message is displayed.

This issue occurred because a wrong form id was referenced in `AutoForm.hooks`: `paypal-update-form` instead of `paypal-update-form-express`. This same error was also observed in `paypal payflow`.

###### Fix
```
- Update form id referenced in `AutoForm.hooks`
- Display Alert message using `Alerts.toast`
```

Test

1. Login as admin
1. Enter settings for Paypal Express/Paypal PayFlow
1. Observe that a toast message is displayed


