### PR TITLE
#3437 Fix can't set brand image for shop

### DIFF
--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -76,12 +76,16 @@ Template.shopSettings.helpers({
     return "";
   },
   brandImageSelectProps() {
+    const shopId = Reaction.getShopId();
+
     const media = Media.find({
+      "metadata.ownerId": Meteor.userId(),
+      "metadata.shopId": shopId,
       "metadata.type": "brandAsset"
     });
 
     const shop = Shops.findOne({
-      "_id": Reaction.getShopId(),
+      "_id": shopId,
       "brandAssets.type": "navbarBrandImage"
     });
 

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -79,7 +79,6 @@ Template.shopSettings.helpers({
     const shopId = Reaction.getShopId();
 
     const media = Media.find({
-      "metadata.ownerId": Meteor.userId(),
       "metadata.shopId": shopId,
       "metadata.type": "brandAsset"
     });

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -109,6 +109,9 @@ Meteor.methods({
     // TODO audience permissions need to be consolidated into [object] and not [string]
     // permissions with [string] on layout ie. orders and checkout, cause the insert to fail
     delete shop.layout;
+    // delete brandAssets object from shop to prevent new shops from carrying over existing shop's
+    // brand image
+    delete shop.brandAssets;
 
     let newShopId;
 


### PR DESCRIPTION
This PR fixes issues where a market shop owners can't upload their brand image and always see the primary shop's brand image if set on the primary shop.

## How to Test

1. Upload a brand image on main shop
2. Create a shop
3. Login as shop admin
4. Observe that you don't see the brand image set on the main shop
5. Go to "Shops" and try to set your shop image
6. Observe that you can now set shop image


Closes #3437  
  