### PR TITLE
Fix #3457 adding taxes and discounts

### DIFF
--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -769,7 +769,7 @@ export const methods = {
             refundTotal * userCurrencyExchangeRate, userCurrencyFormatting
           ),
           total: accounting.formatMoney(
-            (subtotal + shippingCost) * userCurrencyExchangeRate, userCurrencyFormatting
+            (subtotal + shippingCost + taxes - discounts) * userCurrencyExchangeRate, userCurrencyFormatting
           ),
           adjustedTotal: accounting.formatMoney(
             (amount - refundTotal) * userCurrencyExchangeRate, userCurrencyFormatting


### PR DESCRIPTION
### Fix for #3457 

### To test
1. Run reaction
1. Set tax rate to Custom tax rate and set a rate of 10% at your pincode.
1. Place order for the Example product at the same pincode. An email will be sent to your email-id.
1. Check the email, which should show correct total calculation like shown in the screenshot.
<img width="339" alt="screen shot 2018-01-16 at 1 23 28 pm" src="https://user-images.githubusercontent.com/7762605/34977692-80f62b26-fac1-11e7-8a02-1c3e70584b26.png">

