### PR TITLE
(fix): Pass constraint props to Popover menu

### DIFF
--- a/imports/plugins/core/accounts/client/components/mainDropdown.js
+++ b/imports/plugins/core/accounts/client/components/mainDropdown.js
@@ -112,6 +112,10 @@ class MainDropdown extends Component {
               menuStyle={menuStyle}
               className="accounts-li-tag"
               onChange={this.props.handleChange}
+              constraints={[{
+                to: "window",
+                attachment: "together"
+              }]}
             >
               {this.renderUserIcons()}
               {this.renderAdminIcons()}

--- a/imports/plugins/core/ui/client/components/menu/dropDownMenu.js
+++ b/imports/plugins/core/ui/client/components/menu/dropDownMenu.js
@@ -91,6 +91,7 @@ class DropDownMenu extends Component {
             label={this.label}
           />
         }
+        constraints={this.props.constraints}
         isOpen={this.isOpen}
         onClick={this.handleDropdownToggle}
         onRequestOpen={this.handleOpen}
@@ -117,6 +118,7 @@ DropDownMenu.propTypes = {
   children: PropTypes.node,
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   closeOnClick: PropTypes.bool,
+  constraints: PropTypes.array,
   isClickable: PropTypes.bool,
   isEnabled: PropTypes.bool,
   isOpen: PropTypes.bool,


### PR DESCRIPTION
The `constraint` prop was not being passed all the way through our `DropDownMenu` component to the `Popover` component.

This update passes the props through, as well as adds the constraint prop to nav accounts dropdown to keep it from scrolling incorrectly when a fixed navbar is used.

To Test:
- Start up reaction
- See the accounts dropdown works correctly. You should see no changes to how the app currently works.
  