### PR TITLE
jsdoc: reformat react components proptypes

### DIFF
--- a/imports/plugins/core/checkout/client/components/addEmail.js
+++ b/imports/plugins/core/checkout/client/components/addEmail.js
@@ -6,12 +6,12 @@ import { Reaction, i18next } from "/client/api";
 import { Components } from "@reactioncommerce/reaction-components";
 
 /**
- * @summary Allows user to add an email after completing an order
- * @param {Object} props - React PropTypes
- * @property {Object} order - An object representing the order
- * @property {String} orderEmail - a string containing the email attached to the order if it exists
- * @return {Node} React node containing input box when no email has been attached to the order
+ * @file AddEmail React Component allows user to add an email after completing an order
+ *
+ * @module AddEmail
+ * @extends Component
  */
+
 class AddEmail extends Component {
   constructor(props) {
     super(props);
@@ -25,6 +25,8 @@ class AddEmail extends Component {
   }
 
   /**
+   * @name handleFieldChange()
+   * @method
    * @summary handle setting state whenever the field on the form change
    * @param {Event} event - the event that fired
    * @param {String} value - the new value for the field
@@ -38,6 +40,8 @@ class AddEmail extends Component {
   };
 
   /**
+   * @name handleSubmit()
+   * @method
    * @summary Handle submitting the email form
    * @param {Event} event - the event that fired
    * @returns {null} null
@@ -107,6 +111,14 @@ class AddEmail extends Component {
   }
 }
 
+/**
+ * @name AddEmail propTypes
+ * @type {propTypes}
+ * @param {Object} props - React PropTypes
+ * @property {Object} order - An object representing the order
+ * @property {String} orderEmail - a string containing the email attached to the order if it exists
+ * @return {Node} React node containing input box when no email has been attached to the order
+ */
 AddEmail.propTypes = {
   order: PropTypes.object,
   orderEmail: PropTypes.string

--- a/imports/plugins/core/orders/client/components/invoiceActions.js
+++ b/imports/plugins/core/orders/client/components/invoiceActions.js
@@ -4,26 +4,34 @@ import { formatPriceString } from "/client/api";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 
 /**
-  * @summary React component for displaying the actionable data on the invoice section on the orders sideview
-  * @param {Object} props - React PropTypes
-  * @property {Object} invoice - An object representing an invoice
-  * @property {Array} refunds - An array/list of refunds
-  * @property {Function} handleApprove - A function for approving payments
-  * @property {Function} handleCapturePayment - A function for capturing payments
-  * @property {Function} handleRefund - A function for refunding payments
-  * @property {Object} currency - A object represting current shop currency details
-  * @property {String} printOrder - A string representing the route/path for printed order
-  * @property {Number} adjustedTotal - The calculated adjusted total after refunds/discounts
-  * @property {Bool} paymentCaptured - A boolean indicating whether payment has been captured
-  * @property {Bool} hasRefundingEnabled - A boolean indicating whether payment supports refunds
-  * @property {Bool} paymentApproved - A boolean indicating whether payment has been approved
-  * @property {Bool} paymentPendingApproval - A boolean indicating whether payment is yet to be approved
-  * @property {Bool} showAfterPaymentCaptured - A boolean indicating that status of the order is completed
-  * @property {Bool} isCapturing - A boolean indicating whether payment is being captured
-  * @property {Bool} isRefunding - A boolean indicating whether payment is being refunded
-  * @return {Node} React node containing component for displaying the `invoice` section on the orders sideview
-  */
+ * @file InvoiceActions React Component for displaying the actionable data on the invoice section on the orders sideview
+ *
+ * @module InvoiceActions
+ * @extends Component
+ */
+
 class InvoiceActions extends Component {
+  /**
+   * @name InvoiceActions propTypes
+   * @summary React component for displaying the actionable data on the invoice section on the orders sideview
+   * @param {Object} props - React PropTypes
+   * @property {Object} invoice - An object representing an invoice
+   * @property {Array} refunds - An array/list of refunds
+   * @property {Function} handleApprove - A function for approving payments
+   * @property {Function} handleCapturePayment - A function for capturing payments
+   * @property {Function} handleRefund - A function for refunding payments
+   * @property {Object} currency - A object represting current shop currency details
+   * @property {String} printOrder - A string representing the route/path for printed order
+   * @property {Number} adjustedTotal - The calculated adjusted total after refunds/discounts
+   * @property {Bool} paymentCaptured - A boolean indicating whether payment has been captured
+   * @property {Bool} hasRefundingEnabled - A boolean indicating whether payment supports refunds
+   * @property {Bool} paymentApproved - A boolean indicating whether payment has been approved
+   * @property {Bool} paymentPendingApproval - A boolean indicating whether payment is yet to be approved
+   * @property {Bool} showAfterPaymentCaptured - A boolean indicating that status of the order is completed
+   * @property {Bool} isCapturing - A boolean indicating whether payment is being captured
+   * @property {Bool} isRefunding - A boolean indicating whether payment is being refunded
+   * @return {Node} React node containing component for displaying the `invoice` section on the orders sideview
+   */
   static propTypes = {
     adjustedTotal: PropTypes.number,
     currency: PropTypes.object,

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -9,27 +9,35 @@ import { formatPriceString } from "/client/api";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 
 /**
-  * @summary React component for displaying the actionable data on the invoice section on the orders sideview
-  * @param {Object} props - React PropTypes
-  * @property {Object} order - An object represnting an order
-  * @property {Object} uniqueItems - An object representing a line item
-  * @property {Array} editedItems - An array/list of line items that have been edited/modified
-  * @property {Array} selectedItems - An array of all the line items  that have been selected
-  * @property {Function} displayMedia - A function to display line items images
-  * @property {Function} clearRefunds - A function to clear edited/selected items
-  * @property {Function} getRefundedItemsInfo - A function that returns an object containing refunded items info
-  * @property {Function} getSelectedItemsInfo - A function that returns an object containing selected items info
-  * @property {Function} handleInputChange - A function to handle numeric input change
-  * @property {Function} handleItemSelect - A function to handle selecting an item via chekbox
-  * @property {Function} handlePopOverOpen - A function to handle the popover open and close
-  * @property {Function} handleRefundItems - A function to handle items return
-  * @property {Function} handleSelectAllItems - A function to handle selecting of all items
-  * @property {Bool} selectAllItems - A boolean indicating whether all items have been selected
-  * @property {Bool} isRefunding - A boolean indicating whether payment is being refunded
-  * @property {Bool} popOverIsOpen - A boolean indicating whether popover is open
-  * @return {Node} React node containing component for displaying the `invoice` section on the orders sideview
-  */
+ * @file LineItems React Component for displaying the actionable data on the invoice section on the orders sideview
+ *
+ * @module LineItems
+ * @extends Component
+ */
+
 class LineItems extends Component {
+  /**
+   * @name LineItems propTypes
+   * @summary React component for displaying the actionable data on the invoice section on the orders sideview
+   * @param {Object} props - React PropTypes
+   * @property {Object} order - An object represnting an order
+   * @property {Object} uniqueItems - An object representing a line item
+   * @property {Array} editedItems - An array/list of line items that have been edited/modified
+   * @property {Array} selectedItems - An array of all the line items  that have been selected
+   * @property {Function} displayMedia - A function to display line items images
+   * @property {Function} clearRefunds - A function to clear edited/selected items
+   * @property {Function} getRefundedItemsInfo - A function that returns an object containing refunded items info
+   * @property {Function} getSelectedItemsInfo - A function that returns an object containing selected items info
+   * @property {Function} handleInputChange - A function to handle numeric input change
+   * @property {Function} handleItemSelect - A function to handle selecting an item via chekbox
+   * @property {Function} handlePopOverOpen - A function to handle the popover open and close
+   * @property {Function} handleRefundItems - A function to handle items return
+   * @property {Function} handleSelectAllItems - A function to handle selecting of all items
+   * @property {Bool} selectAllItems - A boolean indicating whether all items have been selected
+   * @property {Bool} isRefunding - A boolean indicating whether payment is being refunded
+   * @property {Bool} popOverIsOpen - A boolean indicating whether popover is open
+   * @return {Node} React node containing component for displaying the `invoice` section on the orders sideview
+   */
   static propTypes = {
     clearRefunds: PropTypes.func,
     displayMedia: PropTypes.func,

--- a/imports/plugins/core/orders/client/components/orderSearch.js
+++ b/imports/plugins/core/orders/client/components/orderSearch.js
@@ -4,11 +4,19 @@ import PropTypes from "prop-types";
 import { Components, registerComponent, withPermissions } from "@reactioncommerce/reaction-components";
 
 /**
- * React class for Search bar on Order Dashboard
- * @summary horizontal search bar on the order dashboard. can be replaced with registerComponent as "OrderSearch"
- * @property {Function} handleChange - function called to update state field on parent after search input text changes
+ * @file React class for Search bar on Order Dashboard
+ *
+ * @module OrderSearch
+ * @extends Component
  */
+
 class OrderSearch extends Component {
+  /**
+   * @name OrderSearch propTypes
+   * @type {propTypes}
+   * @summary horizontal search bar on the order dashboard. can be replaced with registerComponent as "OrderSearch"
+   * @property {Function} handleChange - function called to update state field on parent after search input text changes
+   */
   static propTypes = {
     handleChange: PropTypes.func
   };
@@ -18,10 +26,12 @@ class OrderSearch extends Component {
   }
 
   /**
-    * handleChange - handler to call onchange of search input
-    * @param {string} event - event object
-    * @return {null} -
-    */
+   * @name handleChange()
+   * @method
+   * @summary handleChange - handler to call onchange of search input
+   * @param {string} event - event object
+   * @return {null} -
+   */
   handleChange = (event) => {
     const value = event.target.value;
 
@@ -32,9 +42,11 @@ class OrderSearch extends Component {
   }
 
   /**
-    * handleClear - handler called onclick of search clear text
-    * @return {null} -
-    */
+   * @name handleClear()
+   * @method
+   * @summary handleClear - handler called onclick of search clear text
+   * @return {null} -
+   */
   handleClear = () => {
     this.setState({
       value: ""


### PR DESCRIPTION
## What this PR does
- Adds `@type {propTypes}` to AddEmail, InvoiceActions, LineItems and OrderSearch React components

## Notes
These React components are part of different `imports/plugins/core` packages. In later PRs, I would like to group these components as a `@module` (or `@namespace` maybe) as a part of that package as a whole. For now, however, since the rest of the packages are not documented yet, I would like to simply reformat these components as individuals so that 1) the propTypes render correctly and 2) the sidebar makes these components visible. Better fixes to come after!
