### PR TITLE
Fix missing product grid images

### DIFF
--- a/imports/plugins/included/product-variant/components/productGridItems.js
+++ b/imports/plugins/included/product-variant/components/productGridItems.js
@@ -57,7 +57,7 @@ class ProductGridItems extends Component {
       );
     }
     return (
-      <span className="product-image" style={{ backgroundImage: `url(${this.props.media().url({ store: "large" })})` }}/>
+      <span className="product-image" style={{ backgroundImage: `url('${this.props.media().url({ store: "large" })}')` }}/>
     );
   }
 
@@ -67,7 +67,7 @@ class ProductGridItems extends Component {
         return (
           <div className={`product-additional-images ${this.renderVisible()}`}>
             {this.props.additionalMedia().map((media) => {
-              return <span key={media._id} className="product-image" style={{ backgroundImage: `url(${media.url({ store: "medium" })})` }} />;
+              return <span key={media._id} className="product-image" style={{ backgroundImage: `url('${media.url({ store: "medium" })}')` }} />;
             })}
             {this.renderOverlay()}
           </div>


### PR DESCRIPTION
Resolves #3137 

This PR fixes the issue on images with spaces in filename not showing up on the product grid page.

## Test

1. Login as admin
2. Add product and create product variant
3. Upload image from filename with one or more spaces in it & publish
4. See that it shows on PDP page
5. Go to product grid and see that it shows