### PR TITLE
Gitlab ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 image: node:7
 
 variables:
-  DOCKER_VERSION: 17.03.1-ce
-  DOCKER_COMPOSE_VERSION: 1.13.0
-  METEOR_ALLOW_SUPERUSER: true
+  - DOCKER_VERSION: 17.03.1-ce
+  - DOCKER_COMPOSE_VERSION: 1.13.0
+  - METEOR_ALLOW_SUPERUSER: true
 
 stages:
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,10 @@
 image: node:7
 
+variables:
+  DOCKER_VERSION: 17.03.1-ce
+  DOCKER_COMPOSE_VERSION: 1.13.0
+  METEOR_ALLOW_SUPERUSER: true
+
 stages:
   - build
   - install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,25 @@
+image: node:7
+
+stages:
+  - build
+  - install
+  - test
+  - deploy
+
+install:
+  script:
+    - .circleci/install.sh
+    - meteor npm install
+
+build:
+  script:
+    - .circleci/build.sh
+
+test:
+  script:
+    - npm test
+    - reaction test
+
+deploy:
+  script:
+    - .circleci/deploy.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 image: node:7
 
 variables:
-  - DOCKER_VERSION: 17.03.1-ce
-  - DOCKER_COMPOSE_VERSION: 1.13.0
-  - METEOR_ALLOW_SUPERUSER: true
+  DOCKER_VERSION: '17.03.1-ce'
+  DOCKER_COMPOSE_VERSION: '1.13.0'
+  METEOR_ALLOW_SUPERUSER: 'true'
 
 stages:
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 image: node:7
 
+
 variables:
   DOCKER_VERSION: '17.03.1-ce'
   DOCKER_COMPOSE_VERSION: '1.13.0'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,8 +9,8 @@ variables:
 stages:
   - build
   - install
-  #- test
-  #- deploy
+  - test
+  - deploy
 
 install:
   script:


### PR DESCRIPTION
I am trying to have very reproducible issues when it comes to stuff like this [out of memory error](https://github.com/reactioncommerce/reaction/issues/3023), so I'm integrating a few other CI platforms aside from circleCI

You should be able to push this fork into a gitlab instance (*that has a CI runner enabled), and it will attempt to build reaction as closely as possible to how the circleCI method does.



