### PR TITLE
(fix): orders date filter not appearing

### DIFF
--- a/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
+++ b/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
@@ -20,6 +20,23 @@ class CalendarPicker extends Component {
     };
   }
 
+  /**
+   * Getter returning a value of `true` if the current drection is set to RTL
+   * @return {Boolean} true if RTL false if LTR
+   */
+  get isRTL() {
+    if (typeof this.props.isRTL === "boolean") {
+      // If isRTL is set from props, then use
+      return this.props.isRTL;
+    } else if (document) {
+      // Otherwise try to determine RTL status from the html class name "rtl"
+      return document.getElementsByTagName("html")[0].className.includes("rtl");
+    }
+
+    // Return false if above matches fail
+    return false;
+  }
+
   onDatesChange = ({ startDate, endDate }) => {
     this.setState({ startDate, endDate });
 
@@ -48,6 +65,7 @@ class CalendarPicker extends Component {
         onDatesChange={this.onDatesChange}
         onFocusChange={this.onFocusChange}
         focusedInput={focusedInput}
+        isRTL={this.isRTL}
         startDate={startDate}
         endDate={endDate}
         navPrev={< i className = "fa fa-arrow-left" />}
@@ -77,7 +95,7 @@ CalendarPicker.defaultProps = {
   onOutsideClick() {},
   keepOpenOnDateSelect: false,
   renderCalendarInfo: null,
-  isRTL: false,
+  isRTL: undefined,
 
   // navigation related props
   navPrev: null,

--- a/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
+++ b/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import "react-dates/initialize";
 import { DayPickerRangeController } from "react-dates";
 import omit from "lodash/omit";
 import { registerComponent } from "@reactioncommerce/reaction-components";

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -222,20 +222,20 @@
   text-align: left;
 }
 
-.DayPicker--horizontal {
+.DayPicker__horizontal {
   background: #fff;
   box-shadow: none;
   border-radius: 3px;
 }
 
-.DayPicker--horizontal.DayPicker--portal {
+.DayPicker__horizontal.DayPicker__portal {
   box-shadow: none;
   position: absolute;
   left: 50%;
   top: 50%;
 }
 
-.DayPicker--vertical.DayPicker--portal {
+.DayPicker__vertical.DayPicker__portal {
   position: initial;
 }
 
@@ -247,7 +247,7 @@
   position: relative;
 }
 
-.DayPicker--horizontal .DayPicker_weekHeaders {
+.DayPicker__horizontal .DayPicker_weekHeaders {
   margin-left: 9px;
 }
 
@@ -272,22 +272,22 @@
   text-align: center;
 }
 
-.DayPicker--vertical .DayPicker_weekHeader {
+.DayPicker__vertical .DayPicker_weekHeader {
   left: 50%;
 }
 
-.DayPicker--vertical-scrollable {
+.DayPicker__vertical-scrollable {
   height: 100%;
 }
 
-.DayPicker--vertical-scrollable .DayPicker_weekHeader {
+.DayPicker__vertical-scrollable .DayPicker_weekHeader {
   top: 0;
   display: table-row;
   border-bottom: 1px solid #dbdbdb;
   background: #fff;
 }
 
-.DayPicker--vertical-scrollable .transition-container--vertical {
+.DayPicker__vertical-scrollable .transition-container__vertical {
   padding-top: 20px;
   height: 100%;
   position: absolute;
@@ -298,7 +298,7 @@
   overflow-y: scroll;
 }
 
-.DayPicker--vertical-scrollable .DayPicker_weekHeader {
+.DayPicker__vertical-scrollable .DayPicker_weekHeader {
   margin-left: 0;
   left: 0;
   width: 100%;
@@ -311,11 +311,11 @@
   border-radius: 3px;
 }
 
-.transition-container--horizontal {
+.transition-container__horizontal {
   transition: height 0.2s ease-in-out;
 }
 
-.transition-container--vertical {
+.transition-container__vertical {
   width: 100%;
 }
 

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -242,15 +242,15 @@
   outline: none;
 }
 
-.DayPicker_week-headers {
+.DayPicker_weekHeaders {
   position: relative;
 }
 
-.DayPicker--horizontal .DayPicker_week-headers {
+.DayPicker--horizontal .DayPicker_weekHeaders {
   margin-left: 9px;
 }
 
-.DayPicker_week-header {
+.DayPicker_weekHeader {
   color: #757575;
   position: absolute;
   top: 62px;
@@ -259,19 +259,19 @@
   text-align: left;
 }
 
-.DayPicker_week-header ul {
+.DayPicker_weekHeader ul {
   list-style: none;
   margin: 1px 0;
   padding-left: 0;
   padding-right: 0;
 }
 
-.DayPicker_week-header li {
+.DayPicker_weekHeader li {
   display: inline-block;
   text-align: center;
 }
 
-.DayPicker--vertical .DayPicker_week-header {
+.DayPicker--vertical .DayPicker_weekHeader {
   left: 50%;
 }
 
@@ -279,7 +279,7 @@
   height: 100%;
 }
 
-.DayPicker--vertical-scrollable .DayPicker_week-header {
+.DayPicker--vertical-scrollable .DayPicker_weekHeader {
   top: 0;
   display: table-row;
   border-bottom: 1px solid #dbdbdb;
@@ -297,7 +297,7 @@
   overflow-y: scroll;
 }
 
-.DayPicker--vertical-scrollable .DayPicker_week-header {
+.DayPicker--vertical-scrollable .DayPicker_weekHeader {
   margin-left: 0;
   left: 0;
   width: 100%;

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -26,73 +26,73 @@
   outline: 0;
 }
 
-.CalendarDay--highlighted-calendar {
+.CalendarDay__highlighted-calendar {
   background: #ffe8bc;
   color: #565a5c;
   cursor: default;
 }
 
-.CalendarDay--highlighted-calendar:active {
+.CalendarDay__highlighted-calendar:active {
   background: #007a87;
 }
 
-.CalendarDay--outside {
+.CalendarDay__outside {
   border: 0;
   cursor: default;
 }
 
-.CalendarDay--outside:active {
+.CalendarDay__outside:active {
   background: #fff;
 }
 
-.CalendarDay--hovered {
+.CalendarDay__hovered {
   background: @rui-info-hover;
   border-radius: 50%;
   border: 1px solid @rui-info-hover;
   color: inherit;
 }
 
-.CalendarDay--blocked-minimum-nights {
+.CalendarDay__blocked-minimum-nights {
   color: #cacccd;
   background: #fff;
   border: 1px solid #e4e7e7;
   cursor: default;
 }
 
-.CalendarDay--blocked-minimum-nights:active {
+.CalendarDay__blocked-minimum-nights:active {
   background: #fff;
 }
 
-.CalendarDay--selected-span {
+.CalendarDay__selected_span {
   background: @rui-info-bg;
   border: 1px solid @rui-info-bg;
   color: @rui-default-text;
 }
 
-.CalendarDay--selected-span.CalendarDay--hovered, .CalendarDay--selected-span:active {
+.CalendarDay__selected_span.CalendarDay__hovered, .CalendarDay__selected_span:active {
   background: @rui-info-hover;
   border-radius: 50%;
   border: 1px solid @rui-info-hover;
 }
 
-.CalendarDay--selected-span.CalendarDay--last-in-range {
+.CalendarDay__selected_span.CalendarDay__last-in-range {
   border-right: @rui-info-bg;
 }
 
-.CalendarDay--hovered.CalendarDay--hovered-span {
+.CalendarDay__hovered.CalendarDay__hovered_span {
   background: @rui-info-hover;
 }
 
-.CalendarDay--hovered-span,
-.CalendarDay--after-hovered-start {
+.CalendarDay__hovered_span,
+.CalendarDay__after-hovered_start {
   background: @rui-info-bg;
   border: 1px solid @rui-info-bg;
   color: @rui-default-text;
 }
 
-.CalendarDay--selected-start,
-.CalendarDay--selected-end,
-.CalendarDay--selected {
+.CalendarDay__selected_start,
+.CalendarDay__selected_end,
+.CalendarDay__selected {
   color: @rui-default-text;
   background: #f7f7f7;
 
@@ -102,30 +102,30 @@
   }
 }
 
-.CalendarDay--selected-start:active,
-.CalendarDay--selected-end:active,
-.CalendarDay--selected:active {
+.CalendarDay__selected_start:active,
+.CalendarDay__selected_end:active,
+.CalendarDay__selected:active {
   background: @rui-info;
 }
 
-.CalendarDay--blocked-calendar {
+.CalendarDay__blocked-calendar {
   background: #cacccd;
   color: #82888a;
   cursor: default;
 }
 
-.CalendarDay--blocked-calendar:active {
+.CalendarDay__blocked-calendar:active {
   background: #cacccd;
 }
 
-.CalendarDay--blocked-out-of-range {
+.CalendarDay__blocked-out-of-range {
   color: #cacccd;
   background: #fff;
   border: 1px solid #e4e7e7;
   cursor: default;
 }
 
-.CalendarDay--blocked-out-of-range:active {
+.CalendarDay__blocked-out-of-range:active {
   background: #fff;
 }
 

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -330,7 +330,7 @@
   background: #f2f2f2;
 }
 
-.DayPickerNavigation--horizontal {
+.DayPickerNavigation__horizontal {
   position: relative;
 }
 
@@ -431,50 +431,50 @@
   z-index: 2;
 }
 
-.DayPickerKeyboardShortcuts_show--bottom-right {
+.DayPickerKeyboardShortcuts_show__bottom-right {
   border-top: 26px solid transparent;
   border-right: 33px solid #00a699;
   bottom: 0;
   right: 0;
 }
 
-.DayPickerKeyboardShortcuts_show--bottom-right:hover {
+.DayPickerKeyboardShortcuts_show__bottom-right:hover {
   border-right: 33px solid #008489;
 }
 
-.DayPickerKeyboardShortcuts_show--bottom-right .DayPickerKeyboardShortcuts_show_span {
+.DayPickerKeyboardShortcuts_show__bottom-right .DayPickerKeyboardShortcuts_show_span {
   bottom: 0;
   right: -28px;
 }
 
-.DayPickerKeyboardShortcuts_show--top-right {
+.DayPickerKeyboardShortcuts_show__top-right {
   border-bottom: 26px solid transparent;
   border-right: 33px solid #00a699;
   top: 0;
   right: 0;
 }
 
-.DayPickerKeyboardShortcuts_show--top-right:hover {
+.DayPickerKeyboardShortcuts_show__top-right:hover {
   border-right: 33px solid #008489;
 }
 
-.DayPickerKeyboardShortcuts_show--top-right .DayPickerKeyboardShortcuts_show_span {
+.DayPickerKeyboardShortcuts_show__top-right .DayPickerKeyboardShortcuts_show_span {
   top: 1px;
   right: -28px;
 }
 
-.DayPickerKeyboardShortcuts_show--top-left {
+.DayPickerKeyboardShortcuts_show__top-left {
   border-bottom: 26px solid transparent;
   border-left: 33px solid #00a699;
   top: 0;
   left: 0;
 }
 
-.DayPickerKeyboardShortcuts_show--top-left:hover {
+.DayPickerKeyboardShortcuts_show__top-left:hover {
   border-left: 33px solid #008489;
 }
 
-.DayPickerKeyboardShortcuts_show--top-left .DayPickerKeyboardShortcuts_show_span {
+.DayPickerKeyboardShortcuts_show__top-left .DayPickerKeyboardShortcuts_show_span {
   top: 1px;
   left: -28px;
 }
@@ -556,16 +556,16 @@ outline: none;
   margin-left: 8px;
 }
 
-.DayPickerKeyboardShortcuts_panel--block .KeyboardShortcutRow {
+.DayPickerKeyboardShortcuts_panel__block .KeyboardShortcutRow {
   margin-bottom: 16px;
 }
 
-.DayPickerKeyboardShortcuts_panel--block .KeyboardShortcutRow_key-container {
+.DayPickerKeyboardShortcuts_panel__block .KeyboardShortcutRow_key-container {
   text-align: left;
   display: inline;
 }
 
-.DayPickerKeyboardShortcuts_panel--block .KeyboardShortcutRow_action {
+.DayPickerKeyboardShortcuts_panel__block .KeyboardShortcutRow_action {
   display: inline;
 }
 
@@ -583,8 +583,8 @@ outline: none;
   vertical-align: middle;
 }
 
-.DateInput--with-caret::before,
-.DateInput--with-caret::after {
+.DateInput__with-caret::before,
+.DateInput__with-caret::after {
   content: "";
   display: inline-block;
   position: absolute;
@@ -594,37 +594,37 @@ outline: none;
   z-index: 2;
 }
 
-.DateInput--open-down.DateInput--with-caret::before,
-.DateInput--open-down.DateInput--with-caret::after {
+.DateInput__open-down.DateInput__with-caret::before,
+.DateInput__open-down.DateInput__with-caret::after {
   border-top: 0;
 }
 
-.DateInput--open-down.DateInput--with-caret::before {
+.DateInput__open-down.DateInput__with-caret::before {
   top: 62px;
   border-bottom-color: rgba(0, 0, 0, 0.1);
 }
 
-.DateInput--open-down.DateInput--with-caret::after {
+.DateInput__open-down.DateInput__with-caret::after {
   top: 63px;
   border-bottom-color: #fff;
 }
 
-.DateInput--open-up.DateInput--with-caret::before,
-.DateInput--open-up.DateInput--with-caret::after {
+.DateInput__open-up.DateInput__with-caret::before,
+.DateInput__open-up.DateInput__with-caret::after {
   border-bottom: 0;
 }
 
-.DateInput--open-up.DateInput--with-caret::before {
+.DateInput__open-up.DateInput__with-caret::before {
   top: -24px;
   border-top-color: rgba(0, 0, 0, 0.1);
 }
 
-.DateInput--open-up.DateInput--with-caret::after {
+.DateInput__open-up.DateInput__with-caret::after {
   top: -25px;
   border-top-color: #fff;
 }
 
-.DateInput--disabled {
+.DateInput__disabled {
   background: #cacccd;
 }
 
@@ -651,18 +651,18 @@ outline: none;
   overflow: hidden;
 }
 
-.DateInput_display-text--has-input {
+.DateInput_display-text__has-input {
   color: #484848;
 }
 
-.DateInput_display-text--focused {
+.DateInput_display-text__focused {
   background: #99ede6;
   border-color: #99ede6;
   border-radius: 3px;
   color: #007a87;
 }
 
-.DateInput_display-text--disabled {
+.DateInput_display-text__disabled {
   font-style: italic;
 }
 
@@ -688,27 +688,27 @@ outline: none;
   position: absolute;
 }
 
-.DateRangePicker_picker--rtl {
+.DateRangePicker_picker__rtl {
   direction: rtl;
 }
 
-.DateRangePicker_picker--direction-left {
+.DateRangePicker_picker__direction-left {
   left: 0;
 }
 
-.DateRangePicker_picker--direction-right {
+.DateRangePicker_picker__direction-right {
   right: 0;
 }
 
-.DateRangePicker_picker--open-down {
+.DateRangePicker_picker__open-down {
   top: 72px;
 }
 
-.DateRangePicker_picker--open-up {
+.DateRangePicker_picker__open-up {
   bottom: 72px;
 }
 
-.DateRangePicker_picker--portal {
+.DateRangePicker_picker__portal {
   background-color: rgba(0, 0, 0, 0.3);
   position: fixed;
   top: 0;
@@ -717,7 +717,7 @@ outline: none;
   width: 100%;
 }
 
-.DateRangePicker_picker--full-screen-portal {
+.DateRangePicker_picker__full-screen-portal {
   background-color: #fff;
 }
 
@@ -754,11 +754,11 @@ outline: none;
   display: inline-block;
 }
 
-.DateRangePickerInput--disabled {
+.DateRangePickerInput__disabled {
   background: #cacccd;
 }
 
-.DateRangePickerInput--rtl {
+.DateRangePickerInput__rtl {
   direction: rtl;
 }
 
@@ -795,12 +795,12 @@ outline: none;
   vertical-align: middle;
 }
 
-.DateRangePickerInput_clear-dates--hide {
+.DateRangePickerInput_clear-dates__hide {
   visibility: hidden;
 }
 
 .DateRangePickerInput_clear-dates:focus,
-.DateRangePickerInput_clear-dates--hover {
+.DateRangePickerInput_clear-dates__hover {
   background: #dbdbdb;
   border-radius: 50%;
 }
@@ -837,27 +837,27 @@ outline: none;
   position: absolute;
 }
 
-.SingleDatePicker_picker--rtl {
+.SingleDatePicker_picker__rtl {
   direction: rtl;
 }
 
-.SingleDatePicker_picker--direction-left {
+.SingleDatePicker_picker__direction-left {
   left: 0;
 }
 
-.SingleDatePicker_picker--direction-right {
+.SingleDatePicker_picker__direction-right {
   right: 0;
 }
 
-.SingleDatePicker_picker--open-down {
+.SingleDatePicker_picker__open-down {
   top: 72px;
 }
 
-.SingleDatePicker_picker--open-up {
+.SingleDatePicker_picker__open-up {
   bottom: 72px;
 }
 
-.SingleDatePicker_picker--portal {
+.SingleDatePicker_picker__portal {
   background-color: rgba(0, 0, 0, 0.3);
   position: fixed;
   top: 0;
@@ -866,7 +866,7 @@ outline: none;
   width: 100%;
 }
 
-.SingleDatePicker_picker--full-screen-portal {
+.SingleDatePicker_picker__full-screen-portal {
   background-color: #fff;
 }
 
@@ -902,7 +902,7 @@ outline: none;
   border: 1px solid #dbdbdb;
 }
 
-.SingleDatePickerInput--rtl {
+.SingleDatePickerInput__rtl {
   direction: rtl;
 }
 
@@ -927,12 +927,12 @@ outline: none;
   vertical-align: middle;
 }
 
-.SingleDatePickerInput_clear-date--hide {
+.SingleDatePickerInput_clear-date__hide {
   visibility: hidden;
 }
 
 .SingleDatePickerInput_clear-date:focus,
-.SingleDatePickerInput_clear-date--hover {
+.SingleDatePickerInput_clear-date__hover {
   background: #dbdbdb;
   border-radius: 50%;
 }

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -186,6 +186,7 @@
 .CalendarMonthGrid {
   z-index: 0;
   text-align: left;
+  display: flex;
 
   tr {
     background: #f7f7f7;
@@ -194,23 +195,23 @@
   }
 }
 
-.CalendarMonthGrid--animating {
+.CalendarMonthGrid__animating {
   -webkit-transition: -webkit-transform 0.2s ease-in-out;
   -moz-transition: -moz-transform 0.2s ease-in-out;
   transition: transform 0.2s ease-in-out;
   z-index: 1;
 }
 
-.CalendarMonthGrid--horizontal {
+.CalendarMonthGrid__horizontal {
   position: absolute;
   left: 9px;
 }
 
-.CalendarMonthGrid--vertical {
+.CalendarMonthGrid__vertical {
   margin: 0 auto;
 }
 
-.CalendarMonthGrid--vertical-scrollable {
+.CalendarMonthGrid__vertical-scrollable {
   margin: 0 auto;
   overflow-y: scroll;
 }

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -318,8 +318,7 @@
   width: 100%;
 }
 
-.DayPickerNavigation_prev,
-.DayPickerNavigation_next {
+.DayPickerNavigation_button {
   cursor: pointer;
   line-height: 0.78;
   -webkit-user-select: none;
@@ -329,23 +328,17 @@
   -ms-user-select: none;
   /* IE10+ */
   user-select: none;
-}
-
-.DayPickerNavigation_prev--default,
-.DayPickerNavigation_next--default {
   border: 1px solid #dce0e0;
   background-color: #fff;
   color: #757575;
 }
 
-.DayPickerNavigation_prev--default:focus, .DayPickerNavigation_prev--default:hover,
-.DayPickerNavigation_next--default:focus,
-.DayPickerNavigation_next--default:hover {
+.DayPickerNavigation_button:focus,
+.DayPickerNavigation_button:hover {
   border: 1px solid #c4c4c4;
 }
 
-.DayPickerNavigation_prev--default:active,
-.DayPickerNavigation_next--default:active {
+.DayPickerNavigation_button:active {
   background: #f2f2f2;
 }
 
@@ -353,49 +346,45 @@
   position: relative;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation_prev,
-.DayPickerNavigation--horizontal .DayPickerNavigation_next {
-  border-radius: 50%;
+.DayPickerNavigation_container__horizontal .DayPickerNavigation_button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
   border: 2px solid @rui-default-text;
-  padding: 1px 1px;
+  width: 24px;
+  height: 24px;
   top: 23px;
   background-color: #fff;
   z-index: 2;
   position: absolute;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation_prev {
+.DayPickerNavigation_container__horizontal .DayPickerNavigation_leftButton__horizontal {
   left: 22px;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation_prev--rtl {
+.rtl .DayPickerNavigation_container__horizontal .DayPickerNavigation_leftButton__horizontal {
   left: auto;
   right: 22px;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation_next {
+.DayPickerNavigation_container__horizontal .DayPickerNavigation_rightButton__horizontal {
   right: 22px;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation_next--rtl {
+.rtl .DayPickerNavigation_container__horizontal .DayPickerNavigation_rightButton__horizontal {
   right: auto;
   left: 22px;
 }
 
-.DayPickerNavigation--horizontal i {
+.DayPickerNavigation_container__horizontal i {
   height: 16px;
   width: 14px;
   color: @rui-default-text;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation_prev--default svg,
-.DayPickerNavigation--horizontal .DayPickerNavigation_next--default svg {
-  height: 19px;
-  width: 19px;
-  fill: #82888a;
-}
-
-.DayPickerNavigation--vertical {
+.DayPickerNavigation_container__vertical {
   background: #fff;
   box-shadow: 0 0 5px 2px rgba(0, 0, 0, 0.1);
   position: absolute;
@@ -406,37 +395,28 @@
   z-index: 2;
 }
 
-.DayPickerNavigation--vertical .DayPickerNavigation_prev,
-.DayPickerNavigation--vertical .DayPickerNavigation_next {
+.DayPickerNavigation_container__vertical .DayPickerNavigation_button {
   display: inline-block;
   position: relative;
   height: 100%;
   width: 50%;
 }
 
-.DayPickerNavigation--vertical .DayPickerNavigation_next--default {
+.DayPickerNavigation_container__vertical .DayPickerNavigation_rightButton__vertical {
   border-left: 0;
 }
 
-.DayPickerNavigation--vertical .DayPickerNavigation_prev--default,
-.DayPickerNavigation--vertical .DayPickerNavigation_next--default {
+.DayPickerNavigation_container__vertical .DayPickerNavigation_button {
   text-align: center;
   font-size: 2.5em;
   padding: 5px;
 }
 
-.DayPickerNavigation--vertical .DayPickerNavigation_prev--default svg,
-.DayPickerNavigation--vertical .DayPickerNavigation_next--default svg {
-  height: 42px;
-  width: 42px;
-  fill: #484848;
-}
-
-.DayPickerNavigation--vertical-scrollable {
+.DayPickerNavigation_container__vertical-scrollable {
   position: relative;
 }
 
-.DayPickerNavigation--vertical-scrollable .DayPickerNavigation_next {
+.DayPickerNavigation_container__vertical-scrollable .DayPickerNavigation_rightButton__vertical {
   width: 100%;
 }
 

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -294,6 +294,7 @@
 
 .DayPicker_transitionContainer {
   position: relative;
+  min-height: 340px;
   overflow: hidden;
   border-radius: 3px;
 }

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -144,26 +144,19 @@
   border-spacing: 0 0.225em;
 }
 
-.CalendarMonth--horizontal:first-of-type,
-.CalendarMonth--vertical:first-of-type {
-  position: absolute;
-  z-index: -1;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.CalendarMonth--horizontal {
+.CalendarMonthGrid_month__horizontal {
   display: inline-block;
   min-height: 100%;
 }
 
-.CalendarMonth--vertical {
+.CalendarMonthGrid_month__vertical {
   display: block;
 }
 
 .CalendarMonth_caption {
   color: @rui-default-text;
   margin-top: 7px;
+  padding: 15px 0 35px;
   font-size: 16px;
   text-align: center;
   margin-bottom: 2px;
@@ -174,19 +167,10 @@
   }
 }
 
-.CalendarMonth--horizontal .CalendarMonth_caption,
-.CalendarMonth--vertical .CalendarMonth_caption {
-  padding: 15px 0 35px;
-}
-
-.CalendarMonth--vertical-scrollable .CalendarMonth_caption {
-  padding: 5px 0;
-}
-
 .CalendarMonthGrid {
   z-index: 0;
   text-align: left;
-  display: flex;
+  // display: flex;
 
   tr {
     background: #f7f7f7;
@@ -214,6 +198,10 @@
 .CalendarMonthGrid__vertical-scrollable {
   margin: 0 auto;
   overflow-y: scroll;
+}
+
+.CalendarMonthGrid__vertical-scrollable .CalendarMonth_caption {
+  padding: 5px 0;
 }
 
 .DayPicker {

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -170,7 +170,6 @@
 .CalendarMonthGrid {
   z-index: 0;
   text-align: left;
-  // display: flex;
 
   tr {
     background: #f7f7f7;
@@ -293,17 +292,17 @@
   text-align: center;
 }
 
-.transition-container {
+.DayPicker_transitionContainer {
   position: relative;
   overflow: hidden;
   border-radius: 3px;
 }
 
-.transition-container__horizontal {
+.DayPicker_transitionContainer__horizontal {
   transition: height 0.2s ease-in-out;
 }
 
-.transition-container__vertical {
+.DayPicker_transitionContainer__vertical {
   width: 100%;
 }
 

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -5,7 +5,7 @@
   color: #565a5c;
   cursor: pointer; }
 
-.CalendarDay__button {
+.CalendarDay_button {
   position: relative;
   height: 100%;
   width: 100%;
@@ -22,7 +22,7 @@
   border: 0;
 }
 
-.CalendarDay__button:active {
+.CalendarDay_button:active {
   outline: 0;
 }
 
@@ -161,7 +161,7 @@
   display: block;
 }
 
-.CalendarMonth__caption {
+.CalendarMonth_caption {
   color: @rui-default-text;
   margin-top: 7px;
   font-size: 16px;
@@ -174,12 +174,12 @@
   }
 }
 
-.CalendarMonth--horizontal .CalendarMonth__caption,
-.CalendarMonth--vertical .CalendarMonth__caption {
+.CalendarMonth--horizontal .CalendarMonth_caption,
+.CalendarMonth--vertical .CalendarMonth_caption {
   padding: 15px 0 35px;
 }
 
-.CalendarMonth--vertical-scrollable .CalendarMonth__caption {
+.CalendarMonth--vertical-scrollable .CalendarMonth_caption {
   padding: 5px 0;
 }
 
@@ -238,19 +238,19 @@
   position: initial;
 }
 
-.DayPicker__focus-region {
+.DayPicker_focus-region {
   outline: none;
 }
 
-.DayPicker__week-headers {
+.DayPicker_week-headers {
   position: relative;
 }
 
-.DayPicker--horizontal .DayPicker__week-headers {
+.DayPicker--horizontal .DayPicker_week-headers {
   margin-left: 9px;
 }
 
-.DayPicker__week-header {
+.DayPicker_week-header {
   color: #757575;
   position: absolute;
   top: 62px;
@@ -259,19 +259,19 @@
   text-align: left;
 }
 
-.DayPicker__week-header ul {
+.DayPicker_week-header ul {
   list-style: none;
   margin: 1px 0;
   padding-left: 0;
   padding-right: 0;
 }
 
-.DayPicker__week-header li {
+.DayPicker_week-header li {
   display: inline-block;
   text-align: center;
 }
 
-.DayPicker--vertical .DayPicker__week-header {
+.DayPicker--vertical .DayPicker_week-header {
   left: 50%;
 }
 
@@ -279,7 +279,7 @@
   height: 100%;
 }
 
-.DayPicker--vertical-scrollable .DayPicker__week-header {
+.DayPicker--vertical-scrollable .DayPicker_week-header {
   top: 0;
   display: table-row;
   border-bottom: 1px solid #dbdbdb;
@@ -297,7 +297,7 @@
   overflow-y: scroll;
 }
 
-.DayPicker--vertical-scrollable .DayPicker__week-header {
+.DayPicker--vertical-scrollable .DayPicker_week-header {
   margin-left: 0;
   left: 0;
   width: 100%;
@@ -318,8 +318,8 @@
   width: 100%;
 }
 
-.DayPickerNavigation__prev,
-.DayPickerNavigation__next {
+.DayPickerNavigation_prev,
+.DayPickerNavigation_next {
   cursor: pointer;
   line-height: 0.78;
   -webkit-user-select: none;
@@ -331,21 +331,21 @@
   user-select: none;
 }
 
-.DayPickerNavigation__prev--default,
-.DayPickerNavigation__next--default {
+.DayPickerNavigation_prev--default,
+.DayPickerNavigation_next--default {
   border: 1px solid #dce0e0;
   background-color: #fff;
   color: #757575;
 }
 
-.DayPickerNavigation__prev--default:focus, .DayPickerNavigation__prev--default:hover,
-.DayPickerNavigation__next--default:focus,
-.DayPickerNavigation__next--default:hover {
+.DayPickerNavigation_prev--default:focus, .DayPickerNavigation_prev--default:hover,
+.DayPickerNavigation_next--default:focus,
+.DayPickerNavigation_next--default:hover {
   border: 1px solid #c4c4c4;
 }
 
-.DayPickerNavigation__prev--default:active,
-.DayPickerNavigation__next--default:active {
+.DayPickerNavigation_prev--default:active,
+.DayPickerNavigation_next--default:active {
   background: #f2f2f2;
 }
 
@@ -353,8 +353,8 @@
   position: relative;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation__prev,
-.DayPickerNavigation--horizontal .DayPickerNavigation__next {
+.DayPickerNavigation--horizontal .DayPickerNavigation_prev,
+.DayPickerNavigation--horizontal .DayPickerNavigation_next {
   border-radius: 50%;
   border: 2px solid @rui-default-text;
   padding: 1px 1px;
@@ -364,20 +364,20 @@
   position: absolute;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation__prev {
+.DayPickerNavigation--horizontal .DayPickerNavigation_prev {
   left: 22px;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation__prev--rtl {
+.DayPickerNavigation--horizontal .DayPickerNavigation_prev--rtl {
   left: auto;
   right: 22px;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation__next {
+.DayPickerNavigation--horizontal .DayPickerNavigation_next {
   right: 22px;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation__next--rtl {
+.DayPickerNavigation--horizontal .DayPickerNavigation_next--rtl {
   right: auto;
   left: 22px;
 }
@@ -388,8 +388,8 @@
   color: @rui-default-text;
 }
 
-.DayPickerNavigation--horizontal .DayPickerNavigation__prev--default svg,
-.DayPickerNavigation--horizontal .DayPickerNavigation__next--default svg {
+.DayPickerNavigation--horizontal .DayPickerNavigation_prev--default svg,
+.DayPickerNavigation--horizontal .DayPickerNavigation_next--default svg {
   height: 19px;
   width: 19px;
   fill: #82888a;
@@ -406,27 +406,27 @@
   z-index: 2;
 }
 
-.DayPickerNavigation--vertical .DayPickerNavigation__prev,
-.DayPickerNavigation--vertical .DayPickerNavigation__next {
+.DayPickerNavigation--vertical .DayPickerNavigation_prev,
+.DayPickerNavigation--vertical .DayPickerNavigation_next {
   display: inline-block;
   position: relative;
   height: 100%;
   width: 50%;
 }
 
-.DayPickerNavigation--vertical .DayPickerNavigation__next--default {
+.DayPickerNavigation--vertical .DayPickerNavigation_next--default {
   border-left: 0;
 }
 
-.DayPickerNavigation--vertical .DayPickerNavigation__prev--default,
-.DayPickerNavigation--vertical .DayPickerNavigation__next--default {
+.DayPickerNavigation--vertical .DayPickerNavigation_prev--default,
+.DayPickerNavigation--vertical .DayPickerNavigation_next--default {
   text-align: center;
   font-size: 2.5em;
   padding: 5px;
 }
 
-.DayPickerNavigation--vertical .DayPickerNavigation__prev--default svg,
-.DayPickerNavigation--vertical .DayPickerNavigation__next--default svg {
+.DayPickerNavigation--vertical .DayPickerNavigation_prev--default svg,
+.DayPickerNavigation--vertical .DayPickerNavigation_next--default svg {
   height: 42px;
   width: 42px;
   fill: #484848;
@@ -436,12 +436,12 @@
   position: relative;
 }
 
-.DayPickerNavigation--vertical-scrollable .DayPickerNavigation__next {
+.DayPickerNavigation--vertical-scrollable .DayPickerNavigation_next {
   width: 100%;
 }
 
-.DayPickerKeyboardShortcuts__show,
-.DayPickerKeyboardShortcuts__close {
+.DayPickerKeyboardShortcuts_show,
+.DayPickerKeyboardShortcuts_close {
   background: none;
   border: 0;
   color: inherit;
@@ -452,71 +452,71 @@
   cursor: pointer;
 }
 
-.DayPickerKeyboardShortcuts__show:active,
-.DayPickerKeyboardShortcuts__close:active {
+.DayPickerKeyboardShortcuts_show:active,
+.DayPickerKeyboardShortcuts_close:active {
   outline: none;
 }
 
-.DayPickerKeyboardShortcuts__show {
+.DayPickerKeyboardShortcuts_show {
   width: 22px;
   position: absolute;
   z-index: 2;
 }
 
-.DayPickerKeyboardShortcuts__show--bottom-right {
+.DayPickerKeyboardShortcuts_show--bottom-right {
   border-top: 26px solid transparent;
   border-right: 33px solid #00a699;
   bottom: 0;
   right: 0;
 }
 
-.DayPickerKeyboardShortcuts__show--bottom-right:hover {
+.DayPickerKeyboardShortcuts_show--bottom-right:hover {
   border-right: 33px solid #008489;
 }
 
-.DayPickerKeyboardShortcuts__show--bottom-right .DayPickerKeyboardShortcuts__show_span {
+.DayPickerKeyboardShortcuts_show--bottom-right .DayPickerKeyboardShortcuts_show_span {
   bottom: 0;
   right: -28px;
 }
 
-.DayPickerKeyboardShortcuts__show--top-right {
+.DayPickerKeyboardShortcuts_show--top-right {
   border-bottom: 26px solid transparent;
   border-right: 33px solid #00a699;
   top: 0;
   right: 0;
 }
 
-.DayPickerKeyboardShortcuts__show--top-right:hover {
+.DayPickerKeyboardShortcuts_show--top-right:hover {
   border-right: 33px solid #008489;
 }
 
-.DayPickerKeyboardShortcuts__show--top-right .DayPickerKeyboardShortcuts__show_span {
+.DayPickerKeyboardShortcuts_show--top-right .DayPickerKeyboardShortcuts_show_span {
   top: 1px;
   right: -28px;
 }
 
-.DayPickerKeyboardShortcuts__show--top-left {
+.DayPickerKeyboardShortcuts_show--top-left {
   border-bottom: 26px solid transparent;
   border-left: 33px solid #00a699;
   top: 0;
   left: 0;
 }
 
-.DayPickerKeyboardShortcuts__show--top-left:hover {
+.DayPickerKeyboardShortcuts_show--top-left:hover {
   border-left: 33px solid #008489;
 }
 
-.DayPickerKeyboardShortcuts__show--top-left .DayPickerKeyboardShortcuts__show_span {
+.DayPickerKeyboardShortcuts_show--top-left .DayPickerKeyboardShortcuts_show_span {
   top: 1px;
   left: -28px;
 }
 
-.DayPickerKeyboardShortcuts__show_span {
+.DayPickerKeyboardShortcuts_show_span {
   color: #fff;
   position: absolute;
 }
 
-.DayPickerKeyboardShortcuts__panel {
+.DayPickerKeyboardShortcuts_panel {
   overflow: auto;
   background: #fff;
   border: 1px solid #dbdbdb;
@@ -531,35 +531,35 @@
   margin: 33px;
 }
 
-.DayPickerKeyboardShortcuts__title {
+.DayPickerKeyboardShortcuts_title {
   font-size: 16px;
   font-weight: bold;
   margin: 0;
 }
 
-.DayPickerKeyboardShortcuts__list {
+.DayPickerKeyboardShortcuts_list {
   list-style: none;
   padding: 0;
 }
 
-.DayPickerKeyboardShortcuts__close {
+.DayPickerKeyboardShortcuts_close {
   position: absolute;
   right: 22px;
   top: 22px;
   z-index: 2;
 }
 
-.DayPickerKeyboardShortcuts__close svg {
+.DayPickerKeyboardShortcuts_close svg {
   height: 15px;
   width: 15px;
   fill: #cacccd;
 }
 
-.DayPickerKeyboardShortcuts__close svg:hover, .DayPickerKeyboardShortcuts__close svg:focus {
+.DayPickerKeyboardShortcuts_close svg:hover, .DayPickerKeyboardShortcuts_close svg:focus {
   fill: #82888a;
 }
 
-.DayPickerKeyboardShortcuts__close:active {
+.DayPickerKeyboardShortcuts_close:active {
 outline: none;
 }
 
@@ -567,14 +567,14 @@ outline: none;
   margin: 6px 0;
 }
 
-.KeyboardShortcutRow__key-container {
+.KeyboardShortcutRow_key-container {
   display: inline-block;
   white-space: nowrap;
   text-align: right;
   margin-right: 6px;
 }
 
-.KeyboardShortcutRow__key {
+.KeyboardShortcutRow_key {
   font-family: monospace;
   font-size: 12px;
   text-transform: uppercase;
@@ -582,22 +582,22 @@ outline: none;
   padding: 2px 6px;
 }
 
-.KeyboardShortcutRow__action {
+.KeyboardShortcutRow_action {
   display: inline;
   word-break: break-word;
   margin-left: 8px;
 }
 
-.DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow {
+.DayPickerKeyboardShortcuts_panel--block .KeyboardShortcutRow {
   margin-bottom: 16px;
 }
 
-.DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow__key-container {
+.DayPickerKeyboardShortcuts_panel--block .KeyboardShortcutRow_key-container {
   text-align: left;
   display: inline;
 }
 
-.DayPickerKeyboardShortcuts__panel--block .KeyboardShortcutRow__action {
+.DayPickerKeyboardShortcuts_panel--block .KeyboardShortcutRow_action {
   display: inline;
 }
 
@@ -660,7 +660,7 @@ outline: none;
   background: #cacccd;
 }
 
-.DateInput__input {
+.DateInput_input {
   opacity: 0;
   position: absolute;
   top: 0;
@@ -670,31 +670,31 @@ outline: none;
   width: 100%;
 }
 
-.DateInput__input[readonly] {
+.DateInput_input[readonly] {
   -moz-user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-.DateInput__display-text {
+.DateInput_display-text {
   padding: 4px 8px;
   white-space: nowrap;
   overflow: hidden;
 }
 
-.DateInput__display-text--has-input {
+.DateInput_display-text--has-input {
   color: #484848;
 }
 
-.DateInput__display-text--focused {
+.DateInput_display-text--focused {
   background: #99ede6;
   border-color: #99ede6;
   border-radius: 3px;
   color: #007a87;
 }
 
-.DateInput__display-text--disabled {
+.DateInput_display-text--disabled {
   font-style: italic;
 }
 
@@ -714,33 +714,33 @@ outline: none;
   display: inline-block;
 }
 
-.DateRangePicker__picker {
+.DateRangePicker_picker {
   z-index: 1;
   background-color: #fff;
   position: absolute;
 }
 
-.DateRangePicker__picker--rtl {
+.DateRangePicker_picker--rtl {
   direction: rtl;
 }
 
-.DateRangePicker__picker--direction-left {
+.DateRangePicker_picker--direction-left {
   left: 0;
 }
 
-.DateRangePicker__picker--direction-right {
+.DateRangePicker_picker--direction-right {
   right: 0;
 }
 
-.DateRangePicker__picker--open-down {
+.DateRangePicker_picker--open-down {
   top: 72px;
 }
 
-.DateRangePicker__picker--open-up {
+.DateRangePicker_picker--open-up {
   bottom: 72px;
 }
 
-.DateRangePicker__picker--portal {
+.DateRangePicker_picker--portal {
   background-color: rgba(0, 0, 0, 0.3);
   position: fixed;
   top: 0;
@@ -749,11 +749,11 @@ outline: none;
   width: 100%;
 }
 
-.DateRangePicker__picker--full-screen-portal {
+.DateRangePicker_picker--full-screen-portal {
   background-color: #fff;
 }
 
-.DateRangePicker__close {
+.DateRangePicker_close {
   background: none;
   border: 0;
   color: inherit;
@@ -769,13 +769,13 @@ outline: none;
   z-index: 2;
 }
 
-.DateRangePicker__close svg {
+.DateRangePicker_close svg {
   height: 15px;
   width: 15px;
   fill: #cacccd;
 }
 
-.DateRangePicker__close:hover, .DateRangePicker__close:focus {
+.DateRangePicker_close:hover, .DateRangePicker_close:focus {
   color: #b0b3b4;
   text-decoration: none;
 }
@@ -794,19 +794,19 @@ outline: none;
   direction: rtl;
 }
 
-.DateRangePickerInput__arrow {
+.DateRangePickerInput_arrow {
   display: inline-block;
   vertical-align: middle;
 }
 
-.DateRangePickerInput__arrow svg {
+.DateRangePickerInput_arrow svg {
   vertical-align: middle;
   fill: #484848;
   height: 24px;
   width: 24px;
 }
 
-.DateRangePickerInput__clear-dates {
+.DateRangePickerInput_clear-dates {
   background: none;
   border: 0;
   color: inherit;
@@ -820,24 +820,24 @@ outline: none;
   margin: 0 10px 0 5px;
 }
 
-.DateRangePickerInput__clear-dates svg {
+.DateRangePickerInput_clear-dates svg {
   fill: #82888a;
   height: 12px;
   width: 15px;
   vertical-align: middle;
 }
 
-.DateRangePickerInput__clear-dates--hide {
+.DateRangePickerInput_clear-dates--hide {
   visibility: hidden;
 }
 
-.DateRangePickerInput__clear-dates:focus,
-.DateRangePickerInput__clear-dates--hover {
+.DateRangePickerInput_clear-dates:focus,
+.DateRangePickerInput_clear-dates--hover {
   background: #dbdbdb;
   border-radius: 50%;
 }
 
-.DateRangePickerInput__calendar-icon {
+.DateRangePickerInput_calendar-icon {
   background: none;
   border: 0;
   color: inherit;
@@ -851,7 +851,7 @@ outline: none;
   margin: 0 5px 0 10px;
 }
 
-.DateRangePickerInput__calendar-icon svg {
+.DateRangePickerInput_calendar-icon svg {
   fill: #82888a;
   height: 15px;
   width: 14px;
@@ -863,33 +863,33 @@ outline: none;
   display: inline-block;
 }
 
-.SingleDatePicker__picker {
+.SingleDatePicker_picker {
   z-index: 1;
   background-color: #fff;
   position: absolute;
 }
 
-.SingleDatePicker__picker--rtl {
+.SingleDatePicker_picker--rtl {
   direction: rtl;
 }
 
-.SingleDatePicker__picker--direction-left {
+.SingleDatePicker_picker--direction-left {
   left: 0;
 }
 
-.SingleDatePicker__picker--direction-right {
+.SingleDatePicker_picker--direction-right {
   right: 0;
 }
 
-.SingleDatePicker__picker--open-down {
+.SingleDatePicker_picker--open-down {
   top: 72px;
 }
 
-.SingleDatePicker__picker--open-up {
+.SingleDatePicker_picker--open-up {
   bottom: 72px;
 }
 
-.SingleDatePicker__picker--portal {
+.SingleDatePicker_picker--portal {
   background-color: rgba(0, 0, 0, 0.3);
   position: fixed;
   top: 0;
@@ -898,11 +898,11 @@ outline: none;
   width: 100%;
 }
 
-.SingleDatePicker__picker--full-screen-portal {
+.SingleDatePicker_picker--full-screen-portal {
   background-color: #fff;
 }
 
-.SingleDatePicker__close {
+.SingleDatePicker_close {
   background: none;
   border: 0;
   color: inherit;
@@ -918,13 +918,13 @@ outline: none;
   z-index: 2;
 }
 
-.SingleDatePicker__close svg {
+.SingleDatePicker_close svg {
   height: 15px;
   width: 15px;
   fill: #cacccd;
 }
 
-.SingleDatePicker__close:hover, .SingleDatePicker__close:focus {
+.SingleDatePicker_close:hover, .SingleDatePicker_close:focus {
   color: #b0b3b4;
   text-decoration: none;
 }
@@ -938,7 +938,7 @@ outline: none;
   direction: rtl;
 }
 
-.SingleDatePickerInput__clear-date {
+.SingleDatePickerInput_clear-date {
   background: none;
   border: 0;
   color: inherit;
@@ -952,24 +952,24 @@ outline: none;
   margin: 0 10px 0 5px;
 }
 
-.SingleDatePickerInput__clear-date svg {
+.SingleDatePickerInput_clear-date svg {
   fill: #82888a;
   height: 12px;
   width: 15px;
   vertical-align: middle;
 }
 
-.SingleDatePickerInput__clear-date--hide {
+.SingleDatePickerInput_clear-date--hide {
   visibility: hidden;
 }
 
-.SingleDatePickerInput__clear-date:focus,
-.SingleDatePickerInput__clear-date--hover {
+.SingleDatePickerInput_clear-date:focus,
+.SingleDatePickerInput_clear-date--hover {
   background: #dbdbdb;
   border-radius: 50%;
 }
 
-.SingleDatePickerInput__calendar-icon {
+.SingleDatePickerInput_calendar-icon {
   background: none;
   border: 0;
   color: inherit;
@@ -983,7 +983,7 @@ outline: none;
   margin: 0 5px 0 10px;
 }
 
-.SingleDatePickerInput__calendar-icon svg {
+.SingleDatePickerInput_calendar-icon svg {
   fill: #82888a;
   height: 15px;
   width: 14px;


### PR DESCRIPTION
Fixes #3402 

This PR updates the `CalendarPicker` component as a recent update of `react-dates` introduced some major braking changed

## Highlights of this change

- React dates must be Initialized react dates before importing
- CSS classNames and some properties re-worked to be compatible `react-dates`
- Fixes RTL support for the calendar picker.

## To Test

With a copy of this branch and a fresh `meteor npm install`...

- Open the orders dashboard and attempt to use the date filters. It should work as it used to.
- Add some orders to test if the date filtering still works.
- Switch to an RTL language, see that the date picker is now RTL enabled