### PR TITLE
s/Schemas.Shops/Shops.simpleSchema()

### DIFF
--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -27,7 +27,7 @@ Meteor.methods({
    */
   "shop/createShop": function (shopAdminUserId, shopData) {
     check(shopAdminUserId, Match.Optional(String));
-    check(shopData, Match.Optional(Schemas.Shop));
+    check(shopData, Match.Optional(Collections.Shops.simpleSchema()));
 
     // Get the current marketplace settings
     const marketplace = Reaction.getMarketplaceSettings();
@@ -91,11 +91,6 @@ Meteor.methods({
     // ensure unique id and shop name
     seedShop._id = Random.id();
     seedShop.name = seedShop.name + count;
-
-    // We trust the owner's shop clone, check only when shopData is passed as an argument
-    if (shopData) {
-      check(seedShop, Schemas.Shop);
-    }
 
     const shop = Object.assign({}, seedShop, {
       emails: shopUser.emails,


### PR DESCRIPTION
1) Modify Shop's Schema. for sake of argument:
``` JavaScript
export const ExternalShop = new SimpleSchema({
  externalId: {
    type: Number,
    optional: true
  }
});

Shops.attachSchema(ExternalShop);
```

2) create a shop with `Meteor.call("shop/createShop")`, passing shop data which includes the new externalId.

issue: createShop fails validation because External Id is not known to a Shop's _original_ schema (`Schemas.Shop`).
fix: When a Shop's _current_ schema is used (`Shops.simpleSchema()`), validation passes.

---
I will write tests before merging, but hope to get your thoughts before going too far.