### PR TITLE
Fix cart discount getting overridden to zero

### DIFF
--- a/imports/plugins/core/discounts/server/hooks/cart.js
+++ b/imports/plugins/core/discounts/server/hooks/cart.js
@@ -15,8 +15,8 @@ import { Cart } from "/lib/collections";
 */
 Cart.after.update((userId, cart, fieldNames) => {
   const trigger = ["discount", "billing", "shipping"];
-  let discount = 0;
   if (cart) {
+    let discount = cart.discount;
     for (const field of fieldNames) {
       if (indexOf(trigger, field) !== -1) {
         discount = Meteor.call("discounts/calculate", cart);


### PR DESCRIPTION
**Problem:**
Cart discount was getting overridden when a change happens on a field that is not listed in the trigger array contained within [the hook](https://github.com/reactioncommerce/reaction/blob/master/imports/plugins/core/discounts/server/hooks/cart.js#L17).
So if you already added a discount on a cart and you then go back to add another product to the cart, the discount deduction disappears even though it shows that the discount code is applied to the cart

![screenshot 2017-12-18 14 23 23](https://user-images.githubusercontent.com/5229321/34110677-4c62c55a-e3ff-11e7-93c9-efd95844b899.jpg)


I'm not sure if this is already documented in an issue yet, but it happens for me when a cart workflow changes after a discount was already applied. 

**If the issue I described is by design this PR can be closed then.**

#### How To Test
- Create a discount code as an admin
- As a customer, add a product to your cart, then apply the discount code on the checkout page
- Go back and add another product to your cart
- Proceed to checkout, and select shipping option.
- Notice that the discount still applies unlike the screenshot show above

