### PR TITLE
Show pointer cursor to admins only

### DIFF
--- a/imports/plugins/core/ui/client/components/media/media.js
+++ b/imports/plugins/core/ui/client/components/media/media.js
@@ -103,7 +103,7 @@ class MediaItem extends Component {
   }
 
   render() {
-    const classes = { "gallery-image": true, "img-cursor": Reaction.hasAdminAccess() };
+    const classes = { "gallery-image": true, "admin-gallery-image": Reaction.hasAdminAccess() };
     const mediaElement = (
       <div
         className={classnames(classes)}

--- a/imports/plugins/core/ui/client/components/media/media.js
+++ b/imports/plugins/core/ui/client/components/media/media.js
@@ -1,7 +1,9 @@
 import React, { Component } from "react";
+import classnames from "classnames";
 import PropTypes from "prop-types";
 import { SortableItem } from "../../containers";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
+import { Reaction } from "/client/api";
 
 class MediaItem extends Component {
   handleMouseEnter = (event) => {
@@ -101,9 +103,10 @@ class MediaItem extends Component {
   }
 
   render() {
+    const classes = { "gallery-image": true, "img-cursor": Reaction.hasAdminAccess() };
     const mediaElement = (
       <div
-        className="gallery-image"
+        className={classnames(classes)}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
       >

--- a/imports/plugins/core/ui/client/components/media/mediaGallery.js
+++ b/imports/plugins/core/ui/client/components/media/mediaGallery.js
@@ -2,7 +2,9 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Dropzone from "react-dropzone";
 import Measure from "react-measure";
+import classnames from "classnames";
 import { Components } from "@reactioncommerce/reaction-components";
+import { Reaction } from "/client/api";
 
 class MediaGallery extends Component {
   constructor() {
@@ -132,6 +134,7 @@ class MediaGallery extends Component {
 
   renderMediaGalleryUploader() {
     const containerWidth = this.props.mediaGalleryWidth;
+    const classes = { "admin-featuredImage": Reaction.hasAdminAccess() };
     let featured = this.renderAddItem();
     let gallery;
 
@@ -153,7 +156,7 @@ class MediaGallery extends Component {
           accept="image/jpg, image/png, image/jpeg"
         >
           <div className="rui gallery">
-            <div className="featuredImage" style={{ height: containerWidth + "px" }}>
+            <div className={classnames(classes)} style={{ height: containerWidth + "px" }}>
               {featured}
             </div>
             <div className="rui gallery-thumbnails">
@@ -168,11 +171,12 @@ class MediaGallery extends Component {
 
   renderMediaGallery() {
     const containerWidth = this.props.mediaGalleryWidth;
+    const classes = { "admin-featuredImage": Reaction.hasAdminAccess() };
 
     return (
       <div className="rui media-gallery">
         <div className="rui gallery">
-          <div className="featuredImage" style={{ height: containerWidth + "px" }}>
+          <div className={classnames(classes)} style={{ height: containerWidth + "px" }}>
             {this.renderFeaturedMedia()}
           </div>
           <div className="rui gallery-thumbnails">

--- a/imports/plugins/included/default-theme/client/styles/media.less
+++ b/imports/plugins/included/default-theme/client/styles/media.less
@@ -24,6 +24,10 @@
 .rui.media-gallery .gallery-image:hover {
   background-color: @list-group-hover-bg;
   opacity: 0.7;
+  // cursor: pointer;
+}
+
+.img-cursor {
   cursor: pointer;
 }
 

--- a/imports/plugins/included/default-theme/client/styles/media.less
+++ b/imports/plugins/included/default-theme/client/styles/media.less
@@ -23,12 +23,14 @@
 // Gallery all images
 .rui.media-gallery .gallery-image:hover {
   background-color: @list-group-hover-bg;
-  opacity: 0.7;
-  // cursor: pointer;
 }
 
-.img-cursor {
+.admin-gallery-image {
   cursor: pointer;
+}
+
+.admin-gallery-image:hover {
+  opacity: 0.7;
 }
 
 .rui.media-gallery .gallery-image .img-responsive {
@@ -130,6 +132,7 @@
   margin: 0;
   width: 100%;
   height: 100%;
+  cursor: pointer;
 }
 
 .rui.media-gallery .gallery-image.gallery-tools {

--- a/imports/plugins/included/default-theme/client/styles/media.less
+++ b/imports/plugins/included/default-theme/client/styles/media.less
@@ -21,18 +21,6 @@
 
 
 // Gallery all images
-.rui.media-gallery .gallery-image:hover {
-  background-color: @list-group-hover-bg;
-}
-
-.admin-gallery-image {
-  cursor: pointer;
-}
-
-.admin-gallery-image:hover {
-  opacity: 0.7;
-}
-
 .rui.media-gallery .gallery-image .img-responsive {
   width: 100%;
 }
@@ -150,4 +138,18 @@
 
 .rui.media-gallery .gallery-image:hover .gallery-tools a {
   color: @gray-dark;
+}
+
+.admin-gallery-image {
+  cursor: pointer;
+
+  &:hover {
+    background-color: @list-group-hover-bg;
+    opacity: 0.7;
+  }
+}
+
+.admin-featuredImage:hover {
+  background-color: @list-group-hover-bg;
+  opacity: 0.8;
 }


### PR DESCRIPTION
Resolves #3101 

This PR ensures that the pointer cursor is only visible to admins on the PDP image and also ensures the hover effect is not visible to non-admins.

## Test
1. Login as admin in a browser
2. Open the app in another browser either by logging in as a non-admin or without logging in
3. Click on a product with image set in both browsers
4. On the browser you're logged in as an admin hover the mouse the product's image, confirm you see a pointer cursor
5. On the other browser, confirm you see the default cursor

