### PR TITLE
Fix overlapping badges [UPDATE]

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/badge.less
+++ b/imports/plugins/included/default-theme/client/styles/badge.less
@@ -63,7 +63,9 @@
   border: 1px solid @brand-warning;
 }
 
+
 //TODO: Update badges for low inventory / sold out
+
 .rui.badge-low-inv-warning {
   .label-variant(@label-warning-bg);
 }


### PR DESCRIPTION
Improves [the PR](https://github.com/reactioncommerce/reaction/pull/3067) that resolved #2961.

This PR restores the structure of a LESS stylesheet that was worked on in [the PR](https://github.com/reactioncommerce/reaction/pull/3067) that resolved #2961 .

## Test instructions
- Go to [this link](https://github.com/reactioncommerce/reaction/pull/3198/files) and check that the structure of `badge.less` there matches the one in [this commit](https://github.com/reactioncommerce/reaction/blob/d0351c21ff0071144df143d799a1fcc90cea4a8e/imports/plugins/included/default-theme/client/styles/badge.less).