### PR TITLE
Fixed variant edit view visibility when Edit Mode is switched off

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/containers/variantList.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/variantList.js
@@ -124,7 +124,7 @@ class VariantListContainer extends Component {
       as: Reaction.Router.getQueryParam("as")
     });
 
-    if (Reaction.hasPermission("createProduct")) {
+    if (Reaction.hasPermission("createProduct") && !Reaction.isPreview()) {
       Reaction.showActionView({
         label: "Edit Variant",
         i18nKeyLabel: "productDetailEdit.editVariant",


### PR DESCRIPTION
Resolves #2989 

I found out that in `variantList.js` file , the function `handleEditVariant` definition had a condition where it checks whether a logged in user has the permission, ie.`Reaction.hasPermission("createProduct")`, to create product then proceeds to toggle the Action view to edit variant so I added another condition to also check if Edit mode has also been turned on before proceeding to show the Action view for edit variant.

#### How to test
- Login as admin
- Turn off edit mode
- Select a variant, now you will notice that Edit Variant Action view doesn't display.


