### PR TITLE
(fix): 3379 - sweetAlerts2 ^7.0.0 update compatibility

### DIFF
--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -72,6 +72,7 @@ Object.assign(Alerts, {
   alert(titleOrOptions, messageOrCallback, options, callback) {
     if (_.isObject(titleOrOptions)) {
       return swal({
+        useRejections: true,
         type: "info",
         ...titleOrOptions
       }).then((isConfirm) => {
@@ -94,6 +95,7 @@ Object.assign(Alerts, {
     const message = messageOrCallback;
 
     return swal({
+      useRejections: true,
       title,
       text: message,
       type: "info",


### PR DESCRIPTION
Fixes #3379 

When we updated package.json, it bumped sweetAlerts2 to a `^7.0.0` version, which had breaking changes.

This PR follows [their directions](https://github.com/limonte/sweetalert2/releases/tag/v7.0.0) to add backwards compatibly to our `Alerts.alert` so the pop-up alerts continue to work as they did.

To Test:
- Find any pop-up alert (for instance, deleting a picture from the PDP), and click either the cancel or confirm buttons
- See that the action you select actually happens, instead of just closing the pop-up silently