### PR TITLE
Convert TaxCloud panel to React

### DIFF
--- a/imports/plugins/included/taxes-taxcloud/client/components/index.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/index.js
@@ -1,0 +1,1 @@
+export { default as TaxCloudSettingsForm } from "./taxCloudSettingsForm";

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -1,9 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Form } from "/imports/plugins/core/ui/client/components";
+import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
 
 /**
- * @file TaxCloudSettingsForm is a React Component for changing TaxCloud
+ * @file TaxCloudSettingsForm is a React Component used to change TaxCloud
  * settings.
  * @module TaxCloudSettingsForm
  */
@@ -12,27 +13,33 @@ import { Form } from "/imports/plugins/core/ui/client/components";
  * @method TaxCloudSettingsForm
  * @summary renders a form for updating TaxCloud settings.
  * @param {Object} props - some data for use by this component.
- * @property {Object} doc - current TaxCloud settings.
- * @property {String} docPath - the field in the TaxCloud Package where settings are saved.
- * @property {Object} fields - info about the fields the form is to show.
  * @property {Function} handleSubmit - a function for saving new TaxCloud settings.
- * @property {Array} hideFields - the fields (from the TaxCloud Package) to hide from the form.
- * @property {String} name - the name of this provider in lowercase (i.e taxcloud).
- * @property {Object} schema - info about the structure of the TaxCloud Package.
+ * @property {Array} hiddenFields - the fields (of the TaxCloud Package) to hide from the form.
+ * @property {Object} settings - the value of the "settings" field in the TaxCloud Package.
+ * @property {Object} shownFields - info about the fields the form is to show.
  * @since 1.5.2
  * @return {Node} - a React node containing the TaxCloud settings form.
  */
 const TaxCloudSettingsForm = (props) => {
+  const { handleSubmit, hiddenFields, settings, shownFields } = props;
   return (
-    <Form
-      schema={props.schema}
-      doc={props.doc}
-      docPath={props.docPath}
-      fields={props.fields}
-      hideFields={props.hideFields}
-      name={props.name}
-      onSubmit={props.handleSubmit}
-    />
+    <div>
+      {!settings.taxcloud.apiLoginId &&
+        <div className="alert alert-info">
+          <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>
+          <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
+        </div>
+      }
+      <Form
+        schema={TaxCloudPackageConfig}
+        doc={{ settings }}
+        docPath={"settings.taxcloud"}
+        name={"settings.taxcloud"}
+        fields={shownFields}
+        hideFields={hiddenFields}
+        onSubmit={handleSubmit}
+      />
+    </div>
   );
 };
 
@@ -40,25 +47,19 @@ const TaxCloudSettingsForm = (props) => {
   * @name TaxCloudSettingsForm propTypes
   * @type {propTypes}
   * @param {Object} props - React PropTypes
-  * @property {Object} doc - data about the current TaxCloud settings.
-  * @property {String} docPath - the field in the TaxCloud Package where settings are saved.
-  * @property {Object} fields - info about the fields of the TaxCloud Package
-  * that the settings form will allow users to change.
   * @property {Function} handleSubmit - a function that saves new TaxCloud settings.
-  * @property {Array} hideFields - an array of the TaxCloud Package's fields
+  * @property {Array} hiddenFields - an array of the TaxCloud Package's fields
   * to hide from the settings form.
-  * @property {String} name - the name of this taxes provider in lowercase.
-  * @property {Object} schema - info about the structure of the TaxCloud Package.
+  * @property {Object} settings - the value of the "settings" field in the TaxCloud Package.
+  * @property {Object} shownFields - info about the fields of the TaxCloud Package
+  * that the settings form will allow users to change.
   * @return {Array} React propTypes
   */
 TaxCloudSettingsForm.propTypes = {
-  doc: PropTypes.object,
-  docPath: PropTypes.string,
-  fields: PropTypes.object,
   handleSubmit: PropTypes.func,
-  hideFields: PropTypes.arrayOf(PropTypes.string),
-  name: PropTypes.string,
-  schema: PropTypes.object
+  hiddenFields: PropTypes.arrayOf(PropTypes.string),
+  settings: PropTypes.object,
+  shownFields: PropTypes.object
 };
 
 export default TaxCloudSettingsForm;

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Form } from "/imports/plugins/core/ui/client/components";
+
+const TaxCloudSettingsForm = (props) => {
+  return (
+    <Form
+      schema={props.schema}
+      doc={props.doc}
+      docPath={props.docPath}
+      fields={props.fields}
+      hideFields={props.hideFields}
+      name={props.name}
+      onSubmit={props.handleSubmit}
+    />
+  );
+};
+
+TaxCloudSettingsForm.propTypes = {
+  doc: PropTypes.object,
+  docPath: PropTypes.string,
+  fields: PropTypes.object,
+  handleSubmit: PropTypes.func,
+  hideFields: PropTypes.arrayOf(PropTypes.string),
+  name: PropTypes.string,
+  schema: PropTypes.object
+};
+
+export default TaxCloudSettingsForm;

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -13,12 +13,12 @@ import { Form } from "/imports/plugins/core/ui/client/components";
  * @summary renders a form for updating TaxCloud settings.
  * @param {Object} props - some data for use by this component.
  * @property {Object} doc - current TaxCloud settings.
- * @property {String} docPath - the field in the TaxCloud Package where settings are stored.
+ * @property {String} docPath - the field in the TaxCloud Package where settings are saved.
  * @property {Object} fields - info about the fields the form is to show.
  * @property {Function} handleSubmit - a function for saving new TaxCloud settings.
  * @property {Array} hideFields - the fields (from the TaxCloud Package) to hide from the form.
  * @property {String} name - the name of this provider in lowercase (i.e taxcloud).
- * @property {Object} schema - info about the DB structure of the TaxCloud Package.
+ * @property {Object} schema - info about the structure of the TaxCloud Package.
  * @since 1.5.2
  * @return {Node} - a React node containing the TaxCloud settings form.
  */
@@ -47,8 +47,8 @@ const TaxCloudSettingsForm = (props) => {
   * @property {Function} handleSubmit - a function that saves new TaxCloud settings.
   * @property {Array} hideFields - an array of the TaxCloud Package's fields
   * to hide from the settings form.
-  * @property {String} name - the name of this provider in lowercase.
-  * @property {Object} schema - info about the schema used by the TaxCloud Package.
+  * @property {String} name - the name of this taxes provider in lowercase.
+  * @property {Object} schema - info about the structure of the TaxCloud Package.
   * @return {Array} React propTypes
   */
 TaxCloudSettingsForm.propTypes = {

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -2,6 +2,13 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Form } from "/imports/plugins/core/ui/client/components";
 
+/**
+ * @method TaxCloudSettingsForm
+ * @summary renders a form for updating TaxCloud settings.
+ * @param {Object} props - some data for use by this component.
+ * @since 1.5.1
+ * @return {Object} - returns a JSX element for rendering.
+ */
 const TaxCloudSettingsForm = (props) => {
   return (
     <Form

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Form } from "/imports/plugins/core/ui/client/components";
+import { Components } from "@reactioncommerce/reaction-components";
 import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
 
 /**
@@ -26,7 +27,7 @@ const TaxCloudSettingsForm = (props) => {
     <div className="rui taxcloud-settings-form">
       {!settings.taxcloud.apiLoginId &&
         <div className="alert alert-info">
-          <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>
+          <Components.Translation defaultValue="Add API Login ID to enable" i18nkey="admin.taxSettings.taxcloudCredentials" />
           <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
         </div>
       }

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -3,11 +3,20 @@ import PropTypes from "prop-types";
 import { Form } from "/imports/plugins/core/ui/client/components";
 
 /**
+ * @file TaxCloudSettingsForm is a React Component for changing TaxCloud
+ * settings.
+ * @module TaxCloudSettingsForm
+ * @extends Component
+ */
+
+// TODO: Do I need to add @property docs to this even though it's a pure
+// component?
+/**
  * @method TaxCloudSettingsForm
  * @summary renders a form for updating TaxCloud settings.
  * @param {Object} props - some data for use by this component.
  * @since 1.5.1
- * @return {Object} - returns a JSX element for rendering.
+ * @return {Node} - a React node containing the TaxCloud settings form.
  */
 const TaxCloudSettingsForm = (props) => {
   return (
@@ -23,6 +32,24 @@ const TaxCloudSettingsForm = (props) => {
   );
 };
 
+/**
+  * @name TaxCloudSettingsForm propTypes
+  * @type {propTypes}
+  * @param {Object} props - React PropTypes
+  * @property {Object} doc - data about the current TaxCloud settings.
+  * @property {String} docPath - the "path" (or field) in the TaxCloud Package
+  * where new settings are to be saved.
+  * @property {Object} fields - info about the fields of the TaxCloud Package
+  * that the settings form will allow users to change.
+  * @property {Function} handleSubmit - a function that saves new TaxCloud settings.
+  * @property {Array} hideFields - an array of the TaxCloud Package's fields
+  * to hide from the settings form.
+  * @property {String} name - the field in the TaxCloud Package where new
+  * settings are to be saved.
+  * @property {Object} schema - info about the DB schema used by the
+  * TaxCloud Package.
+  * @return {Array} React propTypes
+  */
 TaxCloudSettingsForm.propTypes = {
   doc: PropTypes.object,
   docPath: PropTypes.string,

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -23,7 +23,7 @@ import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
 const TaxCloudSettingsForm = (props) => {
   const { handleSubmit, hiddenFields, settings, shownFields } = props;
   return (
-    <div>
+    <div className="rui taxcloud-settings-form">
       {!settings.taxcloud.apiLoginId &&
         <div className="alert alert-info">
           <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -6,16 +6,20 @@ import { Form } from "/imports/plugins/core/ui/client/components";
  * @file TaxCloudSettingsForm is a React Component for changing TaxCloud
  * settings.
  * @module TaxCloudSettingsForm
- * @extends Component
  */
 
-// TODO: Do I need to add @property docs to this even though it's a pure
-// component?
 /**
  * @method TaxCloudSettingsForm
  * @summary renders a form for updating TaxCloud settings.
  * @param {Object} props - some data for use by this component.
- * @since 1.5.1
+ * @property {Object} doc - current TaxCloud settings.
+ * @property {String} docPath - the field in the TaxCloud Package where settings are stored.
+ * @property {Object} fields - info about the fields the form is to show.
+ * @property {Function} handleSubmit - a function for saving new TaxCloud settings.
+ * @property {Array} hideFields - the fields (from the TaxCloud Package) to hide from the form.
+ * @property {String} name - the name of this provider in lowercase (i.e taxcloud).
+ * @property {Object} schema - info about the DB structure of the TaxCloud Package.
+ * @since 1.5.2
  * @return {Node} - a React node containing the TaxCloud settings form.
  */
 const TaxCloudSettingsForm = (props) => {
@@ -37,17 +41,14 @@ const TaxCloudSettingsForm = (props) => {
   * @type {propTypes}
   * @param {Object} props - React PropTypes
   * @property {Object} doc - data about the current TaxCloud settings.
-  * @property {String} docPath - the "path" (or field) in the TaxCloud Package
-  * where new settings are to be saved.
+  * @property {String} docPath - the field in the TaxCloud Package where settings are saved.
   * @property {Object} fields - info about the fields of the TaxCloud Package
   * that the settings form will allow users to change.
   * @property {Function} handleSubmit - a function that saves new TaxCloud settings.
   * @property {Array} hideFields - an array of the TaxCloud Package's fields
   * to hide from the settings form.
-  * @property {String} name - the field in the TaxCloud Package where new
-  * settings are to be saved.
-  * @property {Object} schema - info about the DB schema used by the
-  * TaxCloud Package.
+  * @property {String} name - the name of this provider in lowercase.
+  * @property {Object} schema - info about the schema used by the TaxCloud Package.
   * @return {Array} React propTypes
   */
 TaxCloudSettingsForm.propTypes = {

--- a/imports/plugins/included/taxes-taxcloud/client/containers/index.js
+++ b/imports/plugins/included/taxes-taxcloud/client/containers/index.js
@@ -1,0 +1,1 @@
+export { default as TaxCloudSettingsFormContainer } from "./taxCloudSettingsFormContainer";

--- a/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
+++ b/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
@@ -28,7 +28,8 @@ class TaxCloudSettingsFormContainer extends Component {
     * @param {Object} event - event info.
     * @param {Object} changedInfo - info about the new TaxCloud settings.
     * @param {String} targetField - the field to update in the TaxCloud Package.
-    * @property {String} packageName - String className or `classnames` compatible object for the base wrapper
+    * @property {String} packageName - the name of this tax provider in lowercase.
+    * @since 1.5.2
     * @return {null} - returns nothing
     */
   handleSubmit(event, changedInfo, targetField) {
@@ -90,7 +91,7 @@ class TaxCloudSettingsFormContainer extends Component {
   * @type {propTypes}
   * @param {Object} props - React PropTypes
   * @property {String} packageName - the value of the "name" field in the TaxCloud Package.
-  * @property {String} providerName - the name of this provider in small caps i.e "taxcloud".
+  * @property {String} providerName - the name of this provider in lowercase i.e "taxcloud".
   * @property {Object} settings - the value of the "settings" field in the TaxCloud Package.
   * @return {Array} React propTypes
   */

--- a/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
+++ b/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
@@ -107,7 +107,7 @@ const composer = (props, onData) => {
   if (packageSub.ready()) {
     const providerName = "taxcloud";
     const packageName = "taxes-taxcloud";
-    const packageData = Packages.findOne({ name: packageName, shopId });
+    const packageData = Reaction.getPackageSettings(packageName);
     onData(null, { ...packageData, packageName, providerName });
   }
 };

--- a/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
+++ b/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
@@ -106,8 +106,9 @@ const composer = (props, onData) => {
   const packageSub = Meteor.subscribe("Packages", shopId);
   if (packageSub.ready()) {
     const providerName = "taxcloud";
-    const packageData = Packages.findOne({ name: "taxes-taxcloud", shopId });
-    onData(null, { ...packageData, providerName });
+    const packageName = "taxes-taxcloud";
+    const packageData = Packages.findOne({ name: packageName, shopId });
+    onData(null, { ...packageData, packageName, providerName });
   }
 };
 

--- a/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
+++ b/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
@@ -1,0 +1,115 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { composeWithTracker, registerComponent } from  "@reactioncommerce/reaction-components";
+import { Meteor } from "meteor/meteor";
+import { Packages } from "/lib/collections";
+import { Reaction, i18next } from "/client/api";
+import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
+import { TaxCloudSettingsForm } from "../components";
+
+/**
+ * @file TaxCloudSettingsFormContainer is a React Component that serves
+ * as a container for TaxCloudSettingsForm.
+ * @module TaxCloudSettingsFormContainer
+ * @extends Component
+ */
+
+class TaxCloudSettingsFormContainer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  /**
+    * handleSubmit
+    * @method
+    * @summary event handler for when new TaxCloud settings are submitted.
+    * @param {Object} event - event info.
+    * @param {Object} changedInfo - info about the new TaxCloud settings.
+    * @param {String} targetField - the field to update in the TaxCloud Package.
+    * @property {String} packageName - String className or `classnames` compatible object for the base wrapper
+    * @return {null} - returns nothing
+    */
+  handleSubmit(event, changedInfo, targetField) {
+    if (!changedInfo.isValid) {
+      return;
+    }
+    Meteor.call("package/update", this.props.packageName, targetField, changedInfo.doc.settings.taxcloud, (error) => {
+      if (error) {
+        Alerts.toast(
+          i18next.t("admin.update.updateFailed", { defaultValue: "Failed to update TaxCloud settings." }),
+          "error"
+        );
+        return;
+      }
+      Alerts.toast(
+        i18next.t("admin.update.updateSucceeded", { defaultValue: "TaxCloud settings updated." }),
+        "success"
+      );
+    });
+  }
+
+  render() {
+    const providerName = this.props.providerName;
+    const packageSettings = this.props.settings;
+    const shownFields = {
+      [`settings.${providerName}.apiKey`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiKey`],
+      [`settings.${providerName}.apiLoginId`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiLoginId`]
+    };
+    const hiddenFields = [
+      `settings.${providerName}.enabled`,
+      `settings.${providerName}.refreshPeriod`,
+      `settings.${providerName}.taxCodeUrl`
+    ];
+
+    return (
+      <div>
+        {!packageSettings.taxcloud.apiLoginId &&
+          <div className="alert alert-info">
+            <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>
+            <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
+          </div>
+        }
+        <TaxCloudSettingsForm
+          schema={TaxCloudPackageConfig}
+          doc={{ settings: packageSettings }}
+          docPath={`settings.${providerName}`}
+          name={`settings.${providerName}`}
+          fields={shownFields}
+          hideFields={hiddenFields}
+          handleSubmit={this.handleSubmit}
+        />
+      </div>
+    );
+  }
+}
+
+/**
+  * @name TaxCloudSettingsFormContainer propTypes
+  * @type {propTypes}
+  * @param {Object} props - React PropTypes
+  * @property {String} packageName - the value of the "name" field in the TaxCloud Package.
+  * @property {String} providerName - the name of this provider in small caps i.e "taxcloud".
+  * @property {Object} settings - the value of the "settings" field in the TaxCloud Package.
+  * @return {Array} React propTypes
+  */
+TaxCloudSettingsFormContainer.propTypes = {
+  packageName: PropTypes.string,
+  providerName: PropTypes.string,
+  settings: PropTypes.object
+};
+
+const composer = (props, onData) => {
+  const shopId = Reaction.getShopId();
+  const packageSub = Meteor.subscribe("Packages", shopId);
+  if (packageSub.ready()) {
+    const providerName = "taxcloud";
+    const packageData = Packages.findOne({ name: "taxes-taxcloud", shopId });
+    onData(null, { ...packageData, providerName });
+  }
+};
+
+registerComponent("TaxCloudSettingsFormContainer", TaxCloudSettingsFormContainer, composeWithTracker(composer));
+
+export default composeWithTracker(composer)(TaxCloudSettingsFormContainer);

--- a/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
+++ b/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
@@ -27,7 +27,7 @@ class TaxCloudSettingsFormContainer extends Component {
     * @summary event handler for when new TaxCloud settings are submitted.
     * @param {Object} event - event info.
     * @param {Object} changedInfo - info about the new TaxCloud settings.
-    * @param {String} targetField - the field to update in the TaxCloud Package.
+    * @param {String} targetField - where to save the new settings in the TaxCloud Package.
     * @property {String} packageName - the name of this tax provider in lowercase.
     * @since 1.5.2
     * @return {null} - returns nothing

--- a/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
+++ b/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
@@ -1,26 +1,16 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import { compose, withProps } from "recompose";
 import { composeWithTracker, registerComponent } from  "@reactioncommerce/reaction-components";
 import { Meteor } from "meteor/meteor";
-import { Packages } from "/lib/collections";
 import { Reaction, i18next } from "/client/api";
 import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
 import { TaxCloudSettingsForm } from "../components";
 
 /**
- * @file TaxCloudSettingsFormContainer is a React Component that serves
- * as a container for TaxCloudSettingsForm.
- * @module TaxCloudSettingsFormContainer
- * @extends Component
+ * @file This is a container for TaxCloudSettingsForm.
+ * @module taxCloudSettingsFormContainer
  */
 
-class TaxCloudSettingsFormContainer extends Component {
-  constructor(props) {
-    super(props);
-
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
-
+const handlers = {
   /**
     * handleSubmit
     * @method
@@ -28,7 +18,6 @@ class TaxCloudSettingsFormContainer extends Component {
     * @param {Object} event - event info.
     * @param {Object} changedInfo - info about the new TaxCloud settings.
     * @param {String} targetField - where to save the new settings in the TaxCloud Package.
-    * @property {String} packageName - the name of this tax provider in lowercase.
     * @since 1.5.2
     * @return {null} - returns nothing
     */
@@ -36,7 +25,7 @@ class TaxCloudSettingsFormContainer extends Component {
     if (!changedInfo.isValid) {
       return;
     }
-    Meteor.call("package/update", this.props.packageName, targetField, changedInfo.doc.settings.taxcloud, (error) => {
+    Meteor.call("package/update", "taxes-taxcloud", targetField, changedInfo.doc.settings.taxcloud, (error) => {
       if (error) {
         Alerts.toast(
           i18next.t("admin.update.updateFailed", { defaultValue: "Failed to update TaxCloud settings." }),
@@ -50,68 +39,30 @@ class TaxCloudSettingsFormContainer extends Component {
       );
     });
   }
-
-  render() {
-    const providerName = this.props.providerName;
-    const packageSettings = this.props.settings;
-    const shownFields = {
-      [`settings.${providerName}.apiKey`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiKey`],
-      [`settings.${providerName}.apiLoginId`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiLoginId`]
-    };
-    const hiddenFields = [
-      `settings.${providerName}.enabled`,
-      `settings.${providerName}.refreshPeriod`,
-      `settings.${providerName}.taxCodeUrl`
-    ];
-
-    return (
-      <div>
-        {!packageSettings.taxcloud.apiLoginId &&
-          <div className="alert alert-info">
-            <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>
-            <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
-          </div>
-        }
-        <TaxCloudSettingsForm
-          schema={TaxCloudPackageConfig}
-          doc={{ settings: packageSettings }}
-          docPath={`settings.${providerName}`}
-          name={`settings.${providerName}`}
-          fields={shownFields}
-          hideFields={hiddenFields}
-          handleSubmit={this.handleSubmit}
-        />
-      </div>
-    );
-  }
-}
-
-/**
-  * @name TaxCloudSettingsFormContainer propTypes
-  * @type {propTypes}
-  * @param {Object} props - React PropTypes
-  * @property {String} packageName - the value of the "name" field in the TaxCloud Package.
-  * @property {String} providerName - the name of this provider in lowercase i.e "taxcloud".
-  * @property {Object} settings - the value of the "settings" field in the TaxCloud Package.
-  * @return {Array} React propTypes
-  */
-TaxCloudSettingsFormContainer.propTypes = {
-  packageName: PropTypes.string,
-  providerName: PropTypes.string,
-  settings: PropTypes.object
 };
 
 const composer = (props, onData) => {
+  const providerName = "taxcloud";
+  const shownFields = {
+    [`settings.${providerName}.apiKey`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiKey`],
+    [`settings.${providerName}.apiLoginId`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiLoginId`]
+  };
+  const hiddenFields = [
+    `settings.${providerName}.enabled`,
+    `settings.${providerName}.refreshPeriod`,
+    `settings.${providerName}.taxCodeUrl`
+  ];
+
   const shopId = Reaction.getShopId();
   const packageSub = Meteor.subscribe("Packages", shopId);
   if (packageSub.ready()) {
-    const providerName = "taxcloud";
-    const packageName = "taxes-taxcloud";
-    const packageData = Reaction.getPackageSettings(packageName);
-    onData(null, { ...packageData, packageName, providerName });
+    const packageData = Reaction.getPackageSettings("taxes-taxcloud");
+    onData(null, { settings: packageData.settings, shownFields, hiddenFields });
   }
 };
 
-registerComponent("TaxCloudSettingsFormContainer", TaxCloudSettingsFormContainer, composeWithTracker(composer));
+registerComponent("TaxCloudSettingsForm", TaxCloudSettingsForm, [
+  withProps(handlers), composeWithTracker(composer)
+]);
 
-export default composeWithTracker(composer)(TaxCloudSettingsFormContainer);
+export default compose(withProps(handlers), composeWithTracker(composer))(TaxCloudSettingsForm);

--- a/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
+++ b/imports/plugins/included/taxes-taxcloud/client/containers/taxCloudSettingsFormContainer.js
@@ -42,15 +42,14 @@ const handlers = {
 };
 
 const composer = (props, onData) => {
-  const providerName = "taxcloud";
   const shownFields = {
-    [`settings.${providerName}.apiKey`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiKey`],
-    [`settings.${providerName}.apiLoginId`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiLoginId`]
+    ["settings.taxcloud.apiKey"]: TaxCloudPackageConfig._schema["settings.taxcloud.apiKey"],
+    ["settings.taxcloud.apiLoginId"]: TaxCloudPackageConfig._schema["settings.taxcloud.apiLoginId"]
   };
   const hiddenFields = [
-    `settings.${providerName}.enabled`,
-    `settings.${providerName}.refreshPeriod`,
-    `settings.${providerName}.taxCodeUrl`
+    "settings.taxcloud.enabled",
+    "settings.taxcloud.refreshPeriod",
+    "settings.taxcloud.taxCodeUrl"
   ];
 
   const shopId = Reaction.getShopId();

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
@@ -1,6 +1,6 @@
 <template name="taxCloudSettings">
 
-  {{#unless packageData.settings.taxcloud.apiLoginId}}
+  {{#unless taxCloudPackageData.settings.taxcloud.apiLoginId}}
   <div class="alert alert-info">
     <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>
     <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
@@ -1,12 +1,11 @@
 <template name="taxCloudSettings">
 
   {{#unless taxCloudPackageData.settings.taxcloud.apiLoginId}}
-  <div class="alert alert-info">
-    <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>
-    <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
-  </div>
+    <div class="alert alert-info">
+      <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>
+      <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
+    </div>
   {{/unless}}
-
 
   <div>
     {{> React taxCloudCard}}

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
@@ -1,5 +1,5 @@
 <template name="taxCloudSettings">
   <div>
-    {{> React taxCloudCard}}
+    {{> React taxCloudForm}}
   </div>
 </template>

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
@@ -1,12 +1,4 @@
 <template name="taxCloudSettings">
-
-  {{#unless taxCloudPackageData.settings.taxcloud.apiLoginId}}
-    <div class="alert alert-info">
-      <span data-i18n="admin.taxSettings.taxcloudCredentials">Add API Login ID to enable</span>
-      <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
-    </div>
-  {{/unless}}
-
   <div>
     {{> React taxCloudCard}}
   </div>

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.html
@@ -7,15 +7,8 @@
   </div>
   {{/unless}}
 
+
   <div>
-  {{#autoForm collection=Collections.Packages schema=packageConfigSchema doc=packageData type="update" id="taxcloud-update-form"}}
-      <div class="panel-body">
-        {{> afQuickField name='settings.taxcloud.apiLoginId' class='form-control'}}
-        {{> afQuickField name='settings.taxcloud.apiKey' class='form-control'}}
-        <!-- {{> afQuickField name='settings.taxcloud.refreshPeriod' class='form-control'}}
-        {{> afQuickField name='settings.taxcloud.taxCodeUrl' class='form-control'}} -->
-      </div>
-      {{> shopSettingsSubmitButton}}
-  {{/autoForm}}
+    {{> React taxCloudCard}}
   </div>
 </template>

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -7,6 +7,13 @@ import { Reaction, i18next } from "/client/api";
 import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
 import { TaxCloudSettingsForm } from "../components";
 
+/**
+ * @method getPackageData
+ * @summary returns the data for the Package with the name in pkgName.
+ * @param {String} pkgName - the name of the Package required.
+ * @since 1.5.1
+ * @return {Object} - returns the data found for the said Package.
+ */
 function getPackageData(pkgName) {
   return Packages.findOne({
     name: pkgName,
@@ -15,9 +22,23 @@ function getPackageData(pkgName) {
 }
 
 Template.taxCloudSettings.helpers({
+  /**
+   * @method taxCloudPackageData
+   * @summary returns the data for the taxes-taxcloud Package.
+   * @since 1.5.1
+   * @return {Object} - returns data for the said Package.
+   */
   taxCloudPackageData() {
     return getPackageData("taxes-taxcloud");
   },
+  /**
+   * @method taxCloudCard
+   * @summary returns a component for updating the TaxCloud settings for
+   * this app.
+   * @since 1.5.1
+   * @return {Object} - returns an object that contains the component
+   * to render and some data to use as props for it.
+   */
   taxCloudCard() {
     const providerName = "taxcloud";
     const packageName = "taxes-taxcloud";

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -1,8 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
-import { AutoForm } from "meteor/aldeed:autoform";
 import { Packages } from "/lib/collections";
-import { TaxCodes } from "/imports/plugins/core/taxes/lib/collections";
 import { Reaction, i18next } from "/client/api";
 import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
 import { TaxCloudSettingsForm } from "../components";
@@ -77,33 +75,5 @@ Template.taxCloudSettings.helpers({
         });
       }
     };
-  }
-});
-
-
-AutoForm.hooks({
-  "taxcloud-update-form": {
-    onSuccess: function () {
-      if (!TaxCodes.findOne({ taxCodeProvider: "taxes-taxcloud" })) {
-        Meteor.call("taxcloud/getTaxCodes", (err, res) => {
-          if (res && Array.isArray(res)) {
-            Alerts.toast(i18next.t("admin.taxSettings.shopTaxMethodsSaved"),
-              "success");
-            res.forEach((code) => {
-              Meteor.call("taxes/insertTaxCodes", Reaction.getShopId(), code,
-                "taxes-taxcloud");
-            });
-          }
-        });
-      } else {
-        Alerts.toast(i18next.t("admin.taxSettings.shopTaxMethodsAlreadySaved"),
-          "success");
-      }
-    },
-    onError: function (operation, error) {
-      return Alerts.toast(
-        `${i18next.t("admin.taxSettings.shopTaxMethodsFailed")} ${error}`,
-        "error");
-    }
   }
 });

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -67,6 +67,7 @@ Template.taxCloudSettings.helpers({
               i18next.t("admin.update.updateFailed", { defaultValue: "Failed to update TaxCloud settings." }),
               "error"
             );
+            return;
           }
           Alerts.toast(
             i18next.t("admin.update.updateSucceeded", { defaultValue: "TaxCloud settings updated." }),

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -15,7 +15,7 @@ function getPackageData(pkgName) {
 }
 
 Template.taxCloudSettings.helpers({
-  packageData() {
+  taxCloudPackageData() {
     return getPackageData("taxes-taxcloud");
   },
   taxCloudCard() {

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -3,13 +3,13 @@ import { TaxCloudSettingsFormContainer } from "../containers";
 
 Template.taxCloudSettings.helpers({
   /**
-   * @method taxCloudCard
+   * @method taxCloudForm
    * @summary returns a component for updating the TaxCloud settings for
    * this app.
    * @since 1.5.2
    * @return {Object} - an object containing the component to render.
    */
-  taxCloudCard() {
+  taxCloudForm() {
     return { component: TaxCloudSettingsFormContainer };
   }
 });

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -1,65 +1,15 @@
-import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
-import { Reaction, i18next } from "/client/api";
-import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
-import { TaxCloudSettingsForm } from "../components";
+import { TaxCloudSettingsFormContainer } from "../containers";
 
 Template.taxCloudSettings.helpers({
-  /**
-   * @method taxCloudPackageData
-   * @summary returns the data for the taxes-taxcloud Package.
-   * @since 1.5.1
-   * @return {Object} - returns data for the said Package.
-   */
-  taxCloudPackageData() {
-    return Reaction.getPackageSettings("taxes-taxcloud");
-  },
   /**
    * @method taxCloudCard
    * @summary returns a component for updating the TaxCloud settings for
    * this app.
-   * @since 1.5.1
-   * @return {Object} - returns an object that contains the component
-   * to render and some data to use as props for it.
+   * @since 1.5.2
+   * @return {Object} - an object containing the component to render.
    */
   taxCloudCard() {
-    const providerName = "taxcloud";
-    const packageName = "taxes-taxcloud";
-    const packageData = Reaction.getPackageSettings(packageName);
-    return {
-      component: TaxCloudSettingsForm,
-      schema: TaxCloudPackageConfig,
-      doc: { settings: { ...packageData.settings } },
-      docPath: `settings.${providerName}`,
-      name: `settings.${providerName}`,
-      fields: {
-        [`settings.${providerName}.apiKey`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiKey`],
-        [`settings.${providerName}.apiLoginId`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiLoginId`]
-      },
-      hideFields: [
-        `settings.${providerName}.enabled`,
-        `settings.${providerName}.refreshPeriod`,
-        `settings.${providerName}.taxCodeUrl`
-
-      ],
-      handleSubmit: (event, changedInfo, targetField) => {
-        if (!changedInfo.isValid) {
-          return;
-        }
-        Meteor.call("package/update", packageName, targetField, changedInfo.doc.settings.taxcloud, (error) => {
-          if (error) {
-            Alerts.toast(
-              i18next.t("admin.update.updateFailed", { defaultValue: "Failed to update TaxCloud settings." }),
-              "error"
-            );
-            return;
-          }
-          Alerts.toast(
-            i18next.t("admin.update.updateSucceeded", { defaultValue: "TaxCloud settings updated." }),
-            "success"
-          );
-        });
-      }
-    };
+    return { component: TaxCloudSettingsFormContainer };
   }
 });

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -59,7 +59,23 @@ Template.taxCloudSettings.helpers({
         `settings.${providerName}.taxCodeUrl`
 
       ],
-      handleSubmit: () => { console.log("Tried to change tax cloud settings."); }
+      handleSubmit: (event, changedInfo, targetField) => {
+        if (!changedInfo.isValid) {
+          return;
+        }
+        Meteor.call("package/update", packageName, targetField, changedInfo.doc.settings.taxcloud, (error) => {
+          if (error) {
+            Alerts.toast(
+              i18next.t("admin.update.updateFailed", { defaultValue: "Failed to update TaxCloud settings." }),
+              "error"
+            );
+          }
+          Alerts.toast(
+            i18next.t("admin.update.updateSucceeded", { defaultValue: "TaxCloud settings updated." }),
+            "success"
+          );
+        });
+      }
     };
   }
 });

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -5,16 +5,41 @@ import { Packages } from "/lib/collections";
 import { TaxCodes } from "/imports/plugins/core/taxes/lib/collections";
 import { Reaction, i18next } from "/client/api";
 import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
+import { TaxCloudSettingsForm } from "../components";
+
+function getPackageData(pkgName) {
+  return Packages.findOne({
+    name: pkgName,
+    shopId: Reaction.getShopId()
+  });
+}
 
 Template.taxCloudSettings.helpers({
-  packageConfigSchema() {
-    return TaxCloudPackageConfig;
-  },
   packageData() {
-    return Packages.findOne({
-      name: "taxes-taxcloud",
-      shopId: Reaction.getShopId()
-    });
+    return getPackageData("taxes-taxcloud");
+  },
+  taxCloudCard() {
+    const providerName = "taxcloud";
+    const packageName = "taxes-taxcloud";
+    const packageData = getPackageData(packageName);
+    return {
+      component: TaxCloudSettingsForm,
+      schema: TaxCloudPackageConfig,
+      doc: { settings: { ...packageData.settings } },
+      docPath: `settings.${providerName}`,
+      name: `settings.${providerName}`,
+      fields: {
+        [`settings.${providerName}.apiKey`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiKey`],
+        [`settings.${providerName}.apiLoginId`]: TaxCloudPackageConfig._schema[`settings.${providerName}.apiLoginId`]
+      },
+      hideFields: [
+        `settings.${providerName}.enabled`,
+        `settings.${providerName}.refreshPeriod`,
+        `settings.${providerName}.taxCodeUrl`
+
+      ],
+      handleSubmit: () => { console.log("Tried to change tax cloud settings."); }
+    };
   }
 });
 

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -1,23 +1,8 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
-import { Packages } from "/lib/collections";
 import { Reaction, i18next } from "/client/api";
 import { TaxCloudPackageConfig } from "../../lib/collections/schemas";
 import { TaxCloudSettingsForm } from "../components";
-
-/**
- * @method getPackageData
- * @summary returns the data for the Package with the name in pkgName.
- * @param {String} pkgName - the name of the Package required.
- * @since 1.5.1
- * @return {Object} - returns the data found for the said Package.
- */
-function getPackageData(pkgName) {
-  return Packages.findOne({
-    name: pkgName,
-    shopId: Reaction.getShopId()
-  });
-}
 
 Template.taxCloudSettings.helpers({
   /**
@@ -27,7 +12,7 @@ Template.taxCloudSettings.helpers({
    * @return {Object} - returns data for the said Package.
    */
   taxCloudPackageData() {
-    return getPackageData("taxes-taxcloud");
+    return Reaction.getPackageSettings("taxes-taxcloud");
   },
   /**
    * @method taxCloudCard
@@ -40,7 +25,7 @@ Template.taxCloudSettings.helpers({
   taxCloudCard() {
     const providerName = "taxcloud";
     const packageName = "taxes-taxcloud";
-    const packageData = getPackageData(packageName);
+    const packageData = Reaction.getPackageSettings(packageName);
     return {
       component: TaxCloudSettingsForm,
       schema: TaxCloudPackageConfig,

--- a/imports/plugins/included/taxes-taxcloud/server/i18n/en.json
+++ b/imports/plugins/included/taxes-taxcloud/server/i18n/en.json
@@ -21,8 +21,8 @@
           "taxcloudGetCredentialsURL": "Get them here"
         },
         "update": {
-          "updateSucceeded": "Failed to update TaxCloud settings.",
-          "updateFailed": "TaxCloud settings updated."
+          "updateSucceeded": "TaxCloud settings updated.",
+          "updateFailed": "Failed to update TaxCloud settings."
         }
       }
     }

--- a/imports/plugins/included/taxes-taxcloud/server/i18n/en.json
+++ b/imports/plugins/included/taxes-taxcloud/server/i18n/en.json
@@ -19,6 +19,10 @@
           "taxcloudSettingsLabel": "TaxCloud",
           "taxcloudCredentials": "Add credentials to enable",
           "taxcloudGetCredentialsURL": "Get them here"
+        },
+        "update": {
+          "updateSucceeded": "Failed to update TaxCloud settings.",
+          "updateFailed": "TaxCloud settings updated."
         }
       }
     }

--- a/server/imports/fixtures/index.js
+++ b/server/imports/fixtures/index.js
@@ -2,7 +2,7 @@ import accounts from "./accounts";
 import cart from "./cart";
 import orders from "./orders";
 import products from "./products";
-import examplePaymentMethod from "./packages";
+import { examplePaymentMethod, examplePackage } from "./packages";
 // import shipping from "./shipping";
 import shops from "./shops";
 import users from "./users";
@@ -12,6 +12,7 @@ export default function () {
   shops();
   users();
   examplePaymentMethod();
+  examplePackage();
   accounts();
   products();
   cart();

--- a/server/imports/fixtures/packages.js
+++ b/server/imports/fixtures/packages.js
@@ -10,7 +10,7 @@ export const getPkgData = (pkgName) => {
 };
 
 
-export default function () {
+export function examplePaymentMethod() {
   const examplePaymentMethodPackage = {
     name: "example-paymentmethod",
     icon: "fa fa-credit-card-alt",
@@ -34,3 +34,21 @@ export default function () {
   Factory.define("examplePaymentPackage", Packages, Object.assign({}, examplePaymentMethodPackage));
 }
 
+/**
+ * @method examplePackage
+ * @summary creates a new fixture based off of the Packages collection.
+ * @since 1.5.5
+ * @return {undefined} - returns nothing.
+ */
+export function examplePackage() {
+  const examplePkg = {
+    name: "example-package",
+    settings: {
+      enabled: false,
+      apiUrl: "http://example.com/api"
+    },
+    shopId: "random-shop-101"
+  };
+
+  Factory.define("examplePackage", Packages, examplePkg);
+}

--- a/server/methods/core/packages-update.app-test.js
+++ b/server/methods/core/packages-update.app-test.js
@@ -1,0 +1,53 @@
+import { Meteor } from "meteor/meteor";
+import { Factory } from "meteor/dburles:factory";
+import { Packages } from "/lib/collections";
+import { expect } from "meteor/practicalmeteor:chai";
+import { sinon } from "meteor/practicalmeteor:sinon";
+import { Reaction } from "/server/api";
+
+describe.only("Update Package", function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe.only("package/update", function () {
+    it.only("should throw an 'Access Denied' error for non-admins", function (done) {
+      const pkgUpdateSpy = sandbox.spy(Packages, "update");
+      const examplePackage = Factory.create("examplePackage");
+
+      function updatePackage() {
+        return Meteor.call("package/update", examplePackage.name, "settings", {});
+      }
+      expect(updatePackage).to.throw(Meteor.Error, /Access Denied/);
+      expect(pkgUpdateSpy).to.not.have.been.called;
+
+      return done();
+    });
+
+    it.only("should be able to update any Package", function (done) {
+      const packageUpdateSpy = sandbox.spy(Packages, "update");
+      const oldPackage = Factory.create("examplePackage");
+
+      sandbox.stub(Reaction, "getShopId", () => oldPackage.shopId);
+      sandbox.stub(Reaction, "hasPermission", () => true);
+      const packageName = oldPackage.name;
+      const newValues = {
+        enabled: true,
+        apiUrl: "http://foo-bar.com/api/v1"
+      };
+      Meteor.call("package/update", packageName, "settings", newValues);
+      expect(packageUpdateSpy).to.have.been.called;
+      const updatedPackage = Packages.findOne({ name: packageName });
+      expect(oldPackage.settings.enabled).to.not.equal(updatedPackage.settings.enabled);
+      expect(oldPackage.settings.apiUrl).to.not.equal(updatedPackage.settings.apiUrl);
+
+      return done();
+    });
+  });
+});

--- a/server/methods/core/packages-update.app-test.js
+++ b/server/methods/core/packages-update.app-test.js
@@ -6,7 +6,7 @@ import { sinon } from "meteor/practicalmeteor:sinon";
 import { Packages } from "/lib/collections";
 import { Reaction } from "/server/api";
 
-describe.only("Update Package", function () {
+describe("Update Package", function () {
   let sandbox;
 
   beforeEach(function () {
@@ -17,8 +17,8 @@ describe.only("Update Package", function () {
     sandbox.restore();
   });
 
-  describe.only("package/update", function () {
-    it.only("should throw an 'Access Denied' error for non-admins", function (done) {
+  describe("package/update", function () {
+    it("should throw an 'Access Denied' error for non-admins", function (done) {
       const pkgUpdateSpy = sandbox.spy(Packages, "update");
       const examplePackage = Factory.create("examplePackage");
 
@@ -31,7 +31,7 @@ describe.only("Update Package", function () {
       return done();
     });
 
-    it.only("should throw an error when supplied with an argument of the wrong type", function (done) {
+    it("should throw an error when supplied with an argument of the wrong type", function (done) {
       const pkgUpdateSpy = sandbox.spy(Packages, "update");
       sandbox.stub(Reaction, "getShopId", () => "randomId");
       sandbox.stub(Reaction, "hasPermission", () => true);
@@ -47,7 +47,7 @@ describe.only("Update Package", function () {
       return done();
     });
 
-    it.only("should be able to update any Package", function (done) {
+    it("should be able to update any Package", function (done) {
       const packageUpdateSpy = sandbox.spy(Packages, "update");
       const oldPackage = Factory.create("examplePackage");
 

--- a/server/methods/core/packages.js
+++ b/server/methods/core/packages.js
@@ -3,25 +3,39 @@ import { check } from "meteor/check";
 import { Packages } from "/lib/collections";
 import { Reaction } from "/server/api";
 
-export const methods = {
-  "package/update": function (packageName, field, value) {
-    check(packageName, String);
-    check(field, String);
-    check(value, Object);
+/**
+ * @method updatePackage
+ * @summary updates the data stored for a certain Package.
+ * @param {String} packageName - the name of the Package to update.
+ * @param {String} field - the part of the Package's data that is to
+ * be updated.
+ * @param {Object} value - the new data that's to be stored for the said
+ * Package.
+ * @since 1.5.1
+ * @return {Object} - returns an object with info about the update operation.
+ */
+export function updatePackage(packageName, field, value) {
+  check(packageName, String);
+  check(field, String);
+  check(value, Object);
 
-    if (!Reaction.hasPermission([packageName])) {
-      throw new Meteor.Error(403, `Access Denied. You don't have permissions for the ${packageName} package.`);
-    }
-
-    return Packages.update({
-      name: packageName,
-      shopId: Reaction.getShopId()
-    }, {
-      $set: {
-        [field]: value
-      }
-    });
+  if (!Reaction.hasPermission([packageName])) {
+    throw new Meteor.Error(403, `Access Denied. You don't have permissions for the ${packageName} package.`);
   }
-};
 
-Meteor.methods(methods);
+  // TODO: What if the said Package doesn't exist? Should we create it? Or
+  // throw an error?
+
+  return Packages.update({
+    name: packageName,
+    shopId: Reaction.getShopId()
+  }, {
+    $set: {
+      [field]: value
+    }
+  });
+}
+
+Meteor.methods({
+  "package/update": updatePackage
+});

--- a/server/methods/core/packages.js
+++ b/server/methods/core/packages.js
@@ -19,21 +19,24 @@ export function updatePackage(packageName, field, value) {
   check(field, String);
   check(value, Object);
 
-  if (!Reaction.hasPermission([packageName])) {
-    throw new Meteor.Error(403, `Access Denied. You don't have permissions for the ${packageName} package.`);
+  const userId = Meteor.userId();
+  const shopId = Reaction.getShopId();
+  if (!Reaction.hasPermission([packageName], userId, shopId)) {
+    throw new Meteor.Error("access-denied", `Access Denied. You don't have permissions for the ${packageName} package.`);
   }
 
-  // TODO: What if the said Package doesn't exist? Should we create it? Or
-  // throw an error?
-
-  return Packages.update({
+  const updateResult = Packages.update({
     name: packageName,
-    shopId: Reaction.getShopId()
+    shopId: shopId
   }, {
     $set: {
       [field]: value
     }
   });
+  if (updateResult !== 1) {
+    throw new Meteor.Error("not-found", `An error occurred while updating the package ${packageName}.`);
+  }
+  return updateResult;
 }
 
 Meteor.methods({

--- a/server/methods/core/packages.js
+++ b/server/methods/core/packages.js
@@ -1,0 +1,27 @@
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { Packages } from "/lib/collections";
+import { Reaction } from "/server/api";
+
+export const methods = {
+  "package/update": function (packageName, field, value) {
+    check(packageName, String);
+    check(field, String);
+    check(value, Object);
+
+    if (!Reaction.hasPermission([packageName])) {
+      throw new Meteor.Error(403, `Access Denied. You don't have permissions for the ${packageName} package.`);
+    }
+
+    return Packages.update({
+      name: packageName,
+      shopId: Reaction.getShopId()
+    }, {
+      $set: {
+        [field]: value
+      }
+    });
+  }
+};
+
+Meteor.methods(methods);

--- a/server/methods/core/packages.js
+++ b/server/methods/core/packages.js
@@ -34,7 +34,7 @@ export function updatePackage(packageName, field, value) {
     }
   });
   if (updateResult !== 1) {
-    throw new Meteor.Error("not-found", `An error occurred while updating the package ${packageName}.`);
+    throw new Meteor.Error("server-error", `An error occurred while updating the package ${packageName}.`);
   }
   return updateResult;
 }


### PR DESCRIPTION
Resolves #3093 .

This PR converts the TaxCloud settings panel from using [AutoForm](https://github.com/aldeed/meteor-autoform) to using [React](https://reactjs.org/) for editing its settings.

## Test Instructions
- Login as admin.
- Open the TaxCloud settings panel. Observe the current API Login ID and API Key values (if any).
- Change the login ID or/and API key in the TaxCloud settings form and submit the form. Observe an alert that confirms that the new settings were saved successfully.
- Refresh the page and open the TaxCloud panel again. Observe that the form now contains the login ID or API key you entered above.
- Note: Instead of refreshing the page, you can use RoboMongo (or similar) to inspect the DB. Just search the `Package` collection for the package with `name: taxes-taxcloud`. Then cycle between editing the TaxCloud settings form and checking the `settings.taxcloud` field in the said package. You'll notice that that field always changes as appropriate.

