### PR TITLE
fix empty cart flashing when registering user

### DIFF
--- a/imports/plugins/core/checkout/client/templates/checkout/checkout.html
+++ b/imports/plugins/core/checkout/client/templates/checkout/checkout.html
@@ -1,5 +1,5 @@
 <template name="cartCheckout">
-  {{#if cart.items}}
+  {{#if cartCount}}
 
     <div class="checkout-progress">
       <div class="container">

--- a/imports/plugins/core/checkout/client/templates/checkout/checkout.js
+++ b/imports/plugins/core/checkout/client/templates/checkout/checkout.js
@@ -15,6 +15,13 @@ Template.cartCheckout.helpers({
       return Cart.findOne();
     }
     return {};
+  },
+  cartCount() {
+    const cart = Cart.findOne();
+    if (cart.items && cart.items.length > 0) {
+      return true;
+    }
+    return false;
   }
 });
 

--- a/imports/plugins/included/product-variant/containers/gridItemControlsContainer.js
+++ b/imports/plugins/included/product-variant/containers/gridItemControlsContainer.js
@@ -44,10 +44,20 @@ const wrapComponent = (Comp) => (
     // check whether all required fields have been submitted before publishing
     checkValidation = () => {
       // this returns an array with a single object
-      const variants = ReactionProduct.getVariants(this.props.product._id).map((variant) => this.validation.validate(variant));
-      this.setState({
-        validProduct: Object.assign({}, this.props.product, { __isValid: variants[0].isValid })
-      });
+      const variants = ReactionProduct.getVariants(this.props.product._id);
+
+      // should validate variants if they exist to determine if product is Valid
+      if (variants.length !== 0) {
+        const validatedVariants = variants.map((variant) => this.validation.validate(variant));
+        this.setState({
+          validProduct: Object.assign({}, this.props.product, { __isValid: validatedVariants[0].isValid })
+        });
+      } else {
+        // if variants do not exist then validation should pass
+        this.setState({
+          validProduct: Object.assign({}, this.props.product, { __isValid: true })
+        });
+      }
     }
 
     checked = () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "main": "main.js",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
Resolve issue #3036 

This PR fix ```empty cart``` showing up while registering new user,  The reason for the empty cart showing up is that the cart.items is empty at the that window it tries to register the user. What I did was to create a helper method in `checkout.js` called `cartCount` where it checks if the `cart.item` exists and also check if the length is greater than 0.

#### Test
* Place an order.
* Checkout order.
* Next step will show telling you to `register`. 
* Input details and `register`.
* It takes you to the next step.

