### PR TITLE
3466 Fix "trim of undefined" on checkout login

### DIFF
--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -40,8 +40,8 @@ class AuthContainer extends Component {
       isLoading: true
     });
     const errors = {};
-    const username = email ? email.trim() : "";
-    const pword = password ? password.trim() : "";
+    const username = email ? email.trim() : null;
+    const pword = password ? password.trim() : null;
 
     const validatedEmail = LoginFormValidation.email(username);
     const validatedPassword = LoginFormValidation.password(pword, { validationLevel: "exists" });

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -40,8 +40,8 @@ class AuthContainer extends Component {
       isLoading: true
     });
     const errors = {};
-    const username = email.trim();
-    const pword = password.trim();
+    const username = email === undefined ? "" : email.trim();
+    const pword = password === undefined ? "" : password.trim();
 
     const validatedEmail = LoginFormValidation.email(username);
     const validatedPassword = LoginFormValidation.password(pword, { validationLevel: "exists" });

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -40,8 +40,8 @@ class AuthContainer extends Component {
       isLoading: true
     });
     const errors = {};
-    const username = email === undefined ? "" : email.trim();
-    const pword = password === undefined ? "" : password.trim();
+    const username = email ?  email.trim() : "";
+    const pword = password ? password.trim() : "";
 
     const validatedEmail = LoginFormValidation.email(username);
     const validatedPassword = LoginFormValidation.password(pword, { validationLevel: "exists" });

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -40,7 +40,7 @@ class AuthContainer extends Component {
       isLoading: true
     });
     const errors = {};
-    const username = email ?  email.trim() : "";
+    const username = email ? email.trim() : "";
     const pword = password ? password.trim() : "";
 
     const validatedEmail = LoginFormValidation.email(username);


### PR DESCRIPTION
resolve #3466 

This PR fixes trim of undefined when registering/login on checkout. I found out that the trim() method automatically trims an empty field. what I did was to check if the field is undefined then reset it to an empty string else trim it, then perform the necessary validations.

#### Test
- Order a product without login or registering
- Add to cart
- Checkout
- Click on register without filling the form field
- Notice the validation error display for empty field

