### PR TITLE
(fix): 3392 - remove shopId check on payment methods for merchent orders

### DIFF
--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -130,8 +130,7 @@ Template.coreOrderShippingInvoice.events({
     const settingsKey = paymentMethod && paymentMethod.paymentSettingsKey;
     // check if payment provider supports de-authorize
     const checkSupportedMethods = Packages.findOne({
-      _id: packageId,
-      shopId: Reaction.getShopId()
+      _id: packageId
     }).settings[settingsKey].support;
 
     const orderStatus = paymentMethod && paymentMethod.status;

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -1077,8 +1077,7 @@ export const methods = {
     const settingsKey = paymentMethod.paymentSettingsKey;
     // check if payment provider supports de-authorize
     const checkSupportedMethods = Packages.findOne({
-      _id: packageId,
-      shopId: Reaction.getShopId()
+      _id: packageId
     }).settings[settingsKey].support;
 
     const orderMode = paymentMethod.mode;


### PR DESCRIPTION
Fixes #3392 

An error was occurring when trying to process orders as a merchant shop, using a payment method that belonged to the marketplace owner shop.

The package was checking for a packageId && a shop ID, however the shop ID was the active shop, and the packageId belongs to the marketplace shop, so if you were a merchant processing an order, there would never be a match here, causing an error.

the packageIds are specific enough where we don't need this extra shopId check.