### PR TITLE
Re-wrap in variant form in a blaze wrapper to prevent focus loss on tab

### DIFF
--- a/imports/plugins/included/product-variant/client/index.js
+++ b/imports/plugins/included/product-variant/client/index.js
@@ -23,6 +23,9 @@ import "./templates/products/productSettings/productSettings.js";
 import "./templates/products/products.html";
 import "./templates/products/products.js";
 
+import "./templates/products/variantForm.html";
+import "./templates/products/variantForm.js";
+
 export { default as GridItemControls } from "../components/gridItemControls";
 export { default as GridItemNotice } from "../components/gridItemNotice";
 export { default as ProductGrid } from "../components/productGrid";

--- a/imports/plugins/included/product-variant/client/templates/products/variantForm.html
+++ b/imports/plugins/included/product-variant/client/templates/products/variantForm.html
@@ -1,0 +1,5 @@
+<template name="variantForm">
+  <div>
+    {{> React (component)}}
+  </div>
+</template>

--- a/imports/plugins/included/product-variant/client/templates/products/variantForm.js
+++ b/imports/plugins/included/product-variant/client/templates/products/variantForm.js
@@ -1,0 +1,13 @@
+import { Components } from "@reactioncommerce/reaction-components";
+import { Template } from "meteor/templating";
+
+Template.variantForm.helpers({
+  component() {
+    const currentData = Template.currentData() || {};
+
+    return {
+      ...currentData,
+      component: Components.VariantEditForm
+    };
+  }
+});

--- a/imports/plugins/included/product-variant/containers/variantEditContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantEditContainer.js
@@ -89,7 +89,7 @@ function composer(props, onData) {
 }
 
 
-registerComponent("variantForm", VariantEdit, [
+registerComponent("VariantEditForm", VariantEdit, [
   composeWithTracker(composer),
   wrapComponent
 ]);


### PR DESCRIPTION
Wraps the new React variant edit form in a blaze wrapper top prevent an issue with fields loosing focus when tabbing between them.

This is a temporary fix until we can discover the root of the issue.
