### PR TITLE
(fix): Import PropTypes from "prop-types" package

### DIFF
--- a/imports/plugins/core/ui/client/providers/dragDropProvider.js
+++ b/imports/plugins/core/ui/client/providers/dragDropProvider.js
@@ -6,23 +6,6 @@ import { registerComponent } from "@reactioncommerce/reaction-components";
 
 const defaultManager = new DragDropManager(HTML5Backend);
 
-// /**
-//  * This is singleton used to initialize only once dnd in our app.
-//  * If you initialized dnd and then try to initialize another dnd
-//  * context the app will break.
-//  * Here is more info: https://github.com/gaearon/react-dnd/issues/186
-//  *
-//  * The solution is to call Dnd context from this singleton this way
-//  * all dnd contexts in the app are the same.
-//  */
-// export default function getDndContext() {
-//   if (defaultManager) return defaultManager;
-//
-//   defaultManager = new DragDropManager(HTML5Backend);
-//
-//   return defaultManager;
-// }
-
 class DragDropProvider extends Component {
   getChildContext() {
     return {

--- a/imports/plugins/core/ui/client/providers/dragDropProvider.js
+++ b/imports/plugins/core/ui/client/providers/dragDropProvider.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, Children } from "react"; // eslint-disable-line
+import { Component, Children } from "react";
+import PropTypes from "prop-types";
 import { DragDropManager } from "dnd-core";
 import HTML5Backend from "react-dnd-html5-backend";
 import { registerComponent } from "@reactioncommerce/reaction-components";


### PR DESCRIPTION
Fix what seems to be the last instance of importing PropTypes from the "react" package. Now imports it from the "prop-types" package as it should.

### To Test

- start reaction
- see no warning in console
- rejoice
