### PR TITLE
Wrong subject for generated emails

### DIFF
--- a/server/api/core/accounts/password.js
+++ b/server/api/core/accounts/password.js
@@ -226,7 +226,7 @@ export function sendVerificationEmail(userId, email) {
   const subject = "accounts/verifyEmail/subject";
 
   SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl));
-  SSR.compileTemplate(subject, Reaction.Email.getSubject(subject));
+  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
 
   return Reaction.Email.send({
     to: address,
@@ -343,7 +343,7 @@ export function sendUpdatedVerificationEmail(userId, email) {
   const subject = "accounts/verifyUpdatedEmail/subject";
 
   SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl));
-  SSR.compileTemplate(subject, Reaction.Email.getSubject(subject));
+  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
 
   return Reaction.Email.send({
     to: address,


### PR DESCRIPTION
Fixes wrongly sent emails with default subject instead of customized version from Templates collection

Closes #3575 



### How to Test
```
$ reaction reset
$ # please set REACTION_EMAIL in settings.json
$ # please make sure the MAIL gateway is properly configured in reaction.json
$ export NODE_TLS_REJECT_UNAUTHORIZED=0 && export REACTION_SECURE_DEFAULT_ADMIN=true && reaction
$ # Check your inbox. Subject should read: {{shopName}}: Please verify your email address
```