### PR TITLE
fix #3474 making validatedAddress object to prevent exception

### DIFF
--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -286,13 +286,13 @@ export function validateAddress(address) {
       validationErrors = compareAddress(address, validatedAddress);
       if (validationErrors.totalErrors || formErrors.length) {
         validated = false;
-        validatedAddress.failedValidation = false;
+        validatedAddress.failedValidation = true;
       }
     } else {
       // No address, fail validation
       validated = false;
       validatedAddress = {
-        failedValidation: false
+        failedValidation: true
       };
     }
   }

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -291,7 +291,9 @@ export function validateAddress(address) {
     } else {
       // No address, fail validation
       validated = false;
-      validatedAddress.failedValidation = false;
+      validatedAddress = {
+        failedValidation: false
+      };
     }
   }
   const validationResults = { validated, fieldErrors: validationErrors, formErrors, validatedAddress };


### PR DESCRIPTION
### Fix for #3474 

### To test
1. Run `reaction`
2. Buy `Example Product` and go to the checkout sceen.
3. Enter a invalid **US** address and click `Save and Continue`.
4. There should be no exception in the console.