### PR TITLE
Fix undocumented lint issue - blank line after opening block

### DIFF
--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -22,7 +22,6 @@ const { Jobs, Packages, Shops } = Collections;
 export default {
 
   init() {
-
     // run beforeCoreInit hooks
     Hooks.Events.run("beforeCoreInit");
 


### PR DESCRIPTION
Fixes an undocumented linter issue that slipped into 1.5.5. bitHound caught the issue, but couldn't identify the file, so I thought it was a false signal.

Running eslint locally made this one show up.

Removes a blank line padding after the opening of a block, resolving this issue:

> Block must not be padded by blank lines