### PR TITLE
(feat): add classes to nav to easily target data

### DIFF
--- a/imports/plugins/core/accounts/client/components/mainDropdown.js
+++ b/imports/plugins/core/accounts/client/components/mainDropdown.js
@@ -33,8 +33,8 @@ class MainDropdown extends Component {
     const { userImage, userName } = this.props;
     return (
       <Components.Button containerStyle={{ color: "#000", fontWeight: "normal", letterSpacing: 0.8 }}>
-        <span>{userImage}</span>
-        <span>{userName}</span>&nbsp;
+        <span className="main-dropdown-userImage">{userImage}</span>
+        <span className="main-dropdown-userName">{userName}</span>&nbsp;
         <Components.Icon
           icon={"fa fa-caret-down"}
         />


### PR DESCRIPTION
Resolves #3516 

Add a couple classes to our `mainDropdown` to allow for easy targeting of the spans to apply styles to.