### PR TITLE
switch back to official standard-minifier-js

### DIFF
--- a/.circleci/docker-compose.yml
+++ b/.circleci/docker-compose.yml
@@ -14,4 +14,4 @@ reaction:
 
 mongo:
   image: mongo:latest
-  command: mongod --storageEngine=wiredTiger
+  command: mongod --storageEngine=wiredTiger --bind_ip_all

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -33,6 +33,7 @@ service-configuration@1.0.11
 mdg:validated-method
 shell-server@0.3.0
 dynamic-import@0.2.0
+standard-minifier-js@2.2.3
 
 # Meteor Auth Packages
 accounts-base@1.4.0
@@ -47,7 +48,6 @@ twitter-config-ui@1.0.0
 
 
 # Community Packages
-abernix:standard-minifier-js
 alanning:roles
 aldeed:autoform
 aldeed:collection2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,5 +1,3 @@
-abernix:minifier-js@2.1.0
-abernix:standard-minifier-js@2.1.0
 accounts-base@1.4.0
 accounts-facebook@1.3.0
 accounts-google@1.3.0
@@ -103,17 +101,18 @@ logging@1.1.19
 matb33:collection-hooks@0.8.4
 mdg:validated-method@1.1.0
 mdg:validation-error@0.5.1
-meteor@1.8.1
+meteor@1.8.2
 meteor-base@1.2.0
 meteorhacks:ssr@2.2.0
 meteorhacks:subs-manager@1.6.4
 minifier-css@1.2.16
-minimongo@1.4.1
+minifier-js@2.2.2
+minimongo@1.4.2
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14
 modules@0.11.0
-modules-runtime@0.9.0
-momentjs:moment@2.19.2
+modules-runtime@0.9.1
+momentjs:moment@2.19.3
 mongo@1.3.0
 mongo-dev-server@1.1.0
 mongo-id@1.0.6
@@ -151,6 +150,7 @@ shell-server@0.3.0
 spacebars@1.0.15
 spacebars-compiler@1.1.3
 srp@1.0.10
+standard-minifier-js@2.2.3
 templating@1.3.2
 templating-compiler@1.3.3
 templating-runtime@1.3.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ reaction:
 
 mongo:
   image: mongo:latest
-  command: mongod --storageEngine=wiredTiger
+  command: mongod --storageEngine=wiredTiger --bind_ip_all

--- a/imports/plugins/included/connectors-shopify/package-lock.json
+++ b/imports/plugins/included/connectors-shopify/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "reaction-connectors-shopify",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
This resolves #2629 where the production version of React wasn't being used in production builds.  We already made this switch when updating to Meteor 1.5 (#2371), but I don't know why we switched back to `abernix:standard-minifier-js` shortly after that.  Somewhere between June 7 (where Meteor 1.5 was merged) and the release of Reaction 1.3.0 on June 21 it appears that it got reverted to `abernix:standard-minifier-js`.  Possibly a mistake during a merge conflict resolution?  There are no commits to the `.meteor/packages` file during that period that directly reference changing that package, so I'm thinking it had to be unintentional during a merge conflict.

Anyway, please give this a thorough test and see if you can find any build issues.  I've done a full production build/deployment with Docker and haven't seen any issues.