### PR TITLE
#3397 Fix publishing indicator is in the wrong place

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/media.less
+++ b/imports/plugins/included/default-theme/client/styles/media.less
@@ -84,10 +84,10 @@
 
   .rui.status-badge {
     position: absolute;
-    top: -17px;
-    right: -17px;
-    width: 16px;
-    height: 16px;
+    top: -23px;
+    right: -23px;
+    width: 20px;
+    height: 20px;
 
     .icon-only {
 

--- a/imports/plugins/included/default-theme/client/styles/media.less
+++ b/imports/plugins/included/default-theme/client/styles/media.less
@@ -86,8 +86,8 @@
     position: absolute;
     top: -23px;
     right: -23px;
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
 
     .icon-only {
 


### PR DESCRIPTION
Resolves #3397 

This PR fixes the publishing indicator been placed in the wrong place.
<img width="1631" alt="screen shot 2017-12-13 at 16 09 42" src="https://user-images.githubusercontent.com/12285426/33945754-37513d46-e020-11e7-8c38-18e84e3b7f51.png">


## How to test

1. Create a product
2. Add an image to the newly created product
3. Observe that the publishing indicator is in the right place

  Or

1. Change a product
2. See publishing indicator dot is in the right place.