### PR TITLE
jsdoc: remove all {[type]} - causes parsing errors.

### DIFF
--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -58,10 +58,10 @@ Object.assign(Alerts, {
    * }, callbackFunction);
    *
    * @param  {String|Object} titleOrOptions Pass a string or an object containing options
-   * @param  {[type]}   messageOrCallback [description]
-   * @param  {[type]}   options           [description]
+   * @param  {String}   messageOrCallback [description]
+   * @param  {Object}   options           [description]
    * @param  {Function} callback          [description]
-   * @return {[type]}                     [description]
+   * @return {undefined}                     [description]
    */
   alert(titleOrOptions, messageOrCallback, options, callback) {
     if (_.isObject(titleOrOptions)) {

--- a/imports/plugins/included/inventory/server/methods/statusChanges.js
+++ b/imports/plugins/included/inventory/server/methods/statusChanges.js
@@ -148,8 +148,8 @@ Meteor.methods({
    * inventory/clearStatus
    * @summary used to reset status on inventory item (defaults to "new")
    * @param  {Array} cartItems array of objects Schemas.CartItem
-   * @param  {[type]} status optional reset workflow.status, defaults to "new"
-   * @param  {[type]} currentStatus optional matching workflow.status, defaults to "reserved"
+   * @param  {String} status optional reset workflow.status, defaults to "new"
+   * @param  {String} currentStatus optional matching workflow.status, defaults to "reserved"
    * @return {undefined} undefined
    */
   "inventory/clearStatus": function (cartItems, status, currentStatus) {

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -132,7 +132,7 @@ export const cartOrderTransform = {
   /**
    * Aggregates the taxes by shopId
    * @method getTaxesByShop
-   * @return {[type]} An object with a key for each shopId in the cart/order where the value is the tax total for that shop
+   * @return {Object} An object with a key for each shopId in the cart/order where the value is the tax total for that shop
    */
   getTaxesByShop() {
     const subtotals = this.getSubtotalByShop();

--- a/server/api/core/assignRoles.js
+++ b/server/api/core/assignRoles.js
@@ -9,8 +9,8 @@ import { Logger } from "/server/api";
  * however this is to avoid a dependency in core
  * on the router
  * prefix/package name + registry name or route
- * @param  {[type]} packageName  [package name]
- * @param  {[type]} registryItem [registry object]
+ * @param  {String} packageName  [package name]
+ * @param  {Object} registryItem [registry object]
  * @return {String}              [route name]
  */
 function getRouteName(packageName, registryItem) {


### PR DESCRIPTION
The jsdoc Atom package adds `{[type]}` for you as you add doc tags. If you don't fill it out, the `{[type]}` will cause a parse error!

I went through all the instances of `{[type]}` in master and fixed them so we don't get parse errors.