### PR TITLE
(breaking, feat) CoreLayout should probe for React component as fallback

### DIFF
--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -17,14 +17,13 @@ const CoreLayout = ({ actionViewIsOpen, structure }) => {
   const footerComponent = layoutFooter && getComponent(layoutFooter);
 
   let mainNode = null;
-  if (Template[template]) {
-    mainNode = <Blaze template={template} />;
-  } else {
-    try {
-      const mainComponent = getComponent(template);
-      mainNode = React.createElement(mainComponent, {});
-    } catch (error) {
-      // no-op
+  try {
+    const mainComponent = getComponent(template);
+    mainNode = React.createElement(mainComponent, {});
+  } catch (error) {
+    //  Probe for Blaze template (legacy)
+    if (Template[template]) {
+      mainNode = <Blaze template={template} />;
     }
   }
 

--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -16,6 +16,18 @@ const CoreLayout = ({ actionViewIsOpen, structure }) => {
   const headerComponent = layoutHeader && getComponent(layoutHeader);
   const footerComponent = layoutFooter && getComponent(layoutFooter);
 
+  let mainNode = null;
+  if (Template[template]) {
+    mainNode = <Blaze template={template} />;
+  } else {
+    try {
+      const mainComponent = getComponent(template);
+      mainNode = React.createElement(mainComponent, {});
+    } catch (error) {
+      // no-op
+    }
+  }
+
   return (
     <div className={pageClassName} id="reactionAppContainer">
 
@@ -23,10 +35,9 @@ const CoreLayout = ({ actionViewIsOpen, structure }) => {
 
       <Blaze template="cartDrawer" className="reaction-cart-drawer" />
 
-      {Template[template] &&
-        <main>
-          <Blaze template={template} />
-        </main>}
+      <main>
+        {mainNode}
+      </main>
 
       {footerComponent && React.createElement(footerComponent, {})}
     </div>


### PR DESCRIPTION
Closes #3523

This PR enables users to overwrite layouts and/or INDEX_OPTIONS without
being forced to use deprecated Blaze templates.

Through rendering Blaze templates in a precendential manner, the old behaviour
should be guaranteed, even if there's a React component with the same
name.


# How to test
Put this somewhere in code
```
const myMain = () => (
  <h1>My custom main</h1>
);
registerComponent("products", myMain);
```

BREAKING CHANGE: This will break the user's plugins if he has named a React component in the same way we named Blaze templates in core.