### PR TITLE
Fix wrong image display on Grid Settings

### DIFF
--- a/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
@@ -103,7 +103,7 @@ Template.productSettingsListItem.helpers({
   media() {
     const media = Media.findOne({
       "metadata.productId": this._id,
-      "metadata.priority": 0,
+      "metadata.workflow": { $nin: ["archived"] },
       "metadata.toGrid": 1
     }, { sort: { uploadedAt: 1 } });
 


### PR DESCRIPTION
Resolves #3310 

### Bug description
When you select a product on the product grid, the image of the product is not the most current published/uploaded image of selected product.

### How to test
- Go to PDP page
- Drag and drop an image, publish it
- Remove image and publish changes
- Upload a new image for product and publish
- Navigate to home page and select the product
- Confirm that the image on the grid settings panel is the correct image 
