### PR TITLE
#3355 Fix event not defined in Firefox

### DIFF
--- a/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
@@ -45,7 +45,7 @@ const wrapComponent = (Comp) => (
       document.querySelector(".page > main").removeEventListener("click", this.onPageClick);
     }
 
-    onPageClick = () => {
+    onPageClick = (event) => {
       // Do nothing if we are in preview mode
       if (Reaction.isPreview() === false) {
         // Don't trigger the clear selection if we're clicking on a grid item.


### PR DESCRIPTION
This PR fixes "event is not defined" error shown on the Firefox console.

## How to Test

1. Start reaction
2. Open the app on Firefox
3. Click on any part of the page
4. Observe in the console that no error is shown

Closes #3355 