### PR TITLE
(fix): Product images missing from confirmation emails

### DIFF
--- a/private/email/templates/orders/new.html
+++ b/private/email/templates/orders/new.html
@@ -265,6 +265,8 @@
                                                       <td valign="middle" align="left">
                                                         {{#if variantImage}}
                                                           <img src="{{variantImage}}"  width="50" height="50" alt="" />
+                                                        {{else if productImage}}
+                                                          <img src="{{productImage}}"  width="50" height="50" alt="" />
                                                         {{else}}
                                                           <img src="{{placeholderImage}}" width="50" height="50" alt="" />
                                                         {{/if}}

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -699,12 +699,12 @@ export const methods = {
           });
           // variant image
           if (variantImage) {
-            orderItem.variantImage = path.join(Meteor.absoluteUrl(), variantImage.url());
+            orderItem.variantImage = Meteor.absoluteUrl(variantImage.url());
           }
           // find a default image
           const productImage = Media.findOne({ "metadata.productId": orderItem.productId });
           if (productImage) {
-            orderItem.productImage = path.join(Meteor.absoluteUrl(), productImage.url());
+            orderItem.productImage = Meteor.absoluteUrl(productImage.url());
           }
         }
       }


### PR DESCRIPTION
Closes #3391 (see last comment on the issue)

How To Test
- Create a new product with an image. (or use the default Example Product, but first, upload an image for it)
- As a customer, make an order with the above product
- Open the order confirmation email sent to you, and confirm the image for the product shows up (It should not be blank, and it should not use the default placeholder image, since there's a picture on the product.
  
Note: If you tested this on localhost and used Gmail as your email sending service, Gmail (sometimes) mask out urls containing localhost or 127.0... This will make it appear like the image is missing, but the correct link is present (just masked).

  