### PR TITLE
fix order values store as string

### DIFF
--- a/lib/collections/schemas/cart.js
+++ b/lib/collections/schemas/cart.js
@@ -179,8 +179,7 @@ export const Cart = new SimpleSchema({
   },
   billing: {
     type: [Payment],
-    optional: true,
-    blackbox: true
+    optional: true
   },
   tax: {
     type: Number,

--- a/lib/collections/schemas/payments.js
+++ b/lib/collections/schemas/payments.js
@@ -246,7 +246,8 @@ export const Payment = new SimpleSchema({
   },
   paymentMethod: {
     type: PaymentMethod,
-    optional: true
+    optional: true,
+    blackbox: true
   },
   invoice: {
     type: Invoice,

--- a/lib/collections/schemas/payments.js
+++ b/lib/collections/schemas/payments.js
@@ -122,8 +122,7 @@ export const PaymentMethod = new SimpleSchema({
           $setOnInsert: new Date
         };
       }
-    },
-    denyUpdate: true
+    }
   },
   updatedAt: {
     type: Date,


### PR DESCRIPTION
Resolve issue #3215 

Fix Order values storing as `String` in the database even when the schema is set as a `Number`.

#### Fix
- In the Cart Schema there is a `billing` property which has a validation of blackbox set as true is remove.
- In the PaymentMethod Schema  the createAt property with validation of denyUpdate set to true is also remove.

#### Test.
- Place an order
- Open Robomongo or it's alternative
- Go to billing/invoice and observe the values are stored as Double
<img width="669" alt="screen shot 2017-11-02 at 4 00 05 pm" src="https://user-images.githubusercontent.com/20200587/32333103-532f1f28-bfe7-11e7-854d-c297da5f7306.png">



