### PR TITLE
Use Registered Schemas instead of Schema Source

### DIFF
--- a/imports/plugins/core/discounts/lib/collections/schemas/config.js
+++ b/imports/plugins/core/discounts/lib/collections/schemas/config.js
@@ -3,14 +3,12 @@ import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Discounts } from "./discounts";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
 
-const PackageConfig = Schemas.PackageConfig;
-
 /**
 * DiscountsPackageConfig Schema
 */
 
 export const DiscountsPackageConfig = new SimpleSchema([
-  PackageConfig, {
+  Schemas.PackageConfig, {
     "settings.rates": {
       type: Object,
       optional: true

--- a/imports/plugins/core/discounts/lib/collections/schemas/config.js
+++ b/imports/plugins/core/discounts/lib/collections/schemas/config.js
@@ -1,7 +1,9 @@
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-import { PackageConfig } from "/lib/collections/schemas/registry";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Discounts } from "./discounts";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
+
+const PackageConfig = Schemas.PackageConfig;
 
 /**
 * DiscountsPackageConfig Schema

--- a/imports/plugins/core/taxes/lib/collections/schemas/config.js
+++ b/imports/plugins/core/taxes/lib/collections/schemas/config.js
@@ -1,7 +1,9 @@
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-import { PackageConfig } from "/lib/collections/schemas/registry";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Taxes } from "./taxes";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
+
+const PackageConfig = Schemas.PackageConfig;
 
 /**
 * TaxPackageConfig Schema

--- a/imports/plugins/core/taxes/lib/collections/schemas/config.js
+++ b/imports/plugins/core/taxes/lib/collections/schemas/config.js
@@ -3,14 +3,12 @@ import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Taxes } from "./taxes";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
 
-const PackageConfig = Schemas.PackageConfig;
-
 /**
 * TaxPackageConfig Schema
 */
 
 export const TaxPackageConfig = new SimpleSchema([
-  PackageConfig, {
+  Schemas.PackageConfig, {
     "settings.defaultTaxCode": {
       type: String,
       optional: true

--- a/imports/plugins/core/templates/client/templates/settings.js
+++ b/imports/plugins/core/templates/client/templates/settings.js
@@ -9,8 +9,6 @@ import { Schemas } from "@reactioncommerce/reaction-collections";
 import { i18next } from "/client/api";
 import { Templates } from "/lib/collections";
 
-const EmailTemplates = Schemas.EmailTemplates;
-
 /*
  * template templateSettings onCreated
  */
@@ -112,7 +110,7 @@ Template.templateSettings.helpers({
   },
 
   emailTemplateSchema() {
-    return EmailTemplates;
+    return Schemas.EmailTemplates;
   }
 });
 

--- a/imports/plugins/core/templates/client/templates/settings.js
+++ b/imports/plugins/core/templates/client/templates/settings.js
@@ -5,10 +5,11 @@ import { Blaze } from "meteor/blaze";
 import { ReactiveDict } from "meteor/reactive-dict";
 import { Template } from "meteor/templating";
 import { Loading, SortableTable } from "/imports/plugins/core/ui/client/components";
-import { EmailTemplates } from "../../lib/collections/schemas";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { i18next } from "/client/api";
 import { Templates } from "/lib/collections";
 
+const EmailTemplates = Schemas.EmailTemplates;
 
 /*
  * template templateSettings onCreated

--- a/imports/plugins/included/discount-codes/client/collections/codes.js
+++ b/imports/plugins/included/discount-codes/client/collections/codes.js
@@ -1,11 +1,9 @@
 import { Mongo } from "meteor/mongo";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 
-const DiscountSchema = Schemas.DiscountCodes;
-
 /**
  * Client side collections
  */
 export const DiscountCodes = new Mongo.Collection("DiscountCodes");
 // attach discount code specific schema
-DiscountCodes.attachSchema(DiscountSchema);
+DiscountCodes.attachSchema(Schemas.DiscountCodes);

--- a/imports/plugins/included/discount-codes/client/collections/codes.js
+++ b/imports/plugins/included/discount-codes/client/collections/codes.js
@@ -1,6 +1,7 @@
 import { Mongo } from "meteor/mongo";
-import { DiscountCodes as DiscountSchema } from "../../lib/collections/schemas";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 
+const DiscountSchema = Schemas.DiscountCodes;
 
 /**
  * Client side collections

--- a/imports/plugins/included/discount-codes/client/templates/settings.js
+++ b/imports/plugins/included/discount-codes/client/templates/settings.js
@@ -9,8 +9,6 @@ import { Schemas } from "@reactioncommerce/reaction-collections";
 import { IconButton, Loading, SortableTable }  from "/imports/plugins/core/ui/client/components";
 import "./settings.html";
 
-const DiscountSchema = Schemas.DiscountCodes;
-
 /* eslint no-shadow: ["error", { "allow": ["options"] }] */
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "[oO]ptions" }] */
 
@@ -121,7 +119,7 @@ Template.customDiscountCodes.helpers({
   },
   // schema for forms
   discountSchema() {
-    return DiscountSchema;
+    return Schemas.DiscountCodes;
   },
 
   discountCode() {

--- a/imports/plugins/included/discount-codes/client/templates/settings.js
+++ b/imports/plugins/included/discount-codes/client/templates/settings.js
@@ -5,9 +5,11 @@ import { ReactiveDict } from "meteor/reactive-dict";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { DiscountCodes } from "../collections/codes";
 import { i18next } from "/client/api";
-import { DiscountCodes as DiscountSchema } from "../../lib/collections/schemas";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { IconButton, Loading, SortableTable }  from "/imports/plugins/core/ui/client/components";
 import "./settings.html";
+
+const DiscountSchema = Schemas.DiscountCodes;
 
 /* eslint no-shadow: ["error", { "allow": ["options"] }] */
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "[oO]ptions" }] */

--- a/imports/plugins/included/discount-codes/lib/collections/schemas/codes.js
+++ b/imports/plugins/included/discount-codes/lib/collections/schemas/codes.js
@@ -2,8 +2,6 @@ import { SimpleSchema } from "meteor/aldeed:simple-schema";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
 
-const Discounts = Schemas.Discounts;
-
 /**
 * Discount Codes Schema
 * @type {Object}
@@ -11,7 +9,7 @@ const Discounts = Schemas.Discounts;
 * with properties for discount codes.
 */
 export const DiscountCodes = new SimpleSchema([
-  Discounts, {
+  Schemas.Discounts, {
     "discountMethod": {
       label: "Method",
       type: String,

--- a/imports/plugins/included/discount-codes/lib/collections/schemas/codes.js
+++ b/imports/plugins/included/discount-codes/lib/collections/schemas/codes.js
@@ -1,6 +1,8 @@
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-import { Discounts } from "/imports/plugins/core/discounts/lib/collections/schemas";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
+
+const Discounts = Schemas.Discounts;
 
 /**
 * Discount Codes Schema

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -4,7 +4,9 @@ import { Random } from "meteor/random";
 import { Reaction } from "/server/api";
 import { Cart } from "/lib/collections";
 import { Discounts } from  "/imports/plugins/core/discounts/lib/collections";
-import { DiscountCodes as DiscountSchema } from "../../lib/collections/schemas";
+import { Schemas } from "@reactioncommerce/reaction-collections";
+
+const DiscountSchema = Schemas.DiscountCodes;
 
 // attach discount code specific schema
 Discounts.attachSchema(DiscountSchema, { selector: { discountMethod: "code" } });

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -6,10 +6,8 @@ import { Cart } from "/lib/collections";
 import { Discounts } from  "/imports/plugins/core/discounts/lib/collections";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 
-const DiscountSchema = Schemas.DiscountCodes;
-
 // attach discount code specific schema
-Discounts.attachSchema(DiscountSchema, { selector: { discountMethod: "code" } });
+Discounts.attachSchema(Schemas.DiscountCodes, { selector: { discountMethod: "code" } });
 
 //
 // make all discount methods available

--- a/imports/plugins/included/marketplace/client/templates/dashboard/settings.js
+++ b/imports/plugins/included/marketplace/client/templates/dashboard/settings.js
@@ -2,8 +2,10 @@ import { Template } from "meteor/templating";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { Reaction, i18next } from "/client/api";
 import { Packages } from "/lib/collections";
-import { MarketplacePackageConfig } from "../../../lib/collections/schemas";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Components } from "@reactioncommerce/reaction-components";
+
+const MarketplacePackageConfig = Schemas.MarketplacePackageConfig;
 
 /**
  * marketplaceShopSettings helpers

--- a/imports/plugins/included/marketplace/client/templates/dashboard/settings.js
+++ b/imports/plugins/included/marketplace/client/templates/dashboard/settings.js
@@ -5,15 +5,13 @@ import { Packages } from "/lib/collections";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Components } from "@reactioncommerce/reaction-components";
 
-const MarketplacePackageConfig = Schemas.MarketplacePackageConfig;
-
 /**
  * marketplaceShopSettings helpers
  *
  */
 Template.marketplaceShopSettings.helpers({
   MarketplacePackageConfig() {
-    return MarketplacePackageConfig;
+    return Schemas.MarketplacePackageConfig;
   },
 
   packageData() {

--- a/imports/plugins/included/marketplace/lib/collections/schemas/marketplace.js
+++ b/imports/plugins/included/marketplace/lib/collections/schemas/marketplace.js
@@ -1,7 +1,9 @@
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-import { PackageConfig } from "/lib/collections/schemas/registry";
-import { Shop } from "/lib/collections/schemas/shops.js";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
+
+const PackageConfig = Schemas.PackageConfig;
+const Shop = Schemas.Shop;
 
 export const ShopTypes = new SimpleSchema({
   shopType: {

--- a/imports/plugins/included/marketplace/lib/collections/schemas/marketplace.js
+++ b/imports/plugins/included/marketplace/lib/collections/schemas/marketplace.js
@@ -2,9 +2,6 @@ import { SimpleSchema } from "meteor/aldeed:simple-schema";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
 
-const PackageConfig = Schemas.PackageConfig;
-const Shop = Schemas.Shop;
-
 export const ShopTypes = new SimpleSchema({
   shopType: {
     type: String,
@@ -30,7 +27,7 @@ export const EnabledPackagesByShopType = new SimpleSchema({
 registerSchema("EnabledPackagesByShopType", EnabledPackagesByShopType);
 
 export const MarketplacePackageConfig = new SimpleSchema([
-  PackageConfig, {
+  Schemas.PackageConfig, {
     "settings.thirdPartyLogistics": {
       type: Object,
       blackbox: true,
@@ -127,7 +124,7 @@ registerSchema("MarketplacePackageConfig", MarketplacePackageConfig);
  * Seller Shop Schema
  */
 export const SellerShop = new SimpleSchema([
-  Shop, {
+  Schemas.Shop, {
     stripeConnectSettings: {
       type: Object,
       optional: true

--- a/imports/plugins/included/product-detail-simple/client/components/childVariant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/childVariant.js
@@ -3,8 +3,9 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 import { Validation } from "@reactioncommerce/reaction-collections";
-import { ProductVariant } from "/lib/collections/schemas/products";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 
+const ProductVariant = Schemas.ProductVariant;
 
 class ChildVariant extends Component {
   constructor(props) {

--- a/imports/plugins/included/product-detail-simple/client/components/childVariant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/childVariant.js
@@ -5,13 +5,11 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
 import { Validation } from "@reactioncommerce/reaction-collections";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 
-const ProductVariant = Schemas.ProductVariant;
-
 class ChildVariant extends Component {
   constructor(props) {
     super(props);
 
-    this.validation = new Validation(ProductVariant);
+    this.validation = new Validation(Schemas.ProductVariant);
 
     this.state = {
       invalidVariant: false

--- a/imports/plugins/included/product-detail-simple/client/components/variant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variant.js
@@ -8,13 +8,11 @@ import { SortableItem } from "/imports/plugins/core/ui/client/containers";
 import { ReactionProduct } from "/lib/api";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 
-const ProductVariant = Schemas.ProductVariant;
-
 class Variant extends Component {
   constructor(props) {
     super(props);
 
-    this.validation = new Validation(ProductVariant);
+    this.validation = new Validation(Schemas.ProductVariant);
 
     this.state = {
       invalidVariant: [],

--- a/imports/plugins/included/product-detail-simple/client/components/variant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variant.js
@@ -6,8 +6,9 @@ import { Validation } from "@reactioncommerce/reaction-collections";
 import { SortableItem } from "/imports/plugins/core/ui/client/containers";
 
 import { ReactionProduct } from "/lib/api";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 
-import { ProductVariant } from "/lib/collections/schemas";
+const ProductVariant = Schemas.ProductVariant;
 
 class Variant extends Component {
   constructor(props) {

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -12,8 +12,6 @@ import VariantForm from "../components/variantForm";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Validation } from "@reactioncommerce/reaction-collections";
 
-const ProductVariant = Schemas.ProductVariant;
-
 const wrapComponent = (Comp) => (
   class VariantFormContainer extends Component {
     static propTypes = {
@@ -23,7 +21,7 @@ const wrapComponent = (Comp) => (
     constructor(props) {
       super(props);
 
-      this.validation = new Validation(ProductVariant);
+      this.validation = new Validation(Schemas.ProductVariant);
 
       this.state = {
         validationStatus: this.validation.validationStatus,

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -9,8 +9,10 @@ import { Packages } from "/lib/collections";
 import { Reaction, i18next } from "/client/api";
 import { TaxCodes } from "/imports/plugins/core/taxes/lib/collections";
 import VariantForm from "../components/variantForm";
-import { ProductVariant } from "/lib/collections/schemas/products";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Validation } from "@reactioncommerce/reaction-collections";
+
+const ProductVariant = Schemas.ProductVariant;
 
 const wrapComponent = (Comp) => (
   class VariantFormContainer extends Component {

--- a/imports/plugins/included/shipping-rates/server/methods/rates.js
+++ b/imports/plugins/included/shipping-rates/server/methods/rates.js
@@ -6,8 +6,6 @@ import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Reaction } from "/server/api";
 import { shippingRoles } from "../lib/roles";
 
-const ShippingMethod = Schemas.ShippingMethod;
-
 export const methods = {
   /**
    * shipping/rates/add
@@ -69,7 +67,7 @@ export const methods = {
    * @return { Number } update result
    */
   "shipping/rates/update": function (method) {
-    check(method, ShippingMethod);
+    check(method, Schemas.ShippingMethod);
     if (!Reaction.hasPermission(shippingRoles)) {
       throw new Meteor.Error(403, "Access Denied");
     }

--- a/imports/plugins/included/shipping-rates/server/methods/rates.js
+++ b/imports/plugins/included/shipping-rates/server/methods/rates.js
@@ -2,9 +2,11 @@ import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Random } from "meteor/random";
 import { Shipping } from "/lib/collections";
-import { ShippingMethod } from "/lib/collections/schemas";
+import { Schemas } from "@reactioncommerce/reaction-collections";
 import { Reaction } from "/server/api";
 import { shippingRoles } from "../lib/roles";
+
+const ShippingMethod = Schemas.ShippingMethod;
 
 export const methods = {
   /**

--- a/imports/plugins/included/social/client/components/settings.js
+++ b/imports/plugins/included/social/client/components/settings.js
@@ -5,7 +5,9 @@ import {
   SettingsCard,
   Form
 } from "/imports/plugins/core/ui/client/components";
-import { SocialPackageConfig } from "/lib/collections/schemas/social";
+import { Schemas } from "@reactioncommerce/reaction-collections";
+
+const SocialPackageConfig = Schemas.SocialPackageConfig;
 
 const socialProviders = [
   {

--- a/imports/plugins/included/social/client/components/settings.js
+++ b/imports/plugins/included/social/client/components/settings.js
@@ -7,8 +7,6 @@ import {
 } from "/imports/plugins/core/ui/client/components";
 import { Schemas } from "@reactioncommerce/reaction-collections";
 
-const SocialPackageConfig = Schemas.SocialPackageConfig;
-
 const socialProviders = [
   {
     name: "facebook",
@@ -45,7 +43,7 @@ class SocialSettings extends Component {
   }
 
   getSchemaForField(provider, field) {
-    return SocialPackageConfig._schema[`settings.public.apps.${provider}.${field}`];
+    return Schemas.SocialPackageConfig._schema[`settings.public.apps.${provider}.${field}`];
   }
 
   handleSettingChange = (event, value, name) => {
@@ -84,7 +82,7 @@ class SocialSettings extends Component {
             onSwitchChange={this.props.onSettingEnableChange}
           >
             <Form
-              schema={SocialPackageConfig}
+              schema={Schemas.SocialPackageConfig}
               doc={doc}
               docPath={`settings.public.apps.${provider.name}`}
               hideFields={[


### PR DESCRIPTION
## Allow for projects to modify Schemas

Creating a new database schema is simple enough, however, in order for the frontend to honor it (through Validation), we need a way for core components to use the updated schemas.
If core components refer to the Schema Registry instead of importing from the Schema definition files, this can be achieved.

Take, for instance, the `VariantFormContainer`. In it, [a `Validation` object is initialized](https://github.com/reactioncommerce/reaction/blob/master/imports/plugins/included/product-variant/containers/variantFormContainer.js#L24) using the `ProductVariant` schema.

If one were to add a field to the schema*, however, that Validation would reject changes to the new properties. (I understand that for this simple example, I could extend the Container and simply overwrite the constructor, but, you know, I'd rather not!).

If we replace:
``` JavaScript
import { ProductVariant } from "/lib/collections/schemas/products";
```
with 
``` JavaScript
import { Schemas } from "@reactioncommerce/reaction-collections";
const ProductVariant = Schemas.ProductVariant;
```
then a new `ProductVariant` schema can replace of the original, and the Container could remain untouched.

let me know what you think!


_(If you are comfortable with these changes, I will write some tests)_

---
 \* - assumption is that Schema changes use the `registerSchema` pattern to replace existing schemas, not monkey-patching the original schema.