### PR TITLE
Email logs and email job queuing should check permissions

### DIFF
--- a/server/methods/email.js
+++ b/server/methods/email.js
@@ -111,7 +111,7 @@ Meteor.methods({
    * @return {Boolean} - returns true if job is successfully restarted
    */
   "emails/retryFailed"(jobId) {
-    if (!Reaction.hasPermission(["owner", "admin", "dashboard"], this.userId)) {
+    if (!Reaction.hasPermission(["owner", "admin", "reaction-email"], this.userId)) {
       Logger.error("email/retryFailed: Access Denied");
       throw new Meteor.Error("access-denied", "Access Denied");
     }

--- a/server/publications/email.js
+++ b/server/publications/email.js
@@ -15,7 +15,7 @@ Meteor.publish("Emails", function (query, options) {
   check(query, Match.Optional(Object));
   check(options, Match.Optional(Object));
 
-  if (Reaction.hasPermission(["owner", "admin", "dashboard"], this.userId)) {
+  if (Reaction.hasPermission(["owner", "admin", "reaction-email"], this.userId)) {
     Counts.publish(this, "emails-count", Jobs.find({ type: "sendEmail" }));
     return Jobs.find({ type: "sendEmail" });
   }


### PR DESCRIPTION
Closes #3542

- Prevent Jobs publication to send data to client if user has not email
permission
- Prevent emails from being queued for resending if user has no email permission.
