### PR TITLE
Fix #3478 register variantList

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/containers/variantList.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/variantList.js
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 import { Session } from "meteor/session";
 import { Meteor } from "meteor/meteor";
 import { composeWithTracker } from "@reactioncommerce/reaction-components";
+import { Components } from "@reactioncommerce/reaction-components";
 import { ReactionProduct } from "/lib/api";
 import { Reaction, i18next } from "/client/api";
-import { VariantList } from "../components";
 import { getChildVariants } from "../selectors/variants";
 import { Products, Media } from "/lib/collections";
 import update from "react/lib/update";
@@ -161,7 +161,7 @@ class VariantListContainer extends Component {
   render() {
     return (
       <DragDropProvider>
-        <VariantList
+        <Components.VariantList
           onEditVariant={this.handleEditVariant}
           onMoveVariant={this.handleMoveVariant}
           onVariantClick={this.handleVariantClick}

--- a/imports/plugins/included/product-detail-simple/client/index.js
+++ b/imports/plugins/included/product-detail-simple/client/index.js
@@ -9,7 +9,8 @@ import {
   PriceRange,
   AddToCartButton,
   ProductNotFound,
-  ProductDetail
+  ProductDetail,
+  VariantList
 } from "./components";
 
 import {
@@ -34,6 +35,7 @@ registerComponent("ProductTags", ProductTags);
 registerComponent("ProductMetadata", ProductMetadata);
 registerComponent("PriceRange", PriceRange);
 registerComponent("AlertContainer", Alerts);
+registerComponent("VariantList", VariantList);
 registerComponent("MediaGalleryContainer", MediaGalleryContainer);
 registerComponent("SocialContainer", SocialContainer);
 registerComponent("VariantListContainer", VariantListContainer);


### PR DESCRIPTION
###Fix for #3478 

### To test
1. Run `reaction` 
1. Open the PDP of example-product, everything should be fine in the variant section.
1. Try to add custom code by extending the `VariantList` Component, and then replacing the native component with the `<CustomVariantListComponent>` using `replaceComponent`.
1. There should be no error and the `<CustomVariantListComponent>` should be rendered.