### PR TITLE
Default marketplace to disabled and hide stripe connect settings for non-marketplace

### DIFF
--- a/imports/plugins/included/marketplace/register.js
+++ b/imports/plugins/included/marketplace/register.js
@@ -4,7 +4,7 @@ Reaction.registerPackage({
   label: "Marketplace",
   name: "reaction-marketplace",
   icon: "fa fa-globe",
-  autoEnable: true,
+  autoEnable: false,
   settings: {
     name: "Marketplace",
     enabled: true,

--- a/imports/plugins/included/payments-stripe/client/settings/stripe.html
+++ b/imports/plugins/included/payments-stripe/client/settings/stripe.html
@@ -10,24 +10,26 @@
     <div>
       {{#autoForm collection=Collections.Packages schema=StripePackageConfig doc=packageData type="update" id="stripe-update-form"}}
         {{>afQuickField name='settings.api_key'}}
-        <br>
-        <span data-i18n="admin.paymentSettings.stripeClientIdWarning">The Client ID is a <strong>PUBLIC</strong> field. Please ensure you're using the `client_id` found on the </span>
-        <a target="_blank" href="https://dashboard.stripe.com/account/applications/settings">
-          <span data-i18n="admin.paymentSettings.stripeClientIDLink">Stripe Connect Settings</span>
-        </a>
-        {{>afQuickField name='settings.public.client_id'}}
-        <br>
-        <span data-i18n="admin.connect.applicationFeeDescription">
-          This number represents a percentage fee that the marketplace (this shop) takes for any item which is sold
-          by a merchant shop for this marketplace. This fee applies only if Stripe Connect is setup and enabled on both
-          the marketplace and the merchant shops and if Stripe is the payment provider used to perform the checkout.
-        </span>
-        <br>
-        <span data-i18n="admin.connect.moreDetails">For more details, see the</span>
-        <a target="_blank" href="https://stripe.com/docs/connect/direct-charges#flow-of-funds-with-fees">
-          <span data-i18n="admin.connect.docsLink">Stripe Connect Docs</span>
-        </a>
-        {{>afQuickField name="settings.applicationFee"}}
+        {{#if marketplaceEnabled}}
+          <br>
+          <span data-i18n="admin.paymentSettings.stripeClientIdWarning">The Client ID is a <strong>PUBLIC</strong> field. Please ensure you're using the `client_id` found on the </span>
+          <a target="_blank" href="https://dashboard.stripe.com/account/applications/settings">
+            <span data-i18n="admin.paymentSettings.stripeClientIDLink">Stripe Connect Settings</span>
+          </a>
+          {{>afQuickField name='settings.public.client_id'}}
+          <br>
+          <span data-i18n="admin.connect.applicationFeeDescription">
+            This number represents a percentage fee that the marketplace (this shop) takes for any item which is sold
+            by a merchant shop for this marketplace. This fee applies only if Stripe Connect is setup and enabled on both
+            the marketplace and the merchant shops and if Stripe is the payment provider used to perform the checkout.
+          </span>
+          <br>
+          <span data-i18n="admin.connect.moreDetails">For more details, see the</span>
+          <a target="_blank" href="https://stripe.com/docs/connect/direct-charges#flow-of-funds-with-fees">
+            <span data-i18n="admin.connect.docsLink">Stripe Connect Docs</span>
+          </a>
+          {{>afQuickField name="settings.applicationFee"}}
+        {{/if}}
         {{>afQuickField name="settings.reaction-stripe.support" options="allowed" noselect=true}}
         <button type="submit" class="btn btn-primary pull-right"><span data-i18n="app.saveChanges">Save Changes</span></button>
       {{/autoForm}}

--- a/imports/plugins/included/payments-stripe/client/settings/stripe.js
+++ b/imports/plugins/included/payments-stripe/client/settings/stripe.js
@@ -13,6 +13,10 @@ Template.stripeSettings.helpers({
       name: "reaction-stripe",
       shopId: Reaction.getShopId()
     });
+  },
+  marketplaceEnabled() {
+    const marketplace = Reaction.getMarketplaceSettings();
+    return marketplace && marketplace.enabled;
   }
 });
 


### PR DESCRIPTION
- Sets `autoEnabled` to `false` for the `marketplace` plugin.
- Don't display Stripe Connect settings unless marketplace is enabled