### PR TITLE
Update methods supported by payment providers.

### DIFF
--- a/imports/plugins/included/payments-authnet/lib/collections/schemas/authnet.js
+++ b/imports/plugins/included/payments-authnet/lib/collections/schemas/authnet.js
@@ -23,7 +23,7 @@ export const AuthNetPackageConfig = new SimpleSchema([
     },
     "settings.reaction-auth-net.support.$": {
       type: String,
-      allowedValues: ["Authorize", "De-authorize", "Capture", "Refund"]
+      allowedValues: ["Authorize", "De-authorize", "Capture"]
     },
     "settings.api_id": {
       type: String,

--- a/imports/plugins/included/payments-authnet/register.js
+++ b/imports/plugins/included/payments-authnet/register.js
@@ -17,8 +17,7 @@ Reaction.registerPackage({
       enabled: false,
       support: [
         "Authorize",
-        "Capture",
-        "Refund"
+        "Capture"
       ]
     }
   },


### PR DESCRIPTION
Resolves #3085 

This PR sets default support methods for payment providers. For a payment provider that doesn't support refund the Refund button is unavailable.

## Test Instructions
- Login as admin and configure shipping and Authorize.net as payment provider
- Create an order and capture it
- Try to process a refund, observe that the refund option is not shown (unavailable)