### PR TITLE
(fix): collection hooks caused cancelOrder to fail

### DIFF
--- a/server/imports/fixtures/orders.js
+++ b/server/imports/fixtures/orders.js
@@ -68,6 +68,7 @@ export function getShopId() {
  */
 
 export default function () {
+  const shopId = getShopId();
   Factory.define("order", Orders, {
     // Schemas.OrderItems
     additionalField: faker.lorem.sentence(),
@@ -80,7 +81,7 @@ export default function () {
     notes: [],
 
     // Schemas.Cart
-    shopId: getShopId(),
+    shopId: shopId,
     userId: getUserId(),
     sessionId: "Session",
     email: faker.internet.email(),
@@ -91,13 +92,13 @@ export default function () {
       ]
     },
     items: function () {
-      const product = addProduct();
+      const product = addProduct({ shopId });
       const variant = Products.findOne({ ancestors: [product._id] });
       const childVariants = Products.find({ ancestors: [
         product._id, variant._id
       ] }).fetch();
       const selectedOption = Random.choice(childVariants);
-      const product2 = addProduct();
+      const product2 = addProduct({ shopId });
       const variant2 = Products.findOne({ ancestors: [product2._id] });
       const childVariants2 = Products.find({ ancestors: [
         product2._id, variant2._id
@@ -129,19 +130,19 @@ export default function () {
     },
     requiresShipping: true,
     shipping: [{
-      shopId: getShopId(),
+      shopId: shopId,
       items: [
         {
           _id: itemIdOne,
           productId: Random.id(),
-          shopId: getShopId(),
+          shopId: shopId,
           variantId: Random.id(),
           packed: false
         },
         {
           _id: itemIdTwo,
           productId: Random.id(),
-          shopId: getShopId(),
+          shopId: shopId,
           variantId: Random.id(),
           packed: false
         }
@@ -149,7 +150,7 @@ export default function () {
     }], // Shipping Schema
     billing: [{
       _id: Random.id(),
-      shopId: getShopId(),
+      shopId: shopId,
       address: getAddress({ isBillingDefault: true }),
       paymentMethod: paymentMethod({
         method: "credit",

--- a/server/imports/fixtures/products.js
+++ b/server/imports/fixtures/products.js
@@ -75,12 +75,12 @@ export function productVariant(options = {}) {
   return _.defaults(options, defaults);
 }
 
-export function addProduct() {
-  const product = Factory.create("product");
+export function addProduct(options = {}) {
+  const product = Factory.create("product", options);
   // top level variant
-  const variant = Factory.create("variant", Object.assign({}, productVariant(), { ancestors: [product._id] }));
-  Factory.create("variant", Object.assign({}, productVariant(), { ancestors: [product._id, variant._id] }));
-  Factory.create("variant", Object.assign({}, productVariant(), { ancestors: [product._id, variant._id] }));
+  const variant = Factory.create("variant", Object.assign({}, productVariant(options), { ancestors: [product._id] }));
+  Factory.create("variant", Object.assign({}, productVariant(options), { ancestors: [product._id, variant._id] }));
+  Factory.create("variant", Object.assign({}, productVariant(options), { ancestors: [product._id, variant._id] }));
   return product;
 }
 

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -377,10 +377,8 @@ export const methods = {
               inventoryQuantity: -item.quantity
             }
           }, {
-            publish: true,
-            selector: {
-              type: "variant"
-            }
+            bypassCollection2: true,
+            publish: true
           });
         }
       });

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -368,18 +368,21 @@ export const methods = {
       // Run this Product update inline instead of using ordersInventoryAdjust because the collection hooks fail
       // in some instances which causes the order not to cancel
       order.items.forEach(item => {
-        Products.update({
-          _id: item.variants._id
-        }, {
-          $inc: {
-            inventoryQuantity: -item.quantity
-          }
-        }, {
-          publish: true,
-          selector: {
-            type: "variant"
-          }
-        });
+        if (Reaction.hasPermission("orders", Meteor.userId(), item.shopId)) {
+          Products.update({
+            _id: item.variants._id,
+            shopId: item.shopId
+          }, {
+            $inc: {
+              inventoryQuantity: -item.quantity
+            }
+          }, {
+            publish: true,
+            selector: {
+              type: "variant"
+            }
+          });
+        }
       });
     }
 

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -365,7 +365,22 @@ export const methods = {
     }
 
     if (!returnToStock) {
-      ordersInventoryAdjust(order._id);
+      // Run this Product update inline instead of using ordersInventoryAdjust because the collection hooks fail
+      // in some instances which causes the order not to cancel
+      order.items.forEach(item => {
+        Products.update({
+          _id: item.variants._id
+        }, {
+          $inc: {
+            inventoryQuantity: -item.quantity
+          }
+        }, {
+          publish: true,
+          selector: {
+            type: "variant"
+          }
+        });
+      });
     }
 
     const billingRecord = order.billing.find(billing => billing.shopId === Reaction.getShopId());


### PR DESCRIPTION
This fixes an unreported issue where canceling an order and choosing not to restock would sometimes, with custom payment providers, cause the `orderCancel` method to fail to run all the way through. This failure is connected to the way the `collectionHooks` run, as using `Products.direct.update` works as does moving the Products.update loop out of it's own function.

I've chosen to move the Products.update call inline in the orderCancel function as I don't want to break all of the `collectionHooks` that are being called within the cancellation method.