### PR TITLE
(fix): remove "provides" from label options

### DIFF
--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -116,7 +116,7 @@ export function groupPermissions(packages) {
             permission: registryItem.name || pkg.name + "/" + registryItem.template,
             icon: registryItem.icon,
             // TODO: Rethink naming convention for permissions list
-            label: registryItem.label || registryItem.provides || registryItem.route
+            label: registryItem.label || registryItem.route
           });
         }
       }


### PR DESCRIPTION
Fixes #3508 

There are two React PropType errors that occur in the Permissions panel, when a new package is added that does not have a label in the registry, but does have a `provides`.

`Warning: Failed prop type: Invalid prop `label` of type `array` supplied to `Reaction(ListItem)`, expected `string`.`

`modules.js:51358 Warning: Failed prop type: Invalid prop `defaultValue` of type `array` supplied to `Reaction(Translation)`, expected `string`.`

This stems from a semi-recent change where we changed the Registry's `provides` to be an Array, rather than a string, as the `label` needs to be a string for various components.

This update removes the `provides` option from the list of possible labels, as it is an Array and not a label-worthy string anymore, and keeps `label` and `route` as the only options.