### PR TITLE
Limit marketplaceShops setting to primary shop

### DIFF
--- a/imports/plugins/included/marketplace/register.js
+++ b/imports/plugins/included/marketplace/register.js
@@ -75,6 +75,7 @@ Reaction.registerPackage({
     icon: "fa fa-globe",
     provides: ["settings"],
     container: "dashboard",
+    showForShopTypes: ["primary"],
     meta: {
       actionView: {
         dashboardSize: "lg"

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -22,7 +22,6 @@ const { Jobs, Packages, Shops } = Collections;
 export default {
 
   init() {
-
     // run beforeCoreInit hooks
     Hooks.Events.run("beforeCoreInit");
 


### PR DESCRIPTION
Resolves #3225 

**How to test**
- Login as admin into a new merchant shop. (Create a merchant shop from the main Marketplace under `Shop > Marketplace`)
- On the admin dashboard, confirm that there is no `Marketplace Shops` settings icon/option.