### PR TITLE
jsdoc: add Match namespace for methods that extend meteor/check

### DIFF
--- a/lib/api/match.js
+++ b/lib/api/match.js
@@ -1,8 +1,18 @@
 import { Match } from "meteor/check";
 
 /**
- * Match.OptionalOrNull
- * See Meteor Match methods
+ * @file **Meteor Match** - Extending {@link http://docs.meteor.com/api/check.html Meteor Match} argument checking
+ * @see https://github.com/meteor/meteor/tree/master/packages/check
+ * @extends Meteor/Check
+ * @namespace Match
+ */
+
+/**
+ * @name OptionalOrNull
+ * @method
+ * @memberof Match
+ * @summary Return whether an argument is optional or null
+ * @example check(options, Match.OptionalOrNull(Object))
  * @param {String} pattern - match pattern
  * @return {Boolean} matches - void, null, or pattern
  */
@@ -11,8 +21,10 @@ Match.OptionalOrNull = function (pattern) {
 };
 
 /**
- * Match.OrderHookOption
- * See Meteor Match methods
+ * @name OrderHookOption
+ * @method
+ * @memberof Match
+ * @example check(options, Match.OrderHookOptions())
  * @return {Boolean} matches - void, null, or pattern
  */
 Match.OrderHookOptions = function () {


### PR DESCRIPTION
## What this PR does
1. Add `Match` namespace for methods that extend Meteor/Check
2. Link to Meteor/Check at the top of the file

## How it renders

<img width="1202" alt="screen shot 2017-10-25 at 3 17 51 pm" src="https://user-images.githubusercontent.com/3673236/32026118-c27351ca-b997-11e7-9626-efb56e08984d.png">
