### PR TITLE
(feat): allow getShopName() to accept a shopId parameter

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -489,8 +489,14 @@ export default {
     }
   },
 
-  getShopName() {
-    const shopId = this.getShopId();
+  /**
+   * getShopName
+   * @summary gets name of shop by provided shopId, or current active shop if shopId is not provided
+   * @param {String} providedShopID - shopId of shop to return name of
+   * @return {String} - shop name
+   */
+  getShopName(providedShopId) {
+    const shopId = providedShopId || this.getShopId();
     const shop = Shops.findOne({
       _id: shopId
     });


### PR DESCRIPTION
Add logic to allow `getShopName` method to accept a `shopId` so we can get the name of any shop, not just the name of the active shop.

Falls back to current logic, providing the current shop name if no ID is provided.