### PR TITLE
Stripe Connect Form Pre-Fills (one fix, a few additions)

### DIFF
--- a/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
+++ b/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { Template } from "meteor/templating";
 import { Reaction } from "/lib/api";
 import { i18next } from "/client/api";
@@ -42,7 +41,6 @@ Template.stripeConnectSignupButton.events({
       return Alerts.toast(`${i18next.t("admin.connect.shopAddressNotConfigured")}`, "error");
     }
 
-    const email = shop.emails[0].address;
     const country = shop.addressBook[0].country;
     const phoneNumber = shop.addressBook[0].phone;
     const businessName = shop.addressBook[0].company;
@@ -52,11 +50,16 @@ Template.stripeConnectSignupButton.events({
     const zip = shop.addressBook[0].postal;
 
     const user = Meteor.user() || {};
-    const { address: email } = _.first(user.emails) || {};
-    const [firstName, lastName] = _.split(user.name, " "); // split on " " isn't perfect, but we use it elsewhere, so it's consistent. to that point, consider adding a helper to User
+
+    const defaultEmail =
+      user.emails.find((email) => email.provides === "default");
+    const defaultEmailAddress = defaultEmail ? defaultEmail.address : "";
+
+    const [firstName, ...last] = user.name ? user.name.split(" ") : [];
+    const lastName = last.join(" ");
 
     const stripeConnectAuthorizeUrl = `https://connect.stripe.com/oauth/authorize?response_type=code&state=${shopId}&client_id=${clientId}&scope=read_write`;
-    const autofillParams = `&stripe_user[email]=${email}&stripe_user[country]=${country}&stripe_user[phone_number]=${phoneNumber}&stripe_user[business_name]=${businessName}&stripe_user[street_address]=${streetAddress}&stripe_user[city]=${city}&stripe_user[state]=${state}&stripe_user[zip]=${zip}&stripe_user[email]=${email}&stripe_user[first_name]=${firstName}&stripe_user[last_name]=${lastName}`; // eslint-disable-line max-len
+    const autofillParams = `&stripe_user[email]=${defaultEmailAddress}&stripe_user[country]=${country}&stripe_user[phone_number]=${phoneNumber}&stripe_user[business_name]=${businessName}&stripe_user[street_address]=${streetAddress}&stripe_user[city]=${city}&stripe_user[state]=${state}&stripe_user[zip]=${zip}&stripe_user[first_name]=${firstName}&stripe_user[last_name]=${lastName}`; // eslint-disable-line max-len
     window.open(stripeConnectAuthorizeUrl + autofillParams, "_blank");
   }
 });

--- a/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
+++ b/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
@@ -47,7 +47,7 @@ Template.stripeConnectSignupButton.events({
     const businessName = shop.addressBook[0].company;
     const streetAddress = shop.addressBook[0].address1;
     const city = shop.addressBook[0].city;
-    const state = shop.addressBook[0].state;
+    const state = shop.addressBook[0].region;
     const zip = shop.addressBook[0].postal;
 
     const stripeConnectAuthorizeUrl = `https://connect.stripe.com/oauth/authorize?response_type=code&state=${shopId}&client_id=${clientId}&scope=read_write`;

--- a/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
+++ b/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
@@ -1,3 +1,4 @@
+import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Reaction } from "/lib/api";
 import { i18next } from "/client/api";

--- a/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
+++ b/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { Template } from "meteor/templating";
 import { Reaction } from "/lib/api";
 import { i18next } from "/client/api";
@@ -50,8 +51,12 @@ Template.stripeConnectSignupButton.events({
     const state = shop.addressBook[0].region;
     const zip = shop.addressBook[0].postal;
 
+    const user = Meteor.user() || {};
+    const { address: email } = _.first(user.emails) || {};
+    const [firstName, lastName] = _.split(user.name, " "); // split on " " isn't perfect, but we use it elsewhere, so it's consistent. to that point, consider adding a helper to User
+
     const stripeConnectAuthorizeUrl = `https://connect.stripe.com/oauth/authorize?response_type=code&state=${shopId}&client_id=${clientId}&scope=read_write`;
-    const autofillParams = `&stripe_user[email]=${email}&stripe_user[country]=${country}&stripe_user[phone_number]=${phoneNumber}&stripe_user[business_name]=${businessName}&stripe_user[street_address]=${streetAddress}&stripe_user[city]=${city}&stripe_user[state]=${state}&stripe_user[zip]=${zip}`; // eslint-disable-line max-len
+    const autofillParams = `&stripe_user[email]=${email}&stripe_user[country]=${country}&stripe_user[phone_number]=${phoneNumber}&stripe_user[business_name]=${businessName}&stripe_user[street_address]=${streetAddress}&stripe_user[city]=${city}&stripe_user[state]=${state}&stripe_user[zip]=${zip}&stripe_user[email]=${email}&stripe_user[first_name]=${firstName}&stripe_user[last_name]=${lastName}`; // eslint-disable-line max-len
     window.open(stripeConnectAuthorizeUrl + autofillParams, "_blank");
   }
 });


### PR DESCRIPTION
Code was referencing `address.state` instead of `address.region` when passing data to Stripe Connect. Not a bug necessarily, but it did require the user to complete the state field in Stripe after they had just done so in Reaction.

To test, create a Seller Shop, give it an address, then go through the Stripe Connect process. You will find that the State you entered in Reaction does not pre-fill the Stripe form.

There is a second commit in this PR which adds some additional data to the form. It is optional, but convenient.

