### PR TITLE
[Feature Request] Allow for ShopId when adding Brand Assets

### DIFF
--- a/private/data/i18n/en.json
+++ b/private/data/i18n/en.json
@@ -125,6 +125,8 @@
         "options": "Options",
         "paymentMethods": "Payment methods",
         "externalServices": "External services",
+        "shopBrandAssetsSaved": "Shop brand assets saved",
+        "shopBrandAssetsFailed": "Shop brand assets failed",
         "shopLocalizationSettingsSaved": "Shop localization settings saved.",
         "shopLocalizationSettingsFailed": "Shop localization settings update failed.",
         "shopPaymentMethodsSaved": "Shop Payment Methods settings saved.",

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -11,6 +11,62 @@ import * as Collections from "/lib/collections";
 import * as Schemas from "/lib/collections/schemas";
 
 /**
+ * @name updateShopBrandAssets
+ * @method
+ * @param {Object} asset - brand asset {mediaId: "", type, ""}
+ * @param {String} shopId - the shop id coresponding to the shop for which
+ *                 the asset should be applied (defaults to Reaction.getShopId())
+ * @param {String} userId - the user id on whose behalf we are performing this
+ *                 action (defaults to Meteor.userId())
+ * @return {Int} returns update result
+ */
+export function updateShopBrandAssets(asset, shopId = Reaction.getShopId(), userId = Meteor.userId()) {
+  check(asset, {
+    mediaId: String,
+    type: String
+  });
+  check(shopId, String);
+
+  // must have core permissions
+  if (!Reaction.hasPermission("core", userId, shopId)) {
+    throw new Meteor.Error("access-denied", "Access Denied");
+  }
+
+  // Does our shop contain the brandasset we're tring to add
+  const shopWithBrandAsset = Collections.Shops.findOne({
+    "_id": shopId,
+    "brandAssets.type": asset.type
+  });
+
+  // If it does, then we update it with the new asset reference
+  if (shopWithBrandAsset) {
+    return Collections.Shops.update({
+      "_id": shopId,
+      "brandAssets.type": "navbarBrandImage"
+    }, {
+      $set: {
+        "brandAssets.$": {
+          mediaId: asset.mediaId,
+          type: asset.type
+        }
+      }
+    });
+  }
+
+  // Otherwise we insert a new brand asset reference
+  return Collections.Shops.update({
+    _id: shopId
+  }, {
+    $push: {
+      brandAssets: {
+        mediaId: asset.mediaId,
+        type: asset.type
+      }
+    }
+  });
+}
+
+/**
  * @file Meteor methods for Shop
  *
  *
@@ -856,44 +912,10 @@ Meteor.methods({
       mediaId: String,
       type: String
     });
-    // must have core permissions
-    if (!Reaction.hasPermission("core")) {
-      throw new Meteor.Error("access-denied", "Access Denied");
-    }
+
     this.unblock();
 
-    // Does our shop contain the brandasset we're tring to add
-    const shopWithBrandAsset = Collections.Shops.findOne({
-      "_id": Reaction.getShopId(),
-      "brandAssets.type": asset.type
-    });
-
-    // If it does, then we update it with the new asset reference
-    if (shopWithBrandAsset) {
-      return Collections.Shops.update({
-        "_id": Reaction.getShopId(),
-        "brandAssets.type": "navbarBrandImage"
-      }, {
-        $set: {
-          "brandAssets.$": {
-            mediaId: asset.mediaId,
-            type: asset.type
-          }
-        }
-      });
-    }
-
-    // Otherwise we insert a new brand asset reference
-    return Collections.Shops.update({
-      _id: Reaction.getShopId()
-    }, {
-      $push: {
-        brandAssets: {
-          mediaId: asset.mediaId,
-          type: asset.type
-        }
-      }
-    });
+    return updateShopBrandAssets(asset);
   },
 
   /**


### PR DESCRIPTION
#### Feature Request

I am working on a Shop Importer. i.e., there exists a data feed for all of my customers and with one click, an automated process pulls in their information, their products, and their brand assets.

I do not wish to rewrite code, so I moved the method body for `updateBrandAssets` to a function (and `export`ed it, for server-side reuse), added the `shopId` parameter (which remains `Reaction.getShopId()` when called from the client).

As a result of pulling the code out into a separate function, the diff is not great. I will highlight the changes.

let me know what you think.
