### PR TITLE
Fix 2890 shop products grid

### DIFF
--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -261,7 +261,7 @@ describe("Publication", function () {
         const collector = new PublicationCollector({ userId: Random.id() });
         let isDone = false;
 
-        collector.collect("Products", productScrollLimit, filters, {}, (collections) => {
+        collector.collect("Products", productScrollLimit, filters, {}, true, (collections) => {
           const products = collections.Products;
           expect(products.length).to.equal(3);
 

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -38,7 +38,7 @@ describe("Publication", function () {
       max: 19.99
     };
 
-    before(function () {
+    beforeEach(function () {
       Collections.Products.direct.remove({});
 
       // a product with price range A, and not visible
@@ -261,7 +261,7 @@ describe("Publication", function () {
         const collector = new PublicationCollector({ userId: Random.id() });
         let isDone = false;
 
-        collector.collect("Products", productScrollLimit, filters, {}, true, (collections) => {
+        collector.collect("Products", productScrollLimit, filters, {}, (collections) => {
           const products = collections.Products;
           expect(products.length).to.equal(3);
 

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-import { Products, Revisions } from "/lib/collections";
+import { Products, Shops, Revisions } from "/lib/collections";
 import { Reaction, Logger } from "/server/api";
 import { RevisionApi } from "/imports/plugins/core/revisions/lib/api/revisions";
 import { findProductMedia } from "./product";
@@ -99,6 +99,30 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
   } catch (e) {
     Logger.debug(e, "Invalid Product Filters");
     return this.ready();
+  }
+
+  const shopIdsOrSlugs = productFilters && productFilters.shops;
+
+  if (shopIdsOrSlugs) {
+    // Get all shopIds associated with the slug or Id
+    const shopIds = Shops.find({
+      $or: [{
+        _id: {
+          $in: shopIdsOrSlugs
+        }
+      }, {
+        slug: {
+          $in: shopIdsOrSlugs
+        }
+      }]
+    }).map((shop) => shop._id);
+
+    // If we found shops, update the productFilters
+    if (shopIds) {
+      productFilters.shops = shopIds;
+    } else {
+      return this.ready();
+    }
   }
 
   // Init default selector - Everyone can see products that fit this selector


### PR DESCRIPTION
Fixes #2890 

Appears that when the router was updated in #2929, I neglected to get the shopIds associated with a given shop slug before querying the products, hence we were querying products for the shop slug which will always return empty because products carry the shopId, but not the shop slug.

This fixes that and results in the shop product grid displaying only products from that shop.