### PR TITLE
[Feature Request] Prioritize Primary when multiple Shops match domain

### DIFF
--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -430,15 +430,21 @@ export default {
    */
   getShopIdByDomain() {
     const domain = this.getDomain();
+    const primaryShop = this.getPrimaryShop();
+
+    // in cases where the domain could match multiple shops, we first check
+    // whether the primaryShop matches the current domain. If so, we give it
+    // priority
+    if (primaryShop.domains.includes(domain)) {
+      return primaryShop._id;
+    }
+
     const shop = Shops.find({
       domains: domain
     }, {
       limit: 1,
       fields: {
         _id: 1
-      },
-      orderby: {
-        merchantShops: -1 // give preference to PrimaryShop if multiple results
       }
     }).fetch()[0];
 

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -436,6 +436,9 @@ export default {
       limit: 1,
       fields: {
         _id: 1
+      },
+      orderby: {
+        merchantShops: -1 // give preference to PrimaryShop if multiple results
       }
     }).fetch()[0];
 


### PR DESCRIPTION
#### Feature Request:

When multiple shops match the searched domain, prioritize the Primary Shop. This is important when searching for "shop settings" which are only stored on the Primary Shop (e.g., smtp settings).

This is unlikely to even be noticed because Mongo _usually_ returns documents in the order in which they were stored (and the Primary Shop is stored first), but there are a few scenarios which could disrupt this.
I noticed this recently in development, and figured I would suggest the change now long before it is needed.