### PR TITLE
Release 1.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction",
-  "version": "1.7.0",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "main": "main.js",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
# v1.6.3

## Why
I Oops'd the 1.6.2 release and `package-lock.json` got stuck at 1.7.0. 😞 

This fixes that and bumps to `1.6.3` for both `package.json` and `package-lock.json`

I've updated the [release process docs](https://docs.reactioncommerce.com/reaction-docs/master/release-process) to include tips for how to not do that again.