### PR TITLE
add error message for inactive shops trying to connect to Stripe

### DIFF
--- a/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
+++ b/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
@@ -29,6 +29,10 @@ Template.stripeConnectSignupButton.events({
 
     const shop = Shops.findOne({ _id: shopId });
 
+    if (!shop || !shop.workflow || shop.workflow.status !== "active") {
+      return Alerts.toast(`${i18next.t("admin.connect.shopNotActive")}`, "error");
+    }
+
     if (!shop.emails || !Array.isArray(shop.emails) || shop.emails.length === 0) {
       return Alerts.toast(`${i18next.t("admin.connect.shopEmailNotConfigured")}`, "error");
     }

--- a/imports/plugins/included/marketplace/server/i18n/en.json
+++ b/imports/plugins/included/marketplace/server/i18n/en.json
@@ -20,6 +20,12 @@
         "myShop": "My Shop"
       },
       "admin": {
+        "connect": {
+          "stripeConnectNotEnabled": "Stripe Connect is not enabled for this application. Please contact the adminstrator.",
+          "shopEmailNotConfigured": "Please configure your shop email first.",
+          "shopAddressNotConfigured": "Please configure your shop address first",
+          "shopNotActive": "Your shop is not active. Please contact the marketplace owner."
+        },
         "settings": {
           "dashboardMarketplaceSettingsSaved": "Marketplace settings saved successfully!",
           "dashboardMarketplaceSettingsFailed": "Failed to save Marketplace settings"


### PR DESCRIPTION
We currently do not show any error for `new` or `inactive` shops, when a user tries to click the "Start Accepting Payment" button on the Stripe connect settings. A user would click the button and nothing would happen.

This update adds an error message to direct the user to contact the marketplace admin.

I've also moved a few translations into this package, as they were in a different package and didn't seem to be working.