### PR TITLE
Checking if the variant belongs to current product

### DIFF
--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -128,7 +128,7 @@ ReactionProduct.setProduct = (currentProductId, currentVariantId) => {
   if (product) {
     // set the default variant
     // as the default.
-    if (!variantId) {
+    if (!variantId || !variantIsSelected(variantId)) {
       const variants = ReactionProduct.getTopVariants(productId);
       variantId = Array.isArray(variants) && variants.length &&
         variants[0]._id || null;


### PR DESCRIPTION
## Fix for #3227 

### Problem
The variantId was not getting updated when selecting a new product.

### Solution
In the check for updating the product/variant instead of only checking if `variantId == null` also check that `variantId` belong to the selected product

### Another solution
Maybe a better solution is to call `ReactionProduct.setCurrentVariant(null)` as soon as some PDP page is opened.

### To test 
1. Run `reaction`
2. Add image to example-product and publish.
3. Add another product with image(say test-product).
4. Go to home and then select example-product(image should show).
5. Go to home and select test-product(image should show).
6. Do a refresh(image should show).
