### PR TITLE
Fix 2623 verification email

### DIFF
--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -766,9 +766,11 @@ export function sendWelcomeEmail(shopId, userId) {
     return true;
   }
 
+  const defaultEmail = user.emails.find((email => email.provides === "default"));
+  // Encode email address for URI
+  const encodedEmailAddress = encodeURIComponent(defaultEmail.address);
   // assign verification url
-  const prefix = Reaction.getShopPrefix().replace(/\//, "");
-  dataForEmail.verificationUrl = `${Meteor.absoluteUrl()}${prefix}/account/profile/verify?email=${user.emails[0].address}`;
+  dataForEmail.verificationUrl = `${Meteor.absoluteUrl()}account/profile/verify?email=${encodedEmailAddress}`;
   const userEmail = user.emails[0].address;
 
   let shopEmail;


### PR DESCRIPTION
Resolves #2623 

This resolves the issues we had where a user clicking the link from the verification email would be met with a 404 instead of the "Your email address has been verified" template.

It's ready to merge and I think it's adequate for our `1.5.0` release.

**However**
I have two other problems that should be addressed soon that I uncovered during this fix
1. This verification screen is not a good UX. I think we should probably redirect the user to either their profile or the index and pop-up or persist a "toast" message

2. This email verification isn't robust enough. Right now I could verify any email address simply by visiting the correct url with that email address as the query param. We should be using a token to verify the email address instead of the email address itself.
