### PR TITLE
Fixed browser Back Button anomaly on PDP

### DIFF
--- a/imports/plugins/core/ui-navbar/client/containers/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/containers/navbar.js
@@ -19,7 +19,7 @@ function composer(props, onData) {
   }
 
   if (shop && Array.isArray(shop.brandAssets)) {
-    const brandAsset = _.find(this.getShop().brandAssets, (asset) => asset.type === "navbarBrandImage");
+    const brandAsset = _.find(shop.brandAssets, (asset) => asset.type === "navbarBrandImage");
     brandMedia = Media.findOne(brandAsset.mediaId);
   }
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
@@ -272,7 +272,7 @@ function composer(props, onData) {
   const tagSub = Meteor.subscribe("Tags");
   const shopIdOrSlug = Reaction.Router.getParam("shopSlug");
   const productId = Reaction.Router.getParam("handle");
-  const variantId = Reaction.Router.getParam("variantId");
+  const variantId = ReactionProduct.selectedVariant()._id;
   const revisionType = Reaction.Router.getQueryParam("revision");
   const viewProductAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
@@ -272,7 +272,7 @@ function composer(props, onData) {
   const tagSub = Meteor.subscribe("Tags");
   const shopIdOrSlug = Reaction.Router.getParam("shopSlug");
   const productId = Reaction.Router.getParam("handle");
-  const variantId = ReactionProduct.selectedVariant()._id;
+  const variantId = ReactionProduct.selectedVariantId();
   const revisionType = Reaction.Router.getQueryParam("revision");
   const viewProductAs = Reaction.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 

--- a/imports/plugins/included/product-detail-simple/client/containers/variantList.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/variantList.js
@@ -117,12 +117,6 @@ class VariantListContainer extends Component {
 
     ReactionProduct.setCurrentVariant(variant._id);
     Session.set("variant-form-" + editVariant._id, true);
-    Reaction.Router.go("product", {
-      handle: this.productHandle,
-      variantId: variant._id
-    }, {
-      as: Reaction.Router.getQueryParam("as")
-    });
 
     if (Reaction.hasPermission("createProduct")) {
       Reaction.showActionView({


### PR DESCRIPTION
Resolves #2660 ,

So there was a `Router.go` snippet in `varaintList.js` that was changing the URL when a variant is selected, so based on @mikemurray comment on how to fix the issue , I refactored the composer object (in `productDetail.js`) to get variantId by using `ReactionProduct.selectedVariant()._id` rather than fetching it as a param from the URL.

#### HOW TO TEST
- Go to "Basic Reaction Product"
- Click on Red and add to cart
- Click on Green and add to cart
- Click on Back Button of your browser and you will notice it actually goes back as it should do.


