### PR TITLE
(docs): namespace Meteor/ui methods into Methods/ui

### DIFF
--- a/server/api/core/ui.js
+++ b/server/api/core/ui.js
@@ -33,7 +33,7 @@ function objectToCSS(styles) {
 }
 
 /**
- * @name processAnnotations
+ * @name ui/processAnnotations
  * @method
  * @memberof Methods/ui
  * @summary Uses `parse` method from {@link https://github.com/morishitter/css-annotation|CSS Annotation}
@@ -46,7 +46,7 @@ function annotateCSS(stylesheet) {
 }
 
 /**
- * @name cssToObject
+ * @name ui/cssToObject
  * @method
  * @memberof Methods/ui
  * @param  {String|null|undefied|void} styles CSS as a string
@@ -62,7 +62,7 @@ function cssToObject(styles) {
 }
 
 /**
- * @name themeToCSS
+ * @name ui/themeToCSS
  * @method
  * @memberof Methods/ui
  * @param  {Object} theme Theme
@@ -80,7 +80,7 @@ function themeToCSS(theme) {
 }
 
 /**
- * @name updateStyles
+ * @name ui/updateStyles
  * @method
  * @memberof Methods/ui
  * @param  {Object} data Object with `styles`
@@ -105,7 +105,7 @@ function updateStyles(data) {
 }
 
 /**
- * @name publishTheme
+ * @name ui/publishTheme
  * @method
  * @memberof Methods/ui
  * @example Meteor.call("ui/publishTheme", theme, (error))
@@ -130,7 +130,7 @@ function publishTheme(theme) {
 }
 
 /**
- * @name registerTheme
+ * @name ui/registerTheme
  * @method
  * @memberof Methods/ui
  * @example Reaction.registerTheme(Assets.getText("themes/button.css"));
@@ -186,7 +186,7 @@ export function registerTheme(styles) {
 }
 
 /**
- * @name duplicateTheme
+ * @name ui/duplicateTheme
  * @method
  * @memberof Methods/ui
  * @example Meteor.call("ui/duplicateTheme", theme)

--- a/server/api/core/ui.js
+++ b/server/api/core/ui.js
@@ -8,13 +8,50 @@ import { Meteor } from "meteor/meteor";
 import { Shops, Themes } from "/lib/collections";
 import { Reaction } from "./core";
 
+/**
+ * @file UI methods for CSS and Themes - Uses {@link http://postcss.org/|PostCSS},
+ * {@link https://github.com/postcss/autoprefixer|Autoprefixer} and
+ * {@link https://github.com/morishitter/css-annotation|CSS Annotation}.
+ *
+ * @namespace Methods/ui
+ */
+
 const prefixer = postcssJS.sync([autoprefixer]);
 
+/**
+ * @name objectToCSS
+ * @private
+ * @method
+ * @memberof Methods/ui
+ * @summary Uses `process` from {@link http://api.postcss.org/Processor.html#process|PostCSS JS}
+ * @param  {Object} styles [description]
+ * @return {Object}        Promise proxy
+ */
+function objectToCSS(styles) {
+  const prefixedStyles = prefixer(styles);
+  return postcss().process(prefixedStyles, { parser: postcssJS });
+}
+
+/**
+ * @name processAnnotations
+ * @method
+ * @memberof Methods/ui
+ * @summary Uses `parse` method from {@link https://github.com/morishitter/css-annotation|CSS Annotation}
+ * @param  {String} stylesheet Stylesheet stringified
+ * @return {Array}             Array of parsed CSS
+ */
 function annotateCSS(stylesheet) {
   check(stylesheet, String);
   return cssAnnotation.parse(stylesheet);
 }
 
+/**
+ * @name cssToObject
+ * @method
+ * @memberof Methods/ui
+ * @param  {String|null|undefied|void} styles CSS as a string
+ * @return {Object}        Object with CSS styles
+ */
 function cssToObject(styles) {
   check(styles, Match.OneOf(String, null, undefined, void 0));
 
@@ -24,11 +61,13 @@ function cssToObject(styles) {
   return styleObject;
 }
 
-function objectToCSS(styles) {
-  const prefixedStyles = prefixer(styles);
-  return postcss().process(prefixedStyles, { parser: postcssJS });
-}
-
+/**
+ * @name themeToCSS
+ * @method
+ * @memberof Methods/ui
+ * @param  {Object} theme Theme
+ * @return {String}       Stringified CSS
+ */
 function themeToCSS(theme) {
   check(theme, Object);
   let output = "";
@@ -40,6 +79,13 @@ function themeToCSS(theme) {
   return output;
 }
 
+/**
+ * @name updateStyles
+ * @method
+ * @memberof Methods/ui
+ * @param  {Object} data Object with `styles`
+ * @return {Boolean}     True on success or error object
+ */
 function updateStyles(data) {
   check(data, Object);
   this.unblock();
@@ -58,6 +104,14 @@ function updateStyles(data) {
   });
 }
 
+/**
+ * @name publishTheme
+ * @method
+ * @memberof Methods/ui
+ * @example Meteor.call("ui/publishTheme", theme, (error))
+ * @param  {Object} theme Theme
+ * @return {Boolean}     True on success or error object
+ */
 function publishTheme(theme) {
   check(theme, Object);
   this.unblock();
@@ -75,6 +129,14 @@ function publishTheme(theme) {
   });
 }
 
+/**
+ * @name registerTheme
+ * @method
+ * @memberof Methods/ui
+ * @example Reaction.registerTheme(Assets.getText("themes/button.css"));
+ * @param  {String} styles Stringified CSS
+ * @return {Boolean}     True on success or error object
+ */
 export function registerTheme(styles) {
   check(styles, String);
 
@@ -123,6 +185,14 @@ export function registerTheme(styles) {
   }
 }
 
+/**
+ * @name duplicateTheme
+ * @method
+ * @memberof Methods/ui
+ * @example Meteor.call("ui/duplicateTheme", theme)
+ * @param  {String} name Name of theme
+ * @return {Boolean}     True on success or error object
+ */
 function duplicateTheme(name) {
   check(name, String);
 
@@ -135,7 +205,6 @@ function duplicateTheme(name) {
 
   return Themes.insert(theme);
 }
-
 
 Meteor.methods({
   "ui/updateStyles": updateStyles,


### PR DESCRIPTION
## what this PR does
1. adds `Methods/ui` namespace
2. adds `server/api/core/ui` methods to this namespace

## how that renders
![screen shot 2017-11-07 at 11 27 00 am](https://user-images.githubusercontent.com/3673236/32513278-99dbd3b0-c3ae-11e7-81c3-085845db6e35.png)
![screen shot 2017-11-07 at 11 27 03 am](https://user-images.githubusercontent.com/3673236/32513280-99ed7afc-c3ae-11e7-8162-f942d860656f.png)
