### PR TITLE
jsdoc: add PropTypes namespace for PropType validating methods

### DIFF
--- a/lib/api/prop-types.js
+++ b/lib/api/prop-types.js
@@ -3,7 +3,7 @@ import { check } from "meteor/check";
 import * as Schemas from "/lib/collections/schemas";
 
 /**
- * @file **PropTypes** - React Component PropType methods for validating Tags
+ * @file **PropTypes** - React Component PropTypes methods for validating Tags
  *
  * @namespace PropTypes
  */
@@ -14,7 +14,7 @@ export const PropTypes = {};
 
 /**
  * @name Tag
- * @summary React Component propType validator for a single Tag
+ * @summary React Component PropTypes validator for a single Tag
  * @method
  * @memberof PropTypes
  * @param  {Object} props An object containing all props passed into the component

--- a/lib/api/prop-types.js
+++ b/lib/api/prop-types.js
@@ -34,7 +34,7 @@ PropTypes.Tag = (props, propName) => {
 
 /**
  * @name arrayOfTags
- * @summary React Component propType validator for an array of Tags
+ * @summary React Component PropTypes validator for an array of Tags
  * @method
  * @memberof PropTypes
  * @param  {Object} props An object containing all props passed into the component

--- a/lib/api/prop-types.js
+++ b/lib/api/prop-types.js
@@ -2,12 +2,21 @@ import _ from "lodash";
 import { check } from "meteor/check";
 import * as Schemas from "/lib/collections/schemas";
 
+/**
+ * @file **PropTypes** - React Component PropType methods for validating Tags
+ *
+ * @namespace PropTypes
+ */
+
 const TagSchema = Schemas.Tag.newContext();
 
 export const PropTypes = {};
 
 /**
- * React Component propType validator for a single Tag
+ * @name Tag
+ * @summary React Component propType validator for a single Tag
+ * @method
+ * @memberof PropTypes
  * @param  {Object} props An object containing all props passed into the component
  * @param  {String} propName Name of prop to validate
  * @return {Error|undefined} returns an error if validation us unseccessful
@@ -24,7 +33,10 @@ PropTypes.Tag = (props, propName) => {
 };
 
 /**
- * React Component propType validator for an array of Tags
+ * @name arrayOfTags
+ * @summary React Component propType validator for an array of Tags
+ * @method
+ * @memberof PropTypes
  * @param  {Object} props An object containing all props passed into the component
  * @param  {String} propName Name of prop to validate
  * @return {Error|undefined} returns an error if validation us unseccessful


### PR DESCRIPTION
## What this PR does
1. Adds `PropType` namespace
2. Adds methods to this namespace

## How that renders

<img width="1207" alt="screen shot 2017-10-25 at 3 26 36 pm" src="https://user-images.githubusercontent.com/3673236/32026358-ea56b76c-b998-11e7-9efc-d7247b5fe46f.png">
