### PR TITLE
Fix for newly created variant shows as "archived"

### DIFF
--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -33,6 +33,12 @@ const wrapComponent = (Comp) => (
       this.runVariantValidation(this.props.variant);
     }
 
+    componentWillReceiveProps(nextProps) {
+      this.setState({
+        isDeleted: nextProps.variant && nextProps.variant.isDeleted
+      });
+    }
+
     runVariantValidation(variant) {
       if (variant) {
         const validationStatus = this.validation.validate(variant);


### PR DESCRIPTION
  `isDeleted` is hold as state on the parent component, but wasn't updated in
  componentWillReceiveProps. This caused the children to show a stale
  "archived" property.

  Resolves #3484.