### PR TITLE
Consideration for Marketplace Shops on Different URLs

### DIFF
--- a/client/modules/core/helpers/templates.js
+++ b/client/modules/core/helpers/templates.js
@@ -199,7 +199,7 @@ Template.registerHelper("toCamelCase", function (str) {
  * @return {String} returns site name
  */
 Template.registerHelper("siteName", function () {
-  const shop = Collections.Shops.findOne();
+  const shop = Reaction.getShop();
   return typeof shop === "object" && shop.name ? shop.name : "";
 });
 

--- a/client/modules/i18n/helpers.js
+++ b/client/modules/i18n/helpers.js
@@ -45,7 +45,7 @@ Template.registerHelper("currencySymbol", function () {
   });
   const profileCurrency = user.profile && user.profile.currency;
   if (profileCurrency) {
-    const shop = Shops.findOne();
+    const shop = Reaction.getPrimaryShop();
     if (Match.test(shop, Object) && shop.currencies) {
       return shop.currencies[profileCurrency].symbol;
     }

--- a/client/modules/router/helpers.js
+++ b/client/modules/router/helpers.js
@@ -1,6 +1,7 @@
 import { Template } from "meteor/templating";
 import { Meteor } from "meteor/meteor";
 import Router from "./main";
+import { Reaction } from "/lib/api";
 
 //
 // pathFor
@@ -13,7 +14,7 @@ Template.registerHelper("pathFor", Router.pathFor);
 // template helper to return absolute + path
 //
 Template.registerHelper("urlFor", (path, params) => {
-  return Meteor.absoluteUrl(Router.pathFor(path, params).substr(1));
+  return Reaction.absoluteUrl(Router.pathFor(path, params).substr(1));
 });
 
 Template.registerHelper("active", Router.isActiveClassName);

--- a/imports/plugins/core/accounts/client/templates/addressBook/add/add.js
+++ b/imports/plugins/core/accounts/client/templates/addressBook/add/add.js
@@ -41,7 +41,7 @@ Template.addressBookAdd.helpers({
       }
     }
 
-    const shop = Collections.Shops.findOne(Reaction.getShopId());
+    const shop = Reaction.getShop();
 
     // Set default country code based on shop's shipping address
     if (shop && Array.isArray(shop.addressBook) && shop.addressBook.length > 0) {

--- a/imports/plugins/core/accounts/client/templates/addressBook/form/form.js
+++ b/imports/plugins/core/accounts/client/templates/addressBook/form/form.js
@@ -2,6 +2,7 @@ import { Session } from "meteor/session";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { AutoForm } from "meteor/aldeed:autoform";
+import { Reaction } from "/client/api";
 import { Countries } from "/client/collections";
 import * as Collections from "/lib/collections";
 
@@ -15,7 +16,7 @@ Template.addressBookForm.helpers({
   },
   statesForCountry: function () {
     let locale;
-    const shop = Collections.Shops.findOne();
+    const shop = Reaction.getShop();
     const selectedCountry = Session.get("addressBookCountry") || AutoForm.getFieldValue("country");
     if (!selectedCountry) {
       return false;

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -138,9 +138,7 @@ Template.shopSettings.helpers({
   },
 
   shop: function () {
-    return Shops.findOne({
-      _id: Reaction.getShopId()
-    });
+    return Reaction.getShop();
   },
   packageData: function () {
     return Packages.findOne({
@@ -149,9 +147,7 @@ Template.shopSettings.helpers({
     });
   },
   addressBook: function () {
-    const address = Shops.findOne({
-      _id: Reaction.getShopId()
-    }).addressBook;
+    const address = this.shop().addressBook;
     return address[0];
   },
   showAppSwitch(template) {

--- a/imports/plugins/core/i18n/client/containers/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/containers/localizationSettings.js
@@ -62,7 +62,7 @@ const wrapComponent = (Comp) => (
 
 function composer(props, onData) {
   const languages = [];
-  const shop = Shops.findOne();
+  const shop = Reaction.getPrimaryShop(); // TODO?: Reaction.getShop()?
   const countries = Countries.find().fetch();
   const preferences = Reaction.getUserPreferences("reaction-i18n", "settingsCards", {});
 
@@ -107,7 +107,7 @@ function composer(props, onData) {
   }
 
 
-  const unitsOfMeasure = Shops.findOne().unitsOfMeasure;
+  const unitsOfMeasure = Reaction.getPrimaryShop().unitsOfMeasure; // TODO: Reaction.getShop()?
   const uomOptions = [];
   if (Array.isArray(unitsOfMeasure)) {
     for (const measure of unitsOfMeasure) {

--- a/imports/plugins/core/layout/client/templates/theme/theme.js
+++ b/imports/plugins/core/layout/client/templates/theme/theme.js
@@ -45,18 +45,14 @@ Router.Hooks.onEnter(addBodyClasses);
 Meteor.startup(() => {
   Tracker.autorun(() => {
     if (Reaction.Subscriptions.PrimaryShop.ready() && Reaction.Subscriptions.MerchantShops.ready()) {
-      let shopId;
+      let shop;
 
       // Choose shop to get theme from
       if (Reaction.marketplaceEnabled && Reaction.merchantTheme) {
-        shopId = Reaction.getShopId();
+        shop = Reaction.getShop();
       } else {
-        shopId = Reaction.getPrimaryShopId();
+        shop = Reaction.getPrimaryShop();
       }
-
-      const shop = Shops.findOne({
-        _id: shopId
-      });
 
       if (shop) {
         if (shop.theme) {

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -37,7 +37,7 @@ Template.dashboardOrdersList.helpers({
     return shippingObject.shipmentMethod.tracking;
   },
   shopName() {
-    const shop = Shops.findOne(this.shopId);
+    const shop = Reaction.getShop();
     return shop !== null ? shop.name : void 0;
   }
 });

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -39,7 +39,7 @@ Template.coreOrderShippingInvoice.onCreated(function () {
   this.autorun(() => {
     const currentData = Template.currentData();
     const order = Orders.findOne(currentData.orderId);
-    const shop = Shops.findOne({});
+    const shop = Reaction.getShop();
 
     this.state.set("order", order);
     this.state.set("currency", shop.currencies[shop.currency]);

--- a/imports/plugins/core/payments/client/settings/settings.js
+++ b/imports/plugins/core/payments/client/settings/settings.js
@@ -38,7 +38,7 @@ Template.paymentSettings.helpers({
     return options;
   },
   shop() {
-    return Shops.findOne(Reaction.getShopId());
+    return Reaction.getShop();
   }
 });
 

--- a/imports/plugins/core/router/client/startup.js
+++ b/imports/plugins/core/router/client/startup.js
@@ -15,21 +15,21 @@ Meteor.startup(function () {
   // using the subscriptions manager sometimes causes issues when signing in/out where you may seee a grey screen
   // or missing shop data throughout the app.
   // TODO: Revisit subscriptions manager usage and waiting for shops to exist client side before rendering.
-  const primaryShopSub = Meteor.subscribe("PrimaryShop");
+  const shopSub = Meteor.subscribe("Shop");
   const merchantShopSub = Meteor.subscribe("MerchantShops");
   const packageSub = Meteor.subscribe("Packages");
 
   Tracker.autorun(function () {
     // initialize client routing
     if (
-      primaryShopSub.ready() &&
+      shopSub.ready() &&
       merchantShopSub.ready() &&
       packageSub.ready() &&
       // In addition to the subscriptions, shopId must be defined before we proceed
       // to avoid conditions where the subscriptions may be ready, but the cached
       // shopId has yet been set.
-      // Reaction.primaryShopId is a reactive data source
-      Reaction.primaryShopId !== null
+      // Reaction.getShopId() is a reactive data source
+      Reaction.getShopId() !== null
     ) {
       const shops = Shops.find({}).fetch();
       //  initBrowserRouter calls Router.initPackageRoutes which calls shopSub.ready which is reactive,

--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -421,8 +421,7 @@ function selectLayout(layout, setLayout, setWorkflow) {
 export function ReactionLayout(options = {}) {
   // Find a workflow layout to render
 
-  // By default we'll use the primary shop for layouts
-  let shopId = Router.Reaction.getPrimaryShopId();
+  let shop;
 
   // We'll check the marketplace settings too so that we can use the active shopId
   // if merchantTemplates is enabled
@@ -441,11 +440,10 @@ export function ReactionLayout(options = {}) {
 
   // If merchantTemplates is enabled, use the active shopId
   if (marketplaceSettings && marketplaceSettings.merchantTemplates === true) {
-    shopId = Router.Reaction.getShopId();
+    shop = Router.Reaction.getShop();
+  } else {
+    shop = Router.Reaction.getPrimaryShop();
   }
-
-  // Get the shop data
-  const shop = Shops.findOne(shopId);
 
   // get the layout & workflow from options if they exist
   // Otherwise get them from the Session. this is set in `/client/config/defaults`

--- a/imports/plugins/core/taxes/client/settings/custom.js
+++ b/imports/plugins/core/taxes/client/settings/custom.js
@@ -6,7 +6,7 @@ import { AutoForm } from "meteor/aldeed:autoform";
 import { Shops } from "/lib/collections";
 import { Countries } from "/client/collections";
 import { Taxes, TaxCodes } from "../../lib/collections";
-import { i18next } from "/client/api";
+import { Reaction, i18next } from "/client/api";
 import { Taxes as TaxSchema } from "../../lib/collections/schemas";
 import { IconButton, Loading, SortableTable } from "/imports/plugins/core/ui/client/components";
 
@@ -127,7 +127,7 @@ Template.customTaxRates.helpers({
     return Countries.find().fetch();
   },
   statesForCountry: function () {
-    const shop = Shops.findOne();
+    const shop = Reaction.getShop();
     const selectedCountry = AutoForm.getFieldValue("country");
     if (!selectedCountry) {
       return false;
@@ -150,7 +150,7 @@ Template.customTaxRates.helpers({
     return options;
   },
   taxRate() {
-    const shop = Shops.findOne();
+    const shop = Reaction.getShop();
     const instance = Template.instance();
     const id = instance.state.get("editingId");
     const tax = Taxes.findOne(id) || {};

--- a/imports/plugins/core/ui-navbar/client/containers/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/containers/navbar.js
@@ -5,7 +5,7 @@ import NavBar from "../components/navbar";
 import { Media, Shops } from "/lib/collections";
 
 function composer(props, onData) {
-  const shop = Shops.findOne(Reaction.getShopId());
+  const shop = Reaction.getShop();
   const searchPackage = Reaction.Apps({ provides: "ui-search" });
   let searchEnabled;
   let searchTemplate;

--- a/imports/plugins/core/versions/server/migrations/7_add_shop_slugs_to_schema.js
+++ b/imports/plugins/core/versions/server/migrations/7_add_shop_slugs_to_schema.js
@@ -1,5 +1,6 @@
 import { Migrations } from "meteor/percolate:migrations";
 import { Shops } from "/lib/collections";
+import { Reaction } from "/server/api";
 import { getSlug } from "/lib/api";
 
 Migrations.add({
@@ -8,7 +9,7 @@ Migrations.add({
     // Get all shops
     const shops = Shops.find();
     // Get primary shop
-    const primaryShop = Shops.findOne({ shopType: "primary" });
+    const primaryShop = Reaction.getPrimaryShop();
     // Init list of merchant shops
     const merchantShops = [];
 

--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.js
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.js
@@ -29,8 +29,8 @@ Template.shopifyImport.events({
     if (Reaction.getShopId() === Reaction.getPrimaryShopId()) {
       Router.go("index");
     } else {
+      const shop = Reaction.getShop();
       const shopId = Reaction.getShopId();
-      const shop = Shops.findOne({ _id: shopId });
 
       // Check to see if this shop has a slug, otherwise direct to shopId route
       if (shop && shop.slug) {

--- a/imports/plugins/included/connectors-shopify/server/methods/webhooks/webhooks.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/webhooks/webhooks.js
@@ -48,7 +48,7 @@ export const methods = {
       shopName: settings.shopName
     });
 
-    const host = options.absoluteUrl || Meteor.absoluteUrl();
+    const host = options.absoluteUrl || Reaction.absoluteUrl();
     const webhookAddress = `${host}webhooks/shopify/${options.topic.replace(/\//g, "-")}?shopId=${Reaction.getShopId()}`;
     try {
       // Create webhook on Shopify

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
@@ -15,16 +15,25 @@ Template.shopSelect.helpers({
   },
 
   currentShopName() {
-    const _id = Router.getParam("shopId") || Reaction.getShopId(); // or prime shop
+    const _id = Router.getParam("shopId");
     let shop;
 
     if (_id) {
       shop = Shops.findOne({
         _id
       });
-      if (shop) {
-        return shop.name;
-      }
+    }
+
+    if (!shop) {
+      shop = Reaction.getShop();
+    }
+
+    if (!shop) {
+      shop = Reaction.getPrimaryShop();
+    }
+
+    if (shop) {
+      return shop.name;
     }
 
     return "Shop Name";

--- a/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
+++ b/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
@@ -27,7 +27,7 @@ Template.stripeConnectSignupButton.events({
       return Alerts.toast(`${i18next.t("admin.connect.stripeConnectNotEnabled")}`, "error");
     }
 
-    const shop = Shops.findOne({ _id: shopId });
+    const shop = Reaction.getShop();
 
     if (!shop || !shop.workflow || shop.workflow.status !== "active") {
       return Alerts.toast(`${i18next.t("admin.connect.shopNotActive")}`, "error");

--- a/imports/plugins/included/payments-authnet/client/checkout/authnet.js
+++ b/imports/plugins/included/payments-authnet/client/checkout/authnet.js
@@ -70,7 +70,7 @@ AutoForm.addHooks("authnet-payment-form", {
     };
     const paymentInfo = {
       total: Cart.findOne().getTotal(),
-      currency: Shops.findOne().currency
+      currency: Reaction.getPrimaryShop().currency // TODO: Reaction.getShop()?
     };
 
     // Submit for processing

--- a/imports/plugins/included/payments-braintree/client/checkout/braintree.js
+++ b/imports/plugins/included/payments-braintree/client/checkout/braintree.js
@@ -55,7 +55,7 @@ function submitToBrainTree(doc, template) {
     type: getCardType(doc.cardNumber)
   };
   const cartTotal = Cart.findOne().getTotal();
-  const currencyCode = Shops.findOne().currency;
+  const currencyCode = Reaction.getPrimaryShop().currency // TODO: Reaction.getShop()?;
 
   Braintree.authorize(cardData, {
     total: cartTotal,

--- a/imports/plugins/included/payments-example/client/checkout/example.js
+++ b/imports/plugins/included/payments-example/client/checkout/example.js
@@ -63,7 +63,7 @@ AutoForm.addHooks("example-payment-form", {
     });
     Example.authorize(form, {
       total: Cart.findOne().getTotal(),
-      currency: Shops.findOne().currency
+      currency: Reaction.getPrimaryShop().currency // TODO: Reaction.getShop()?
     }, function (error, transaction) {
       submitting = false;
       let paymentMethod;

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.js
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.js
@@ -86,7 +86,7 @@ AutoForm.addHooks("paypal-payment-form", {
     const storedCard = form.type.charAt(0).toUpperCase() + form.type.slice(1) + " " + doc.cardNumber.slice(-4);
     PayPal.authorize(form, {
       total: Cart.findOne().getTotal(),
-      currency: Shops.findOne().currency
+      currency: Reaction.getPrimaryShop().currency // TODO: Reaction.getShop()?
     }, function (error, transaction) {
       submitting = false; // todo: check scope
       if (error) {

--- a/imports/plugins/included/payments-paypal/server/methods/payflowproApi.js
+++ b/imports/plugins/included/payments-paypal/server/methods/payflowproApi.js
@@ -41,7 +41,7 @@ PayflowproApi.apiCall.captureCharge = function (paymentCaptureDetails) {
 
   let result;
   // TODO: This should be changed to some ReactionCore method
-  const shop = Shops.findOne(Reaction.getShopId());
+  const shop = Reaction.getShop();
   const wrappedFunc = Meteor.wrapAsync(PayFlow.authorization.capture, PayFlow.authorization);
   const wrappedFuncVoid = Meteor.wrapAsync(PayFlow.authorization.void, PayFlow.authorization);
   const captureTotal = Math.round(parseFloat(paymentCaptureDetails.amount) * 100) / 100;

--- a/imports/plugins/included/payments-stripe/server/methods/stripe.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripe.js
@@ -271,8 +271,7 @@ export const methods = {
 
     // TODO: If there is only one transactionsByShopId and the shopId is primaryShopId -
     // Create a standard charge and bypass creating a customer for this charge
-    const primaryShop = Shops.findOne({ _id: primaryShopId });
-    const currency = primaryShop.currency;
+    const currency = Reaction.getPrimaryShop().currency; // TODO: Reaction.getShop()?
 
     try {
       // Creates a customer object, adds a source via the card data

--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -46,8 +46,7 @@ function getScores(customFields, settings, collection = "products") {
 }
 
 function getSearchLanguage() {
-  const shopId = Reaction.getShopId();
-  const shopLanguage = Shops.findOne(shopId).language;
+  const shopLanguage = Reaction.getPrimaryShop().language // TODO: Reaction.getShop()?;
   if (supportedLanguages.includes(shopLanguage)) {
     return { default_language: shopLanguage };
   }

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -378,7 +378,7 @@ taxCalc.getTaxCodes = function () {
 function cartToSalesOrder(cart) {
   const pkgData = taxCalc.getPackageData();
   const { companyCode, shippingTaxCode } = pkgData.settings.avalara;
-  const company = Shops.findOne(Reaction.getShopId());
+  const company = Reaction.getShop();
   const companyShipping = _.filter(company.addressBook, (o) => o.isShippingDefault)[0];
   const currencyCode = company.currency;
   const cartShipping = cart.getShippingTotal();
@@ -484,7 +484,7 @@ function orderToSalesInvoice(order) {
   } else {
     documentType = "SalesOrder";
   }
-  const company = Shops.findOne(Reaction.getShopId());
+  const company = Reaction.getShop();
   const companyShipping = _.filter(company.addressBook, (o) => o.isShippingDefault)[0];
   const currencyCode = company.currency;
   const orderShipping = order.getShippingTotal();
@@ -586,7 +586,7 @@ taxCalc.reportRefund = function (order, refundAmount, callback) {
   check(callback, Function);
   const pkgData = taxCalc.getPackageData();
   const { companyCode } = pkgData.settings.avalara;
-  const company = Shops.findOne(Reaction.getShopId());
+  const company = Reaction.getShop();
   const companyShipping = _.filter(company.addressBook, (o) => o.isShippingDefault)[0];
   const currencyCode = company.currency;
   const baseUrl = getUrl();

--- a/imports/plugins/included/ui-search/lib/containers/searchSubscription.js
+++ b/imports/plugins/included/ui-search/lib/containers/searchSubscription.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { Meteor } from "meteor/meteor";
+import { Reaction } from "/client/api";
 import * as Collections from "/lib/collections";
 import { Components, composeWithTracker } from "@reactioncommerce/reaction-components";
 import SearchModal from "../components/searchModal";
@@ -13,7 +14,7 @@ class SearchSubscription extends Component {
 }
 
 function getSiteName() {
-  const shop = Collections.Shops.findOne();
+  const shop = Reaction.getShop();
   return typeof shop === "object" && shop.name ? shop.name : "";
 }
 

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -1,4 +1,3 @@
-import url from "url";
 import { slugify } from "transliteration";
 import { Meteor } from "meteor/meteor";
 import { Router } from "/imports/plugins/core/router/lib";
@@ -61,7 +60,7 @@ export function getShopName() {
     return shop && shop.name || "";
   }
 
-  const domain = url.parse(Meteor.absoluteUrl()).hostname;
+  const domain = Core.Reaction.getDomain();
 
   shop = Shops.find({ domains: { $in: [domain] } }, {
     limit: 1
@@ -121,11 +120,9 @@ export function getShopPrefix(leading = "/") {
 export function getAbsoluteUrl(path) {
   const prefix = getShopPrefix("");
   if (prefix) {
-    const absUrl = Meteor.absoluteUrl(`${prefix}/${path}`);
-    return absUrl;
+    return Core.Reaction.absoluteUrl(`${prefix}/${path}`);
   }
-  const absUrl = Meteor.absoluteUrl(`${path}`);
-  return absUrl;
+  return Core.Reaction.absoluteUrl(`${path}`);
 }
 
 /**

--- a/lib/collections/schemas/helpers.js
+++ b/lib/collections/schemas/helpers.js
@@ -78,9 +78,7 @@ export function shopDefaultCountry() {
       return this.value;
     } else if (Meteor.isServer && !this.isUpdate || Meteor.isClient && this.isInsert) {
       // Find the current shop
-      const shop = Shops.findOne({
-        _id: Reaction.getShopId()
-      });
+      const shop = Reaction.getShop();
 
       // Find the current shops primary shipping address
       if (shop && shop.addressBook) {

--- a/server/api/core/accounts/password.js
+++ b/server/api/core/accounts/password.js
@@ -53,23 +53,23 @@ export function sendResetPasswordEmail(userId, optionalEmail) {
   Meteor._ensure(user, "services", "password").reset = tokenObj;
 
   // Get shop data for email display
-  const shop = Shops.findOne(Reaction.getShopId());
+  const shop = Reaction.getShop();
 
   // Get shop logo, if available. If not, use default logo from file-system
   let emailLogo;
   if (Array.isArray(shop.brandAssets)) {
     const brandAsset = _.find(shop.brandAssets, (asset) => asset.type === "navbarBrandImage");
     const mediaId = Media.findOne(brandAsset.mediaId);
-    emailLogo = path.join(Meteor.absoluteUrl(), mediaId.url());
+    emailLogo = path.join(Reaction.absoluteUrl(), mediaId.url());
   } else {
-    emailLogo = Meteor.absoluteUrl() + "resources/email-templates/shop-logo.png";
+    emailLogo = Reaction.absoluteUrl() + "resources/email-templates/shop-logo.png";
   }
 
   const dataForEmail = {
     // Shop Data
     shop: shop,
     contactEmail: shop.emails[0].address,
-    homepage: Meteor.absoluteUrl(),
+    homepage: Reaction.absoluteUrl(),
     emailLogo: emailLogo,
     copyrightDate: moment().format("YYYY"),
     legalName: shop.addressBook[0].company,
@@ -84,17 +84,17 @@ export function sendResetPasswordEmail(userId, optionalEmail) {
       display: true,
       facebook: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/facebook-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/facebook-icon.png",
         link: "https://www.facebook.com"
       },
       googlePlus: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/google-plus-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/google-plus-icon.png",
         link: "https://plus.google.com"
       },
       twitter: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/twitter-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/twitter-icon.png",
         link: "https://www.twitter.com"
       }
     },
@@ -173,8 +173,8 @@ export function sendVerificationEmail(userId, email) {
   const dataForEmail = {
     // Reaction Information
     contactEmail: "hello@reactioncommerce.com",
-    homepage: Meteor.absoluteUrl(),
-    emailLogo: Meteor.absoluteUrl() + "resources/placeholder.gif",
+    homepage: Reaction.absoluteUrl(),
+    emailLogo: Reaction.absoluteUrl() + "resources/placeholder.gif",
     copyrightDate: moment().format("YYYY"),
     legalName: "Reaction Commerce",
     physicalAddress: {
@@ -288,8 +288,8 @@ export function sendUpdatedVerificationEmail(userId, email) {
   const dataForEmail = {
     // Reaction Information
     contactEmail: "hello@reactioncommerce.com",
-    homepage: Meteor.absoluteUrl(),
-    emailLogo: Meteor.absoluteUrl() + "resources/placeholder.gif",
+    homepage: Reaction.absoluteUrl(),
+    emailLogo: Reaction.absoluteUrl() + "resources/placeholder.gif",
     copyrightDate: moment().format("YYYY"),
     legalName: "Reaction Commerce",
     physicalAddress: {

--- a/server/api/core/setDomain.js
+++ b/server/api/core/setDomain.js
@@ -1,5 +1,5 @@
 import { Shops } from "/lib/collections";
-import { Logger } from "/server/api";
+import { Logger, Reaction } from "/server/api";
 
 /**
  * getDomain
@@ -8,7 +8,7 @@ import { Logger } from "/server/api";
  * @return {String} domain name stripped from requestUrl
  */
 export function getRegistryDomain(requestUrl) {
-  const url = requestUrl || process.env.ROOT_URL;
+  const url = Reaction.absoluteUrl();
   const domain = url.match(/^https?\:\/\/([^\/:?#]+)(?:[\/:?#]|$)/i)[1];
   return domain;
 }
@@ -24,7 +24,7 @@ export function setDomain() {
   let currentDomain;
   // we automatically update the shop domain when ROOT_URL changes
   try {
-    currentDomain = Shops.findOne().domains[0];
+    currentDomain = Shops.findOne().domains[0]; // TODO?: Reaction.getDomain()
   } catch (_error) {
     Logger.error(_error, "Failed to determine default shop.");
   }

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -747,9 +747,9 @@ export function sendWelcomeEmail(shopId, userId) {
   if (Array.isArray(shop.brandAssets)) {
     const brandAsset = _.find(shop.brandAssets, (asset) => asset.type === "navbarBrandImage");
     const mediaId = Media.findOne(brandAsset.mediaId);
-    emailLogo = path.join(Meteor.absoluteUrl(), mediaId.url());
+    emailLogo = path.join(Reaction.absoluteUrl(), mediaId.url());
   } else {
-    emailLogo = Meteor.absoluteUrl() + "resources/email-templates/shop-logo.png";
+    emailLogo = Reaction.absoluteUrl() + "resources/email-templates/shop-logo.png";
   }
 
   const dataForEmail = {
@@ -770,17 +770,17 @@ export function sendWelcomeEmail(shopId, userId) {
       display: true,
       facebook: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/facebook-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/facebook-icon.png",
         link: "https://www.facebook.com"
       },
       googlePlus: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/google-plus-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/google-plus-icon.png",
         link: "https://plus.google.com"
       },
       twitter: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/twitter-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/twitter-icon.png",
         link: "https://www.twitter.com"
       }
     },
@@ -797,7 +797,7 @@ export function sendWelcomeEmail(shopId, userId) {
   // Encode email address for URI
   const encodedEmailAddress = encodeURIComponent(defaultEmail.address);
   // assign verification url
-  dataForEmail.verificationUrl = `${Meteor.absoluteUrl()}account/profile/verify?email=${encodedEmailAddress}`;
+  dataForEmail.verificationUrl = `${Reaction.absoluteUrl()}account/profile/verify?email=${encodedEmailAddress}`;
   const userEmail = user.emails[0].address;
 
   let shopEmail;
@@ -914,9 +914,9 @@ function getEmailLogo(shop) {
   if (Array.isArray(shop.brandAssets)) {
     const brandAsset = _.find(shop.brandAssets, (asset) => asset.type === "navbarBrandImage");
     const mediaId = Media.findOne(brandAsset.mediaId);
-    emailLogo = path.join(Meteor.absoluteUrl(), mediaId.url());
+    emailLogo = path.join(Reaction.absoluteUrl(), mediaId.url());
   } else {
-    emailLogo = Meteor.absoluteUrl() + "resources/email-templates/shop-logo.png";
+    emailLogo = Reaction.absoluteUrl() + "resources/email-templates/shop-logo.png";
   }
   return emailLogo;
 }
@@ -956,13 +956,13 @@ function getCurrentUserName(currentUser) {
  */
 function getDataForEmail(options) {
   const { shop, currentUserName, token, emailLogo, name } = options;
-  const primaryShop = Shops.findOne(Reaction.getPrimaryShopId());
+  const primaryShop = Reaction.getPrimaryShop();
 
   return {
     primaryShop: primaryShop, // Primary shop data - may or may not be the same as shop
     shop: shop, // Shop Data
     contactEmail: _.get(shop, "emails[0].address"),
-    homepage: Meteor.absoluteUrl(),
+    homepage: Reaction.absoluteUrl(),
     emailLogo: emailLogo,
     copyrightDate: moment().format("YYYY"),
     legalName: _.get(shop, "addressBook[0].company"),
@@ -977,17 +977,17 @@ function getDataForEmail(options) {
       display: true,
       facebook: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/facebook-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/facebook-icon.png",
         link: "https://www.facebook.com"
       },
       googlePlus: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/google-plus-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/google-plus-icon.png",
         link: "https://plus.google.com"
       },
       twitter: {
         display: true,
-        icon: Meteor.absoluteUrl() + "resources/email-templates/twitter-icon.png",
+        icon: Reaction.absoluteUrl() + "resources/email-templates/twitter-icon.png",
         link: "https://www.twitter.com"
       }
     },
@@ -1001,7 +1001,7 @@ function getDataForEmail(options) {
     if (userToken) {
       return MeteorAccounts.urls.enrollAccount(userToken);
     }
-    return Meteor.absoluteUrl();
+    return Reaction.absoluteUrl();
   }
 }
 

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -288,7 +288,7 @@ export const methods = {
 
     return Orders.update({
       "_id": order._id,
-      "billing.shopId": Reaction.getShopId,
+      "billing.shopId": Reaction.getShopId(),
       "billing.paymentMethod.method": "credit"
     }, {
       $set: {
@@ -395,7 +395,7 @@ export const methods = {
 
     return Orders.update({
       "_id": order._id,
-      "billing.shopId": Reaction.getShopId,
+      "billing.shopId": Reaction.getShopId(),
       "billing.paymentMethod.method": "credit"
     }, {
       $set: {
@@ -606,9 +606,9 @@ export const methods = {
     if (Array.isArray(shop.brandAssets)) {
       const brandAsset = shop.brandAssets.find((asset) => asset.type === "navbarBrandImage");
       const mediaId = Media.findOne(brandAsset.mediaId);
-      emailLogo = path.join(Meteor.absoluteUrl(), mediaId.url());
+      emailLogo = path.join(Reaction.absoluteUrl(), mediaId.url());
     } else {
-      emailLogo = Meteor.absoluteUrl() + "resources/email-templates/shop-logo.png";
+      emailLogo = Reaction.absoluteUrl() + "resources/email-templates/shop-logo.png";
     }
 
     let subtotal = 0;
@@ -682,7 +682,7 @@ export const methods = {
           combinedItems.push(orderItem);
 
           // Placeholder image if there is no product image
-          orderItem.placeholderImage = Meteor.absoluteUrl() + "resources/placeholder.gif";
+          orderItem.placeholderImage = Reaction.absoluteUrl() + "resources/placeholder.gif";
 
           const variantImage = Media.findOne({
             "metadata.productId": orderItem.productId,
@@ -690,12 +690,12 @@ export const methods = {
           });
           // variant image
           if (variantImage) {
-            orderItem.variantImage = path.join(Meteor.absoluteUrl(), variantImage.url());
+            orderItem.variantImage = path.join(Reaction.absoluteUrl(), variantImage.url());
           }
           // find a default image
           const productImage = Media.findOne({ "metadata.productId": orderItem.productId });
           if (productImage) {
-            orderItem.productImage = path.join(Meteor.absoluteUrl(), productImage.url());
+            orderItem.productImage = path.join(Reaction.absoluteUrl(), productImage.url());
           }
         }
       }
@@ -705,7 +705,7 @@ export const methods = {
         // Shop Data
         shop: shop,
         contactEmail: shop.emails[0].address,
-        homepage: Meteor.absoluteUrl(),
+        homepage: Reaction.absoluteUrl(),
         emailLogo: emailLogo,
         copyrightDate: moment().format("YYYY"),
         legalName: shop.addressBook[0].company,
@@ -720,17 +720,17 @@ export const methods = {
           display: true,
           facebook: {
             display: true,
-            icon: Meteor.absoluteUrl() + "resources/email-templates/facebook-icon.png",
+            icon: Reaction.absoluteUrl() + "resources/email-templates/facebook-icon.png",
             link: "https://www.facebook.com"
           },
           googlePlus: {
             display: true,
-            icon: Meteor.absoluteUrl() + "resources/email-templates/google-plus-icon.png",
+            icon: Reaction.absoluteUrl() + "resources/email-templates/google-plus-icon.png",
             link: "https://plus.google.com"
           },
           twitter: {
             display: true,
-            icon: Meteor.absoluteUrl() + "resources/email-templates/twitter-icon.png",
+            icon: Reaction.absoluteUrl() + "resources/email-templates/twitter-icon.png",
             link: "https://www.twitter.com"
           }
         },

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -81,7 +81,7 @@ Meteor.methods({
     }
 
     // we'll accept a shop object, or clone the current shop
-    const seedShop = shopData || Collections.Shops.findOne(Reaction.getPrimaryShopId());
+    const seedShop = shopData || Reaction.getPrimaryShop();
 
     // Never create a second primary shop
     if (seedShop.shopType === "primary") {
@@ -175,6 +175,7 @@ Meteor.methods({
     }
 
     // get shop locale/currency related data
+    // TODO: use Reaction.getShop() instead of querying
     const shop = Collections.Shops.findOne(Reaction.getShopId(), {
       fields: {
         addressBook: 1,
@@ -277,6 +278,7 @@ Meteor.methods({
     this.unblock();
 
     const field = `currencies.${currency}.rate`;
+    // TODO: use Reaction.getShop() instead of querying
     const shop = Collections.Shops.findOne(Reaction.getShopId(), {
       fields: {
         [field]: 1
@@ -301,6 +303,7 @@ Meteor.methods({
     this.unblock();
 
     const shopId = Reaction.getShopId();
+    // TODO: use Reaction.getShop() instead of querying
     const shop = Collections.Shops.findOne(shopId, {
       fields: {
         addressBook: 1,
@@ -398,6 +401,7 @@ Meteor.methods({
       shopId = Reaction.getPrimaryShopId();
     }
 
+    // TODO: use Reaction.getShop()/getPrimaryShop() instead of querying
     const shop = Collections.Shops.findOne(shopId, {
       fields: {
         currencies: 1
@@ -739,9 +743,7 @@ Meteor.methods({
     }
     this.unblock();
 
-    const shop = Collections.Shops.findOne({
-      _id: Reaction.getShopId()
-    });
+    const shop = Reaction.getShop();
 
     const defaultLanguage = shop.language;
 
@@ -801,9 +803,7 @@ Meteor.methods({
     }
     this.unblock();
 
-    const shop = Collections.Shops.findOne({
-      _id: Reaction.getShopId()
-    });
+    const shop = Reaction.getShopId();
 
     const defaultCurrency = shop.currency;
 
@@ -862,6 +862,7 @@ Meteor.methods({
     this.unblock();
 
     // Does our shop contain the brandasset we're tring to add
+    // TODO: use Reaction.getShop() instead of querying
     const shopWithBrandAsset = Collections.Shops.findOne({
       "_id": Reaction.getShopId(),
       "brandAssets.type": asset.type

--- a/server/publications/collections/shops.js
+++ b/server/publications/collections/shops.js
@@ -5,7 +5,16 @@ import { Shops } from "/lib/collections";
 // We should be able to publish just the enabled languages/currencies/
 Meteor.publish("PrimaryShop", function () {
   return Shops.find({
-    shopType: "primary"
+    _id: Reaction.getPrimaryShopId()
+  }, {
+    fields: {},
+    limit: 1
+  });
+});
+
+Meteor.publish("Shop", function () {
+  return Shops.find({
+    _id: Reaction.getShopId()
   }, {
     fields: {},
     limit: 1

--- a/server/publications/collections/translations.js
+++ b/server/publications/collections/translations.js
@@ -18,8 +18,7 @@ import { Reaction } from "/server/api";
  */
 Meteor.publish("Translations", function (languages) {
   check(languages, Match.OneOf(String, Array));
-  const shopId = Reaction.getShopId();
-  const shopLanguage = Shops.findOne(shopId).language;
+  const shopLanguage = Reaction.getPrimaryShop().language // TODO: Reaction.getShop()?;
   const sessionLanguages = [];
   const langTranQuery = [];
 

--- a/server/security/policy.js
+++ b/server/security/policy.js
@@ -1,8 +1,7 @@
-import url from "url";
 import { Meteor } from "meteor/meteor";
 import { BrowserPolicy } from "meteor/browser-policy-common";
 import { WebApp } from "meteor/webapp";
-
+import { Reaction } from "/lib/api";
 
 /**
  * Set headers for Reaction CDN
@@ -27,7 +26,7 @@ if (process.env.NODE_ENV === "development") {
 }
 
 // get current hostname of app
-const { hostname } = url.parse(Meteor.absoluteUrl());
+const hostname = Reaction.getDomain();
 
 // allow websockets (Safari fails without this)
 BrowserPolicy.content.allowConnectOrigin(`ws://${hostname}`);


### PR DESCRIPTION
This PR is to address Merchant Shops which live on a different URL than the Primary Shop.
For example, my Primary Shop is hosted at https://reserve.brewline.io and a Merchant Shop at https://twolights.brewline.io. Visiting the latter shows the branding and products of the Primary Shop.
Opening developer tools on the Merchant Shop and running `ReactionCore.getPrimaryShopId() === ReactionCore.getShopId()` yields true (and the merchant shop has its `domains` attribute set properly).

Digging into the code yielded that `Meteor.absoluteUrl` relies on `$ROOT_URL` which is a problem when using the domain as an identifier.

First step was to wrap `Meteor.absoluteUrl` (in `Reaction.absoluteUrl`) passing a `rootUrl` option, and doing a find/replace throughout (there are many files changed, but few actual changes).

Next, once the active shop was correctly determined by the hostname, there were a few places which I believe were using the wrong shop.
I went through each use of `Shops.find`/`Shops.findOne` and replaced with `Reaction.getShop()` (or `Reaction.getPrimaryShop()`, where applicable).

Lastly, I added documentation to any method I created/modified.

(now that I write this, it's pretty clear that I should have broken this PR up. I will work on that tomorrow, but will leave this here if you'd like to start commenting).