### PR TITLE
3398 Fix Can't change UOM in settings panel 

### DIFF
--- a/imports/plugins/core/i18n/client/containers/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/containers/localizationSettings.js
@@ -32,6 +32,7 @@ const wrapComponent = (Comp) => (
           timezone: doc.timezone,
           currency: doc.currency,
           baseUOM: doc.baseUOM,
+          baseUOL: doc.baseUOL,
           language: doc.language
         }
       });


### PR DESCRIPTION
Resolve #3398 

This PR fix base unit of length not updating but reset to it's former value. This happens because the `baseUOL` wasn't added to `shop.update()`

#### Test
- Login as an admin
- Click on the localization icon
- Attempt to change "Base unit of length"
- Observe that when you change it, it updates.

