### PR TITLE
(docs): Fix dead link to "Requirements" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Since anything in our codebase can be extended, overwritten, or installed as a p
 
 ### Requirements
 
-Reaction requires Meteor, Git, MongoDB, OS-specific build tools and optionally, ImageMagick. For step-by-step instructions, check out the [Requirements](https://docs.reactioncommerce.com/reaction-docs/master/requirements).
+Reaction requires Meteor, Git, MongoDB, OS-specific build tools and optionally, ImageMagick. For step-by-step instructions, check out this [page](https://docs.reactioncommerce.com/reaction-docs/master/installation).
 
 ### Install and create your first store
 


### PR DESCRIPTION
This PR fixes issue #3433.
There's no page "requirements" in docs. Probably this page has been superseded by the new installation instructions. 

Link should probably point to: https://docs.reactioncommerce.com/reaction-docs/master/installation
