### PR TITLE
(breaking): (perf): improve products publication performance

### DIFF
--- a/imports/plugins/included/connectors-shopify/package-lock.json
+++ b/imports/plugins/included/connectors-shopify/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "reaction-connectors-shopify",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
@@ -126,15 +126,13 @@ const wrapComponent = (Comp) => (
     }
 
     additionalProductMedia = () => {
-      const variants = ReactionProduct.getVariants(this.props.product._id);
-      const variantIds = variants.map(variant => variant._id);
       const mediaArray = Media.find({
-        "metadata.productId": this.props.product._id,
-        "metadata.variantId": {
-          $in: variantIds
-        },
-        "metadata.workflow": { $nin: ["archived", "unpublished"] }
-      }, { limit: 3 });
+        "metadata.productId": this.props.product._id
+      }, {
+        sort: { "metadata.priority": 1, "uploadedAt": 1 },
+        skip: 1, // Skip the primary product media
+        limit: 3
+      });
 
       return mediaArray.count() > 1 ? mediaArray : false;
     }

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -334,29 +334,6 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
 
     let newSelector = selector;
 
-    // Remove hashtag filter from selector (hashtags are not applied to variants, we need to get variants)
-    if (productFilters && productFilters.tags) {
-      newSelector = _.omit(selector, ["hashtags", "ancestors"]);
-
-      // Re-configure selector to pick either Variants of one of the top-level products, or the top-level products in the filter
-      _.extend(newSelector, {
-        $or: [{
-          ancestors: {
-            $in: productIds
-          }
-        }, {
-          $and: [{
-            hashtags: {
-              $in: productFilters.tags
-            }
-          }, {
-            _id: {
-              $in: productIds
-            }
-          }]
-        }]
-      });
-    }
 
     if (RevisionApi.isRevisionControlEnabled()) {
       const productCursor = Products.find(newSelector, {

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -2,11 +2,48 @@ import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-import { Products, Shops, Revisions } from "/lib/collections";
+import { Products, Shops, Media, Revisions } from "/lib/collections";
 import { Reaction, Logger } from "/server/api";
 import { RevisionApi } from "/imports/plugins/core/revisions/lib/api/revisions";
-import { findProductMedia } from "./product";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
+
+/**
+ * Helper method that creates a Media cursor for the Products publication. This method returns only the media that has
+ * been set to show up in the grid via `toGrid: 1`
+ * @method findProductsMedia
+ * @param {object} publicationInstance instance of the publication that invokes this method
+ * @param {array} productIds array of productIds
+ * @return {object} Media Cursor containing the product media that matches the selector
+ */
+export function findProductsMedia(publicationInstance, productIds) {
+  const selector = {};
+
+  // Find media that matches the productIds provided in the args
+  selector["metadata.productId"] = {
+    $in: productIds
+  };
+
+  // Find media that is set to show in the grid
+  selector["metadata.toGrid"] = 1;
+
+  // Ignore media that is archived
+  selector["metadata.workflow"] = {
+    $nin: ["archived"]
+  };
+
+  // Users with the createProduct role can see both published and unpublished images
+  // There is an implied shopId in Reaction.hasPermission that defaults to
+  // the active shopId via Reaction.getShopId
+  if (!Reaction.hasPermission(["createProduct"], publicationInstance.userId)) {
+    selector["metadata.workflow"].$in = [null, "published"];
+  }
+
+  return Media.find(selector, {
+    sort: {
+      "metadata.priority": 1
+    }
+  });
+}
 
 //
 // define search filters as a schema so we can validate
@@ -96,12 +133,12 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
   }
 
   // Get active shop id's to use for filtering
-  const activeShopsIds = Shops.find({
+  const activeShopIds = Shops.find({
     $or: [
       { "workflow.status": "active" },
       { _id: Reaction.getPrimaryShopId() }
     ]
-  }).fetch().map(activeShop => activeShop._id);
+  }).map(activeShop => activeShop._id);
 
   // if there are filter/params that don't match the schema
   // validate, catch except but return no results
@@ -116,6 +153,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
 
   if (shopIdsOrSlugs) {
     // Get all shopIds associated with the slug or Id
+    // TODO: Combine this lookup with the activeShop lookup
     const shopIds = Shops.find({
       $or: [{
         _id: {
@@ -140,7 +178,8 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
   const selector = {
     ancestors: [], // Lookup top-level products
     isDeleted: { $in: [null, false] }, // by default, we don't publish deleted products
-    isVisible: true // by default, only lookup visible products
+    isVisible: true, // by default, only lookup visible products
+    shopId: { $in: activeShopIds } // TODO: Connect the activeShopId filter to the merchant shop management workflow
   };
 
   if (productFilters) {
@@ -204,6 +243,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
     }
 
     // filter by visibility
+    // Security??
     if (productFilters.visibility !== undefined) {
       _.extend(selector, {
         isVisible: productFilters.visibility
@@ -285,9 +325,6 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
     selector.isVisible = {
       $in: [true, false, null, undefined]
     };
-    selector.shopId = {
-      $in: activeShopsIds
-    };
 
     // Get _ids of top-level products
     const productIds = Products.find(selector, {
@@ -319,23 +356,13 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
           }]
         }]
       });
-    } else {
-      newSelector = _.omit(selector, ["hashtags", "ancestors"]);
-      _.extend(newSelector, {
-        $or: [{
-          ancestors: {
-            $in: productIds
-          }
-        }, {
-          _id: {
-            $in: productIds
-          }
-        }]
-      });
     }
 
     if (RevisionApi.isRevisionControlEnabled()) {
-      const productCursor = Products.find(newSelector);
+      const productCursor = Products.find(newSelector, {
+        limit: productScrollLimit,
+        sort: sort
+      });
       const handle = productCursor.observeChanges({
         added: (id, fields) => {
           const revisions = Revisions.find({
@@ -350,6 +377,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
             }
           }).fetch();
           fields.__revisions = revisions;
+
 
           this.added("Products", id, fields);
         },
@@ -430,19 +458,21 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
       });
 
       const mediaProductIds = productCursor.fetch().map((p) => p._id);
-      const mediaCursor = findProductMedia(this, mediaProductIds);
+      const mediaCursor = findProductsMedia(this, mediaProductIds);
 
       return [
+        productCursor,
         mediaCursor
       ];
     }
-    // Revision control is disabled, but is admin
+
+    // Else revision control is disabled, but user is an admin
     const productCursor = Products.find(newSelector, {
       sort: sort,
       limit: productScrollLimit
     });
     const mediaProductIds = productCursor.fetch().map((p) => p._id);
-    const mediaCursor = findProductMedia(this, mediaProductIds);
+    const mediaCursor = findProductsMedia(this, mediaProductIds);
 
     return [
       productCursor,
@@ -450,100 +480,15 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
     ];
   }
 
-  // This is where the publication begins for non-admin users
-  // Get _ids of top-level products
-  const productIds = Products.find(selector, {
+  // Else, user is not an admin
+  // Create product cursor for default selector
+  const productCursor = Products.find(selector, {
     sort: sort,
     limit: productScrollLimit
-  }).map(product => product._id);
-
-  let newSelector = { ...selector };
-
-  // Remove hashtag filter from selector (hashtags are not applied to variants, we need to get variants)
-  if (productFilters && Object.keys(productFilters).length === 0 && productFilters.constructor === Object) {
-    newSelector = _.omit(selector, ["hashtags", "ancestors"]);
-
-    if (productFilters.tags) {
-      // Re-configure selector to pick either Variants of one of the top-level products,
-      // or the top-level products in the filter
-      _.extend(newSelector, {
-        $or: [{
-          ancestors: {
-            $in: productIds
-          }
-        }, {
-          $and: [{
-            hashtags: {
-              $in: productFilters.tags
-            }
-          }, {
-            _id: {
-              $in: productIds
-            }
-          }]
-        }]
-      });
-    }
-    // filter by query
-    if (productFilters.query) {
-      const cond = {
-        $regex: productFilters.query,
-        $options: "i"
-      };
-      _.extend(newSelector, {
-        $or: [{
-          title: cond
-        }, {
-          pageTitle: cond
-        }, {
-          description: cond
-        }, {
-          ancestors: {
-            $in: productIds
-          }
-        },
-        {
-          _id: {
-            $in: productIds
-          }
-        }]
-      });
-    }
-  } else {
-    newSelector = _.omit(selector, ["hashtags", "ancestors"]);
-
-    _.extend(newSelector, {
-      $or: [{
-        ancestors: {
-          $in: productIds
-        }
-      }, {
-        _id: {
-          $in: productIds
-        }
-      }]
-    });
-  }
-
-  // Adjust the selector to include only active shops
-  newSelector = {
-    ...newSelector,
-    shopId: {
-      $in: activeShopsIds
-    }
-  };
-
-  // Returning Complete product tree for top level products to avoid sold out warning.
-  const productCursor = Products.find(newSelector, {
-    sort: sort
-    // TODO: REVIEW Limiting final products publication for non-admins
-    // I think we shouldn't limit here, otherwise we are limited to 24 total products which
-    // could be far less than 24 top-level products
-    // limit: productScrollLimit
   });
 
   const mediaProductIds = productCursor.fetch().map((p) => p._id);
-  const mediaCursor = findProductMedia(this, mediaProductIds);
+  const mediaCursor = findProductsMedia(this, mediaProductIds);
 
   return [
     productCursor,

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -326,21 +326,15 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
       $in: [true, false, null, undefined]
     };
 
-    // Get _ids of top-level products
-    const productIds = Products.find(selector, {
+    const adminProductCursor = Products.find(selector, {
       sort: sort,
       limit: productScrollLimit
-    }).map(product => product._id);
+    });
 
-    let newSelector = selector;
-
+    const adminProductIds = adminProductCursor.map((p) => p._id);
 
     if (RevisionApi.isRevisionControlEnabled()) {
-      const productCursor = Products.find(newSelector, {
-        limit: productScrollLimit,
-        sort: sort
-      });
-      const handle = productCursor.observeChanges({
+      const handle = adminProductCursor.observeChanges({
         added: (id, fields) => {
           const revisions = Revisions.find({
             "$or": [
@@ -434,25 +428,20 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
         handle2.stop();
       });
 
-      const mediaProductIds = productCursor.fetch().map((p) => p._id);
+      const mediaProductIds = adminProductCursor.fetch().map((p) => p._id);
       const mediaCursor = findProductsMedia(this, mediaProductIds);
 
       return [
-        productCursor,
+        // adminProductCursor,
         mediaCursor
       ];
     }
 
-    // Else revision control is disabled, but user is an admin
-    const productCursor = Products.find(newSelector, {
-      sort: sort,
-      limit: productScrollLimit
-    });
-    const mediaProductIds = productCursor.fetch().map((p) => p._id);
+    const mediaProductIds = adminProductCursor.fetch().map((p) => p._id);
     const mediaCursor = findProductsMedia(this, mediaProductIds);
 
     return [
-      productCursor,
+      adminProductCursor,
       mediaCursor
     ];
   }

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -374,6 +374,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
       });
 
       const handle2 = Revisions.find({
+        "revision.documentId": adminProductIds,
         "workflow.status": {
           $nin: [
             "revision/published"


### PR DESCRIPTION
This PR drastically improves the performance of the `Products` publication by reducing the number of documents that are sent to the client.

It contains some potentially breaking or backward incompatible changes:
- Changes the product publication to publish only top-level products. Until now, we've been publishing top level products and all variants associated with those products, sometimes hundreds of documents. We've also been publishing every image associated with those documents
- Changes the Media publication for the Products publication to publish only media items associated with the top level products, and only media items that have `"metadata.toGrid": 1` 
- until #3367 is merged, this PR will cause the GridItemNotice tags to report the status of inventory availability incorrectly as GridItemNotice currently depends on having all variants available. Because of that, I'm listing this as `blocked` by #3367
- Changes the revision `observeChanges` method to only publish revisions associated with top-level products.

@mikemurray this last item has potential to interfere with the way that revisions published and cascaded through product variants and options. I think that's something that could/should probably be done on the server, but it should probably find it's way into this PR if it's breaking the way that revisions are intended to be published. Also possible that it's working as expected.

If users or plugins rely on every variant being published to the client instead of using denormalized data on the top-level product they will need to be updated to be compatible with this update

This PR accomplishes the performance improvement by doing the following:
- Improves the selection of products that are published to the grid. Until now, we've been publishing products up to the scroll limit as well as each variant and variant option associated with that product. This led to hundreds of products getting published in some cases.
- Changes the `observeChanges` methods for Products and Revisions to respect the scroll limit. This resolves an issue where the products publication was being invalidated and additional products were being added to the publication beyond the scroll limit any time there was a revision added or changed on the server.

**To Test**
- As an admin, import products from Shopify. Observe that the number of products published is limited to the set scroll limit (24 by default)
- Publish a bunch of products and visit as a guest - observe that the number of products published is limited to the set scroll limit.