### PR TITLE
Determine if password reset overlay is setting or resetting password

### DIFF
--- a/imports/plugins/core/accounts/client/components/updatePasswordOverlay.js
+++ b/imports/plugins/core/accounts/client/components/updatePasswordOverlay.js
@@ -12,6 +12,7 @@ class UpdatePasswordOverlay extends Component {
     onCancel: PropTypes.func,
     onError: PropTypes.func,
     onFormSubmit: PropTypes.func,
+    type: PropTypes.string,
     uniqueId: PropTypes.string
   }
 
@@ -77,6 +78,7 @@ class UpdatePasswordOverlay extends Component {
   }
 
   renderSpinnerOnWait() {
+    const { type } = this.props;
     if (this.props.isDisabled === true) {
       return (
         <div className="col-sm-6" style={{ textAlign: "center" }}>
@@ -84,6 +86,22 @@ class UpdatePasswordOverlay extends Component {
         </div>
       );
     }
+
+    if (type === "setPassword") {
+      return (
+        <div className="col-sm-6">
+          <Components.Button
+            className="btn-block"
+            primary={true}
+            bezelStyle="solid"
+            i18nKeyLabel="accountsUI.setPassword"
+            label="Set your password"
+            type="submit"
+          />
+        </div>
+      );
+    }
+
     return (
       <div className="col-sm-6">
         <Components.Button
@@ -106,6 +124,20 @@ class UpdatePasswordOverlay extends Component {
     );
   }
 
+  renderPasswordResetText() {
+    const { type } = this.props;
+
+    if (type === "setPassword") {
+      return (
+        <Components.Translation defaultValue="Set Your Password" i18nKey="accountsUI.setPassword"/>
+      );
+    }
+
+    return (
+      <Components.Translation defaultValue="Update Your Password" i18nKey="accountsUI.updateYourPassword"/>
+    );
+  }
+
   render() {
     const passwordClasses = classnames({
       "form-group": true,
@@ -124,7 +156,7 @@ class UpdatePasswordOverlay extends Component {
                 <form className="modal-content" onSubmit={this.handleSubmit}>
                   <div className="modal-header">
                     <h4 className="modal-title">
-                      <Components.Translation defaultValue="Update Your Password" i18nKey="accountsUI.updateYourPassword"/>
+                      {this.renderPasswordResetText()}
                     </h4>
                   </div>
 

--- a/imports/plugins/core/accounts/client/containers/passwordOverlay.js
+++ b/imports/plugins/core/accounts/client/containers/passwordOverlay.js
@@ -16,6 +16,7 @@ const wrapComponent = (Comp) => (
       formMessages: PropTypes.object,
       isOpen: PropTypes.bool,
       token: PropTypes.string,
+      type: PropTypes.string,
       uniqueId: PropTypes.string
     }
 
@@ -120,6 +121,7 @@ const wrapComponent = (Comp) => (
             onCancel={this.handleFormCancel}
             isOpen={this.state.isOpen}
             isDisabled={this.state.isDisabled}
+            type={this.props.type}
           />
         </TranslationProvider>
       );

--- a/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
+++ b/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
@@ -17,7 +17,8 @@ Accounts.onResetPasswordLink((token, done) => {
   Blaze.renderWithData(Template.loginFormUpdatePasswordOverlay, {
     token: token,
     callback: done,
-    isOpen: true
+    isOpen: true,
+    type: "updatePassword"
   }, $("body").get(0));
 });
 
@@ -29,7 +30,8 @@ Accounts.onEnrollmentLink((token, done) => {
   Blaze.renderWithData(Template.loginFormUpdatePasswordOverlay, {
     token: token,
     callback: done,
-    isOpen: true
+    isOpen: true,
+    type: "setPassword"
   }, $("body").get(0));
 });
 


### PR DESCRIPTION
This PR adds a prop, `type`, which determines what type of password overlay we are seeing: a password reset, or an initial password setting overlay, which only happens when a new user is invited via email.

This will allow us to update the text shown for each type of display independently, as the language is currently confusing, only allowing the same text for both types of forms.

This is step one to resolving #2797 

To test:
1) Invite a user, via the Accounts dashboard
2) See the password modal displays `Set password` text
3) Log out, and send a password reset email to the same user
4) See the password modal displays `Update password` text