### PR TITLE
Use correct value when you flag an order failed

### DIFF
--- a/imports/plugins/included/connectors-shopify/server/jobs/order-export.js
+++ b/imports/plugins/included/connectors-shopify/server/jobs/order-export.js
@@ -13,7 +13,7 @@ function markExportFailed(order) {
     Orders.update({ _id: order._id }, {
       $push: {
         exportHistory: {
-          status: "failed",
+          status: "failure",
           dateAttempted: new Date(),
           exportMethod: "reaction-connectors-shopify",
           shopId: shopId


### PR DESCRIPTION
Resolves #3562 

The wrong values was used to mark an order as failed export

### To test
1. Login as admin and enable Shopify export
1. Cause the export to fail somehow (disabling network while using example-payment)
1. Place an order
1. Observe no error from marking the order failed (besides the failed export of course)
