### PR TITLE
Get proper variantId so you can show proper image

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
@@ -322,7 +322,10 @@ function composer(props, onData) {
           // Loop through ancestors in reverse to find a variant that has media to use
           for (const ancestor of selectedVariant.ancestors.reverse()) {
             const media = Media.find({
-              "metadata.variantId": ancestor
+              $or: [
+                { "metadata.variantId": ancestor },
+                { "metadata.productId": ancestor }
+              ]
             }, {
               sort: {
                 "metadata.priority": 1

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -145,12 +145,11 @@ ReactionProduct.setCurrentVariant = (variantId) => {
  * @memberof ReactionProduct
  * @summary method to set default/parameterized product variant
  * @param {String} currentProductId - set current productId
- * @param {String} currentVariantId - set current variantId
  * @return {Object} product object
  */
-ReactionProduct.setProduct = (currentProductId, currentVariantId) => {
+ReactionProduct.setProduct = (currentProductId) => {
   let productId = currentProductId || Router.getParam("handle");
-  let variantId = currentVariantId || Router.getParam("variantId");
+  let variantId = Router.getParam("variantId");
 
   // Find the current product
   const product = Products.findOne({


### PR DESCRIPTION
Resolves #3263 and I believe #3227 as well

### Probems

1. Media query was not searching for image from both the variant and the product. So when the appropriate image was at the product level it would not show. (this may not affect images that are uploaded, but when importing images it wasn't working)
1. `ReactionProduct.setProduct` was constantly just calling itself with the wrong variantId, which would never change until you refreshed so `selectedVariant` was `null` so no `Media` was found. I just eliminated this parameter since getting it from the router worked 100% of the time.

### To Test

1. Add several products with a single image at the product level
1. Navigate to various products.
1. Observe that the proper image is always being shown without having to refresh
