### PR TITLE
Fix 3079 Cannot read profile of undefined

### DIFF
--- a/imports/plugins/core/i18n/client/containers/currencyDropdown.js
+++ b/imports/plugins/core/i18n/client/containers/currencyDropdown.js
@@ -48,7 +48,7 @@ const composer = (props, onData) => {
     const user = Accounts.findOne({
       _id: Meteor.userId()
     });
-    const profileCurrency = user.profile && user.profile.currency;
+    const profileCurrency = user && user.profile && user.profile.currency;
 
     if (Match.test(shop, Object) && shop.currency) {
       const locale = Reaction.Locale.get();


### PR DESCRIPTION
Resolves #3079 

**To Test:**
1. Login
2. Change currency
3. Logout
4. Observe that the error in #3079 is not thrown.