### PR TITLE
ProductGridContaintainer should pass all properties to child component

### DIFF
--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -13,12 +13,10 @@ import ProductGrid from "../components/productGrid";
 const wrapComponent = (Comp) => (
   class ProductGridContainer extends Component {
     static propTypes = {
-      canEdit: PropTypes.bool,
       isSearch: PropTypes.bool,
       productIds: PropTypes.array,
       products: PropTypes.array,
-      productsByKey: PropTypes.object,
-      unmountMe: PropTypes.func
+      productsByKey: PropTypes.object
     }
 
     constructor(props) {
@@ -145,12 +143,10 @@ const wrapComponent = (Comp) => (
       return (
         <Components.DragDropProvider>
           <Comp
+            {...this.props}
             products={this.products}
             onMove={this.handleProductDrag}
             itemSelectHandler={this.handleSelectProductItem}
-            canEdit={this.props.canEdit}
-            isSearch={this.props.isSearch}
-            unmountMe={this.props.unmountMe}
           />
         </Components.DragDropProvider>
       );


### PR DESCRIPTION
Closes #3511.

Per convention, all properties should be passed to child component:
https://reactjs.org/docs/higher-order-components.html#refs-arent-passed-through

This is enables us to use the HOC child component agnostic.
