### PR TITLE
Fix dropdown alignment

### DIFF
--- a/imports/plugins/core/accounts/client/components/adminInviteForm.js
+++ b/imports/plugins/core/accounts/client/components/adminInviteForm.js
@@ -111,8 +111,8 @@ class AdminInviteForm extends Component {
       <Components.DropDownMenu
         buttonElement={buttonElement(dropOptions)}
         onChange={this.handleGroupSelect}
-        attachment="bottom right"
-        targetAttachment="top right"
+        attachment="top right"
+        targetAttachment="bottom right"
       >
         {dropOptions
           .map((grp, index) => (


### PR DESCRIPTION
## Fix for #3283 

### To test
Log-in as admin, click on accounts, try and change type of user you are inviting.
The menu should be a simple drop-down menu.

### Review
Should the drop down menu be left aligned or right aligned?

__Left Aligned__ ->
<img width="325" alt="screen shot 2017-11-15 at 10 33 24 am" src="https://user-images.githubusercontent.com/7762605/32819688-b07f8704-c9f0-11e7-856a-ce934b1226ff.png">

__Right Aligned__ ->
<img width="396" alt="screen shot 2017-11-15 at 10 34 10 am" src="https://user-images.githubusercontent.com/7762605/32819693-b93e0d48-c9f0-11e7-8be9-8261275198d1.png">

