### PR TITLE
(ref): remove unused Router code

### DIFF
--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -10,7 +10,6 @@ import { Meteor } from "meteor/meteor";
 import Blaze from "meteor/gadicc:blaze-react-component";
 import { Template } from "meteor/templating";
 import { Session } from "meteor/session";
-import { Counts } from "meteor/tmeasday:publish-counts";
 import { Tracker } from "meteor/tracker";
 import { Packages, Shops } from "/lib/collections";
 import { getComponent } from "@reactioncommerce/reaction-components/components";

--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -566,7 +566,6 @@ Router.initPackageRoutes = (options) => {
   Router.routes = [];
 
   const pkgs = Packages.find().fetch();
-  const shops = Shops.find({}, { fields: { _id: 1, name: 1, shopType: 1 } }).fetch();
 
   const routeDefinitions = [];
 
@@ -579,7 +578,6 @@ Router.initPackageRoutes = (options) => {
     if (shopSub.ready()) {
       shopSubWaitFor.stop();
       // using tmeasday:publish-counts
-      const shopCount = Counts.get("shops-count");
 
       // Default layouts
       const indexLayout = ReactionLayout(options.indexRoute);

--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -568,25 +568,6 @@ Router.initPackageRoutes = (options) => {
   const pkgs = Packages.find().fetch();
   const shops = Shops.find({}, { fields: { _id: 1, name: 1, shopType: 1 } }).fetch();
 
-  const shopPrefixes = shops.reduce((prefixesByShopId, shop) => {
-    const shopName = shop.name;
-    const shopSlug = Router.Reaction.getSlug(shopName.toLowerCase());
-
-    // If this is the primary shop
-    if (shop.shopType === "primary") {
-      // If naked routes is turned off, use the shop slug for our primary shop routes
-      if (Router.Reaction.marketplace && Router.Reaction.marketplace.marketplaceNakedRoutes === false) {
-        prefixesByShopId[shop._id] = `/${shopSlug}`;
-      } else {
-        prefixesByShopId[shop._id] = "";
-      }
-    } else {
-      // If this is not the primary shop, use the shop slug in routes for this shop
-      prefixesByShopId[shop._id] = `/${shopSlug}`;
-    }
-    return prefixesByShopId;
-  }, {});
-
   const routeDefinitions = [];
 
   // prefixing isnt necessary if we only have one shop
@@ -706,12 +687,6 @@ Router.initPackageRoutes = (options) => {
             if (route.route.substring(0, 1) !== "/") {
               route.route = "/" + route.route;
               route.group.prefix = "";
-            } else if (shopCount <= 1) {
-              route.group.prefix = "";
-            } else {
-              const prefix = shopPrefixes[pkg.shopId];
-              route.group.prefix = prefix;
-              route.route = `${prefix}${route.route}`;
             }
 
             routeDefinitions.push(route);

--- a/server/publications/collections/cart.js
+++ b/server/publications/collections/cart.js
@@ -77,16 +77,24 @@ Meteor.publish("CartImages", function (cartItems) {
 
   // return image for each the top level product or the variant and let the client code decide which to display
   const productImages = Media.find(
-    { "$or":
-    [{
-      "metadata.productId": { $in: productIds }
-    },
     {
-      "metadata.productId": { $in: variantIds }
+      "$or": [
+        {
+          "metadata.productId": {
+            $in: productIds
+          }
+        },
+        {
+          "metadata.productId": {
+            $in: variantIds
+          }
+        }
+      ],
+      "metadata.workflow": {
+        $nin: ["archived", "unpublished"]
+      }
     }
-    ],
-    "metadata.workflow": { $nin: ["archived", "unpublished"] }
-    }
+
   );
 
   return productImages;


### PR DESCRIPTION
While working on a client project, we discovered this extraneous `Router` code that was left over from a previous refactor, and was causing some conflicts in the client project. 

The code was used to push all routes from all shops into the `Router`. In core Reaction, this is unneeded functionality, as we do not publish all routes from all shops, therefore the code seemed to be doing nothing in it's current state.

Removing it should have no affect on the existing `Router` functionality.