### PR TITLE
Revert "changed user collection to Accounts instead"

### DIFF
--- a/client/modules/i18n/currency.js
+++ b/client/modules/i18n/currency.js
@@ -1,7 +1,7 @@
 import accounting from "accounting-js";
 import { Meteor } from "meteor/meteor";
 import { Reaction, Logger } from "/client/api";
-import { Shops, Accounts } from "/lib/collections";
+import { Shops } from "/lib/collections";
 import { currencyDep } from "./main";
 
 /**
@@ -21,9 +21,7 @@ function findCurrency(defaultCurrency, useDefaultShopCurrency) {
   });
 
   const shopCurrency = shop && shop.currency || "USD";
-  const user = Accounts.findOne({
-    _id: Meteor.userId()
-  });
+  const user = Meteor.user();
   const profileCurrency = user.profile && user.profile.currency;
   if (typeof shop === "object" && shop.currencies && profileCurrency) {
     let userCurrency = {};

--- a/client/modules/i18n/helpers.js
+++ b/client/modules/i18n/helpers.js
@@ -2,7 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { check, Match } from "meteor/check";
 import { Reaction, Logger, i18next } from "/client/api";
-import { Shops, Accounts } from "/lib/collections";
+import { Shops } from "/lib/collections";
 import { localeDep, i18nextDep } from  "./main";
 import { formatPriceString } from "./currency";
 
@@ -37,9 +37,7 @@ Template.registerHelper("i18n", function (i18nKey, i18nMessage) {
  */
 Template.registerHelper("currencySymbol", function () {
   const locale = Reaction.Locale.get();
-  const user = Accounts.findOne({
-    _id: Meteor.userId()
-  });
+  const user = Meteor.user();
   const profileCurrency = user.profile && user.profile.currency;
   if (profileCurrency) {
     const shop = Shops.findOne();

--- a/client/modules/i18n/main.js
+++ b/client/modules/i18n/main.js
@@ -4,7 +4,7 @@ import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
 import { Reaction } from "/client/api";
-import { Shops, Accounts } from "/lib/collections";
+import { Shops } from "/lib/collections";
 
 //
 // Reaction i18n Translations, RTL and Currency Exchange Support
@@ -120,9 +120,7 @@ Meteor.startup(() => {
           moment.locale(locale.language);
           // flag in case the locale currency isn't enabled
           locale.currencyEnabled = locale.currency.enabled;
-          const user = Accounts.findOne({
-            _id: Meteor.userId()
-          });
+          const user = Meteor.user();
 
           let profileCurrency = user.profile && user.profile.currency;
           if (!profileCurrency) {
@@ -142,7 +140,7 @@ Meteor.startup(() => {
               }
             }
 
-            Accounts.update(user._id, { $set: { "profile.currency": profileCurrency } });
+            Meteor.users.update(user._id, { $set: { "profile.currency": profileCurrency } });
           }
 
           Reaction.Locale.set(locale);

--- a/imports/plugins/core/i18n/client/containers/currencyDropdown.js
+++ b/imports/plugins/core/i18n/client/containers/currencyDropdown.js
@@ -3,7 +3,7 @@ import { Meteor } from "meteor/meteor";
 import { Match } from "meteor/check";
 import { Reaction } from "/client/api";
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
-import { Cart, Shops, Accounts } from "/lib/collections";
+import { Cart, Shops } from "/lib/collections";
 import CurrencyDropdown from "../components/currencyDropdown";
 
 const handlers = {
@@ -15,7 +15,7 @@ const handlers = {
     // and only possible because we allow it in the
     // UserProfile and ShopMembers publications.
     //
-    Accounts.update(Meteor.userId(), { $set: { "profile.currency": currencyName } });
+    Meteor.users.update(Meteor.userId(), { $set: { "profile.currency": currencyName } });
 
     const cart = Cart.findOne({ userId: Meteor.userId() });
 
@@ -45,9 +45,7 @@ const composer = (props, onData) => {
       }
     });
 
-    const user = Accounts.findOne({
-      _id: Meteor.userId()
-    });
+    const user = Meteor.user();
     const profileCurrency = user.profile && user.profile.currency;
 
     if (Match.test(shop, Object) && shop.currency) {


### PR DESCRIPTION
Reverts the change that switched from using Meteor.users to using Reaction Accounts for currency. The Accounts update caused the currency dropdown to stop working and display multiple currencies in the navbar.

@lcampanis I'd still like to update to use the Account instead of the Meteor user, but had to back this change out as it was breaking.