### PR TITLE
Handle null Addresses when sending emails

### DIFF
--- a/server/api/core/accounts/password.js
+++ b/server/api/core/accounts/password.js
@@ -74,12 +74,12 @@ export function sendResetPasswordEmail(userId, optionalEmail) {
     homepage: Meteor.absoluteUrl(),
     emailLogo: emailLogo,
     copyrightDate: moment().format("YYYY"),
-    legalName: shop.addressBook[0].company,
+    legalName: _.get(shop, "addressBook[0].company"),
     physicalAddress: {
-      address: shop.addressBook[0].address1 + " " + shop.addressBook[0].address2,
-      city: shop.addressBook[0].city,
-      region: shop.addressBook[0].region,
-      postal: shop.addressBook[0].postal
+      address: `${_.get(shop, "addressBook[0].address1")} ${_.get(shop, "addressBook[0].address2")}`,
+      city: _.get(shop, "addressBook[0].city"),
+      region: _.get(shop, "addressBook[0].region"),
+      postal: _.get(shop, "addressBook[0].postal")
     },
     shopName: shop.name,
     socialLinks: {

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -758,12 +758,12 @@ export function sendWelcomeEmail(shopId, userId) {
     contactEmail: shop.emails[0].address,
     emailLogo: emailLogo,
     copyrightDate: moment().format("YYYY"),
-    legalName: shop.addressBook[0].company,
+    legalName: _.get(shop, "addressBook[0].company"),
     physicalAddress: {
-      address: shop.addressBook[0].address1 + " " + shop.addressBook[0].address2,
-      city: shop.addressBook[0].city,
-      region: shop.addressBook[0].region,
-      postal: shop.addressBook[0].postal
+      address: `${_.get(shop, "addressBook[0].address1")} ${_.get(shop, "addressBook[0].address2")}`,
+      city: _.get(shop, "addressBook[0].city"),
+      region: _.get(shop, "addressBook[0].region"),
+      postal: _.get(shop, "addressBook[0].postal")
     },
     shopName: shop.name,
     socialLinks: {

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -717,12 +717,12 @@ export const methods = {
         homepage: Meteor.absoluteUrl(),
         emailLogo: emailLogo,
         copyrightDate: moment().format("YYYY"),
-        legalName: shop.addressBook[0].company,
+        legalName: _.get(shop, "addressBook[0].company"),
         physicalAddress: {
-          address: shop.addressBook[0].address1 + " " + shop.addressBook[0].address2,
-          city: shop.addressBook[0].city,
-          region: shop.addressBook[0].region,
-          postal: shop.addressBook[0].postal
+          address: `${_.get(shop, "addressBook[0].address1")} ${_.get(shop, "addressBook[0].address2")}`,
+          city: _.get(shop, "addressBook[0].city"),
+          region: _.get(shop, "addressBook[0].region"),
+          postal: _.get(shop, "addressBook[0].postal")
         },
         shopName: shop.name,
         socialLinks: {


### PR DESCRIPTION
I tried to send a reset password email today and the action failed due to a missing address (which is strange, since the current shop definitely _has_ an address... I'll tackle that issue next). This code adds some safety to grabbing details about the first address.

To reproduce, try to send a reset password in a store with no addresses (tbh, I'm not sure how I wound up in this state... you may have to update the document in the DB).

---
_(the code, btw, is copied from [accounts.js](https://github.com/reactioncommerce/reaction/blob/pmn4%2Fphysical-address/server/methods/accounts/accounts.js#L968))_