### PR TITLE
Fix "PayPal Express isn't fully setup by default' bug

### DIFF
--- a/imports/plugins/included/payments-paypal/client/templates/settings/express.html
+++ b/imports/plugins/included/payments-paypal/client/templates/settings/express.html
@@ -21,7 +21,7 @@
     {{>afQuickField name='settings.password' type="password"}}
     {{>afQuickField name='settings.signature'}}
     {{>afQuickField name="settings.express.support" options="allowed" noselect=true}}
-    {{>afQuickField name="settings.express_auth_and_capture" type="boolean-select" trueLabel="Authorize, Capture immediately." falseLabel="Authorize, Capture on complete." }}
+    {{>afQuickField name="settings.expressAuthAndCapture" type="boolean-select" trueLabel="Authorize, Capture immediately." falseLabel="Authorize, Capture on complete." }}
     {{>afQuickField name='settings.express_mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Testing - Sandbox Mode"}}
 
     <button type="submit" class="btn btn-primary pull-right"><span data-i18n="app.saveChanges">Save Changes</span></button>

--- a/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
+++ b/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
@@ -3,7 +3,7 @@ import { PackageConfig } from "/lib/collections/schemas/registry";
 
 export const PaypalPackageConfig = new SimpleSchema([
   PackageConfig, {
-    "settings.express_auth_and_capture": {
+    "settings.expressAuthAndCapture": {
       type: Boolean,
       label: "Capture at time of Auth",
       defaultValue: false

--- a/imports/plugins/included/payments-paypal/register.js
+++ b/imports/plugins/included/payments-paypal/register.js
@@ -6,6 +6,7 @@ Reaction.registerPackage({
   icon: "fa fa-paypal",
   autoEnable: true,
   settings: {
+    expressAuthAndCapture: false,
     express: {
       enabled: false,
       support: [

--- a/imports/plugins/included/payments-paypal/server/methods/express.js
+++ b/imports/plugins/included/payments-paypal/server/methods/express.js
@@ -88,7 +88,7 @@ export const methods = {
     const shop = Shops.findOne(cart.shopId);
     const currency = shop.currency;
     const options = PayPal.expressCheckoutAccountOptions();
-    const captureAtAuth = getSetting(cart.shopId, "express_auth_and_capture");
+    const captureAtAuth = getSetting(cart.shopId, "expressAuthAndCapture");
     let paymentAction;
     if (captureAtAuth) {
       paymentAction = "Sale";


### PR DESCRIPTION
Resolves [#3001](https://github.com/reactioncommerce/reaction/issues/3001)
After enabling PayPal express, I'm forced to select when payment should be captured.

A default option is not selected because `express_auth_and_capture` is not registered in the database.

###### Fix
```
- Register `express_auth_and_capture` in database
- Rename all instances of `express_auth_and_capture` to `expressAuthAndCapture`. 
This was to fix an eslint error.
```

###### Test
```
Login as admin
Goto Payment options
Enable Paypal Express
Observe that the field labelled `Capture at time of Auth` has an already selected option: `Authorize, Capture on complete`
```

