### PR TITLE
Fixes reaction issue #3154

### DIFF
--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -21,6 +21,10 @@ const { Jobs, Packages, Shops, Groups } = Collections;
 export default {
 
   init() {
+
+    // run beforeCoreInit hooks
+    Hooks.Events.run("beforeCoreInit");
+
     // make sure the default shop has been created before going further
     while (!this.getShopId()) {
       Logger.warn("No shopId, waiting one second...");


### PR DESCRIPTION
Resolves #3154 

This PR provides a new hook in the very first line of initialization function, right before the shopId validation.
Version 1.5.0 came with a new validation in server/startup/load-data that uses SKIP_FIXTURES environment variable to skip default data load.
With this new hook a user could load default data from a custom plugin before the shopId validation.

**Test**
+ In the server/init.js file from a custom plugin add a new function to the hook
```javascript
Hooks.Events.add("beforeCoreInit", () => {
  CustomDataImportModule.startJob();
});
```
+ Then run reaction skipping default data
```bash
SKIP_FIXTURES=true reaction
```
