### PR TITLE
Fix cannot cancel order processed using Authorize.net

### DIFF
--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -348,7 +348,16 @@ export const methods = {
     });
 
     // refund payment to customer
-    Meteor.call("orders/refunds/create", order._id, paymentMethod, Number(invoiceTotal));
+    const paymentMethodId = paymentMethod && paymentMethod.paymentPackageId;
+    const paymentMethodName = paymentMethod && paymentMethod.paymentSettingsKey;
+    const paymentMethods = Packages.findOne({ _id: paymentMethodId });
+    const isRefundable = paymentMethods && paymentMethods.settings && paymentMethods.settings[paymentMethodName]
+      && paymentMethods.settings[paymentMethodName].support.includes("Refund");
+
+    if (isRefundable) {
+      Meteor.call("orders/refunds/create", order._id, paymentMethod, Number(invoiceTotal));
+    }
+
 
     // send notification to user
     const prefix = Reaction.getShopPrefix();

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -355,6 +355,7 @@ export const methods = {
       && paymentMethods.settings[paymentMethodName].support.includes("Refund");
 
     if (isRefundable) {
+      console.log(isRefundable);
       Meteor.call("orders/refunds/create", order._id, paymentMethod, Number(invoiceTotal));
     }
 

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -355,7 +355,6 @@ export const methods = {
       && paymentMethods.settings[paymentMethodName].support.includes("Refund");
 
     if (isRefundable) {
-      console.log(isRefundable);
       Meteor.call("orders/refunds/create", order._id, paymentMethod, Number(invoiceTotal));
     }
 


### PR DESCRIPTION
Remove exception error  for Authorize.Net payment method when user click on cancel order.

#### Fix
since refund cannot happen with a payment method that does not support refund. `isRefundable` check is place to make sure a payment method  refund is enabled before performing a refund action.

#### Test
- Place an order using Authorize.NET
- Approve and Capture the order
- Click on "Cancel"
- Observe that nothing happens and no exception error thrown in the server.

