### PR TITLE
Fix 3080 Cannot read property theme of undefined

### DIFF
--- a/imports/plugins/core/layout/client/templates/theme/theme.js
+++ b/imports/plugins/core/layout/client/templates/theme/theme.js
@@ -28,7 +28,9 @@ function addBodyClasses(context) {
 
 
   // add theme class for route layout
-  classes.push(context.route.options.theme);
+  if (context && context.route && context.route.options && context.route.options.theme) {
+    classes.push(context.route.options.theme);
+  }
 
   classes = classes.join(" ");
 


### PR DESCRIPTION
Resolves #3080 

Adds a guard around the `context.route.options.theme` to ensure that route.options exists before pushing the theme into the `classes` array.