### PR TITLE
Fix cart items image displays placeholder

### DIFF
--- a/imports/plugins/core/checkout/client/components/cartItems.js
+++ b/imports/plugins/core/checkout/client/components/cartItems.js
@@ -50,7 +50,7 @@ class CartItems extends Component {
           onClick={this.handleClick}
         >
           {handleImage(item) ?
-            <div className="center-cropped" style={{ backgroundImage: `url(${handleImage(item).url({ store: "small" })})` }}>
+            <div className="center-cropped" style={{ backgroundImage: `url('${handleImage(item).url({ store: "small" })}')` }}>
               <img src={handleImage(item).url({ store: "small" })} className="product-grid-item-images img-responsive" />
             </div> :
             <div className="center-cropped" style={{ backgroundImage: "url('/resources/placeholder.gif')" }}>


### PR DESCRIPTION
Resolves #3263 

This PR fixes a bug where items in cart images are sometimes not showing or displays placeholder.

## How to Test

1. Login as an Admin or Merchant
2. Create few products w/ or w/o variants and add pictures for each.
3. Add created products to cart.
4. Click on cart
5. Observe that images are shown for each items in cart