### PR TITLE
fix ReactionAvatar to display correct Avatar

### DIFF
--- a/imports/plugins/core/accounts/client/templates/profile/profile.js
+++ b/imports/plugins/core/accounts/client/templates/profile/profile.js
@@ -101,7 +101,8 @@ Template.accountProfile.helpers({
    */
   ReactionAvatar() {
     return {
-      component: Components.ReactionAvatar
+      component: Components.ReactionAvatar,
+      currentUser: true
     };
   },
 

--- a/imports/plugins/core/ui/client/components/avatar/avatar.js
+++ b/imports/plugins/core/ui/client/components/avatar/avatar.js
@@ -21,6 +21,7 @@ const ReactionAvatar = (props) => {
       style={style}
       // Below props usually aren't passed, and will use defaults
       color={props.color}
+      currentUser={props.currentUser}
       facebookId={props.facebookId}
       fgColor={props.fgColor}
       googleId={props.googleId}
@@ -39,6 +40,7 @@ ReactionAvatar.propTypes = {
   className: PropTypes.string,
   color: PropTypes.string,
   colors: PropTypes.array,
+  currentUser: PropTypes.bool,
   email: PropTypes.string,
   facebookId: PropTypes.string,
   fgColor: PropTypes.string,
@@ -59,6 +61,7 @@ ReactionAvatar.propTypes = {
 ReactionAvatar.defaultProps = {
   className: null,
   color: null,
+  currentUser: true,
   email: null,
   facebookId: null,
   fgColor: "#FFFFFF",

--- a/imports/plugins/core/ui/client/containers/avatar.js
+++ b/imports/plugins/core/ui/client/containers/avatar.js
@@ -7,12 +7,19 @@ import { ReactionAvatar } from "../components/avatar";
 const composer = (props, onData) => {
   const targetUserId = Reaction.Router.getQueryParam("userId");
   let account = Accounts.findOne(targetUserId);
+  let email;
 
-  if (!account) {
+  // If an email is provided via props, use that email
+  if (props.email) {
+    email = props.email;
+  }
+
+  // If there is no email provided, no query param provide, and the avatar is for the current user, find their account
+  if (!email && !account && props.currentUser) {
     account = Accounts.findOne(Meteor.userId());
   }
 
-  let email;
+  // If we now have an account, and that account has an email address, return it
   if (account && Array.isArray(account.emails)) {
     const defaultEmail = account.emails.find((emailObj) => emailObj.provides === "default");
     email = defaultEmail.address;


### PR DESCRIPTION
There is an issue where if a user is logged in, we will show the logged-in users Avatar everywhere `ReactionAvatar` is used, regardless if we are trying to show a different users avatar. This is due to the `ReactionAvatar` using `email` as the primary source of info to send to Gravatar, and our code looking for the email of the logged in user when creating the Avatar.

This update does the following:
- adds a `currentUser` prop to `ReactionAvatar`, that defaults to true, so the current workflow doesn't need to change. 
- If the `currentUser` is `false`, we skip searching for the current users email address (which we were doing before), and use only the information provided directly to the component.