### PR TITLE
(fix): Determine denormalized product inventory status during Shopify import

### DIFF
--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -412,14 +412,14 @@ export const methods = {
 
                         // Save all relevant variant images to our option
                         const optionImages = findVariantImages(shopifyOption.id, shopifyProduct.images);
-                        for (const optionImage of optionImages) {
+                        for (const [index, optionImage] of optionImages.entries()) {
                           saveImage(optionImage.src, {
                             ownerId: Meteor.userId(),
                             productId: reactionProductId,
                             variantId: reactionOptionId,
                             shopId: shopId,
                             priority: 1,
-                            toGrid: 0
+                            toGrid: index === 0 ? 1 : 0 // We save the first of each variant image to the grid
                           });
                         }
 
@@ -471,14 +471,14 @@ export const methods = {
 
                               // Save all relevant variant images to our option
                               const ternaryOptionImages = findVariantImages(shopifyTernaryOption.id, shopifyProduct.images);
-                              for (const ternaryOptionImage of ternaryOptionImages) {
+                              for (const [index, ternaryOptionImage] of ternaryOptionImages.entries()) {
                                 saveImage(ternaryOptionImage.src, {
                                   ownerId: Meteor.userId(),
                                   productId: reactionProductId,
                                   variantId: reactionOptionId,
                                   shopId: shopId,
                                   priority: 1,
-                                  toGrid: 0
+                                  toGrid: index === 0 ? 1 : 0 // We save the first of each variant image to the grid
                                 });
                               } // So many close parens and brackets. Don't get lost.
                             }
@@ -511,14 +511,14 @@ export const methods = {
 
                     // Save all relevant variant images to our variant.
                     const variantImages = findVariantImages(shopifyVariant.id, shopifyProduct.images);
-                    for (const variantImage of variantImages) {
+                    for (const [index, variantImage] of variantImages.entries()) {
                       saveImage(variantImage.src, {
                         ownerId: Meteor.userId(),
                         productId: reactionProductId,
                         variantId: reactionVariantId,
                         shopId: shopId,
                         priority: 1,
-                        toGrid: 0
+                        toGrid: index === 0 ? 1 : 0 // We save the first of each variant image to the grid
                       });
                     }
                     Logger.debug(`Imported ${shopifyProduct.title} ${variant}`);

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -39,6 +39,9 @@ function createReactionProductFromShopifyProduct(options) {
     hashtags: hashtags,
     isDeleted: false,
     isVisible: false,
+    isSoldOut: false,
+    isLowQuantity: false,
+    isBackorder: false,
     metafields: [],
     pageTitle: shopifyProduct.pageTitle,
     productType: shopifyProduct.product_type,
@@ -278,6 +281,8 @@ export const methods = {
           if (!Products.findOne({ shopifyId: shopifyProduct.id }, { fields: { _id: 1 } })) {
             Logger.debug(`Importing ${shopifyProduct.title}`);
             const price = { min: null, max: null, range: "0.00" };
+            let isSoldOut = true;
+            let isBackorder = false;
 
             // Get tags from shopify and register them if they don't exist.
             // push tag Id's into our hashtags array for use in the product
@@ -384,14 +389,25 @@ export const methods = {
                         ids.push(reactionOptionId);
                         Logger.debug(`Imported ${shopifyProduct.title} ${variant}/${option}`);
 
-                        // Update Max Price
+                        // Update max price
                         if (price.max === null || price.max < reactionOption.price) {
                           price.max = reactionOption.price;
                         }
 
-                        // Update Min Price
+                        // Update min price
                         if (price.min === null || price.min > reactionOption.price) {
                           price.min = reactionOption.price;
+                        }
+
+                        // Update denormalized sold out status
+                        if (isSoldOut && reactionOption.inventoryQuantity > 0) {
+                          isSoldOut = false;
+                        }
+
+                        // Update denormalized backordered status
+                        // if at least one variant has inventoryPolicy = false, then the product isBackorder
+                        if (!isBackorder) {
+                          isBackorder = !reactionOption.inventoryPolicy;
                         }
 
                         // Save all relevant variant images to our option
@@ -432,14 +448,25 @@ export const methods = {
                               ids.push(reactionTernaryOptionId);
                               Logger.debug(`Imported ${shopifyProduct.title} ${variant}/${option}/${ternaryOption}`);
 
-                              // Update Max Price
+                              // Update max price
                               if (price.max === null || price.max < reactionTernaryOption.price) {
                                 price.max = reactionTernaryOption.price;
                               }
 
-                              // Update Min Price
+                              // Update min price
                               if (price.min === null || price.min > reactionTernaryOption.price) {
                                 price.min = reactionTernaryOption.price;
+                              }
+
+                              // Update denormalized sold out status
+                              if (isSoldOut && reactionTernaryOption.inventoryQuantity > 0) {
+                                isSoldOut = false;
+                              }
+
+                              // Update denormalized backordered status
+                              // if at least one variant has inventoryPolicy = false, then the product isBackorder
+                              if (!isBackorder) {
+                                isBackorder = !reactionTernaryOption.inventoryPolicy;
                               }
 
                               // Save all relevant variant images to our option
@@ -461,14 +488,25 @@ export const methods = {
                     }); // End shopifyOptions forEach loop
                   } else {
                     // Product does not have options, just variants
-                    // Update Max Price
+                    // Update max price
                     if (price.max === null || price.max < reactionVariant.price) {
                       price.max = reactionVariant.price;
                     }
 
-                    // Update Min Price
+                    // Update min price
                     if (price.min === null || price.min > reactionVariant.price) {
                       price.min = reactionVariant.price;
+                    }
+
+                    // Update denormalized sold out status
+                    if (isSoldOut && reactionVariant.inventoryQuantity > 0) {
+                      isSoldOut = false;
+                    }
+
+                    // Update denormalized backordered status
+                    // if at least one variant has inventoryPolicy = false, then the product isBackorder
+                    if (!isBackorder) {
+                      isBackorder = !reactionVariant.inventoryPolicy;
                     }
 
                     // Save all relevant variant images to our variant.
@@ -495,14 +533,23 @@ export const methods = {
             } else {
               price.range = `${price.max}`;
             }
-            Products.update({ _id: reactionProductId }, { $set: { price: price } }, { selector: { type: "simple" }, publish: true });
+            Products.update({
+              _id: reactionProductId
+            }, {
+              $set: {
+                price: price,
+                isSoldOut: isSoldOut,
+                isBackorder: isBackorder
+              }
+            }, { selector: { type: "simple" }, publish: true });
+
             Logger.debug(`Product ${shopifyProduct.title} added`);
           } else { // product already exists check
             Logger.debug(`Product ${shopifyProduct.title} already exists`);
           }
         } // End product loop
       } // End pages loop
-      Logger.info(`Reaction Shopify Connector has finished importing ${ids.length} products`);
+      Logger.info(`Reaction Shopify Connector has finished importing ${ids.length} products and variants`);
 
       // Run jobs to import all queued images;
       importImages();


### PR DESCRIPTION
Fixes an unreported issue where denormalized product inventory status was not set during import of products from Shopify.

This PR resolves this by setting `isSoldOut`, `isLowQuantity`, and `isBackorder` flags correctly on the top level product during import.