### PR TITLE
Spencer import shopify images via job

### DIFF
--- a/imports/plugins/included/connectors-shopify/server/jobs/image-import.js
+++ b/imports/plugins/included/connectors-shopify/server/jobs/image-import.js
@@ -1,0 +1,24 @@
+import { Jobs, Media } from "/lib/collections";
+
+export const importImages = () => {
+  Jobs.processJobs("connectors/shopify/import/image", {
+    pollInterval: 60 * 60 * 1000, // Retry failed images after an hour
+    workTimeout: 5 * 1000 // No image import should last more than 5 seconds
+  }, (job, callback) => {
+    const { url, metadata } = job.data;
+    try {
+      const fileObj = new FS.File();
+      fileObj.attachData(url);
+
+      // Set workflow to "published" to bypass revision control on insert for this image.
+      fileObj.metadata = { ...metadata, workflow: "published" };
+      Media.insert(fileObj);
+      // Logger.info(`Image inserted from ${url} into ${metadata}`);
+      job.done(`Finished importing image from ${url}`);
+      callback();
+    } catch (error) {
+      job.fail(`Failed to import image from ${url}.`);
+      callback();
+    }
+  });
+};

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -171,7 +171,6 @@ function createTagCache() {
 }
 
 
-
 /**
  * Finds and returns arrays of option values for each of Shopify's option layers
  * returns an object consisting of the following three values:

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -258,7 +258,7 @@ export const methods = {
     const apiCreds = getApiInfo();
     const shopify = new Shopify(apiCreds);
     const shopId = Reaction.getShopId();
-    const limit = 20; // Shopify returns a maximum of 250 results per request
+    const limit = 50; // Shopify returns a maximum of 250 results per request
     const tagCache = createTagCache();
     const ids = [];
     const opts = Object.assign({}, {
@@ -268,7 +268,7 @@ export const methods = {
 
     try {
       const productCount = await shopify.product.count();
-      const numPages = 5; // Math.ceil(productCount / limit);
+      const numPages = Math.ceil(productCount / limit);
       const pages = [...Array(numPages).keys()];
       Logger.info(`Shopify Connector is preparing to import ${productCount} products`);
 

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -277,7 +277,7 @@ export const methods = {
         const shopifyProducts = await shopify.product.list({ ...opts, page: page });
         for (const shopifyProduct of shopifyProducts) {
           if (!Products.findOne({ shopifyId: shopifyProduct.id }, { fields: { _id: 1 } })) {
-            Logger.info(`Importing ${shopifyProduct.title}`);
+            Logger.debug(`Importing ${shopifyProduct.title}`);
             const price = { min: null, max: null, range: "0.00" };
 
             // Get tags from shopify and register them if they don't exist.
@@ -431,7 +431,7 @@ export const methods = {
 
                               const reactionTernaryOptionId = Products.insert(reactionTernaryOption, { type: "variant" });
                               ids.push(reactionTernaryOptionId);
-                              Logger.info(`Imported ${shopifyProduct.title} ${variant}/${option}/${ternaryOption}`);
+                              Logger.debug(`Imported ${shopifyProduct.title} ${variant}/${option}/${ternaryOption}`);
 
                               // Update Max Price
                               if (price.max === null || price.max < reactionTernaryOption.price) {
@@ -499,7 +499,7 @@ export const methods = {
             Products.update({ _id: reactionProductId }, { $set: { price: price } }, { selector: { type: "simple" }, publish: true });
             Logger.debug(`Product ${shopifyProduct.title} added`);
           } else { // product already exists check
-            Logger.info(`Product ${shopifyProduct.title} already exists`);
+            Logger.debug(`Product ${shopifyProduct.title} already exists`);
           }
         } // End product loop
       } // End pages loop


### PR DESCRIPTION
This PR should help with bulk product import performance.
* Creates a job for each image import so that we can import all products first and then import images as a job afterwards. We could run a separate service to import these images as well if we wanted, but for now just getting them out of the primary import thread should help significantly.
* Abstract the tag cache creation to it's own function.

I plan to move the product imports themselves into jobs as well, but this is a pretty huge savings already (products could each have up to 30 images (or more) associated with them) and want to keep PRs small. This is self contained and should increase performance.