### PR TITLE
fix: ‘order’ should be translated to '订单' rather than ‘命令’ in Chinese

### DIFF
--- a/imports/plugins/core/orders/server/i18n/zh.json
+++ b/imports/plugins/core/orders/server/i18n/zh.json
@@ -14,7 +14,7 @@
       },
       "admin": {
         "shortcut": {
-          "ordersLabel": "命令"
+          "ordersLabel": "订单"
         },
         "orderRisk": {
           "high": "高风险",
@@ -22,8 +22,8 @@
           "riskCaptureWarn": "您即将捕获带有收费风险的订单。继续之前确认。"
         },
         "dashboard": {
-          "ordersLabel": "命令",
-          "ordersTitle": "命令",
+          "ordersLabel": "订单",
+          "ordersTitle": "订单",
           "ordersDescription": "完成订单",
           "clearSearch": "明确"
         },


### PR DESCRIPTION

In Chinese, we use "订单" to express ’order for goods‘ rather than ’命令‘.
And when Chinese people use ’命令‘, we want to express ‘command’ .
So I suggest that 'order' in ecommerce should be translated to "订单" in Chinese.

