### PR TITLE
(fix): Update toolbar component usage with registerComponent

### DIFF
--- a/imports/plugins/core/dashboard/client/components/toolbar.js
+++ b/imports/plugins/core/dashboard/client/components/toolbar.js
@@ -1,12 +1,11 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Blaze from "meteor/gadicc:blaze-react-component";
+import { Components } from "@reactioncommerce/reaction-components";
 import {
   DropDownMenu,
   MenuItem,
   FlatButton,
-  Toolbar,
-  ToolbarGroup,
   Switch,
   Icon,
   VerticalDivider
@@ -119,7 +118,7 @@ class PublishControls extends Component {
 
   renderAdminButton() {
     return (
-      <ToolbarGroup visibleOnMobile={true}>
+      <Components.ToolbarGroup visibleOnMobile={true}>
         <VerticalDivider key={"divder-2"} />
         <FlatButton
           key="dashboard-button"
@@ -133,7 +132,7 @@ class PublishControls extends Component {
         >
           <Icon icon="icon icon-reaction-logo" />
         </FlatButton>
-      </ToolbarGroup>
+      </Components.ToolbarGroup>
     );
   }
 
@@ -182,18 +181,18 @@ class PublishControls extends Component {
 
   render() {
     return (
-      <Toolbar>
-        <ToolbarGroup firstChild={true}>
+      <Components.Toolbar>
+        <Components.ToolbarGroup firstChild={true}>
           {this.renderVisibilitySwitch()}
           {this.renderShopSelect()}
-        </ToolbarGroup>
-        <ToolbarGroup lastChild={true}>
+        </Components.ToolbarGroup>
+        <Components.ToolbarGroup lastChild={true}>
           {this.renderAddButton()}
           {this.renderPackageButons()}
           {this.renderCustomControls()}
-        </ToolbarGroup>
+        </Components.ToolbarGroup>
         {this.renderAdminButton()}
-      </Toolbar>
+      </Components.Toolbar>
     );
   }
 }

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Components } from "@reactioncommerce/reaction-components";
 import {
   Button,
   FlatButton,
@@ -7,7 +8,6 @@ import {
   Divider,
   DropDownMenu,
   MenuItem,
-  ToolbarGroup,
   Switch,
   Icon
 } from "/imports/plugins/core/ui/client/components";
@@ -378,14 +378,14 @@ class PublishControls extends Component {
   render() {
     if (this.props.isEnabled) {
       return (
-        <ToolbarGroup lastChild={true}>
+        <Components.ToolbarGroup lastChild={true}>
           {this.renderDeletionStatus()}
           {this.renderUndoButton()}
           {this.renderArchiveButton()}
           {this.renderViewControls()}
           {this.renderPublishButton()}
           {/* this.renderMoreOptionsButton() */}
-        </ToolbarGroup>
+        </Components.ToolbarGroup>
       );
     }
 


### PR DESCRIPTION
The Toolbar and ToolbarGroup components even though were "registered" using the components API, weren't referenced via the `Components.x` interface when used. This means these components cannot be replaced in a custom plugin.

This PR changes such references to use the correct `Components.Toolbar`.


### How To Test
- Login as admin
- Confirm that the toolbar still works as before (even now that it uses the Components.x version)
