### PR TITLE
jsdoc: add Helpers methods namespace

### DIFF
--- a/client/modules/core/helpers/globals.js
+++ b/client/modules/core/helpers/globals.js
@@ -3,16 +3,15 @@ import { Session } from "meteor/session";
 import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 
-// Reaction Globals
-//
-// These should all be removed. PR's happily accepted.
-//
 /* eslint "no-extend-native": [2, {"exceptions": ["String"]}] */
 /* eslint "no-alert": 0 */
 
 /**
- * toggleSession
- * quick and easy snippet for toggling sessions
+ * @name toggleSession
+ * @method
+ * @memberof Helpers
+ * @todo These should all be removed. PR's happily accepted.
+ * @summary Quick and easy snippet for toggling sessions
  * @param {String} sessionVariable - string name, see http://docs.meteor.com/#/basic/session
  * @param {String} positiveState - optional, if is is positiveState, set opposite
  * @return {Object} return session value
@@ -28,10 +27,12 @@ export function toggleSession(sessionVariable, positiveState) {
   return Session.get(sessionVariable);
 }
 
-
 /**
- * getCardTypes
- * @summary determine the card type and return label
+ * @name getCardTypes
+ * @method
+ * @memberof Helpers
+ * @todo These should all be removed. PR's happily accepted.
+ * @summary Determine the card type and return label
  * @todo needs i18n conversion?
  * @param {String} cardNumber - a credit card number
  * @return {String} card label, ie: visa
@@ -57,8 +58,11 @@ export function getCardType(cardNumber) {
 }
 
 /**
- * getGuestLoginState
- * @summary determines if a guest checkout is enabled and the login state for users
+ * @name getGuestLoginState
+ * @method
+ * @memberof Helpers
+ * @todo These should all be removed. PR's happily accepted.
+ * @summary Determines if a guest checkout is enabled and the login state for users
  * @return {Boolean} true if authenticated user
  */
 export function getGuestLoginState() {

--- a/client/modules/core/helpers/utils.js
+++ b/client/modules/core/helpers/utils.js
@@ -1,9 +1,12 @@
 import { slugify } from "transliteration";
 
 /**
- * getSlug - return a client slugified string using the "slugify"
- * global from the transliteration package
- * https://www.npmjs.com/package/transliteration
+ * @name getSlug
+ * @summary Return a client slugified string using the "slugify" global from the transliteration package
+ * @see https://www.npmjs.com/package/transliteration
+ * @method
+ * @memberof Helpers
+ * @locus Client
  * @param  {String} slugString - string to slugify
  * @return {String} slugified string
  */

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -4,6 +4,11 @@ import { Meteor } from "meteor/meteor";
 import { Router } from "/imports/plugins/core/router/lib";
 import { Shops } from "/lib/collections";
 
+/**
+ * @file Various helper methods
+ *
+ * @namespace Helpers
+ */
 
 let Core;
 if (Meteor.isClient) {
@@ -13,20 +18,29 @@ if (Meteor.isClient) {
 }
 
 /**
- * getShopId
+ * @name getShopId
+ * @method
+ * @memberof Helpers
  * @return {String} returns current shopId
  */
 export function getShopId() {
   return Core.Reaction.getShopId();
 }
 
+/**
+ * @name getPrimaryShopId
+ * @method
+ * @memberof Helpers
+ * @return {String} returns primary shopId
+ */
 export function getPrimaryShopId() {
   return Core.Reaction.getPrimaryShopId();
 }
 
-
 /**
- * getShopName
+ * @name getShopName
+ * @method
+ * @memberof Helpers
  * @return {String} returns current shop name
  */
 export function getShopName() {
@@ -49,7 +63,9 @@ export function getShopName() {
 }
 
 /**
- * getShopPrefix
+ * @name getShopPrefix
+ * @method
+ * @memberof Helpers
  * @param {String} leading - Default "/", prefix, the prefix with a leading shash
  * @return {String} returns shop url prefix
  */
@@ -88,7 +104,9 @@ export function getShopPrefix(leading = "/") {
 }
 
 /**
- * getAbsoluteUrl
+ * @name getAbsoluteUrl
+ * @method
+ * @memberof Helpers
  * @param {String} path - path to append to absolute Url, path should be prefixed with / if necessary
  * @return {String} returns absolute url (shop prefix + path)
  */
@@ -103,7 +121,9 @@ export function getAbsoluteUrl(path) {
 }
 
 /**
- * getCurrentTag
+ * @name getCurrentTag
+ * @method
+ * @memberof Helpers
  * @return {String} returns current tag
  */
 export function getCurrentTag() {
@@ -113,9 +133,11 @@ export function getCurrentTag() {
   return null;
 }
 
-
 /**
- * getSlug - return a slugified string using "slugify" from transliteration
+ * @name getSlug
+ * @method
+ * @memberof Helpers
+ * @summary return a slugified string using "slugify" from transliteration
  * https://www.npmjs.com/package/transliteration
  * @param  {String} slugString - string to slugify
  * @return {String} slugified string
@@ -125,8 +147,10 @@ export function getSlug(slugString) {
 }
 
 /**
- * toCamelCase helper for i18n
- * @summary special toCamelCase for converting a string to camelCase for use with i18n keys
+ * @name toCamelCase
+ * @method
+ * @memberof Helpers
+ * @summary helper for i18n - special toCamelCase for converting a string to camelCase for use with i18n keys
  * @param {String} needscamels String to be camel cased.
  * @return {String} camelCased string
  */
@@ -143,7 +167,9 @@ export function toCamelCase(needscamels) {
 }
 
 /**
- * translateRegistry
+ * @name translateRegistry
+ * @method
+ * @memberof Helpers
  * @summary adds i18n strings to registry object
  * @param {Object} registry registry object
  * @param {Object} [app] complete package object
@@ -173,7 +199,10 @@ export function translateRegistry(registry, app) {
 }
 
 /**
- * Simple is object check.
+ * @name isObject
+ * @method
+ * @memberof Helpers
+ * @summary Simple is object check.
  * @param {Object} item item to check if is an object
  * @returns {boolean} return true if object
  */
@@ -182,7 +211,10 @@ export function isObject(item) {
 }
 
 /**
- * Helper for Deep merge two objects.
+ * @name mergeDeep
+ * @method
+ * @memberof Helpers
+ * @summary Helper for Deep merge two objects.
  * @param {Object} target deep merge into this object
  * @param {Object} source merge this object
  * @returns {Object} return deep merged object

--- a/server/api/core/utils.js
+++ b/server/api/core/utils.js
@@ -1,8 +1,12 @@
 import { slugify } from "transliteration";
 
 /**
- * getSlug - return a slugified string using "slugify" from transliteration
- * https://www.npmjs.com/package/transliteration
+ * @name getSlug
+ * @summary Return a slugified string using "slugify" from transliteration
+ * @see https://www.npmjs.com/package/transliteration
+ * @method
+ * @memberof Helpers
+ * @locus Server
  * @param  {String} slugString - string to slugify
  * @return {String} slugified string
  */


### PR DESCRIPTION
## What this PR does:
- Adds `Helpers` namespace for both client and server-side methods

## Questions for discussion:
- Should Helpers be broken out into Client-side helpers and Server-side helpers?
- Example: There are 3 methods named `getSlug()`, from `lib/api/helpers.js`, `
client/modules/core/helpers/utils.js`, `server/api/core/utils.js`. Should these be in separate Helper buckets, like `Client-side Helpers`, `Server-side Helpers` and `API Helpers`?

<img width="1197" alt="screen shot 2017-10-25 at 12 38 47 pm" src="https://user-images.githubusercontent.com/3673236/32019268-7e1ef08a-b981-11e7-954f-58045d735e81.png">


## How that renders:
<img width="1205" alt="screen shot 2017-10-25 at 12 36 58 pm" src="https://user-images.githubusercontent.com/3673236/32019184-37a2d2f2-b981-11e7-854e-3457bbfc60f7.png">

