### PR TITLE
[WIP] Fix Reaction.hasPermissions for anonymous users

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -192,9 +192,6 @@ export default {
       if (!checkPermissions) {
         return false;
       }
-      if (typeof checkPermissions !== "string" && !Array.isArray(checkPermissions)) {
-        return false;
-      }
 
       if (Roles.userIsInRole(userId, checkPermissions, group)) {
         return true;

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -159,14 +159,19 @@ export default {
   },
 
   /**
-   * hasPermission - client
-   * client permissions checks
-   * hasPermission exists on both the server and the client.
-   *
-   * @param {String | Array} checkPermissions -String or Array of permissions if empty, defaults to "admin, owner"
-   * @param {String} checkUserId - userId, defaults to Meteor.userId()
-   * @param {String} checkGroup group - default to shopId
-   * @return {Boolean} Boolean - true if has permission
+   * hasPermission - Performs client-side permission checks. Note that
+   * hasPermission exists on both the server and the client. So this is
+   * the client-side version.
+   * @param {String | Array} checkPermissions - permissions to check for. If
+   * empty/undefined, this function returns false.
+   * @param {String} checkUserId - user ID. If empty/undefined, this function uses
+   * the value returned by Meteor.userId().
+   * @param {String} checkGroup - the group that the user being checked
+   * belongs to. If empty/undefined, this function uses the ID of the
+   * current shop or Roles.GLOBAL_GROUP.
+   * @since 0.14
+   * @return {Boolean} - returns true if the said user has any of the permissions
+   * in checkPermissions, and false if s/he has none of them.
    */
   hasPermission(checkPermissions, checkUserId, checkGroup) {
     let group;

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -195,15 +195,6 @@ export default {
       } else if (typeof checkPermissions === "string") {
         permissions = [checkPermissions];
       } else {
-        /* TODO: Consult and add the code below if it is thought
-        of as useful.
-        if (!Array.isArray(checkPermissions)) {
-          return false;
-        }
-        if (checkPermissions.length === 0) {
-          return false;
-        }
-        */
         permissions = checkPermissions;
       }
       // if the user has owner permissions we'll always check if those roles are enough

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -180,14 +180,10 @@ export default {
     let permissions = ["owner"];
     let id = "";
     const userId = checkUserId || Meteor.userId();
-    //
-    // local roleCheck function
-    // is the bulk of the logic
-    // called out a userId is validated.
-    //
-    function roleCheck() {
-      // TODO: There're some outdated comments in this function. Clean them out.
 
+    // This is declared as a function for the sake of reuse. Note that it is
+    // only called after userId is validated.
+    function roleCheck() {
       // permissions can be either a string or an array
       // we'll force it into an array and use that
       if (checkPermissions === undefined) {
@@ -197,46 +193,16 @@ export default {
       } else {
         permissions = checkPermissions;
       }
-      // if the user has owner permissions we'll always check if those roles are enough
-      // By adding the "owner" role to the permissions list, we are making hasPermission always return
-      // true for "owners". This gives owners global access.
-      // TODO: Review this way of granting global access for owners
 
-      // TODO: Find out why were we ever joining "owner" to the permissions
-      // array in the first place.
-
-      //
-      // return if user has permissions in the group
-      //
       if (Roles.userIsInRole(userId, permissions, group)) {
         return true;
       }
 
-      // global roles check
-      // TODO: Review this commented out code
-      /*
-
-      const sellerShopPermissions = Roles.getGroupsForUser(userId, "admin");
-      // we're looking for seller permissions.
-      if (sellerShopPermissions) {
-        // loop through shops roles and check permissions
-        for (const key in sellerShopPermissions) {
-          if (key) {
-            const shop = sellerShopPermissions[key];
-            if (Roles.userIsInRole(userId, permissions, shop)) {
-              return true;
-            }
-          }
-        }
-      }*/
-      // no specific permissions found returning false
       return false;
     }
 
-    //
-    // check if a user id has been found
-    // in line 156 setTimeout
-    //
+    // If userId has been found, this calls roleCheck and then returns the
+    // result of that call. Returns false otherwise.
     function validateUserId() {
       if (Meteor.userId()) {
         Meteor.clearTimeout(id);
@@ -246,21 +212,17 @@ export default {
       return false;
     }
 
-    //
-    // actual logic block to check permissions
-    // we'll bypass unecessary checks during
-    // a user logging, as we'll check again
-    // when everything is ready
-    //
+    /*
+      Checks for permissions. We'll skip performing some checks if the user is
+      currently logging in, as those will be done when log in is complete.
+    */
     if (Meteor.loggingIn() === false) {
-      //
       // this userId check happens because when logout
-      // occurs it takes a few cycles for a new anonymous user
+      // occurs. It takes a few cycles for a new anonymous user
       // to get created and during this time the user has no
       // permission, not even guest permissions so we
       // need to wait and reload the routes. This
-      // mainly affects the logout from dashboard pages
-      //
+      // mainly affects the logout from dashboard pages.
       if (!userId) {
         id = Meteor.setTimeout(validateUserId, 5000);
       } else {

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -189,7 +189,7 @@ export default {
      * @method roleCheck
      * @summary check whether or not a user is in a list of roles.
      * @private
-     * @since 1.5.5
+     * @since 0.15.0
      * @return {Boolean} - returns true if a user is in one or more of the roles
      * listed and false if not.
      */
@@ -210,7 +210,7 @@ export default {
      * @summary verifies that Meteor.userId() returns a value, after which
      * it calls some functions, especially roleCheck.
      * @private
-     * @since 1.5.5
+     * @since 0.15.0
      * @return {Boolean} - if userId has been found, this calls roleCheck and
      * then returns the result of that call. Returns false otherwise.
      */

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -177,33 +177,20 @@ export default {
       group = this.getShopId() || Roles.GLOBAL_GROUP;
     }
 
-    let permissions = ["owner"];
     let id = "";
     const userId = checkUserId || Meteor.userId();
 
     // This is declared as a function for the sake of reuse. Note that it is
     // only called after userId is validated.
     function roleCheck() {
-      // permissions can be either a string or an array
-      // we'll force it into an array and use that
-      // TODO: Should we also cater for checkPermissions === "" and checkPermissions === []?
-      if (checkPermissions === undefined) {
-        permissions = ["owner"];
-      } else if (typeof checkPermissions === "string") {
-        if (checkPermissions === "owner") {
-          return Roles.userIsInRole(userId, "owner", group);
-        }
-
-        permissions = [checkPermissions];
-      } else {
-        if (checkPermissions.length === 1 && checkPermissions[0] === "owner") {
-          return Roles.userIsInRole(userId, checkPermissions, group);
-        }
-
-        permissions = checkPermissions;
+      if (!checkPermissions) {
+        return false;
+      }
+      if (typeof checkPermissions !== "string" && !Array.isArray(checkPermissions)) {
+        return false;
       }
 
-      if (Roles.userIsInRole(userId, permissions, group)) {
+      if (Roles.userIsInRole(userId, checkPermissions, group)) {
         return true;
       }
 

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -180,8 +180,14 @@ export default {
     let id = "";
     const userId = checkUserId || Meteor.userId();
 
-    // This is declared as a function for the sake of reuse. Note that it is
-    // only called after userId is validated.
+    /**
+     * @method roleCheck
+     * @summary check whether or not a user is in a list of roles.
+     * @private
+     * @since 1.5.5
+     * @return {Boolean} - returns true if a user is in one or more of the roles
+     * listed and false if not.
+     */
     function roleCheck() {
       if (!checkPermissions) {
         return false;
@@ -197,8 +203,15 @@ export default {
       return false;
     }
 
-    // If userId has been found, this calls roleCheck and then returns the
-    // result of that call. Returns false otherwise.
+    /**
+     * @method validateUserId
+     * @summary verifies that Meteor.userId() returns a value, after which
+     * it calls some functions, especially roleCheck.
+     * @private
+     * @since 1.5.5
+     * @return {Boolean} - if userId has been found, this calls roleCheck and
+     * then returns the result of that call. Returns false otherwise.
+     */
     function validateUserId() {
       if (Meteor.userId()) {
         Meteor.clearTimeout(id);

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -186,6 +186,8 @@ export default {
     // called out a userId is validated.
     //
     function roleCheck() {
+      // TODO: There're some outdated comments in this function. Clean them out.
+
       // permissions can be either a string or an array
       // we'll force it into an array and use that
       if (checkPermissions === undefined) {
@@ -193,14 +195,26 @@ export default {
       } else if (typeof checkPermissions === "string") {
         permissions = [checkPermissions];
       } else {
+        /* TODO: Consult and add the code below if it is thought
+        of as useful.
+        if (!Array.isArray(checkPermissions)) {
+          return false;
+        }
+        if (checkPermissions.length === 0) {
+          return false;
+        }
+        */
         permissions = checkPermissions;
       }
       // if the user has owner permissions we'll always check if those roles are enough
       // By adding the "owner" role to the permissions list, we are making hasPermission always return
       // true for "owners". This gives owners global access.
       // TODO: Review this way of granting global access for owners
-      permissions.push("owner");
-      permissions = _.uniq(permissions);
+
+      // TODO: Find out why were we ever joining "owner" to the permissions
+      // array in the first place.
+      // permissions.push("owner");
+      // permissions = _.uniq(permissions);
 
       //
       // return if user has permissions in the group

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -186,11 +186,20 @@ export default {
     function roleCheck() {
       // permissions can be either a string or an array
       // we'll force it into an array and use that
+      // TODO: Should we also cater for checkPermissions === "" and checkPermissions === []?
       if (checkPermissions === undefined) {
         permissions = ["owner"];
       } else if (typeof checkPermissions === "string") {
+        if (checkPermissions === "owner") {
+          return Roles.userIsInRole(userId, "owner", group);
+        }
+
         permissions = [checkPermissions];
       } else {
+        if (checkPermissions.length === 1 && checkPermissions[0] === "owner") {
+          return Roles.userIsInRole(userId, checkPermissions, group);
+        }
+
         permissions = checkPermissions;
       }
 

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -213,8 +213,6 @@ export default {
 
       // TODO: Find out why were we ever joining "owner" to the permissions
       // array in the first place.
-      // permissions.push("owner");
-      // permissions = _.uniq(permissions);
 
       //
       // return if user has permissions in the group

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -221,13 +221,14 @@ export default {
       return false;
     }
 
-    /*
-      Checks for permissions. We'll skip performing some checks if the user is
-      currently logging in, as those will be done when log in is complete.
-    */
+    // Actual logic block to check permissions.
+    // We'll bypass unnecessary checks during
+    // a user's log in, as we'll check again
+    // when everything is ready.
+    //
     if (Meteor.loggingIn() === false) {
       // this userId check happens because when logout
-      // occurs. It takes a few cycles for a new anonymous user
+      // occurs, it takes a few cycles for a new anonymous user
       // to get created and during this time the user has no
       // permission, not even guest permissions so we
       // need to wait and reload the routes. This

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -101,13 +101,17 @@ export default {
   registerTemplate: registerTemplate,
 
   /**
-   * hasPermission - server
-   * server permissions checks
-   * hasPermission exists on both the server and the client.
-   * @param {String | Array} checkPermissions -String or Array of permissions if empty, defaults to "admin, owner"
-   * @param {String} userId - userId, defaults to Meteor.userId()
-   * @param {String} checkGroup group - default to shopId
-   * @return {Boolean} Boolean - true if has permission
+   * hasPermission - Performs server-side permission checks. Note that
+   * hasPermission exists on both the server and the client. This is
+   * the server-side version.
+   * @param {String | Array} checkPermissions - permissions to check for. If
+   * empty/undefined, this function returns false.
+   * @param {String} userId - user ID. Defaults to Meteor.userId().
+   * @param {String} checkGroup - the group that the user being checked belongs
+   * to. Defaults to the ID of the current shop or Roles.GLOBAL_GROUP.
+   * @since 0.14
+   * @return {Boolean} - returns true if the said user has any of the permissions
+   * in checkPermissions, and false if s/he has none of them.
    */
   hasPermission(checkPermissions, userId = Meteor.userId(), checkGroup = this.getShopId()) {
     // check(checkPermissions, Match.OneOf(String, Array)); check(userId, String); check(checkGroup,

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -112,7 +112,6 @@ export default {
   hasPermission(checkPermissions, userId = Meteor.userId(), checkGroup = this.getShopId()) {
     // check(checkPermissions, Match.OneOf(String, Array)); check(userId, String); check(checkGroup,
     // Match.Optional(String));
-    let permissions;
     // default group to the shop or global if shop isn't defined for some reason.
     let group;
     if (checkGroup !== undefined && typeof checkGroup === "string") {
@@ -121,21 +120,12 @@ export default {
       group = this.getShopId() || Roles.GLOBAL_GROUP;
     }
 
-    // permissions can be either a string or an array we'll force it into an array and use that
-    if (checkPermissions === undefined) {
-      permissions = ["owner"];
-    } else if (typeof checkPermissions === "string") {
-      permissions = [checkPermissions];
-    } else {
-      permissions = checkPermissions;
+    if (!checkPermissions) {
+      return false;
     }
 
-    // if the user has admin, owner permissions we'll always check if those roles are enough
-    permissions.push("owner");
-    permissions = _.uniq(permissions);
-
     // return if user has permissions in the group
-    return Roles.userIsInRole(userId, permissions, group);
+    return Roles.userIsInRole(userId, checkPermissions, group);
   },
 
   hasOwnerAccess() {

--- a/server/api/core/hasPermission.app-test.js
+++ b/server/api/core/hasPermission.app-test.js
@@ -33,16 +33,9 @@ describe.only("hasPermission", function () {
     expect(hasPermissions).to.be.false;
   });
 
-  it.only("should return false for anonymous users when `permissions === [owner]`", function () {
-    const anonymousUser = Factory.create("anonymous");
-    sandbox.stub(Meteor, "userId", () => anonymousUser._id);
-    const hasPermissions = Core.hasPermission(["owner"]);
-    expect(hasPermissions).to.be.false;
-  });
-
-  it.only("should return false for registered users when `permissions === [owner]`", function () {
-    const user = Factory.create("registeredUser");
-    sandbox.stub(Meteor, "userId", () => user._id);
+  it.only("should return false for users that don't have the `owner` permission", function () {
+    const registeredUser = Factory.create("registeredUser");
+    sandbox.stub(Meteor, "userId", () => registeredUser._id);
     const hasPermissions = Core.hasPermission(["owner"]);
     expect(hasPermissions).to.be.false;
   });

--- a/server/api/core/hasPermission.app-test.js
+++ b/server/api/core/hasPermission.app-test.js
@@ -4,7 +4,7 @@ import { sinon } from "meteor/practicalmeteor:sinon";
 import { Factory } from "meteor/dburles:factory";
 import Core from "./core";
 
-describe.only("hasPermission", function () {
+describe("hasPermission", function () {
   let sandbox;
 
   beforeEach(function () {
@@ -15,42 +15,54 @@ describe.only("hasPermission", function () {
     sandbox.restore();
   });
 
-  it.only("should return false when not passed any permissions", function () {
+  it("should return false when not passed any permissions", function () {
     sandbox.stub(Meteor, "userId", () => "random-user-id");
     const hasPermissions = Core.hasPermission();
     expect(hasPermissions).to.be.false;
   });
 
-  it.only("should return false when `permissions` is an empty string", function () {
+  it("should return false when `permissions` is an empty string", function () {
     sandbox.stub(Meteor, "userId", () => "random-user-id");
     const hasPermissions = Core.hasPermission("");
     expect(hasPermissions).to.be.false;
   });
 
-  it.only("should return false when `permissions` is an empty array", function () {
+  it("should return false when `permissions` is an empty array", function () {
     sandbox.stub(Meteor, "userId", () => "random-user-id");
     const hasPermissions = Core.hasPermission([]);
     expect(hasPermissions).to.be.false;
   });
 
-  it.only("should return false for users that don't have the `owner` permission", function () {
+  it("should return false for users that don't have the `owner` permission", function () {
     const registeredUser = Factory.create("registeredUser");
     sandbox.stub(Meteor, "userId", () => registeredUser._id);
     const hasPermissions = Core.hasPermission(["owner"]);
     expect(hasPermissions).to.be.false;
   });
 
-  it.only("should return true for anonymous users when `permissions === ['anonymous', 'guest']`", function () {
+  it("should return true for anonymous users when `permissions === ['anonymous', 'guest']`", function () {
     const user = Factory.create("anonymous");
     sandbox.stub(Meteor, "userId", () => user._id);
-    const hasPermissions = Core.hasPermission(["anonymous", "guest"]);
+
+    // It is necessary to explicity supply shopId to the Core.hasPermission call
+    // below. If we don't, the said function defaults to using Core.getShopId
+    // which, when this test is run, will give a shop ID that will be different
+    // from the one used by Factory.create("anonymous").
+    const shopId = Object.keys(user.roles)[0];
+    const hasPermissions = Core.hasPermission(["anonymous", "guest"], user._id, shopId);
     expect(hasPermissions).to.be.true;
   });
 
-  it.only("should return true for registered users when `permissions === ['account/profile', 'guest']`", function () {
+  it("should return true for registered users when `permissions === ['account/profile', 'guest']`", function () {
     const user = Factory.create("registeredUser");
     sandbox.stub(Meteor, "userId", () => user._id);
-    const hasPermissions = Core.hasPermission(["account/profile", "guest"]);
+
+    // It is necessary to explicity supply shopId to the Core.hasPermission call
+    // below. If we don't, the said function defaults to using Core.getShopId
+    // which, when this test is run, will give a shop ID that will be different
+    // from the one used by Factory.create("registeredUser").
+    const shopId = Object.keys(user.roles)[0];
+    const hasPermissions = Core.hasPermission(["account/profile", "guest"], user._id, shopId);
     expect(hasPermissions).to.be.true;
   });
 });

--- a/server/api/core/hasPermission.app-test.js
+++ b/server/api/core/hasPermission.app-test.js
@@ -1,0 +1,63 @@
+import { Meteor } from "meteor/meteor";
+import { expect } from "meteor/practicalmeteor:chai";
+import { sinon } from "meteor/practicalmeteor:sinon";
+import { Factory } from "meteor/dburles:factory";
+import Core from "./core";
+
+describe.only("hasPermission", function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it.only("should return false when not passed any permissions", function () {
+    sandbox.stub(Meteor, "userId", () => "random-user-id");
+    const hasPermissions = Core.hasPermission();
+    expect(hasPermissions).to.be.false;
+  });
+
+  it.only("should return false when `permissions` is an empty string", function () {
+    sandbox.stub(Meteor, "userId", () => "random-user-id");
+    const hasPermissions = Core.hasPermission("");
+    expect(hasPermissions).to.be.false;
+  });
+
+  it.only("should return false when `permissions` is an empty array", function () {
+    sandbox.stub(Meteor, "userId", () => "random-user-id");
+    const hasPermissions = Core.hasPermission([]);
+    expect(hasPermissions).to.be.false;
+  });
+
+  it.only("should return false for anonymous users when `permissions === [owner]`", function () {
+    const anonymousUser = Factory.create("anonymous");
+    sandbox.stub(Meteor, "userId", () => anonymousUser._id);
+    const hasPermissions = Core.hasPermission(["owner"]);
+    expect(hasPermissions).to.be.false;
+  });
+
+  it.only("should return false for registered users when `permissions === [owner]`", function () {
+    const user = Factory.create("registeredUser");
+    sandbox.stub(Meteor, "userId", () => user._id);
+    const hasPermissions = Core.hasPermission(["owner"]);
+    expect(hasPermissions).to.be.false;
+  });
+
+  it.only("should return true for anonymous users when `permissions === ['anonymous', 'guest']`", function () {
+    const user = Factory.create("anonymous");
+    sandbox.stub(Meteor, "userId", () => user._id);
+    const hasPermissions = Core.hasPermission(["anonymous", "guest"]);
+    expect(hasPermissions).to.be.true;
+  });
+
+  it.only("should return true for registered users when `permissions === ['account/profile', 'guest']`", function () {
+    const user = Factory.create("registeredUser");
+    sandbox.stub(Meteor, "userId", () => user._id);
+    const hasPermissions = Core.hasPermission(["account/profile", "guest"]);
+    expect(hasPermissions).to.be.true;
+  });
+});


### PR DESCRIPTION
Resolves #2895.

This PR removes the behaviour of `hasPermission` (on both the client and server) where it auto-appends the `owner` permission to the list of permissions supplied to it. Before now, if an `owner` user was logged in and the app ran `hasPermission("anonymous")`, the call would return `true` even though `owner` users don't have the `anonymous` permission. This PR fixes that by removing the auto-appending behaviour. Now, you have to explicitly list all the permissions you want `hasPermission` to check for whenever you call it.

## Test instructions
- For the server-side `hasPermission`, I have written some unit tests for it in `server/api/core/hasPermission.app-test.js`. You can check out the tests and then run them with `reaction test` to see whether they fail or not.
- For the client-side `hasPermission`, you can:
  - add [these logging statements](https://github.com/reactioncommerce/reaction/pull/3196#issuecomment-341572933) to any client-side file e.g the `render` method of `imports/plugins/core/ui/client/components/app/app.js`.
  - login as admin and navigate to `localhost:PORT/`.
  - open your browser's console and observe different calls to `hasPermission` and their results.