### PR TITLE
Added missing Mail parameter for reaction.json.example

### DIFF
--- a/private/settings/reaction.json.example
+++ b/private/settings/reaction.json.example
@@ -18,7 +18,8 @@
                 "user": "",
                 "password": "",
                 "host": "",
-                "port": ""
+                "port": "",
+                "service": ""
             },
             "cart": {
                 "cleanupDurationDays": "older than 3 days"

--- a/private/settings/reaction.json.example
+++ b/private/settings/reaction.json.example
@@ -19,7 +19,7 @@
                 "password": "",
                 "host": "",
                 "port": "",
-                "service": ""
+                "service": "custom"
             },
             "cart": {
                 "cleanupDurationDays": "older than 3 days"


### PR DESCRIPTION
Resolves #2516 

Added a `service` parameter to the mail object in `reaction.json.example`.

#### HOW TO TEST
- Rename the `reaction.json.example` in `/private/settings/` to `reaction.json`.
- Perform a `reaction reset` and then `reaction` in your terminal.
- Log in as admin and configure your email SMTP , you will now see that the status changes to green.
