### PR TITLE
jsdoc: document methods into Methods/Taxes, Methods/Templates

### DIFF
--- a/imports/plugins/core/taxes/server/methods/methods.js
+++ b/imports/plugins/core/taxes/server/methods/methods.js
@@ -5,12 +5,18 @@ import { Taxes } from "../../lib/collections";
 import Reaction from "../api";
 import { Logger } from "/server/api";
 
-//
-// make all tax methods available
-//
+/**
+ * @file Methods for Taxes. Run these methods using `Meteor.call()`.
+ *
+ *
+ * @namespace Methods/Taxes
+*/
+
 export const methods = {
   /**
-   * taxes/deleteRate
+   * @name taxes/deleteRate
+   * @method
+   * @memberof Methods/Taxes
    * @param  {String} taxId tax taxId to delete
    * @return {String} returns update/insert result
    */
@@ -26,7 +32,9 @@ export const methods = {
   },
 
   /**
-   * taxes/addRate
+   * @name taxes/addRate
+   * @method
+   * @memberof Methods/Taxes
    * @param  {String} modifier update statement
    * @param  {String} docId    tax docId
    * @return {String} returns update/insert result
@@ -48,8 +56,10 @@ export const methods = {
   },
 
   /**
-   * taxes/setRate
-   * update the cart without hooks
+   * @name taxes/setRate
+   * @summary Update the cart without hooks
+   * @method
+   * @memberof Methods/Taxes
    * @param  {String} cartId cartId
    * @param  {Number} taxRate taxRate
    * @param  {Object} taxes taxes
@@ -69,15 +79,16 @@ export const methods = {
   },
 
   /**
-   * taxes/setRateByShopAndItem
-   * update the cart without hooks
-   * Options:
-   *   taxRatesByShop - Object shopIds: taxRates
-   *   itemsWithTax - items array with computed tax details
-   *   cartTaxRate - tax rate for shop associated with cart.shopId
-   *   cartTaxData - tax data for shop associated with cart.shopId
+   * @name taxes/setRateByShopAndItem
+   * @method
+   * @memberof Methods/Taxes
+   * @summary Update the cart without hooks
    * @param  {String} cartId cartId
    * @param  {Object} options - Options object
+   * @param  {Object} options.taxRatesByShop - Object shopIds: taxRates
+   * @param  {Array}  options.itemsWithTax - Items array with computed tax details
+   * @param  {Object} options.cartTaxRate - Tax rate for shop associated with cart.shopId
+   * @param  {Object} options.cartTaxData - Tax data for shop associated with cart.shopId
    * @return {Number} returns update result
    */
   "taxes/setRateByShopAndItem": function (cartId, options) {
@@ -102,7 +113,9 @@ export const methods = {
   },
 
   /**
-   * taxes/calculate
+   * @name taxes/calculate
+   * @method
+   * @memberof Methods/Taxes
    * @param  {String} cartId cartId
    * @return {Object}  returns tax object
    */
@@ -222,5 +235,4 @@ export const methods = {
   } // end taxes/calculate
 };
 
-// export tax methods to Meteor
 Meteor.methods(methods);

--- a/imports/plugins/core/templates/server/methods.js
+++ b/imports/plugins/core/templates/server/methods.js
@@ -2,10 +2,20 @@ import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Templates } from "/lib/collections";
 
+/**
+ * @file Methods for Templates. Run these methods using `Meteor.call()`.
+ *
+ *
+ * @namespace Methods/Templates
+*/
+
 export const methods = {
   /**
-   * templates/email/update
-   * @summary updates email template in Templates collection
+   * @name templates/email/update
+   * @method
+   * @memberof Methods/Templates
+   * @todo Add permissions
+   * @summary Updates email template in Templates collection
    * @param {String} templateId - id of template to remove
    * @param {Object} doc - data to update
    * @return {Number} remove template


### PR DESCRIPTION
## What this PR does
- add Methods/Taxes methods as namespace from core Taxes plugin
- adds Methods/Templates method as namespace from core Templates plugin

## What that renders

![screen shot 2017-10-24 at 6 41 23 pm](https://user-images.githubusercontent.com/3673236/31976210-f7d976c6-b8ea-11e7-8e08-7c0487a5f767.png)
