### PR TITLE
Reduced button's padding on smaller screens

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/navbar.less
+++ b/imports/plugins/included/default-theme/client/styles/navbar.less
@@ -176,6 +176,12 @@ html:not(.rtl) .rui.navbar .languages .dropdown-menu {
   .padding-left(@navbar-padding-vertical);
 }
 
+@media only screen and (min-width: 300px) and (max-width: 400px) {
+  .rui.navbar .accounts .accounts.dropdown .dropdown-toggle {
+    padding: 0px 10px;
+  }
+}
+
 .rui.navbar .accounts .dropdown {
   height: 100%;
 }
@@ -270,6 +276,12 @@ html:not(.rtl) .rui.navbar .languages .dropdown-menu {
   height: @navbar-height;
   padding: 0px @navbar-padding-vertical;
   cursor: pointer;
+}
+
+@media only screen and (min-width: 300px) and (max-width: 400px) {
+  .rui.navbar .search {
+    padding: 0px;
+  }
 }
 
 .rui.navbar .search:hover {


### PR DESCRIPTION
## Fix for #3264

### Solution
Reduced the padding(only on smaller screens) that was getting added to the search and user buttons.

### To test
1. Run `reaction` 
2. In chrome open dev tools and select responsive dev. In that choose iPhone5.
3. The Cart icon should be completely visible along with the quantity. Something like below 
<img width="368" alt="screen shot 2017-11-09 at 11 14 39 pm" src="https://user-images.githubusercontent.com/7762605/32620472-d2b092e2-c5a3-11e7-9272-bfeec13a9c0b.png">
