### PR TITLE
Spencer resolve 3125 shopify redirect

### DIFF
--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.js
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.js
@@ -2,8 +2,8 @@ import { Meteor } from "meteor/meteor";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { Template } from "meteor/templating";
 import { $ } from "meteor/jquery";
-import { Reaction, i18next } from "/client/api";
-import { Packages } from "/lib/collections";
+import { Reaction, Router, i18next } from "/client/api";
+import { Packages, Shops } from "/lib/collections";
 import { ShopifyConnectPackageConfig } from "../../lib/collections/schemas";
 import "./shopify.html";
 
@@ -24,6 +24,20 @@ Template.shopifyImport.events({
     event.preventDefault();
     $(event.currentTarget).html(`<i class='fa fa-circle-o-notch fa-spin'></i> ${i18next.t("admin.shopifyConnectSettings.importing")}`);
     event.currentTarget.disabled = true;
+
+    // If this is the primary shop, redirect to index
+    if (Reaction.getShopId() === Reaction.getPrimaryShopId()) {
+      console.log("redirecting to index");
+      Router.go("index");
+    } else {
+      const shop = Shops.findOne({ _id: Reaction.getShopId() });
+      if (shop && shop.slug) {
+        Router.go(`/shop/${shop.slug}`);
+      } else {
+        Router.go(`/shop/${Reaction.getShopId()}`);
+      }
+      // Check to see if this shop has a slug, otherwise direct to shopId route
+    }
 
     Meteor.call("connectors/shopify/import/products", (err) => {
       $(event.currentTarget).html(`

--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.js
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.js
@@ -27,16 +27,17 @@ Template.shopifyImport.events({
 
     // If this is the primary shop, redirect to index
     if (Reaction.getShopId() === Reaction.getPrimaryShopId()) {
-      console.log("redirecting to index");
       Router.go("index");
     } else {
-      const shop = Shops.findOne({ _id: Reaction.getShopId() });
+      const shopId = Reaction.getShopId();
+      const shop = Shops.findOne({ _id: shopId });
+
+      // Check to see if this shop has a slug, otherwise direct to shopId route
       if (shop && shop.slug) {
         Router.go(`/shop/${shop.slug}`);
       } else {
-        Router.go(`/shop/${Reaction.getShopId()}`);
+        Router.go(`/shop/${shopId}`);
       }
-      // Check to see if this shop has a slug, otherwise direct to shopId route
     }
 
     Meteor.call("connectors/shopify/import/products", (err) => {


### PR DESCRIPTION
Resolves #3125 
- Redirects to the index route if current shop is primary.
- Redirects to the shop slug index route if non-primary shop has slug, otherwise use shopId index route.

**To Test**
1. Invite, accept and login as a merchant shop
2. Run the Shopify importer with the merchant shop
3. Check to see if you're redirected to that shop's index route.

helpful hints:
if you don't want the importer to import _all_ products from the test shop, change these lines for testing

change the limit to something like `5` here: https://github.com/reactioncommerce/reaction/blob/d778d94f0a19f03def7c24c4848fe0fe026d1288/imports/plugins/included/connectors-shopify/server/methods/import/products.js#L238
and 
change the number of pages to `1` or `2` here: https://github.com/reactioncommerce/reaction/blob/d778d94f0a19f03def7c24c4848fe0fe026d1288/imports/plugins/included/connectors-shopify/server/methods/import/products.js#L257

This will greatly speed up the import as it's not importing 1000+ products and even more images.