### PR TITLE
Fix uniqueItem._id undefined

### DIFF
--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -679,6 +679,7 @@ const composer = (props, onData) => {
           return tax.lineNumber === item._id;
         });
         item.taxDetail = taxDetail;
+        return item;
       }
     });
   } else {


### PR DESCRIPTION
Resolves #3104 

This PR fixes the a bug where uniqueItem._id is undefined when an order is made with Avalara enabled.

## How to Test

- Login as admin
- Enable Shippo shipment method
- Enable Stripe payment
- Enable Avalara Tax calculations
- Place an order
- Go to the Order Dashboard
- Click on the order you placed
- Observe that the "Invoice" section is displayed just after the "Summary" section
- Observe in the console that there's no error