### PR TITLE
Fix 2782 Router Hooks not running

### DIFF
--- a/imports/plugins/core/router/client/browserRouter.js
+++ b/imports/plugins/core/router/client/browserRouter.js
@@ -101,7 +101,14 @@ class BrowserRouter extends Component {
     const previousRoute = previousRouteData.route;
 
     // If routes are not identical, run onExit and onEnter
-    if (!equal(previousRouteData, routeData)) {
+    if (!equal({ params: previousRouteData.params,
+                  query: previousRouteData.query,
+                  route: previousRouteData.route
+                }, {
+                  params: routeData.params,
+                  query: routeData.query,
+                  route: routeData.route
+                })) {
       // Run onExit hooks if the previousRoute exists
       if (previousRoute) {
         Router.Hooks.run("onExit", "GLOBAL", previousRouteData);

--- a/imports/plugins/core/router/client/browserRouter.js
+++ b/imports/plugins/core/router/client/browserRouter.js
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import { matchPath } from "react-router";
 import { Router as ReactRouter } from "react-router-dom";
+import equal from "deep-equal";
 import { Reaction } from "/client/api";
 import pathToRegexp from "path-to-regexp";
-import { isEqual } from "lodash";
 import queryParse from "query-parse";
 import { Session } from "meteor/session";
 import { Tracker } from "meteor/tracker";
@@ -92,28 +92,27 @@ class BrowserRouter extends Component {
       payload: location
     };
 
-    // Get the previousroute, which is the currentRoute just before it changes
-    const previousRoute = Router.current();
+    // The currentRoute is equal to the routeData.route that we just setup
+    const currentRoute = routeData.route || {};
 
-    // If it seems like we've moved to a differen route, then run the onExit
-    // hooks for the previousRoute
-    const routesAreSame = isEqual(previousRoute.route, routeData.route);
-    const paramsAreSame = isEqual(previousRoute.params, routeData.params);
-    const queryParamsAreSame = isEqual(previousRoute.query, routeData.query);
+    // Get the previousRouteData, which is the Router.current() just before it changes.
+    // Default to empty objects to guard against error
+    const previousRouteData = Router.current() || {};
+    const previousRoute = previousRouteData.route;
 
-    const routesDiffer = routesAreSame && paramsAreSame && queryParamsAreSame;
-
-    if (routesDiffer === false) {
-      // Run on enter hooks
-      Router.Hooks.run("onExit", "GLOBAL", routeData);
-      Router.Hooks.run("onExit", previousRoute.name, previousRoute);
+    // If routes are not identical, run onExit and onEnter
+    if (!equal(previousRouteData, routeData)) {
+      // Run onExit hooks if the previousRoute exists
+      if (previousRoute) {
+        Router.Hooks.run("onExit", "GLOBAL", previousRouteData);
+        Router.Hooks.run("onExit", previousRoute.name, previousRouteData);
+      }
 
       // Set current route reactive-var
       Router.setCurrentRoute(routeData);
-
       // Run on enter hooks for the new route
       Router.Hooks.run("onEnter", "GLOBAL", routeData);
-      Router.Hooks.run("onEnter", routeData.name, routeData);
+      Router.Hooks.run("onEnter", currentRoute.name, routeData);
     }
   }
 


### PR DESCRIPTION
Resolves #2782 

As suggested by @tespher in #2782
The issue was the way that `Router.Hooks.run` was implemented in `browserRouter.js`. By updating the implementation, hooks now run. 

I've tested this with several onEnter and onExit hooks and it seems to be fixed now.