### PR TITLE
Fix validation for when variants don't exist

### DIFF
--- a/imports/plugins/included/product-variant/containers/gridItemControlsContainer.js
+++ b/imports/plugins/included/product-variant/containers/gridItemControlsContainer.js
@@ -44,10 +44,20 @@ const wrapComponent = (Comp) => (
     // check whether all required fields have been submitted before publishing
     checkValidation = () => {
       // this returns an array with a single object
-      const variants = ReactionProduct.getVariants(this.props.product._id).map((variant) => this.validation.validate(variant));
-      this.setState({
-        validProduct: Object.assign({}, this.props.product, { __isValid: variants[0].isValid })
-      });
+      const variants = ReactionProduct.getVariants(this.props.product._id);
+
+      // should validate variants if they exist to determine if product is Valid
+      if (variants.length !== 0) {
+        const validatedVariants = variants.map((variant) => this.validation.validate(variant));
+        this.setState({
+          validProduct: Object.assign({}, this.props.product, { __isValid: validatedVariants[0].isValid })
+        });
+      } else {
+        // if variants do not exist then validation should pass
+        this.setState({
+          validProduct: Object.assign({}, this.props.product, { __isValid: true })
+        });
+      }
     }
 
     checked = () => {


### PR DESCRIPTION
Resolves #3346 

### Problem description
Before, if you had a product with no variants, when you open the products grid an endless spinner displays and you get an error message on your browser console.

### Steps to reproduce 
- Create a new product
- Go to your db and delete the variant instance of the new product
- Try loading the product grid and observe your browser console. Confirm no errors occur.
