### PR TITLE
#3254 Fix Marketplace Search

### DIFF
--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -20,6 +20,11 @@ function getProductFindTerm(searchTerm, searchTags, userId) {
   if (!Roles.userIsInRole(userId, ["admin", "owner"], shopId)) {
     findTerm.isVisible = true;
   }
+  // Deletes the shopId field from "findTerm" for primary shop
+  // thereby allowing users on primary shop to search all products
+  if (shopId === Reaction.getPrimaryShopId()) {
+    delete findTerm.shopId;
+  }
   return findTerm;
 }
 
@@ -97,7 +102,13 @@ getResults.orders = function (searchTerm, facets, maxResults, userId) {
           $options: "i"
         } }
       ] }
-    ] };
+    ]
+  };
+  // Deletes the shopId field from "findTerm" for primary shop
+  // thereby allowing users on primary shop to search all products
+  if (shopId === Reaction.getPrimaryShopId()) {
+    delete findTerm.$and[0].shopId;
+  }
   if (Reaction.hasPermission("orders", userId)) {
     orderResults = OrderSearch.find(findTerm, { limit: maxResults });
     Logger.debug(`Found ${orderResults.count()} orders searching for ${regexSafeSearchTerm}`);
@@ -131,7 +142,13 @@ getResults.accounts = function (searchTerm, facets, maxResults, userId) {
             $options: "i"
           } }
         ] }
-      ] };
+      ]
+    };
+    // Deletes the shopId field from "findTerm" for primary shop
+    // thereby allowing users on primary shop to search all products
+    if (shopId === Reaction.getPrimaryShopId()) {
+      delete findTerm.$and[0].shopId;
+    }
     accountResults = AccountSearch.find(findTerm, {
       limit: maxResults
     });


### PR DESCRIPTION
This PR fixes marketplace search allowing primary shop owners search all products/orders/accounts

## How to Test

1. Login in as admin
2. Enable Marketplace shops and invite few users
3. On the primary shop and merchant shop(s), add products
4. Use the search, to search through products/accounts/order.
5. Observe that as a merchant, you only see products you created and in the case of accounts you see just your account.
6. Observe that as an admin, you see all products/accounts.

Closes #3254 