### PR TITLE
Hide option panel for Merchant Shops

### DIFF
--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
@@ -97,7 +97,7 @@
               <span data-i18n="{{i18nKeyLabel}}">{{label}}</span>
             </a>
           </div>
-          {{#if showAppSwitch}}
+          {{#if showAppSwitch template}}
           <div class="panel-controls">
             <input class="checkbox-switch" type="checkbox" name="enabled" data-id={{packageId}} data-key="{{settingsKey}}" {{checked enabled}}>
           </div>
@@ -114,7 +114,7 @@
 </template>
 
 <template name="optionsShopSettings">
-  <div class="panel-body">
+  <div class="optionsShopSettings">
     {{#autoForm collection=Collections.Packages schema=Schemas.CorePackageConfig
     doc=packageData id="shopEditExternalServicesForm" type="method-update" meteormethod="shop/updateShopExternalServices"}}
       {{> afQuickField name='settings.openexchangerates.appId'}}

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
@@ -83,7 +83,7 @@
       </div>
     </div>
 
-    <div class="panel panel-default">
+    <!-- <div class="panel panel-default">
       <div class="panel-heading">
         <div class="panel-title">
           <a
@@ -108,7 +108,7 @@
           {{/autoForm}}
         </div>
       </div>
-    </div>
+    </div> -->
 
     {{#each reactionApps provides='shopSettings'}}
       <div class="panel panel-default">
@@ -137,6 +137,22 @@
         </div>
       </div>
     {{/each}}
+  </div>
+</template>
+
+<template name="optionsShopSettings">
+  <div id="options" class="panel-collapse collapse" role="tabpanel" aria-labelledby="options">
+    <div class="panel-body">
+      {{#autoForm collection=Collections.Packages schema=Schemas.CorePackageConfig
+      doc=packageData id="shopEditExternalServicesForm" type="method-update" meteormethod="shop/updateShopExternalServices"}}
+        {{> afQuickField name='settings.openexchangerates.appId'}}
+        {{> afQuickField name='settings.openexchangerates.refreshPeriod' placeholder="every 1 hour"}}
+        {{> afQuickField name='settings.google.clientId'}}
+        {{> afQuickField name='settings.google.apiKey'}}
+        {{> afQuickField name='settings.cart.cleanupDurationDays' placeholder="older than 3 days"}}
+        {{> shopSettingsSubmitButton}}
+        {{/autoForm}}
+    </div>
   </div>
 </template>
 

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
@@ -83,33 +83,6 @@
       </div>
     </div>
 
-    <!-- <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class="panel-title">
-          <a
-            href="#options"
-            aria-controls="options"
-            role="button"
-            data-toggle="collapse"
-            data-parent="#shopSettingsAccordian"
-            data-i18n="admin.settings.options.label">Options</a>
-        </div>
-      </div>
-      <div id="options" class="panel-collapse collapse" role="tabpanel" aria-labelledby="options">
-        <div class="panel-body">
-          {{#autoForm collection=Collections.Packages schema=Schemas.CorePackageConfig
-          doc=packageData id="shopEditExternalServicesForm" type="method-update" meteormethod="shop/updateShopExternalServices"}}
-            {{> afQuickField name='settings.openexchangerates.appId'}}
-            {{> afQuickField name='settings.openexchangerates.refreshPeriod' placeholder="every 1 hour"}}
-            {{> afQuickField name='settings.google.clientId'}}
-            {{> afQuickField name='settings.google.apiKey'}}
-            {{> afQuickField name='settings.cart.cleanupDurationDays' placeholder="older than 3 days"}}
-            {{> shopSettingsSubmitButton}}
-          {{/autoForm}}
-        </div>
-      </div>
-    </div> -->
-
     {{#each reactionApps provides='shopSettings'}}
       <div class="panel panel-default">
         <div class="panel-heading panel-heading-flex">
@@ -141,18 +114,16 @@
 </template>
 
 <template name="optionsShopSettings">
-  <div id="options" class="panel-collapse collapse" role="tabpanel" aria-labelledby="options">
-    <div class="panel-body">
-      {{#autoForm collection=Collections.Packages schema=Schemas.CorePackageConfig
-      doc=packageData id="shopEditExternalServicesForm" type="method-update" meteormethod="shop/updateShopExternalServices"}}
-        {{> afQuickField name='settings.openexchangerates.appId'}}
-        {{> afQuickField name='settings.openexchangerates.refreshPeriod' placeholder="every 1 hour"}}
-        {{> afQuickField name='settings.google.clientId'}}
-        {{> afQuickField name='settings.google.apiKey'}}
-        {{> afQuickField name='settings.cart.cleanupDurationDays' placeholder="older than 3 days"}}
-        {{> shopSettingsSubmitButton}}
-        {{/autoForm}}
-    </div>
+  <div class="panel-body">
+    {{#autoForm collection=Collections.Packages schema=Schemas.CorePackageConfig
+    doc=packageData id="shopEditExternalServicesForm" type="method-update" meteormethod="shop/updateShopExternalServices"}}
+      {{> afQuickField name='settings.openexchangerates.appId'}}
+      {{> afQuickField name='settings.openexchangerates.refreshPeriod' placeholder="every 1 hour"}}
+      {{> afQuickField name='settings.google.clientId'}}
+      {{> afQuickField name='settings.google.apiKey'}}
+      {{> afQuickField name='settings.cart.cleanupDurationDays' placeholder="older than 3 days"}}
+      {{> shopSettingsSubmitButton}}
+      {{/autoForm}}
   </div>
 </template>
 

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -245,3 +245,12 @@ Template.shopSettings.events({
     Meteor.call("shop/togglePackage", packageId, !event.target.checked);
   }
 });
+
+Template.optionsShopSettings.helpers({
+  packageData: function () {
+    return Packages.findOne({
+      name: "core",
+      shopId: Reaction.getShopId()
+    });
+  }
+});

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -154,7 +154,12 @@ Template.shopSettings.helpers({
     }).addressBook;
     return address[0];
   },
-  showAppSwitch() {
+  showAppSwitch(template) {
+    if (template === "optionsShopSettings") {
+      // do not have switch for options card/panel
+      return false;
+    }
+
     if (Reaction.getMarketplaceSettings()) {
       // if marketplace is enabled, only the primary shop can switch apps on and off.
       return Reaction.getShopId() === Reaction.getPrimaryShopId();

--- a/imports/plugins/core/dashboard/register.js
+++ b/imports/plugins/core/dashboard/register.js
@@ -42,6 +42,12 @@ Reaction.registerPackage({
     icon: "fa fa-th",
     provides: ["settings"],
     container: "dashboard"
+  }, {
+    label: "Options",
+    provides: ["shopSettings"],
+    container: "dashboard",
+    template: "optionsShopSettings",
+    hideForShopTypes: ["merchant"]
   }],
   layout: [{
     layout: "coreLayout",

--- a/imports/plugins/core/dashboard/register.js
+++ b/imports/plugins/core/dashboard/register.js
@@ -47,7 +47,7 @@ Reaction.registerPackage({
     provides: ["shopSettings"],
     container: "dashboard",
     template: "optionsShopSettings",
-    hideForShopTypes: ["merchant"]
+    showForShopTypes: ["primary"]
   }],
   layout: [{
     layout: "coreLayout",


### PR DESCRIPTION
Resolves #3246 

### How to test
- Log in as merchant shop
- On the sidebar click on shops icon
- Notice option card is not visible to merchant shop admins
