### PR TITLE
Update thousands separator in Polish currency formatting

### DIFF
--- a/private/data/Shops.json
+++ b/private/data/Shops.json
@@ -429,7 +429,8 @@
       "enabled": false,
       "format": "%v %s",
       "symbol": "zł",
-      "decimal": ","
+      "decimal": ",",
+      "thousand": " "
     },
     "QAR": {
       "enabled": false,


### PR DESCRIPTION
This PR changes thousands separator in polish currency formatting rules.

1. Run reaction
2. Enable PLN currency unit from i18n menu option.
3. Select PLN as the default currency unit from the same menu.
4. Go to example-product and see the correct format.