### PR TITLE
(fix): Translation component issue returning undefined instead of defaultValue

### DIFF
--- a/imports/plugins/core/ui/client/components/translation/translation.js
+++ b/imports/plugins/core/ui/client/components/translation/translation.js
@@ -8,6 +8,23 @@ const Translation = ({ i18nKey, defaultValue, ...rest }) => {
   const key = i18nKey || camelCase(defaultValue);
   const translation = i18next.t(key, { defaultValue });
 
+  // i18next returns 'undefined' if the default value happens to be the key for a set of definitions
+  // ```
+  // "components": {
+  //    "componentDef": "Translated Component Def"
+  // }
+  // ```
+  // In this case, a request for i18next.t("components", "defaultValue") will return undefined
+  // but i18next.t("components.componentDef", "defaultValue") will return correctly
+  //
+  // This checks to see if translation is undefined and returns the default value instead
+  if (typeof translation === "undefined") {
+    return (
+      <span {... rest}>{defaultValue}</span>
+    );
+  }
+
+
   return (
     <span {...rest}>{translation}</span>
   );

--- a/imports/plugins/core/ui/client/components/translation/translation.js
+++ b/imports/plugins/core/ui/client/components/translation/translation.js
@@ -20,7 +20,7 @@ const Translation = ({ i18nKey, defaultValue, ...rest }) => {
   // This checks to see if translation is undefined and returns the default value instead
   if (typeof translation === "undefined") {
     return (
-      <span {... rest}>{defaultValue}</span>
+      <span {...rest}>{defaultValue}</span>
     );
   }
 

--- a/imports/plugins/core/ui/client/components/translation/translation.js
+++ b/imports/plugins/core/ui/client/components/translation/translation.js
@@ -24,7 +24,6 @@ const Translation = ({ i18nKey, defaultValue, ...rest }) => {
     );
   }
 
-
   return (
     <span {...rest}>{translation}</span>
   );


### PR DESCRIPTION
When the translation component is passed a defaultValue that matches an i18n key with
an object value, `i18next.t` returns `undefined` instead of the default value.

Example of the issue
example en.json file
```
...
"components": {
	"componentDef": "Translated Component Def"
}
```
In this case, a request for `i18next.t("components", "defaultValue")` will return undefined
but `i18next.t("components.componentDef", "defaultValue")` will return correctly

Our Translation component was then returning an empty string in place of the default value
for these translations. This PR resolves this issue by checking to see if `i18next.t` returns `undefined` and returning the default value if so.

**To test:**
You can see this by passing a default value that matches a "category" within an i18n definition file into a `Translation` component, before this PR, that would result in an empty string, now it should result in the default value getting returned

The easiest way to test the premise of this PR is to drop a debugger on line 10 of the `translations.js` file that this PR modifies and then to test out several different keys and defaultValues from the console.