### PR TITLE
(feat): Split shop invite email templates for existing or new user accounts

### DIFF
--- a/imports/plugins/included/email-templates/lib/paths.js
+++ b/imports/plugins/included/email-templates/lib/paths.js
@@ -11,6 +11,7 @@ export const coreDefaultTemplate = "coreDefault";
 /*
  * Account related email templates
  */
+export const inviteNewShopMemberTemplate = "accounts/inviteNewShopMember";
 export const inviteShopMemberTemplate = "accounts/inviteShopMember";
 export const inviteShopOwnerTemplate = "accounts/inviteShopOwner";
 export const resetPaswordTemplate = "accounts/resetPassword";

--- a/imports/plugins/included/email-templates/server/index.js
+++ b/imports/plugins/included/email-templates/server/index.js
@@ -19,14 +19,26 @@ Reaction.registerTemplate({
  */
 
 /*
- * Accounts - Invite Shop member
+ * Accounts - Invite Shop member with an Existing User Account
  * When: Admin invites new member to shop
  */
 Reaction.registerTemplate({
-  title: "Accounts - Invite Shop Member",
+  title: "Accounts - Invite Shop Member - Existing User Account",
   name: TemplatePaths.inviteShopMemberTemplate,
   type: "email",
   template: Reaction.Email.getTemplateFile(TemplatePaths.inviteShopMemberTemplate),
+  subject: "You have been invited to join the group \"{{groupName}}\" in the store \"{{shop.name}}\""
+});
+
+/*
+ * Accounts - Invite Shop member and create new user account
+ * When: Admin invites new member to shop
+ */
+Reaction.registerTemplate({
+  title: "Accounts - Invite Shop Member - New User Account",
+  name: TemplatePaths.inviteNewShopMemberTemplate,
+  type: "email",
+  template: Reaction.Email.getTemplateFile(TemplatePaths.inviteNewShopMemberTemplate),
   subject: "You have been invited to join the group \"{{groupName}}\" in the store \"{{shop.name}}\""
 });
 

--- a/private/email/templates/accounts/inviteNewShopMember.html
+++ b/private/email/templates/accounts/inviteNewShopMember.html
@@ -1,0 +1,172 @@
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<meta name="format-detection" content="telephone=no">
+<title>Basic Email</title>
+<link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+<style type="text/css">
+a[href^=tel] { color: inherit; text-decoration: none; }
+a img { border:0; outline:0;}
+img { border:0; outline:0;}
+
+/* Outlook link fix */
+#outlook a {padding:0;}
+/* Hotmail background &amp; line height fixes */
+.ExternalClass {width:100% !important;}
+.ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font,
+.ExternalClass td, .ExternalClass div {line-height: 100%;}
+/* Image borders &amp; formatting */
+img {outline:none; text-decoration:none; -ms-interpolation-mode: bicubic; margin:0 0 0 0 !important;}
+a img {border:none; margin:0 0 0 0 !important;}
+/* Re-style iPhone automatic links (eg. phone numbers) */
+.applelinks a {color:#222222; text-decoration: none;}
+/* Hotmail symbol fix for mobile devices */
+.ExternalClass img[class^=Emoji] { width: 10px !important; height: 10px !important; display: inline !important; }
+.tpl-content	 { display:inline !important;}
+
+/* Media Query for mobile */
+@media screen and (max-width: 600px) {
+table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !important;}
+}
+</style>
+</head>
+
+<body style="margin:0; padding:0;">
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td align="center" valign="middle">
+    <table width="600" class="wrap1001" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+        <td align="left" valign="top" bgcolor="#ffffff"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td height="4" align="left" valign="top" bgcolor="#1999dd" style="font-size:1px; line-height:1px;">&nbsp;</td>
+          </tr>
+          <tr>
+            <td align="center" valign="top"><table width="480" class="wrap1001" border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
+
+                  <!-- Begin Header -->
+                  <tr>
+                    <td height="34" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td align="left" valign="top"><a href="#"><img src="{{emailLogo}}" width="49" height="49" alt="logo"></a></td>
+                  </tr>
+                  <tr>
+                    <td height="32" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <!-- End Header -->
+
+                  <!-- Begin Body -->
+                  <tr>
+                    <td align="left" valign="top" style="font-family: 'Lato', sans-serif; font-size:22px; font-weight:bold; line-height:22px; color:#1e98d5; letter-spacing: -0.7px;">Hi, {{invitedUserName}}.</td>
+                  </tr>
+                  <tr>
+                    <td height="20" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td align="left" valign="top" style="font-family: 'Lato', sans-serif; font-size:13px; font-weight:bold; line-height:18px; color:#4d4d4d; letter-spacing: -0.5px;"><span style="font-weight:bold;">{{currentUserName}}</span> from {{shopName}} has invited you to join the group {{groupName}}.</td>
+                  </tr>
+                  <tr>
+                    <td height="25" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td align="left" valign="top"><table width="100%" border="0" cellspacing="0" cellpadding="0">
+                      <tr>
+                        <td width="223" height="40" align="center" valign="middle" bgcolor="#1999dd" style="font-family: 'Source Sans Pro', sans-serif; font-size:18px; font-weight:normal; line-height:18px;"><a href="{{url}}" style="text-decoration:none; color:#ffffff;">Get Started</a></td>
+                        <td>&nbsp;</td>
+                      </tr>
+                    </table></td>
+                  </tr>
+                  <!-- End Body -->
+
+                  <!-- Begin Footer -->
+                  <tr>
+                    <td height="32" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td height="1" align="left" valign="middle" bgcolor="#e2e2e2" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td height="15" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:17px;">You received this email because you were invited to join a group in the store {{shopName}}. Questions or suggestions? Email us at <a href="mailto:{{contactEmail}}" style="text-decoration:none; color:#1e98d5;">{{contactEmail}}</a></td>
+                  </tr>
+                  <!-- Begin Social Icons -->
+                  {{#if socialLinks.display}}
+                  <tr>
+                    <td height="21" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td align="left" valign="top">
+                      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="emailwrapto100pc">
+                        <tr>
+                          {{#if socialLinks.twitter.display}}
+                          <td width="26" align="left" valign="top">
+                            <a href="{{socialLinks.twitter.link}}"><img src="{{socialLinks.twitter.icon}}" width="26"
+                                  height="26" alt="twt_icon"></a>
+                          </td>
+                          {{/if}}
+                          {{#if socialLinks.facebook.display}}
+                          <td width="10" align="left" valign="top">&nbsp;</td>
+                          <td width="26" align="left" valign="top">
+                            <a href="{{socialLinks.facebook.link}}"><img src="{{socialLinks.facebook.icon}}" width="26"
+                                  height="26" alt="fb_icon"></a>
+                          </td>
+                          {{/if}}
+                          {{#if socialLinks.googlePlus.display}}
+                          <td width="10" align="left" valign="top">&nbsp;</td>
+                          <td>
+                            <a href="{{socialLinks.googlePlus.link}}"><img src="{{socialLinks.googlePlus.icon}}" width="26"
+                                  height="26" alt="g_plus_icon"></a>
+                          </td>
+                          {{/if}}
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td height="28" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  {{else}}
+                  <tr>
+                    <td height="15" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  {{/if}}
+                  <!-- End Social Icons -->
+                  <tr>
+                    <td height="3" align="left" valign="top" bgcolor="#1f97d4" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td height="18" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                  </tr>
+                  <tr>
+                    <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <tr>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}</td>
+                  </tr>
+                  <tr>
+                    <td height="19" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
+                  </tr>
+                  <!-- End Footer -->
+
+
+                </table></td>
+              </tr>
+            </table></td>
+          </tr>
+        </table></td>
+      </tr>
+    </table>
+    </td>
+  </tr>
+</table>
+
+</body>

--- a/private/email/templates/accounts/inviteShopMember.html
+++ b/private/email/templates/accounts/inviteShopMember.html
@@ -75,7 +75,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                   <tr>
                     <td align="left" valign="top"><table width="100%" border="0" cellspacing="0" cellpadding="0">
                       <tr>
-                        <td width="223" height="40" align="center" valign="middle" bgcolor="#1999dd" style="font-family: 'Source Sans Pro', sans-serif; font-size:18px; font-weight:normal; line-height:18px;"><a href="{{url}}" style="text-decoration:none; color:#ffffff;">Vist {{shopName}}</a></td>
+                        <td width="223" height="40" align="center" valign="middle" bgcolor="#1999dd" style="font-family: 'Source Sans Pro', sans-serif; font-size:18px; font-weight:normal; line-height:18px;"><a href="{{url}}" style="text-decoration:none; color:#ffffff;">Visit {{shopName}}</a></td>
                         <td>&nbsp;</td>
                       </tr>
                     </table></td>

--- a/private/email/templates/accounts/inviteShopMember.html
+++ b/private/email/templates/accounts/inviteShopMember.html
@@ -75,7 +75,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                   <tr>
                     <td align="left" valign="top"><table width="100%" border="0" cellspacing="0" cellpadding="0">
                       <tr>
-                        <td width="223" height="40" align="center" valign="middle" bgcolor="#1999dd" style="font-family: 'Source Sans Pro', sans-serif; font-size:18px; font-weight:normal; line-height:18px;"><a href="{{url}}" style="text-decoration:none; color:#ffffff;">Get Started</a></td>
+                        <td width="223" height="40" align="center" valign="middle" bgcolor="#1999dd" style="font-family: 'Source Sans Pro', sans-serif; font-size:18px; font-weight:normal; line-height:18px;"><a href="{{url}}" style="text-decoration:none; color:#ffffff;">Vist {{shopName}}</a></td>
                         <td>&nbsp;</td>
                       </tr>
                     </table></td>

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -692,11 +692,10 @@ export function inviteShopMember(options) {
     Meteor.call("group/addUser", userId, groupId);
 
     // do not send token, as no password reset is needed
-    token = null;
     const url = Meteor.absoluteUrl();
 
     // use primaryShop's data (name, address etc) in email copy sent to new shop manager
-    dataForEmail = getDataForEmail({ shop: primaryShop, currentUserName, name, token, emailLogo, url });
+    dataForEmail = getDataForEmail({ shop: primaryShop, currentUserName, name, emailLogo, url });
 
     // Get email template and subject
     tpl = "accounts/inviteShopMember";

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -693,9 +693,10 @@ export function inviteShopMember(options) {
 
     // do not send token, as no password reset is needed
     token = null;
+    const url = Meteor.absoluteUrl();
 
     // use primaryShop's data (name, address etc) in email copy sent to new shop manager
-    dataForEmail = getDataForEmail({ shop: primaryShop, currentUserName, name, token, emailLogo });
+    dataForEmail = getDataForEmail({ shop: primaryShop, currentUserName, name, token, emailLogo, url });
 
     // Get email template and subject
     tpl = "accounts/inviteShopMember";
@@ -971,7 +972,7 @@ function getCurrentUserName(currentUser) {
  * emailLogo, legalName, physicalAddress, shopName, socialLinks, user, invitedUserName, url
  */
 function getDataForEmail(options) {
-  const { shop, currentUserName, token, emailLogo, name } = options;
+  const { shop, currentUserName, token, emailLogo, name, url } = options;
   const primaryShop = Shops.findOne(Reaction.getPrimaryShopId());
 
   return {
@@ -1010,7 +1011,7 @@ function getDataForEmail(options) {
     user: Meteor.user(), // Account Data
     currentUserName,
     invitedUserName: name,
-    url: getEmailUrl(token)
+    url: url || getEmailUrl(token)
   };
 
   function getEmailUrl(userToken) {

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -679,7 +679,7 @@ export function inviteShopMember(options) {
   const currentUserName = getCurrentUserName(currentUser);
   const emailLogo = getEmailLogo(primaryShop);
   const user = Meteor.users.findOne({ "emails.address": email });
-  let token = Random.id();
+  const token = Random.id();
   let dataForEmail;
   let userId;
   let tpl;

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -678,17 +678,30 @@ export function inviteShopMember(options) {
   const currentUser = Meteor.users.findOne(this.userId);
   const currentUserName = getCurrentUserName(currentUser);
   const emailLogo = getEmailLogo(primaryShop);
-  const token = Random.id();
   const user = Meteor.users.findOne({ "emails.address": email });
+  let token = Random.id();
   let dataForEmail;
   let userId;
+  let tpl;
+  let subject;
 
+  // If the user already has an account, send informative email, not "invite" email
   if (user) {
-    userId = user._id; // since user exists, we promote the account
+    // The user already exists, we promote the account, rather than creating a new one
+    userId = user._id;
     Meteor.call("group/addUser", userId, groupId);
+
+    // do not send token, as no password reset is needed
+    token = null;
+
     // use primaryShop's data (name, address etc) in email copy sent to new shop manager
     dataForEmail = getDataForEmail({ shop: primaryShop, currentUserName, name, token, emailLogo });
+
+    // Get email template and subject
+    tpl = "accounts/inviteShopMember";
+    subject = "accounts/inviteShopMember/subject";
   } else {
+    // The user does not already exist, we need to create a new account
     userId = MeteorAccounts.createUser({
       profile: { invited: true },
       email,
@@ -701,15 +714,18 @@ export function inviteShopMember(options) {
       name
     };
     Meteor.users.update(userId, { $set: tokenUpdate });
+
     // use primaryShop's data (name, address etc) in email copy sent to new shop manager
     dataForEmail = getDataForEmail({ shop: primaryShop, currentUserName, name, token, emailLogo });
+
+    // Get email template and subject
+    tpl = "accounts/inviteNewShopMember";
+    subject = "accounts/inviteNewShopMember/subject";
   }
 
   dataForEmail.groupName = _.startCase(group.name);
 
   // Compile Email with SSR
-  const tpl = "accounts/inviteShopMember";
-  const subject = "accounts/inviteShopMember/subject";
   SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl));
   SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
 


### PR DESCRIPTION
Fixes #3449 

When an existing user was invited to become a shop manager / invited to a group on a shop, the user was sent an email that included our enrollment link, which would hang when clicked as the user already existed.

This update makes it so there are two separate emails sent out for invitations, one for existing user accounts, and one for new user accounts. The new user account will work in the same way as the app previously worked. The existing user email will include a link to the landing page, instead of the enrollment link.

**Testing**
- As a shop admin, invite a _NEW_ user to become a shop manager (or other group member) of your shop.
- Receive an email that will direct you to create a password when you click the "Get Started" link in the email

- Create a new user account
- As a shop admin, invite this user you just created to become a shop manager (or other group member) of your shop.
- Receive an email that will direct you to the home / landing page of Reaction, and not require a password setting