### PR TITLE
Accept Shop Data when Inviting Shop Owner

### DIFF
--- a/imports/plugins/included/marketplace/client/components/inviteOwner.js
+++ b/imports/plugins/included/marketplace/client/components/inviteOwner.js
@@ -29,8 +29,9 @@ class InviteOwner extends Component {
     this.setState({ isLoading: true });
     const { name, email, alertId } = this.state;
     const alertOptions = { placement: alertId, id: alertId, autoHide: 4000 };
+    const shopData = {}; // TODO: add optional shop data to the form (maybe just name?)
 
-    Meteor.call("accounts/inviteShopOwner", { name, email }, (error, result) => {
+    Meteor.call("accounts/inviteShopOwner", { name, email }, shopData, (error, result) => {
       let message = "";
       if (error) {
         let messageKey;

--- a/server/methods/accounts/accounts.app-test.js
+++ b/server/methods/accounts/accounts.app-test.js
@@ -575,5 +575,30 @@ describe("Account Meteor method ", function () {
 
       return done();
     });
+
+    it("creates a shop with the data provided", function () {
+      const primaryShop = getShop();
+      const name = Random.id();
+      const shopData = { name };
+
+      sandbox.stub(Reaction, "hasPermission", () => true);
+      sandbox.stub(Reaction, "getPrimaryShop", () => primaryShop);
+
+      const newUser = Factory.create("user");
+      // create Account to go with new user
+      const newAccount = Factory.create("account", { _id: newUser.id, shopId: primaryShop.id });
+      // to resolve an issue in the onCreateUser hook, stub user creation
+      sandbox.stub(MeteorAccount, "createUser", () => newUser._id);
+      sandbox.stub(Accounts, "findOne", () => newAccount)
+        .withArgs({ id: newUser._id });
+
+      Meteor.call("accounts/inviteShopOwner", {
+        email: "custom1@email.co",
+        name: "custom name"
+      }, shopData);
+
+      const newShopCount = Shops.find({ name }).count();
+      expect(newShopCount).to.equal(1);
+    });
   });
 });

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -589,12 +589,14 @@ export function addressBookRemove(addressId, accountUserId) {
  * @param {Object} options -
  * @param {String} options.email - email of invitee
  * @param {String} options.name - name of invitee
+ * @param {Object} shopData - (optional) data used to create the new shop
  * @returns {Boolean} returns true
  */
-export function inviteShopOwner(options) {
+export function inviteShopOwner(options, shopData) {
   check(options, Object);
   check(options.email, String);
   check(options.name, String);
+  check(shopData, Match.Maybe(Object));
   const { name, email } = options;
 
   if (!Reaction.hasPermission("admin", this.userId, Reaction.getPrimaryShopId())) {
@@ -613,7 +615,7 @@ export function inviteShopOwner(options) {
     });
   }
 
-  Meteor.call("shop/createShop", userId);
+  Meteor.call("shop/createShop", userId, shopData);
   const primaryShop = Reaction.getPrimaryShop();
 
   // Compile Email with SSR
@@ -936,16 +938,18 @@ export function setUserPermissions(userId, permissions, group) {
  * @return {String} Name of currentUser or "Admin"
  */
 function getCurrentUserName(currentUser) {
-  if (currentUser && currentUser.profile && currentUser.profile.name) {
-    return currentUser.profile.name;
-  }
+  if (currentUser) {
+    if (currentUser.profile && currentUser.profile.name) {
+      return currentUser.profile.name;
+    }
 
-  if (currentUser.name) {
-    return currentUser.name;
-  }
+    if (currentUser.name) {
+      return currentUser.name;
+    }
 
-  if (currentUser.username) {
-    return currentUser.username;
+    if (currentUser.username) {
+      return currentUser.username;
+    }
   }
 
   return "Admin";

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -28,24 +28,26 @@ function cloneShop(shop, partialShopData = {}) {
   // merge in the partial shop data and some other current user attributes
   Object.assign(shop, partialShopData || {});
 
+  const cleanShop = Schemas.Shop.clean(shop);
+
   // Never create a second primary shop
-  if (!shop.shopType || shop.shopType === "primary") {
-    shop.shopType = "merchant";
+  if (!cleanShop.shopType || cleanShop.shopType === "primary") {
+    cleanShop.shopType = "merchant";
   }
 
   // Clean up values that get automatically added
-  delete shop._id;
-  delete shop.createdAt;
-  delete shop.updatedAt;
-  delete shop.slug;
+  delete cleanShop._id;
+  delete cleanShop.createdAt;
+  delete cleanShop.updatedAt;
+  delete cleanShop.slug;
   // TODO audience permissions need to be consolidated into [object] and not [string]
   // permissions with [string] on layout ie. orders and checkout, cause the insert to fail
-  delete shop.layout;
+  delete cleanShop.layout;
   // delete brandAssets object from shop to prevent new shops from carrying over existing shop's
   // brand image
-  delete shop.brandAssets;
+  delete cleanShop.brandAssets;
 
-  return shop;
+  return cleanShop;
 }
 
 /**

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -14,13 +14,11 @@ import * as Schemas from "/lib/collections/schemas";
  * @summary Returns an existing shop object, with some values removed or changed such
  *   that it is suitable for inserting as a new shop.
  * @method
- * @param {String} shopId - the ID of the shop to clone
+ * @param {Object} shop - the shop to clone
  * @param {Object} partialShopData - any properties you'd like to override
  * @return {Object|null} The cloned shop object or null if a shop with that ID can't be found
  */
-function cloneShop(shopId, partialShopData = {}) {
-  const shop = Collections.Shops.findOne({ _id: shopId }) || {};
-
+function cloneShop(shop, partialShopData = {}) {
   // if a name is not provided, generate a unique name
   if (!partialShopData || !partialShopData.name) {
     const count = Collections.Shops.find().count() || "";
@@ -182,7 +180,6 @@ Meteor.methods({
 
     let shopUser = currentUser;
     let shopAccount = currentAccount;
-
     // TODO: Create a grantable permission for creating shops so we can decouple ownership from shop creation
     // Only marketplace owners can create shops for others
     if (hasPrimaryShopOwnerPermission) {
@@ -200,7 +197,7 @@ Meteor.methods({
       );
     }
 
-    const shop = cloneShop(Reaction.getPrimaryShopId(), partialShopData);
+    const shop = cloneShop(Reaction.getPrimaryShop(), partialShopData);
 
     shop.emails = shopUser.emails;
     shop.addressBook = shopAccount.addressBook;

--- a/server/methods/core/shops.app-test.js
+++ b/server/methods/core/shops.app-test.js
@@ -6,7 +6,7 @@ import { expect } from "meteor/practicalmeteor:chai";
 import { Factory } from "meteor/dburles:factory";
 import { sinon, stubs, spies } from "meteor/practicalmeteor:sinon";
 import Fixtures from "/server/imports/fixtures";
-import { Reaction } from "/server/api";
+import { Reaction, Logger } from "/server/api";
 import { Shops } from "/lib/collections";
 
 Fixtures();
@@ -21,23 +21,20 @@ describe("Shop Methods", function () {
     stubs.restoreAll();
   });
 
-  it("shop factory should create a new shop", function (done) {
+  it("shop factory should create a new shop", function () {
     stubs.create("hasPermissionStub", Reaction, "hasPermission");
     stubs.hasPermissionStub.returns(true);
     spies.create("shopInsertSpy", Shops, "insert");
     Factory.create("shop");
     expect(spies.shopInsertSpy).to.have.been.called;
-    return done();
   });
 });
 
 describe("core shop methods", function () {
-  let shop;
   let sandbox;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    shop = Factory.create("shop");
   });
 
   afterEach(function () {
@@ -46,68 +43,77 @@ describe("core shop methods", function () {
 
   describe("shop/createShop", function () {
     let primaryShop;
+    let insertShopSpy;
 
     beforeEach(function () {
       Shops.remove({});
 
       primaryShop = Factory.create("shop");
       sandbox.stub(Reaction, "getPrimaryShop", () => primaryShop);
+
+      insertShopSpy = sandbox.spy(Shops, "insert");
     });
 
-    it("should throw 403 error by non admin", function (done) {
-      sandbox.stub(Reaction, "hasPermission", () => false);
-      const insertShopSpy = sandbox.spy(Shops, "insert");
-      function createShopFunc() {
-        return Meteor.call("shop/createShop");
-      }
-      expect(createShopFunc).to.throw(Meteor.Error, /Access Denied/);
-      expect(insertShopSpy).to.not.have.been.called;
-      return done();
+    describe("failure conditions", function () {
+      it("throws a 403 error by non admin", function () {
+        sandbox.stub(Reaction, "hasPermission", () => false);
+
+        expect(() => Meteor.call("shop/createShop"))
+          .to.throw(Meteor.Error, /Access Denied/);
+        expect(insertShopSpy).to.not.have.been.called;
+      });
     });
 
-    it("should create new shop for admin for userId and shopObject", function () {
-      this.timeout(5000);
-      sandbox.stub(Meteor, "user", () => ({
-        userId: "12345678",
-        emails: [{
-          address: "user@example.com",
-          provides: "default",
-          verified: true
-        }]
-      }));
-      const shopId = Random.id();
-      Factory.create("account", { _id: "12345678", shopId });
+    describe("success conditions", function () {
+      let userId;
+      let shopId;
+      let name;
 
-      sandbox.stub(Reaction, "hasPermission", () => true);
-      sandbox.stub(Reaction, "getPrimaryShopId", () => shopId);
-      Meteor.call("shop/createShop", "12345678", shop);
-      const newShopCount = Shops.find({ name: shop.name }).count();
-      expect(newShopCount).to.equal(1);
-    });
+      beforeEach(function () {
+        userId = Random.id();
+        shopId = Random.id();
+        name = Random.id();
 
-    it("creates a new shop for admin for userId and a partial shopObject", function () {
-      // this.timeout(5000);
-      const userId = Random.id();
-      const shopId = Random.id();
-      const partialShop = { name: Random.id() };
+        Factory.create("account", { _id: userId, shopId });
 
-      Factory.create("account", { _id: userId, shopId });
+        sandbox.stub(Meteor, "user", () => ({
+          userId,
+          emails: [{
+            address: `${userId}@example.com`,
+            provides: "default",
+            verified: true
+          }]
+        }));
+        sandbox.stub(Reaction, "hasPermission", () => true);
+        sandbox.stub(Reaction, "getPrimaryShopId", () => shopId);
 
-      sandbox.stub(Meteor, "user", () => ({
-        userId,
-        emails: [{
-          address: `${userId}@example.com`,
-          provides: "default",
-          verified: true
-        }]
-      }));
-      sandbox.stub(Reaction, "hasPermission", () => true);
-      sandbox.stub(Reaction, "getPrimaryShopId", () => shopId);
+        // a logging statement exists, stub it to keep the output clean
+        sandbox.stub(Logger, "info")
+          .withArgs(sinon.match(/Created shop/), sinon.match.string);
+      });
 
-      Meteor.call("shop/createShop", userId, partialShop);
+      afterEach(function () {
+        const newShopCount = Shops.find({ name }).count();
+        expect(newShopCount).to.equal(1);
+      });
 
-      const newShopCount = Shops.find({ name: partialShop.name }).count();
-      expect(newShopCount).to.equal(1);
+      it("creates a new shop for admin for userId and a partial shopObject", function () {
+        const partialShop = { name };
+
+        Meteor.call("shop/createShop", userId, partialShop);
+      });
+
+      it("creates a new shop for admin for userId and a partial shopObject ignoring extraneous data", function () {
+        const extraneousData = Random.id();
+        const partialShop = { name, extraneousData };
+
+        Meteor.call("shop/createShop", userId, partialShop);
+
+        expect(insertShopSpy)
+          .to.have.been.calledWith(sinon.match({ name }));
+        expect(insertShopSpy)
+          .to.not.have.been.calledWith(sinon.match({ extraneousData }));
+      });
     });
   });
 });


### PR DESCRIPTION
Feature Request: Accept Shop Data when Inviting a Shop Owner (not just _User_ data)

This PR was prompted by a Shop Importer that I am working on.
I would like to leverage the `inviteShopOwner` code which creates an account, a new shop, kicks off emails, etc., but currently creates a shop with a copy of the Primary Shop (e.g., the name is "Reaction Shop 1").

As far as testing goes, there should be no impact on current functionality since there are no UI changes. Server code can now call `inviteShopOwner` with both user data _and_ shop data: `Meteor.call("accounts/inviteShopOwner", userData, shopData)`.
There is a test to show how it might be used.