### PR TITLE
#3176 Fix search modal not closed on back/forward navigation

### DIFF
--- a/imports/plugins/included/ui-search/lib/containers/searchModalContainer.js
+++ b/imports/plugins/included/ui-search/lib/containers/searchModalContainer.js
@@ -26,10 +26,16 @@ const wrapComponent = (Comp) => (
 
     componentDidMount() {
       document.addEventListener("keydown", this.handleKeyDown);
+      window.addEventListener("popstate", this.handleUrlChange);
     }
 
     componentWillUnmount() {
       document.removeEventListener("keydown", this.handleKeyDown);
+      window.removeEventListener("popstate", this.handleUrlChange);
+    }
+
+    handleUrlChange = () => {
+      this.handleChildUnmount();
     }
 
     handleKeyDown = (event) => {


### PR DESCRIPTION
This PR fixes an issue that causes the search modal to stay open on navigating away from the current page using the back/forward button on the browser.

## How to Test
1. Add a product if none exist
2. View a product by clicking on a product
3. Click on Search
4. Press the Back button, the URL changes
5. Observe that the search modal is closed on leaving the current page

Closes #3176 