### PR TITLE
Add AWS region for api publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: Deploy to S3 if tests pass and branch is Master
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              aws s3 sync /tmp/reaction-docs ${API_DOC_BUCKET} --delete --region us-west-2
+              aws s3 sync /tmp/reaction-docs ${API_DOC_BUCKET} --delete --region ${API_DOC_BUCKET_REGION}
             else
               echo "Not master branch so not deploying"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: Deploy to S3 if tests pass and branch is Master
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              aws s3 sync /tmp/reaction-docs s3://api.docs.reactioncommerce.com/ --delete
+              aws s3 sync /tmp/reaction-docs ${API_DOC_BUCKET} --delete --region us-west-2
             else
               echo "Not master branch so not deploying"
             fi


### PR DESCRIPTION
- While working w/o locally, region is needed on circleci 
- tested via ci ssh
- adds `API_DOC_BUCKET`, `API_DOC_BUCKET_REGION` to env variables for CircleCI