### PR TITLE
Casting strings to ints

### DIFF
--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -585,10 +585,10 @@ export const methods = {
     let tracking;
     let carrier = "";
     for (const billingRecord of order.billing) {
-      subtotal += billingRecord.invoice.subtotal;
-      taxes += billingRecord.invoice.taxes;
-      discounts += billingRecord.invoice.discounts;
-      amount += billingRecord.paymentMethod.amount;
+      subtotal += parseFloat(billingRecord.invoice.subtotal);
+      taxes += parseFloat(billingRecord.invoice.taxes);
+      discounts += parseFloat(billingRecord.invoice.discounts);
+      amount += parseFloat(billingRecord.paymentMethod.amount);
       address = billingRecord.address;
       paymentMethod = billingRecord.paymentMethod;
     }


### PR DESCRIPTION
Fix for #3120 

The problem was that the prices are being stored as Strings. So while summing casting has to be done.

### To Test
1. Place a order and checkout
2. In the mail received, the total would be a float.

