### PR TITLE
(fix): resend email from dashboard even if completed

### DIFF
--- a/server/methods/email.js
+++ b/server/methods/email.js
@@ -117,10 +117,25 @@ Meteor.methods({
     }
 
     check(jobId, String);
+    let emailJobId = jobId;
 
     Logger.debug(`emails/retryFailed - restarting email job "${jobId}"`);
 
-    Jobs.update({ _id: jobId }, {
+    // Get email job to retry
+    const job = Jobs.getJob(jobId);
+    // If this job was never completed, restart it and set it to "ready"
+    if (job._doc.status !== "completed") {
+      job.restart();
+      job.ready();
+    } else {
+      // Otherwise rerun the completed job
+      // `rerun` clones the job and returns the id.
+      // We'll set the new one to ready
+      emailJobId = job.rerun(); // Clone job to rerun
+    }
+
+    // Set the job status to ready to trigger the Jobs observer to trigger sendEmail
+    Jobs.update({ _id: emailJobId }, {
       $set: {
         status: "ready"
       }


### PR DESCRIPTION
Resolves #3388 

Enables admins to resend an email from the email dashboard even if the email was previously successfully sent.

This was not working because of the way that the [job-collection](https://atmospherejs.com/vsivsi/job-collection) treats completed jobs. Only jobs that have failed or been canceled can be restarted. Completed jobs must be rerun. This PR determines what status an email job is, and then reruns or restarts it appropriately.

Side Effect: when you resend an email that was previously successful, an additional entry will be added to the emails table rather than updating the existing entry. This is how the job collection works. Restarting a failed email will update that entry.