### PR TITLE
[WIP] Refactor paymentMethod.supports into an array of booleans rather than string

### DIFF
--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -224,8 +224,7 @@ class InvoiceContainer extends Component {
     const paymentMethodName = orderBillingInfo.paymentMethod && orderBillingInfo.paymentMethod.paymentSettingsKey;
     const paymentMethod = Packages.findOne({ _id: paymentMethodId });
     const isRefundable = paymentMethod && paymentMethod.settings && paymentMethod.settings[paymentMethodName]
-      && paymentMethod.settings[paymentMethodName].support.includes("Refund");
-
+      && paymentMethod.settings[paymentMethodName].support.refund;
     return isRefundable;
   }
 

--- a/imports/plugins/included/connectors-shopify/package-lock.json
+++ b/imports/plugins/included/connectors-shopify/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "reaction-connectors-shopify",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/imports/plugins/included/payments-authnet/client/settings/authnet.html
+++ b/imports/plugins/included/payments-authnet/client/settings/authnet.html
@@ -17,6 +17,9 @@
         id="authnet-update-form"
       }}
       {{>afQuickField name="settings.reaction-auth-net.support" options="allowed" noselect=true}}
+      {{>afQuickField name="settings.reaction-auth-net.support.authorize" type="boolean-checkbox"}}
+      {{>afQuickField name="settings.reaction-auth-net.support.de_authorize" type="boolean-checkbox"}}
+      {{>afQuickField name="settings.reaction-auth-net.support.capture" type="boolean-checkbox"}}
       {{>afQuickField name='settings.mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Test - Sandbox Mode"}}
       {{>afQuickField name="settings.api_id"}}
       {{>afQuickField name="settings.transaction_key"}}

--- a/imports/plugins/included/payments-authnet/lib/collections/schemas/authnet.js
+++ b/imports/plugins/included/payments-authnet/lib/collections/schemas/authnet.js
@@ -18,12 +18,23 @@ export const AuthNetPackageConfig = new SimpleSchema([
       defaultValue: false
     },
     "settings.reaction-auth-net.support": {
-      type: Array,
+      type: Object,
       label: "Payment provider supported methods"
     },
-    "settings.reaction-auth-net.support.$": {
-      type: String,
-      allowedValues: ["Authorize", "De-authorize", "Capture"]
+    "settings.reaction-auth-net.support.authorize": {
+      type: Boolean,
+      label: "Authorize",
+      defaultValue: true
+    },
+    "settings.reaction-auth-net.support.de_authorize": {
+      type: Boolean,
+      label: "De-Authorize",
+      defaultValue: false
+    },
+    "settings.reaction-auth-net.support.capture": {
+      type: Boolean,
+      label: "Capture",
+      defaultValue: true
     },
     "settings.api_id": {
       type: String,

--- a/imports/plugins/included/payments-authnet/register.js
+++ b/imports/plugins/included/payments-authnet/register.js
@@ -15,10 +15,10 @@ Reaction.registerPackage({
     },
     "reaction-auth-net": {
       enabled: false,
-      support: [
-        "Authorize",
-        "Capture"
-      ]
+      support: {
+        authorize: true,
+        capture: true
+      }
     }
   },
   registry: [

--- a/imports/plugins/included/payments-braintree/client/settings/braintree.html
+++ b/imports/plugins/included/payments-braintree/client/settings/braintree.html
@@ -17,6 +17,10 @@
         {{>afQuickField name='settings.public_key'}}
         {{>afQuickField name='settings.private_key'}}
         {{>afQuickField name="settings.reaction-braintree.support" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.reaction-braintree.support.authorize" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.reaction-braintree.support.de_authorize" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.reaction-braintree.support.capture" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.reaction-braintree.support.refund" type="boolean-checkbox" options="allowed" noselect=true}}
         {{>afQuickField name='settings.mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Testing - Sandbox Mode"}}
         <button type="submit" class="btn btn-primary pull-right"><span data-i18n="app.saveChanges">Save Changes</span></button>
       {{/autoForm}}

--- a/imports/plugins/included/payments-braintree/lib/collections/schemas/braintree.js
+++ b/imports/plugins/included/payments-braintree/lib/collections/schemas/braintree.js
@@ -35,13 +35,33 @@ export const BraintreePackageConfig = new SimpleSchema([
       optional: false
     },
     "settings.reaction-braintree.support": {
-      type: Array,
+      type: Object,
       label: "Payment provider supported methods"
     },
-    "settings.reaction-braintree.support.$": {
-      type: String,
-      allowedValues: ["Authorize", "De-authorize", "Capture", "Refund"]
+    "settings.reaction-braintree.support.authorize": {
+      type: Boolean,
+      label: "Authorize",
+      defaultValue: true
+    },
+    "settings.reaction-braintree.support.de_authorize": {
+      type: Boolean,
+      label: "De-Authorize",
+      defaultValue: false
+    },
+    "settings.reaction-braintree.support.capture": {
+      type: Boolean,
+      label: "Capture",
+      defaultValue: true
+    },
+    "settings.reaction-braintree.support.refund": {
+      type: Boolean,
+      label: "Refund",
+      defaultValue: true
     }
+    // "settings.reaction-braintree.support.$": {
+    //   type: String,
+    //   allowedValues: ["Authorize", "De-authorize", "Capture", "Refund"]
+    // }
   }
 ]);
 

--- a/imports/plugins/included/payments-braintree/lib/collections/schemas/braintree.js
+++ b/imports/plugins/included/payments-braintree/lib/collections/schemas/braintree.js
@@ -58,10 +58,6 @@ export const BraintreePackageConfig = new SimpleSchema([
       label: "Refund",
       defaultValue: true
     }
-    // "settings.reaction-braintree.support.$": {
-    //   type: String,
-    //   allowedValues: ["Authorize", "De-authorize", "Capture", "Refund"]
-    // }
   }
 ]);
 

--- a/imports/plugins/included/payments-braintree/register.js
+++ b/imports/plugins/included/payments-braintree/register.js
@@ -14,11 +14,11 @@ Reaction.registerPackage({
     "private_key": "",
     "reaction-braintree": {
       enabled: false,
-      support: [
-        "Authorize",
-        "Capture",
-        "Refund"
-      ]
+      support: {
+        authorize: true,
+        capture: true,
+        refund: true
+      }
     }
   },
   registry: [

--- a/imports/plugins/included/payments-example/register.js
+++ b/imports/plugins/included/payments-example/register.js
@@ -14,11 +14,11 @@ Reaction.registerPackage({
     },
     "example-paymentmethod": {
       enabled: false,
-      support: {
-        authorize: true,
-        capture: true,
-        refund: true
-      }
+      support: [
+        "Authorize",
+        "Capture",
+        "Refund"
+      ]
     }
   },
   registry: [

--- a/imports/plugins/included/payments-example/register.js
+++ b/imports/plugins/included/payments-example/register.js
@@ -14,11 +14,11 @@ Reaction.registerPackage({
     },
     "example-paymentmethod": {
       enabled: false,
-      support: [
-        "Authorize",
-        "Capture",
-        "Refund"
-      ]
+      support: {
+        authorize: true,
+        capture: true,
+        refund: true
+      }
     }
   },
   registry: [

--- a/imports/plugins/included/payments-paypal/client/templates/settings/express.html
+++ b/imports/plugins/included/payments-paypal/client/templates/settings/express.html
@@ -21,6 +21,10 @@
     {{>afQuickField name='settings.password' type="password"}}
     {{>afQuickField name='settings.signature'}}
     {{>afQuickField name="settings.express.support" options="allowed" noselect=true}}
+     {{>afQuickField name="settings.express.support.authorize" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.express.support.de_authorize" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.express.support.capture" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.express.support.refund" type="boolean-checkbox" options="allowed" noselect=true}}
     {{>afQuickField name="settings.expressAuthAndCapture" type="boolean-select" trueLabel="Authorize, Capture immediately." falseLabel="Authorize, Capture on complete." }}
     {{>afQuickField name='settings.express_mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Testing - Sandbox Mode"}}
 

--- a/imports/plugins/included/payments-paypal/client/templates/settings/payflow.html
+++ b/imports/plugins/included/payments-paypal/client/templates/settings/payflow.html
@@ -17,6 +17,10 @@
     {{>afQuickField name='settings.client_id'}}
     {{>afQuickField name='settings.client_secret' type="password"}}
     {{>afQuickField name="settings.payflow.support" options="allowed" noselect=true}}
+     {{>afQuickField name="settings.payflow.support.authorize" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.payflow.support.de_authorize" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.payflow.support.capture" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.payflow.support.refund" type="boolean-checkbox" options="allowed" noselect=true}}
     {{>afQuickField name='settings.payflow_mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Testing - Sandbox Mode"}}
     <button type="submit" class="btn btn-primary pull-right"><span data-i18n="app.saveChanges">Save Changes</span></button>
   {{/autoForm}}

--- a/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
+++ b/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
@@ -16,22 +16,22 @@ export const PaypalPackageConfig = new SimpleSchema([
     "settings.express.support.authorize": {
       type: Boolean,
       defaultValue: true,
-      label: Authorize
+      label: "Authorize"
     },
     "settings.express.support.de_authorize": {
       type: Boolean,
       defaultValue: true,
-      label: De-Authorize
+      label: "De-Authorize"
     },
     "settings.express.support.capture": {
       type: Boolean,
       defaultValue: true,
-      label: Capture
+      label: "Capture"
     },
     "settings.express.support.refund": {
       type: Boolean,
       defaultValue: true,
-      label: Refund,
+      label: "Refund",
     },
     "settings.payflow.support": {
       type: Object,
@@ -40,22 +40,22 @@ export const PaypalPackageConfig = new SimpleSchema([
     "settings.payflow.support.authorize": {
       type: Boolean,
       defaultValue: true,
-      label: Authorize
+      label: "Authorize"
     },
     "settings.payflow.support.de_authorize": {
       type: Boolean,
       defaultValue: true,
-      label: De-Authorize
+      label: "De-Authorize"
     },
     "settings.payflow.support.capture": {
       type: Boolean,
       defaultValue: true,
-      label: Capture
+      label: "Capture"
     },
     "settings.payflow.support.refund": {
       type: Boolean,
       defaultValue: true,
-      label: Refund,
+      label: "Refund",
     },
     "settings.merchantId": {
       type: String,

--- a/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
+++ b/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
@@ -10,20 +10,52 @@ export const PaypalPackageConfig = new SimpleSchema([
       defaultValue: false
     },
     "settings.express.support": {
-      type: Array,
+      type: Object,
       label: "Payment provider supported methods"
     },
-    "settings.express.support.$": {
-      type: String,
-      allowedValues: ["Authorize", "De-authorize", "Capture", "Refund"]
+    "settings.express.support.authorize": {
+      type: Boolean,
+      defaultValue: true,
+      label: Authorize
+    },
+    "settings.express.support.de_authorize": {
+      type: Boolean,
+      defaultValue: true,
+      label: De-Authorize
+    },
+    "settings.express.support.capture": {
+      type: Boolean,
+      defaultValue: true,
+      label: Capture
+    },
+    "settings.express.support.refund": {
+      type: Boolean,
+      defaultValue: true,
+      label: Refund,
     },
     "settings.payflow.support": {
-      type: Array,
+      type: Object,
       label: "Payment provider supported methods"
     },
-    "settings.payflow.support.$": {
-      type: String,
-      allowedValues: ["Authorize", "De-authorize", "Capture", "Refund"]
+    "settings.payflow.support.authorize": {
+      type: Boolean,
+      defaultValue: true,
+      label: Authorize
+    },
+    "settings.payflow.support.de_authorize": {
+      type: Boolean,
+      defaultValue: true,
+      label: De-Authorize
+    },
+    "settings.payflow.support.capture": {
+      type: Boolean,
+      defaultValue: true,
+      label: Capture
+    },
+    "settings.payflow.support.refund": {
+      type: Boolean,
+      defaultValue: true,
+      label: Refund,
     },
     "settings.merchantId": {
       type: String,

--- a/imports/plugins/included/payments-paypal/register.js
+++ b/imports/plugins/included/payments-paypal/register.js
@@ -9,19 +9,19 @@ Reaction.registerPackage({
     expressAuthAndCapture: false,
     express: {
       enabled: false,
-      support: [
-        "Authorize",
-        "Capture",
-        "Refund"
-      ]
+      support: {
+        authorize: true,
+        capture: true,
+        refund: true
+      }
     },
     payflow: {
       enabled: false,
-      support: [
-        "Authorize",
-        "Capture",
-        "Refund"
-      ]
+      support: {
+        authorize: true,
+        capture: true,
+        refund: true
+      }
     }
   },
   registry: [

--- a/imports/plugins/included/payments-stripe/client/settings/stripe.html
+++ b/imports/plugins/included/payments-stripe/client/settings/stripe.html
@@ -31,6 +31,10 @@
           {{>afQuickField name="settings.applicationFee"}}
         {{/if}}
         {{>afQuickField name="settings.reaction-stripe.support" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.reaction-stripe.support.authorize" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.reaction-stripe.support.de_authorize" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.reaction-stripe.support.capture" type="boolean-checkbox" options="allowed" noselect=true}}
+        {{>afQuickField name="settings.reaction-stripe.support.refund" type="boolean-checkbox" options="allowed" noselect=true}}
         <button type="submit" class="btn btn-primary pull-right"><span data-i18n="app.saveChanges">Save Changes</span></button>
       {{/autoForm}}
     </div>

--- a/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
+++ b/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
@@ -63,22 +63,22 @@ export const StripePackageConfig = new SimpleSchema([
     "settings.reaction-stripe.support.authorize": {
       type: Boolean,
       defaultValue: true,
-      label: Authorize
+      label: "Authorize"
     },
     "settings.reaction-stripe.support.de_authorize": {
       type: Boolean,
       defaultValue: false,
-      label: De-Authorize
+      label: "De-Authorize"
     },
     "settings.reaction-stripe.support.capture": {
       type: Boolean,
       defaultValue: true,
-      label: Capture
+      label: "Capture"
     },
     "settings.reaction-stripe.support.refund": {
       type: Boolean,
       defaultValue: true,
-      label: Refund
+      label: "Refund"
     },
 
     // Public Settings

--- a/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
+++ b/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
@@ -57,12 +57,28 @@ export const StripePackageConfig = new SimpleSchema([
       optional: true
     },
     "settings.reaction-stripe.support": {
-      type: Array,
+      type: Object,
       label: "Payment provider supported methods"
     },
-    "settings.reaction-stripe.support.$": {
-      type: String,
-      allowedValues: ["Authorize", "De-authorize", "Capture", "Refund"]
+    "settings.reaction-stripe.support.authorize": {
+      type: Boolean,
+      defaultValue: true,
+      label: Authorize
+    },
+    "settings.reaction-stripe.support.de_authorize": {
+      type: Boolean,
+      defaultValue: false,
+      label: De-Authorize
+    },
+    "settings.reaction-stripe.support.capture": {
+      type: Boolean,
+      defaultValue: true,
+      label: Capture
+    },
+    "settings.reaction-stripe.support.refund": {
+      type: Boolean,
+      defaultValue: true,
+      label: Refund
     },
 
     // Public Settings

--- a/imports/plugins/included/payments-stripe/register.js
+++ b/imports/plugins/included/payments-stripe/register.js
@@ -11,11 +11,11 @@ Reaction.registerPackage({
     "api_key": "",
     "reaction-stripe": {
       enabled: false,
-      support: [
-        "Authorize",
-        "Capture",
-        "Refund"
-      ]
+      support: {
+        authorize: true,
+        capture: true,
+        refund: true
+      }
     },
     "public": {
       client_id: ""

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -384,7 +384,7 @@ export const methods = {
     const paymentMethodName = paymentMethod && paymentMethod.paymentSettingsKey;
     const getPaymentMethod = Packages.findOne({ _id: paymentMethodId });
     const isRefundable = getPaymentMethod && getPaymentMethod.settings && getPaymentMethod.settings[paymentMethodName]
-      && getPaymentMethod.settings[paymentMethodName].support.includes("Refund");
+      && getPaymentMethod.settings[paymentMethodName].support.refund;
 
     if (isRefundable) {
       Meteor.call("orders/refunds/create", order._id, paymentMethod, Number(invoiceTotal));


### PR DESCRIPTION
Working on #3373

This is a work in progress  PR that does:
- Refactor payment schema with an array in `support` property
- Change the `array of String` to `object of Boolean`
- Make sure payment work properly.

#### Test 1
- Log in
- Open the payment settings panel
- Enable either `Braintree or Authnet` payment method.
- Go to `Payment provider supported methods` check  or uncheck any of the supported methods the click on `save changes`. Notice the toast with a message of updated.
- Open Robomongo or it's alternative 
- Go to packages open `settings-reaction-braintree.support` or `settings-reaction-auth-net.support` depending on the current payment method  notice the type of `Boolean` and the changed from either true to false or false to true.

#### Test 2
- Log in
- Enable either `Braintree or Authnet` payment method.
- Place an order
- Checkout using any of the payment method stated above
- Notice the payment worked as normal.

