### PR TITLE
Tags.updatedAt should set when not specified

### DIFF
--- a/lib/collections/schemas/tags.js
+++ b/lib/collections/schemas/tags.js
@@ -86,7 +86,10 @@ export const Tag = new SimpleSchema({
     }
   },
   updatedAt: {
-    type: Date
+    type: Date,
+    autoValue: function () {
+      return new Date;
+    }
   }
 });
 


### PR DESCRIPTION
This should be an auto-populated field when not specified so that Tags can be easily populated from fixtures w/o specifying a value.
