### PR TITLE
Fix: hide settings panels merchant shops

### DIFF
--- a/imports/plugins/core/accounts/register.js
+++ b/imports/plugins/core/accounts/register.js
@@ -30,7 +30,8 @@ Reaction.registerPackage({
     route: "/dashboard/account/settings",
     container: "accounts",
     workflow: "coreAccountsWorkflow",
-    template: "accountsSettings"
+    template: "accountsSettings",
+    showForShopTypes: ["primary"]
   }, {
     route: "/dashboard/accounts",
     name: "dashboard/accounts",

--- a/imports/plugins/included/analytics/register.js
+++ b/imports/plugins/included/analytics/register.js
@@ -39,6 +39,7 @@ Reaction.registerPackage({
     route: "/dashboard/analytics/settings",
     provides: ["settings"],
     container: "dashboard",
-    template: "reactionAnalyticsSettings"
+    template: "reactionAnalyticsSettings",
+    showForShopTypes: ["primary"]
   }]
 });

--- a/imports/plugins/included/sms/register.js
+++ b/imports/plugins/included/sms/register.js
@@ -22,6 +22,7 @@ Reaction.registerPackage({
     route: "/dashboard/sms",
     provides: ["settings"],
     container: "dashboard",
-    template: "smsSettings"
+    template: "smsSettings",
+    showForShopTypes: ["primary"]
   }]
 });


### PR DESCRIPTION
This PR hides the following settings panels from `merchant` type shops
- Account settings (used for setting up OAuth login)
- Analytics settings (used for connecting 3rd party analytics services)
- Sms settings (used for connecting SMS services such as Twilio)

These settings panels contain settings that are meant for the primary shop and do not need to be visible at the merchant shop level.

To test:
1. Invite a merchant shop
2. Observe that the three settings panels listed above are not present in the merchant shop dashboard, but are still available on the primary shop dashboard.
