### PR TITLE
[WIP] (fix): eslint rule updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -263,7 +263,7 @@
     * Additional rules to enable one by one
     */
     "array-bracket-spacing": ["error", "never"],
-    // "array-callback-return": ["error", { "allowImplicit": true }],
+    "array-callback-return": ["error", { "allowImplicit": true }],
     "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": false }],
     "arrow-parens": [ "error", "always", { "requireForBlockBody": true }],
     // "block-spacing": ["error", "always"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -264,7 +264,7 @@
     */
     "array-bracket-spacing": ["error", "never"],
     // "array-callback-return": ["error", { "allowImplicit": true }],
-    // "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": false }],
+    "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": false }],
     // "arrow-parens": [ "error", "always", { "requireForBlockBody": true }],
     // "block-spacing": ["error", "always"],
     // "computed-property-spacing": ["error", "never"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -265,7 +265,7 @@
     "array-bracket-spacing": ["error", "never"],
     // "array-callback-return": ["error", { "allowImplicit": true }],
     "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": false }],
-    // "arrow-parens": [ "error", "always", { "requireForBlockBody": true }],
+    "arrow-parens": [ "error", "always", { "requireForBlockBody": true }],
     // "block-spacing": ["error", "always"],
     // "computed-property-spacing": ["error", "never"],
     // "dot-location": ["error", "property"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -262,7 +262,7 @@
     /**
     * Additional rules to enable one by one
     */
-    // "array-bracket-spacing": ["error", "never"],
+    "array-bracket-spacing": ["error", "never"],
     // "array-callback-return": ["error", { "allowImplicit": true }],
     // "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": false }],
     // "arrow-parens": [ "error", "always", { "requireForBlockBody": true }],

--- a/client/modules/core/helpers/apps.js
+++ b/client/modules/core/helpers/apps.js
@@ -185,6 +185,4 @@ export function Apps(optionHash) {
 }
 
 // Register global template helper
-Template.registerHelper("reactionApps", (optionHash) => {
-  return Reaction.Apps(optionHash);
-});
+Template.registerHelper("reactionApps", (optionHash) => Reaction.Apps(optionHash));

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -287,7 +287,7 @@ export default {
 
     // Nested find that determines if a user has any of the permissions
     // specified in the `permissions` array for any shop
-    const hasPermissions = Object.keys(user.roles).find((shopId) => user.roles[shopId].find((role) => permissions.find(permission => permission === role)));
+    const hasPermissions = Object.keys(user.roles).find((shopId) => user.roles[shopId].find((role) => permissions.find((permission) => permission === role)));
 
     // Find returns undefined if nothing is found.
     // This will return true if permissions are found, false otherwise
@@ -307,7 +307,7 @@ export default {
     const shopIds = Object.keys(user.roles);
     // Remove "__global_roles__" from the list of shopIds, as this function will always return true for
     // marketplace admins if that "id" is left in the check
-    const filteredShopIds = shopIds.filter(shopId => shopId !== "__global_roles__");
+    const filteredShopIds = shopIds.filter((shopId) => shopId !== "__global_roles__");
 
     // Reduce shopIds to shopsWithPermission, using the roles passed in to this function
     const shopIdsWithRoles = filteredShopIds.reduce((shopsWithPermission, shopId) => {

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -287,11 +287,7 @@ export default {
 
     // Nested find that determines if a user has any of the permissions
     // specified in the `permissions` array for any shop
-    const hasPermissions = Object.keys(user.roles).find((shopId) => {
-      return user.roles[shopId].find((role) => {
-        return permissions.find(permission => permission === role);
-      });
-    });
+    const hasPermissions = Object.keys(user.roles).find((shopId) => user.roles[shopId].find((role) => permissions.find(permission => permission === role)));
 
     // Find returns undefined if nothing is found.
     // This will return true if permissions are found, false otherwise

--- a/client/modules/router/helpers.js
+++ b/client/modules/router/helpers.js
@@ -12,8 +12,6 @@ Template.registerHelper("pathFor", Router.pathFor);
 // urlFor
 // template helper to return absolute + path
 //
-Template.registerHelper("urlFor", (path, params) => {
-  return Meteor.absoluteUrl(Router.pathFor(path, params).substr(1));
-});
+Template.registerHelper("urlFor", (path, params) => Meteor.absoluteUrl(Router.pathFor(path, params).substr(1)));
 
 Template.registerHelper("active", Router.isActiveClassName);

--- a/imports/plugins/core/accounts/client/components/accountsDashboard.js
+++ b/imports/plugins/core/accounts/client/components/accountsDashboard.js
@@ -67,18 +67,16 @@ class AccountsDashboard extends Component {
       return (
         <div className="group-container">
           {this.state.loading && <Components.Loading />}
-          {groups.map((group, index) => {
-            return (
-              <Components.GroupsTable
-                {...this.props}
-                key={index}
-                group={group}
-                onMethodLoad={this.handleMethodLoad}
-                onMethodDone={this.handleMethodDone}
-                onGroupSelect={this.handleGroupSelect}
-              />
-            );
-          })}
+          {groups.map((group, index) => (
+            <Components.GroupsTable
+              {...this.props}
+              key={index}
+              group={group}
+              onMethodLoad={this.handleMethodLoad}
+              onMethodDone={this.handleMethodDone}
+              onGroupSelect={this.handleGroupSelect}
+            />
+          ))}
         </div>
       );
     }

--- a/imports/plugins/core/accounts/client/components/adminInviteForm.js
+++ b/imports/plugins/core/accounts/client/components/adminInviteForm.js
@@ -49,11 +49,9 @@ class AdminInviteForm extends Component {
     this.setState({ group });
   };
 
-  removeAlert = (oldAlert) => {
-    return this.setState({
-      alertArray: this.state.alertArray.filter((alert) => !_.isEqual(alert, oldAlert))
-    });
-  };
+  removeAlert = (oldAlert) => this.setState({
+    alertArray: this.state.alertArray.filter((alert) => !_.isEqual(alert, oldAlert))
+  });
 
   handleSubmit(event) {
     event.preventDefault();

--- a/imports/plugins/core/accounts/client/components/editGroup.js
+++ b/imports/plugins/core/accounts/client/components/editGroup.js
@@ -46,28 +46,22 @@ class EditGroup extends Component {
     this.setState({ groups, selectedGroup });
   }
 
-  selectGroup = (grp) => {
-    return (event) => {
-      event.preventDefault();
-      if (this.props.onChangeGroup) {
-        this.props.onChangeGroup(grp);
-      }
-      this.setState({ isEditing: false });
-    };
+  selectGroup = (grp) => (event) => {
+    event.preventDefault();
+    if (this.props.onChangeGroup) {
+      this.props.onChangeGroup(grp);
+    }
+    this.setState({ isEditing: false });
   };
 
-  groupListClass = (grp) => {
-    return classnames({
-      "groups-item-selected": grp._id === this.state.selectedGroup._id,
-      "groups-list": true
-    });
-  };
+  groupListClass = (grp) => classnames({
+    "groups-item-selected": grp._id === this.state.selectedGroup._id,
+    "groups-list": true
+  });
 
-  removeAlert = (oldAlert) => {
-    return this.setState({
-      alertArray: this.state.alertArray.filter((alert) => !_.isEqual(alert, oldAlert))
-    });
-  };
+  removeAlert = (oldAlert) => this.setState({
+    alertArray: this.state.alertArray.filter((alert) => !_.isEqual(alert, oldAlert))
+  });
 
   createGroup = (groupData) => {
     Meteor.call("group/createGroup", groupData, Reaction.getShopId(), (err, res) => {
@@ -117,12 +111,10 @@ class EditGroup extends Component {
     });
   };
 
-  showForm = ((grp) = {}) => {
-    return (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.setState({ isEditing: true, selectedGroup: grp });
-    };
+  showForm = ((grp) = {}) => (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.setState({ isEditing: true, selectedGroup: grp });
   };
 
   renderGroupForm = () => {

--- a/imports/plugins/core/accounts/client/components/groupsTable.js
+++ b/imports/plugins/core/accounts/client/components/groupsTable.js
@@ -8,12 +8,10 @@ const GroupsTable = (props) => {
   const { group } = props;
   const fields = ["name", "email", "createdAt", "dropdown", "button"];
 
-  const tableClass = (length) => {
-    return classnames({
-      "accounts-group-table": true,
-      "empty-table": !length
-    });
-  };
+  const tableClass = (length) => classnames({
+    "accounts-group-table": true,
+    "empty-table": !length
+  });
 
   const columnMetadata = fields.map((columnName) => ({
     Header: <Components.GroupHeader columnName={columnName} numberOfRows={group.users && group.users.length} />,

--- a/imports/plugins/core/accounts/client/components/groupsTableCell.js
+++ b/imports/plugins/core/accounts/client/components/groupsTableCell.js
@@ -68,8 +68,8 @@ const GroupsTableCell = ({ account, columnName, group, adminGroups, handleRemove
     // Permission check. Remove owner option, if user is not current owner.
     // Also remove groups user does not have roles to manage. This is also checked on the server
     const dropOptions = groups
-      .filter(grp => (grp.slug === "owner" && !hasOwnerAccess) ? false : true)
-      .filter(grp => Reaction.canInviteToGroup({ group: grp })) || [];
+      .filter((grp) => (grp.slug === "owner" && !hasOwnerAccess) ? false : true)
+      .filter((grp) => Reaction.canInviteToGroup({ group: grp })) || [];
 
     if (dropOptions.length < 2) { return dropDownButton(); } // do not use dropdown if only one option
 
@@ -82,7 +82,7 @@ const GroupsTableCell = ({ account, columnName, group, adminGroups, handleRemove
           onChange={handleUserGroupChange({ account, ownerGrpId: ownerGroup._id, onMethodDone, onMethodLoad })}
         >
           {dropOptions
-            .filter(grp => grp._id !== group._id)
+            .filter((grp) => grp._id !== group._id)
             .map((grp, index) => (
               <Components.MenuItem
                 key={index}

--- a/imports/plugins/core/accounts/client/components/loginButtons.js
+++ b/imports/plugins/core/accounts/client/components/loginButtons.js
@@ -12,9 +12,7 @@ class LoginButtons extends Component {
   }
 
   renderLoginButtons() {
-    const enabledServices = this.props.loginServices().filter((service) => {
-      return service.enabled;
-    });
+    const enabledServices = this.props.loginServices().filter((service) => service.enabled);
 
     return (
       <div>

--- a/imports/plugins/core/accounts/client/components/manageGroups.js
+++ b/imports/plugins/core/accounts/client/components/manageGroups.js
@@ -44,7 +44,7 @@ class ManageGroups extends Component {
         <Components.EditGroup
           // filter out owner group from editable groups.
           // The edit group meteor method also prevents editing owner group
-          groups={this.state.groups.filter(grp => grp.slug !== "owner")}
+          groups={this.state.groups.filter((grp) => grp.slug !== "owner")}
           selectedGroup={this.state.group}
           onChangeGroup={this.props.onChangeGroup}
         />

--- a/imports/plugins/core/accounts/client/components/permissionsList.js
+++ b/imports/plugins/core/accounts/client/components/permissionsList.js
@@ -49,23 +49,21 @@ class PermissionsList extends Component {
     this.setState({ group: nextProps.group });
   }
 
-  togglePermission = (toggledPermission) => {
-    return (event, checked) => {
-      const groupData = Object.assign({}, this.state.group);
-      const permissions = resolvePermissions(toggledPermission);
-      if (!groupData.permissions) {
-        groupData.permissions = [];
-      }
-      if (checked) {
-        groupData.permissions = _.uniq([...groupData.permissions, ...permissions]);
-      } else {
-        groupData.permissions = removePermissions(groupData.permissions, permissions);
-      }
+  togglePermission = (toggledPermission) => (event, checked) => {
+    const groupData = Object.assign({}, this.state.group);
+    const permissions = resolvePermissions(toggledPermission);
+    if (!groupData.permissions) {
+      groupData.permissions = [];
+    }
+    if (checked) {
+      groupData.permissions = _.uniq([...groupData.permissions, ...permissions]);
+    } else {
+      groupData.permissions = removePermissions(groupData.permissions, permissions);
+    }
 
-      if (this.props.updateGroup) {
-        return this.props.updateGroup(this.state.group._id, groupData);
-      }
-    };
+    if (this.props.updateGroup) {
+      return this.props.updateGroup(this.state.group._id, groupData);
+    }
   };
 
   checked = (permission) => {
@@ -79,18 +77,16 @@ class PermissionsList extends Component {
     if (permission.permissions.length) {
       return (
         <div className="child-item">
-          {permission.permissions.map((childPermission, index) => {
-            return (
-              <Components.ListItem
-                key={`${childPermission.name}-${index}`}
-                actionType="switch"
-                label={childPermission.label}
-                switchOn={this.checked(childPermission.permission)}
-                switchName={childPermission.permission}
-                onSwitchChange={this.togglePermission(childPermission)}
-              />
-            );
-          })}
+          {permission.permissions.map((childPermission, index) => (
+            <Components.ListItem
+              key={`${childPermission.name}-${index}`}
+              actionType="switch"
+              label={childPermission.label}
+              switchOn={this.checked(childPermission.permission)}
+              switchName={childPermission.permission}
+              onSwitchChange={this.togglePermission(childPermission)}
+            />
+          ))}
         </div>
       );
     }

--- a/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
+++ b/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
@@ -13,9 +13,7 @@ const handlers = {
 
       if (groupId === ownerGrpId) {
         return alertConfirm()
-          .then(() => {
-            return updateMethodCall(groupId);
-          })
+          .then(() => updateMethodCall(groupId))
           .catch(() => {
             if (onMethodDone) { onMethodDone(); }
           });
@@ -55,9 +53,7 @@ const handlers = {
   handleRemoveUserFromGroup(account, groupId) {
     return () => {
       alertConfirm()
-        .then(() => {
-          return removeMethodCall();
-        })
+        .then(() => removeMethodCall())
         .catch(() => false);
 
       function removeMethodCall() {

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -108,13 +108,11 @@ class AuthContainer extends Component {
     return false;
   }
 
-  formMessages = () => {
-    return (
-      <Components.LoginFormMessages
-        messages={this.state.formMessages}
-      />
-    );
-  }
+  formMessages = () => (
+    <Components.LoginFormMessages
+      messages={this.state.formMessages}
+    />
+  )
 
   services = () => {
     const serviceHelper = new ServiceConfigHelper();
@@ -131,9 +129,7 @@ class AuthContainer extends Component {
     return !!Package["accounts-password"] && enabledServices.length > 0;
   }
 
-  capitalizeName = (str) => {
-    return LoginFormSharedHelpers.capitalize(str);
-  }
+  capitalizeName = (str) => LoginFormSharedHelpers.capitalize(str)
 
   handleSocialLogin = (value) => {
     let serviceName = value;
@@ -159,9 +155,7 @@ class AuthContainer extends Component {
     });
   }
 
-  hasPasswordService = () => {
-    return !!Package["accounts-password"];
-  }
+  hasPasswordService = () => !!Package["accounts-password"]
 
   renderAuthView() {
     if (this.props.currentView === "loginFormSignInView") {

--- a/imports/plugins/core/accounts/client/containers/forgotPassword.js
+++ b/imports/plugins/core/accounts/client/containers/forgotPassword.js
@@ -78,13 +78,11 @@ class ForgotPasswordContainer extends Component {
     });
   }
 
-  formMessages = () => {
-    return (
-      <Components.LoginFormMessages
-        messages={this.state.formMessages}
-      />
-    );
-  }
+  formMessages = () => (
+    <Components.LoginFormMessages
+      messages={this.state.formMessages}
+    />
+  )
 
   hasError = (error) => {
     // True here means the field is valid

--- a/imports/plugins/core/accounts/client/containers/passwordOverlay.js
+++ b/imports/plugins/core/accounts/client/containers/passwordOverlay.js
@@ -93,11 +93,9 @@ const wrapComponent = (Comp) => (
       });
     }
 
-    formMessages = () => {
-      return (
-        <Components.LoginFormMessages messages={this.state.formMessages} />
-      );
-    }
+    formMessages = () => (
+      <Components.LoginFormMessages messages={this.state.formMessages} />
+    )
 
     hasError = (error) => {
       // True here means the field is valid

--- a/imports/plugins/core/accounts/client/containers/userOrdersListContainer.js
+++ b/imports/plugins/core/accounts/client/containers/userOrdersListContainer.js
@@ -65,8 +65,9 @@ function composer(props, onData) {
           paymentMethods: order.getUniquePaymentMethods(),
           productImages
         };
-        return allOrdersInfo.push(orderInfo);
+        allOrdersInfo.push(orderInfo);
       }
+      return;
     });
     onData(null, {
       allOrdersInfo,

--- a/imports/plugins/core/accounts/client/containers/userOrdersListContainer.js
+++ b/imports/plugins/core/accounts/client/containers/userOrdersListContainer.js
@@ -65,7 +65,7 @@ function composer(props, onData) {
           paymentMethods: order.getUniquePaymentMethods(),
           productImages
         };
-        allOrdersInfo.push(orderInfo);
+        return allOrdersInfo.push(orderInfo);
       }
     });
     onData(null, {

--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -50,8 +50,8 @@ export function sortGroups(groups) {
  */
 export function getInvitableGroups(groups) {
   return groups
-    .filter(grp => grp.slug !== "owner")
-    .filter(grp => Reaction.canInviteToGroup({ group: grp }));
+    .filter((grp) => grp.slug !== "owner")
+    .filter((grp) => Reaction.canInviteToGroup({ group: grp }));
 }
 
 /**
@@ -67,14 +67,14 @@ export function getInvitableGroups(groups) {
 export function getDefaultUserInviteGroup(groups) {
   let result;
   const user = Collections.Accounts.findOne({ userId: Meteor.userId() });
-  result = groups.find(grp => user && user.groups.indexOf(grp._id) > -1);
+  result = groups.find((grp) => user && user.groups.indexOf(grp._id) > -1);
 
   if (result && result.slug === "owner") {
-    result = groups.find(grp => grp.slug === "shop manager");
+    result = groups.find((grp) => grp.slug === "shop manager");
   }
 
   if (!result) {
-    result = groups.find(firstGroup => firstGroup);
+    result = groups.find((firstGroup) => firstGroup);
   }
 
   return result;

--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -17,6 +17,7 @@ export default function sortUsersIntoGroups({ accounts, groups }) {
       if (acc.groups && acc.groups.indexOf(group._id) > -1) {
         return acc;
       }
+      return;
     });
     group.users = _.compact(matchingAccounts);
     return group;
@@ -131,6 +132,7 @@ export function groupPermissions(packages) {
         permissions: _.uniq(permissions)
       };
     }
+    return;
   });
 }
 

--- a/imports/plugins/core/accounts/client/helpers/util.js
+++ b/imports/plugins/core/accounts/client/helpers/util.js
@@ -119,9 +119,7 @@ export class ServiceConfigHelper {
    */
   static addProvider(provider, fields) {
     providers[provider] = {
-      fields: () => {
-        return fields;
-      }
+      fields: () => fields
     };
   }
 }

--- a/imports/plugins/core/accounts/client/templates/addressBook/add/add.js
+++ b/imports/plugins/core/accounts/client/templates/addressBook/add/add.js
@@ -45,7 +45,7 @@ Template.addressBookAdd.helpers({
 
     // Set default country code based on shop's shipping address
     if (shop && Array.isArray(shop.addressBook) && shop.addressBook.length > 0) {
-      const defaultAddress = shop.addressBook.find(address => address.isShippingDefault);
+      const defaultAddress = shop.addressBook.find((address) => address.isShippingDefault);
       const defaultCountryCode = defaultAddress.country;
       if (defaultCountryCode) {
         thisAddress.country = defaultCountryCode;

--- a/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
+++ b/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
@@ -44,7 +44,7 @@ Template.accountsDashboard.helpers({
       if (instance.subscriptionsReady()) {
         const shopUsers = Meteor.users.find();
 
-        return shopUsers.map(user => {
+        return shopUsers.map((user) => {
           const member = {};
 
           // Querying the Accounts collection to retrieve user's name because

--- a/imports/plugins/core/checkout/client/components/cartDrawer.js
+++ b/imports/plugins/core/checkout/client/components/cartDrawer.js
@@ -9,20 +9,18 @@ const CartDrawer = ({ productItems, pdpPath, handleRemoveItem, handleCheckout, h
         <div className="cart-drawer-swiper-slide">
           <Components.CartSubTotal />
         </div>
-        {productItems.map(item => {
-          return (
-            <div className="cart-drawer-swiper-slide" key={item._id}>
-              <Components.CartItems
-                item={item}
-                pdpPath={pdpPath}
-                handleLowInventory={handleLowInventory}
-                handleImage={handleImage}
-                handleRemoveItem={handleRemoveItem}
-                handleShowProduct={handleShowProduct}
-              />
-            </div>
-          );
-        })}
+        {productItems.map(item => (
+          <div className="cart-drawer-swiper-slide" key={item._id}>
+            <Components.CartItems
+              item={item}
+              pdpPath={pdpPath}
+              handleLowInventory={handleLowInventory}
+              handleImage={handleImage}
+              handleRemoveItem={handleRemoveItem}
+              handleShowProduct={handleShowProduct}
+            />
+          </div>
+        ))}
       </div>
     </div>
     <div className="cart-drawer-pagination" />

--- a/imports/plugins/core/checkout/client/components/cartDrawer.js
+++ b/imports/plugins/core/checkout/client/components/cartDrawer.js
@@ -9,7 +9,7 @@ const CartDrawer = ({ productItems, pdpPath, handleRemoveItem, handleCheckout, h
         <div className="cart-drawer-swiper-slide">
           <Components.CartSubTotal />
         </div>
-        {productItems.map(item => (
+        {productItems.map((item) => (
           <div className="cart-drawer-swiper-slide" key={item._id}>
             <Components.CartItems
               item={item}

--- a/imports/plugins/core/checkout/client/components/completedOrder.js
+++ b/imports/plugins/core/checkout/client/components/completedOrder.js
@@ -88,6 +88,7 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
                   </div>
                 </div>;
               }
+              return;
             })}
           </div>
 

--- a/imports/plugins/core/checkout/client/components/completedOrderSummary.js
+++ b/imports/plugins/core/checkout/client/components/completedOrderSummary.js
@@ -12,19 +12,18 @@ import ShopOrderSummary from "./shopOrderSummary";
  * @property {boolean} isProfilePage - Checks if current page is Profile Page
  * @return {Node} React node containing the order summary broken down by shop
  */
-const CompletedOrderSummary = ({ shops, orderSummary, isProfilePage }) => {
-  return (
-    <div>
-      <div className="order-details-content-title">
-        <p><Components.Translation defaultValue="Order Summary" i18nKey={"cartCompleted.orderSummary"} /></p>
-      </div>
-      <div className="order-details-info-box">
-        {shops.map((shop) => {
-          const shopKey = Object.keys(shop);
-          return <ShopOrderSummary shopSummary={shop[shopKey]} key={shopKey} isProfilePage={isProfilePage} />;
-        })}
-        <hr />
-        {orderSummary.discounts > 0 &&
+const CompletedOrderSummary = ({ shops, orderSummary, isProfilePage }) => (
+  <div>
+    <div className="order-details-content-title">
+      <p><Components.Translation defaultValue="Order Summary" i18nKey={"cartCompleted.orderSummary"} /></p>
+    </div>
+    <div className="order-details-info-box">
+      {shops.map((shop) => {
+        const shopKey = Object.keys(shop);
+        return <ShopOrderSummary shopSummary={shop[shopKey]} key={shopKey} isProfilePage={isProfilePage} />;
+      })}
+      <hr />
+      {orderSummary.discounts > 0 &&
         <div className="order-summary-line">
           <div className="order-summary-discount-title">
             <Components.Translation defaultValue="Discount Total" i18nKey={"cartCompleted.discountTotal"}/>
@@ -33,19 +32,18 @@ const CompletedOrderSummary = ({ shops, orderSummary, isProfilePage }) => {
             <Components.Currency amount={orderSummary.discounts}/>
           </div>
         </div>
-        }
-        <div className="order-summary-line">
-          <div className="order-summary-total-title">
-            <Components.Translation defaultValue="Order Total" i18nKey={"cartCompleted.orderTotal"}/>
-          </div>
-          <div className="order-summary-total-value">
-            <Components.Currency amount={orderSummary.total}/>
-          </div>
+      }
+      <div className="order-summary-line">
+        <div className="order-summary-total-title">
+          <Components.Translation defaultValue="Order Total" i18nKey={"cartCompleted.orderTotal"}/>
+        </div>
+        <div className="order-summary-total-value">
+          <Components.Currency amount={orderSummary.total}/>
         </div>
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 CompletedOrderSummary.propTypes = {
   isProfilePage: PropTypes.bool,

--- a/imports/plugins/core/checkout/client/components/emptyCartDrawer.js
+++ b/imports/plugins/core/checkout/client/components/emptyCartDrawer.js
@@ -12,33 +12,31 @@ function handleKeepShopping(event) {
   });
 }
 
-const EmptyCartDrawer = () => {
-  return (
-    <div className="cart-drawer" id="cart-drawer">
-      <div className="cart-drawer-empty">
-        <div className="row cart-drawer-empty-msg">
-          <p className="text-align">
-            <i className="fa fa-frown-o fa-lg" />
-          </p>
-          <p className="text-align">
-            <Components.Translation defaultValue="We're sad. Your cart is empty." i18nKey="cartDrawer.empty" />
-          </p>
-        </div>
-        <div className="row">
-          <Components.Button
-            id="btn-keep-shopping"
-            bezelStyle="solid"
-            className="btn-lg btn-block"
-            i18nKeyLabel="cartDrawer.keepShopping"
-            label="Keep on shopping"
-            onClick={handleKeepShopping}
-            status="warning"
-          />
-        </div>
+const EmptyCartDrawer = () => (
+  <div className="cart-drawer" id="cart-drawer">
+    <div className="cart-drawer-empty">
+      <div className="row cart-drawer-empty-msg">
+        <p className="text-align">
+          <i className="fa fa-frown-o fa-lg" />
+        </p>
+        <p className="text-align">
+          <Components.Translation defaultValue="We're sad. Your cart is empty." i18nKey="cartDrawer.empty" />
+        </p>
+      </div>
+      <div className="row">
+        <Components.Button
+          id="btn-keep-shopping"
+          bezelStyle="solid"
+          className="btn-lg btn-block"
+          i18nKeyLabel="cartDrawer.keepShopping"
+          label="Keep on shopping"
+          onClick={handleKeepShopping}
+          status="warning"
+        />
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 EmptyCartDrawer.propTypes = {
   keepShopping: PropTypes.func

--- a/imports/plugins/core/checkout/client/components/shopOrderSummary.js
+++ b/imports/plugins/core/checkout/client/components/shopOrderSummary.js
@@ -9,30 +9,29 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
  * @property {boolean} isProfilePage - Checks if current page is profile page (unused)
  * @return {Node} React node containing the summary information for each shop
  */
-const ShopOrderSummary = ({ shopSummary }) => {
-  return (
-    <div className="order-details-info-box-content">
-      <div className="order-summary-line">
-        <div className="order-summary-header-line" />
-        <div className="order-summary-store-name">
-          <Components.Translation defaultValue="Fulfilled by" i18nKey={"cartCompleted.fulfilledBy"}/> {shopSummary.name}
-        </div>
+const ShopOrderSummary = ({ shopSummary }) => (
+  <div className="order-details-info-box-content">
+    <div className="order-summary-line">
+      <div className="order-summary-header-line" />
+      <div className="order-summary-store-name">
+        <Components.Translation defaultValue="Fulfilled by" i18nKey={"cartCompleted.fulfilledBy"}/> {shopSummary.name}
       </div>
-      <div className="order-summary-line">
-        <div className="order-summary-title">
-          <Components.Translation defaultValue="Items in order" i18nKey={"cartCompleted.orderItems"}/>
-        </div>
-        <div className="order-summary-value">{shopSummary.quantityTotal}</div>
+    </div>
+    <div className="order-summary-line">
+      <div className="order-summary-title">
+        <Components.Translation defaultValue="Items in order" i18nKey={"cartCompleted.orderItems"}/>
       </div>
-      <div className="order-summary-line">
-        <div className="order-summary-title">
-          <Components.Translation defaultValue="Subtotal" i18nKey={"cartCompleted.orderSubtotal"}/>
-        </div>
-        <div className="order-summary-value">
-          <Components.Currency amount={shopSummary.subTotal}/>
-        </div>
+      <div className="order-summary-value">{shopSummary.quantityTotal}</div>
+    </div>
+    <div className="order-summary-line">
+      <div className="order-summary-title">
+        <Components.Translation defaultValue="Subtotal" i18nKey={"cartCompleted.orderSubtotal"}/>
       </div>
-      {shopSummary.shipping > 0 &&
+      <div className="order-summary-value">
+        <Components.Currency amount={shopSummary.subTotal}/>
+      </div>
+    </div>
+    {shopSummary.shipping > 0 &&
       <div className="order-summary-line">
         <div className="order-summary-title">
           <Components.Translation defaultValue="Shipping" i18nKey={"cartCompleted.orderShipping"}/>
@@ -41,8 +40,8 @@ const ShopOrderSummary = ({ shopSummary }) => {
           <Components.Currency amount={shopSummary.shipping}/>
         </div>
       </div>
-      }
-      {shopSummary.taxes > 0 &&
+    }
+    {shopSummary.taxes > 0 &&
       <div className="order-summary-line">
         <div className="order-summary-title">
           <Components.Translation defaultValue="Tax" i18nKey={"cartCompleted.orderTax"}/>
@@ -51,10 +50,9 @@ const ShopOrderSummary = ({ shopSummary }) => {
           <Components.Currency amount={shopSummary.taxes}/>
         </div>
       </div>
-      }
-    </div>
-  );
-};
+    }
+  </div>
+);
 
 ShopOrderSummary.propTypes = {
   isProfilePage: PropTypes.bool,

--- a/imports/plugins/core/checkout/client/containers/cartDrawerContainer.js
+++ b/imports/plugins/core/checkout/client/containers/cartDrawerContainer.js
@@ -57,9 +57,7 @@ const handlers = {
     event.stopPropagation();
     event.preventDefault();
     const currentCartItemId = event.target.getAttribute("id");
-    $(`#${currentCartItemId}`).fadeOut(500, () => {
-      return Meteor.call("cart/removeFromCart", currentCartItemId);
-    });
+    $(`#${currentCartItemId}`).fadeOut(500, () => Meteor.call("cart/removeFromCart", currentCartItemId));
   },
 
   handleCheckout() {

--- a/imports/plugins/core/components/lib/components.js
+++ b/imports/plugins/core/components/lib/components.js
@@ -169,7 +169,7 @@ export function copyHOCs(sourceComponentName, targetComponent) {
  **/
 export function loadRegisteredComponents() {
   Object.keys(ComponentsTable).map((name) => {
-    Components[name] = getComponent(name);
+    return Components[name] = getComponent(name);
   });
 
   return Components;

--- a/imports/plugins/core/components/lib/components.js
+++ b/imports/plugins/core/components/lib/components.js
@@ -168,7 +168,7 @@ export function copyHOCs(sourceComponentName, targetComponent) {
  * @memberof Components
  **/
 export function loadRegisteredComponents() {
-  Object.keys(ComponentsTable).map((name) => Components[name] = getComponent(name));
+  Object.keys(ComponentsTable).map((name) => Components[name] === getComponent(name));
 
   return Components;
 }

--- a/imports/plugins/core/components/lib/components.js
+++ b/imports/plugins/core/components/lib/components.js
@@ -168,9 +168,7 @@ export function copyHOCs(sourceComponentName, targetComponent) {
  * @memberof Components
  **/
 export function loadRegisteredComponents() {
-  Object.keys(ComponentsTable).map((name) => {
-    return Components[name] = getComponent(name);
-  });
+  Object.keys(ComponentsTable).map((name) => Components[name] = getComponent(name));
 
   return Components;
 }

--- a/imports/plugins/core/components/lib/composer/tracker.js
+++ b/imports/plugins/core/components/lib/composer/tracker.js
@@ -31,12 +31,10 @@ import compose from "./compose";
 function getTrackerLoader(reactiveMapper) {
   return (props, onData, env) => {
     let trackerCleanup = null;
-    const handler = Tracker.nonreactive(() => {
-      return Tracker.autorun(() => {
-        // assign the custom clean-up function.
-        trackerCleanup = reactiveMapper(props, onData, env);
-      });
-    });
+    const handler = Tracker.nonreactive(() => Tracker.autorun(() => {
+      // assign the custom clean-up function.
+      trackerCleanup = reactiveMapper(props, onData, env);
+    }));
 
     return () => {
       if (typeof trackerCleanup === "function") trackerCleanup();

--- a/imports/plugins/core/connectors/server/i18n/index.js
+++ b/imports/plugins/core/connectors/server/i18n/index.js
@@ -7,4 +7,4 @@ import en from "./en.json";
 // imports for easier handling by
 // automated translation software
 //
-loadTranslations([ en ]);
+loadTranslations([en]);

--- a/imports/plugins/core/dashboard/client/components/shopSelect.js
+++ b/imports/plugins/core/dashboard/client/components/shopSelect.js
@@ -49,16 +49,14 @@ class ShopSelect extends Component {
     const { shops } = this.props;
 
     if (Array.isArray(shops)) {
-      menuItems = shops.map((shop, index) => {
-        return (
-          <Components.MenuItem
-            label={shop.name}
-            selectLabel={shop.name}
-            value={shop._id}
-            key={index}
-          />
-        );
-      });
+      menuItems = shops.map((shop, index) => (
+        <Components.MenuItem
+          label={shop.name}
+          selectLabel={shop.name}
+          value={shop._id}
+          key={index}
+        />
+      ));
     }
     return (
       <div className={this.props.className || "hidden-xs"}>

--- a/imports/plugins/core/dashboard/client/components/toolbar.js
+++ b/imports/plugins/core/dashboard/client/components/toolbar.js
@@ -146,11 +146,9 @@ class PublishControls extends Component {
 
   renderPackageButons() {
     if (Array.isArray(this.props.packageButtons)) {
-      return this.props.packageButtons.map((packageButton, index) => {
-        return (
-          <FlatButton {...packageButton} key={index} />
-        );
-      });
+      return this.props.packageButtons.map((packageButton, index) => (
+        <FlatButton {...packageButton} key={index} />
+      ));
     }
 
     return null;

--- a/imports/plugins/core/dashboard/client/templates/packages/grid/grid.js
+++ b/imports/plugins/core/dashboard/client/templates/packages/grid/grid.js
@@ -92,9 +92,7 @@ Template.packagesGrid.onCreated(function () {
 
   this.autorun(() => {
     const apps = Reaction.Apps({ provides: "dashboard", enabled: true });
-    const groupedApps = _.groupBy(apps, (app) => {
-      return app.container || "misc";
-    });
+    const groupedApps = _.groupBy(apps, (app) => app.container || "misc");
     this.state.set("apps", apps);
     this.state.set("appsByGroup", groupedApps);
     this.state.set("groups", Object.keys(groupedApps));

--- a/imports/plugins/core/discounts/client/components/list.js
+++ b/imports/plugins/core/discounts/client/components/list.js
@@ -19,9 +19,7 @@ class DiscountList extends Component {
   }
   // list items
   renderList() {
-    const listItems = this.props.listItems.map((listItem) => {
-      return this.renderItem(listItem.id, listItem.code);
-    });
+    const listItems = this.props.listItems.map((listItem) => this.renderItem(listItem.id, listItem.code));
 
     return (
       <div className="rui list-group">{listItems}</div>

--- a/imports/plugins/core/email/client/components/emailLogs.js
+++ b/imports/plugins/core/email/client/components/emailLogs.js
@@ -13,9 +13,7 @@ class EmailLogs extends Component {
 
     // helper adds a class to every grid row
     const customRowMetaData = {
-      bodyCssClassName: () =>  {
-        return "email-grid-row";
-      }
+      bodyCssClassName: () =>  "email-grid-row"
     };
 
     // add i18n handling to headers

--- a/imports/plugins/core/i18n/client/components/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/components/localizationSettings.js
@@ -23,33 +23,29 @@ class LocalizationSettings extends Component {
   }
 
   renderCurrencies() {
-    return this.props.currencies.map((currency, key) => {
-      return (
-        <Components.ListItem
-          actionType={"switch"}
-          key={key}
-          label={currency.label}
-          switchOn={currency.enabled}
-          switchName={currency.name}
-          onSwitchChange={this.props.onUpdateCurrencyConfiguration}
-        />
-      );
-    });
+    return this.props.currencies.map((currency, key) => (
+      <Components.ListItem
+        actionType={"switch"}
+        key={key}
+        label={currency.label}
+        switchOn={currency.enabled}
+        switchName={currency.name}
+        onSwitchChange={this.props.onUpdateCurrencyConfiguration}
+      />
+    ));
   }
 
   renderLanguages() {
-    return this.props.languages.map((language, key) => {
-      return (
-        <Components.ListItem
-          actionType={"switch"}
-          key={key}
-          label={language.label}
-          switchOn={language.enabled}
-          switchName={language.value}
-          onSwitchChange={this.props.onUpdateLanguageConfiguration}
-        />
-      );
-    });
+    return this.props.languages.map((language, key) => (
+      <Components.ListItem
+        actionType={"switch"}
+        key={key}
+        label={language.label}
+        switchOn={language.enabled}
+        switchName={language.value}
+        onSwitchChange={this.props.onUpdateLanguageConfiguration}
+      />
+    ));
   }
 
   handleSubmit = (event, formData) => {

--- a/imports/plugins/core/i18n/client/containers/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/containers/localizationSettings.js
@@ -148,7 +148,7 @@ function composer(props, onData) {
     shop,
     languages,
     currencies: currencyList,
-    enabledLanguages: languages.filter(language => (language.enabled || language.value === shop.language)),
+    enabledLanguages: languages.filter((language) => (language.enabled || language.value === shop.language)),
     countryOptions: countries,
     currencyOptions,
     uomOptions,

--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -79,7 +79,7 @@ Object.assign(Alerts, {
         if (isConfirm === true && typeof messageOrCallback === "function") {
           messageOrCallback(isConfirm, false);
         }
-      }, dismiss => {
+      }, (dismiss) => {
         if (dismiss === "cancel" || dismiss === "esc" || dismiss === "overlay") {
           messageOrCallback(false, dismiss);
         }

--- a/imports/plugins/core/orders/client/__tests__/components/orderSummary.spec.js
+++ b/imports/plugins/core/orders/client/__tests__/components/orderSummary.spec.js
@@ -1,9 +1,7 @@
-jest.mock("/imports/plugins/core/ui/client/components", () => {
-  return {
-    Badge() { return null; },
-    ClickToCopy() { return null; }
-  };
-});
+jest.mock("/imports/plugins/core/ui/client/components", () => ({
+  Badge() { return null; },
+  ClickToCopy() { return null; }
+}));
 
 import React from "react";
 import OrderSummary from "../../components/orderSummary";

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -330,11 +330,9 @@ class LineItems extends Component {
     const { uniqueItems } = this.props;
     return (
       <div className="invoice invoice-line-items" onClick={this.props.handlePopOverOpen}>
-        {uniqueItems.map((uniqueItem) => {
-          return (
-            <div key={uniqueItem._id}> {this.renderLineItem(uniqueItem)} </div>
-          );
-        })}
+        {uniqueItems.map((uniqueItem) => (
+          <div key={uniqueItem._id}> {this.renderLineItem(uniqueItem)} </div>
+        ))}
 
         {
           Roles.userIsInRole(Meteor.userId(), ["orders", "dashboard/orders"], Reaction.getShopId()) &&

--- a/imports/plugins/core/orders/client/components/orderTable.js
+++ b/imports/plugins/core/orders/client/components/orderTable.js
@@ -211,7 +211,7 @@ class OrderTable extends Component {
       // Render order list column/row data
       const filteredFields = {
         name: {
-          accessor: row => getShippingInfo(row).address && getShippingInfo(row).address.fullName,
+          accessor: (row) => getShippingInfo(row).address && getShippingInfo(row).address.fullName,
           id: "shippingFullName"
         },
         email: {
@@ -227,11 +227,11 @@ class OrderTable extends Component {
           id: "_id"
         },
         total: {
-          accessor: row => getBillingInfo(row).invoice && getBillingInfo(row).invoice.total,
+          accessor: (row) => getBillingInfo(row).invoice && getBillingInfo(row).invoice.total,
           id: "billingTotal"
         },
         shipping: {
-          accessor: row => getShippingInfo(row).workflow && getShippingInfo(row).workflow.status,
+          accessor: (row) => getShippingInfo(row).workflow && getShippingInfo(row).workflow.status,
           id: "shippingStatus"
         },
         status: {
@@ -300,7 +300,7 @@ class OrderTable extends Component {
           className: classNames.colClassNames[columnName],
           resizable: resizable,
           sortable: sortable,
-          Cell: row => (
+          Cell: (row) => (
             <OrderTableColumn
               row={row}
               handleClick={this.props.handleClick}
@@ -316,7 +316,7 @@ class OrderTable extends Component {
       // Render order detail column/row data
 
       const columnMeta = {
-        Cell: row => (<div>{this.renderOrderCard(row.original)}</div>)
+        Cell: (row) => (<div>{this.renderOrderCard(row.original)}</div>)
       };
 
       customColumnMetadata.push(columnMeta);

--- a/imports/plugins/core/orders/client/components/orderTable.js
+++ b/imports/plugins/core/orders/client/components/orderTable.js
@@ -119,20 +119,18 @@ class OrderTable extends Component {
         </div>
 
         <div className="order-items">
-          {order.items.map((item, i) => {
-            return (
-              <div className="order-item" key={i}>
-                <div className="order-item-media">
-                  <ProductImage
-                    item={item}
-                    displayMedia={displayMedia}
-                    size="small"
-                    badge={true}
-                  />
-                </div>
+          {order.items.map((item, i) => (
+            <div className="order-item" key={i}>
+              <div className="order-item-media">
+                <ProductImage
+                  item={item}
+                  displayMedia={displayMedia}
+                  size="small"
+                  badge={true}
+                />
               </div>
-            );
-          })}
+            </div>
+          ))}
         </div>
       </div>
     );
@@ -248,23 +246,17 @@ class OrderTable extends Component {
 
       const columnNames = Object.keys(filteredFields);
 
-      getTheadProps = () => {
-        return {
-          className: "order-table-thead"
-        };
-      };
+      getTheadProps = () => ({
+        className: "order-table-thead"
+      });
 
-      getTrGroupProps = () => {
-        return {
-          className: "order-table-tr-group"
-        };
-      };
+      getTrGroupProps = () => ({
+        className: "order-table-tr-group"
+      });
 
-      getTableProps = () => {
-        return {
-          className: "order-table-list"
-        };
-      };
+      getTableProps = () => ({
+        className: "order-table-list"
+      });
 
       // https://react-table.js.org/#/story/cell-renderers-custom-components
       columnNames.forEach((columnName) => {
@@ -329,29 +321,21 @@ class OrderTable extends Component {
 
       customColumnMetadata.push(columnMeta);
 
-      getTheadProps = () => {
-        return {
-          className: "hidden"
-        };
-      };
+      getTheadProps = () => ({
+        className: "hidden"
+      });
 
-      getTrGroupProps = () => {
-        return {
-          className: "order-table-details-tr-group"
-        };
-      };
+      getTrGroupProps = () => ({
+        className: "order-table-details-tr-group"
+      });
 
-      getTableProps = () => {
-        return {
-          className: "order-table-detail"
-        };
-      };
+      getTableProps = () => ({
+        className: "order-table-detail"
+      });
 
-      getTrProps = () => {
-        return {
-          className: "order-table-detail-tr"
-        };
-      };
+      getTrProps = () => ({
+        className: "order-table-detail-tr"
+      });
     }
 
     return (
@@ -385,11 +369,9 @@ class OrderTable extends Component {
           getTheadProps={getTheadProps}
           getTrProps={getTrProps}
           getTrGroupProps={getTrGroupProps}
-          getPaginationProps={() => {
-            return {
-              className: "order-table-pagination-visible"
-            };
-          }}
+          getPaginationProps={() => ({
+            className: "order-table-pagination-visible"
+          })}
           getTableProps={getTableProps}
           showPaginationTop={this.props.selectedItems.length ? false : true}
         />

--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -70,9 +70,7 @@ class InvoiceContainer extends Component {
       selectedItems.push(lineItem._id);
 
       // Add every quantity in the row to be refunded
-      const isEdited = editedItems.find(item => {
-        return item.id === lineItem._id;
-      });
+      const isEdited = editedItems.find(item => item.id === lineItem._id);
 
       const adjustedQuantity = lineItem.quantity - this.state.value;
 
@@ -152,9 +150,7 @@ class InvoiceContainer extends Component {
   handleInputChange = (event, value, lineItem) => {
     let { editedItems } = this.state;
 
-    const isEdited = editedItems.find(item => {
-      return item.id === lineItem._id;
-    });
+    const isEdited = editedItems.find(item => item.id === lineItem._id);
 
     const refundedQuantity = lineItem.quantity - value;
 
@@ -675,9 +671,7 @@ const composer = (props, onData) => {
 
     uniqueItems = returnItems.map((item) => {
       if (taxes.length !== 0) {
-        const taxDetail = taxes.find((tax) => {
-          return tax.lineNumber === item._id;
-        });
+        const taxDetail = taxes.find((tax) => tax.lineNumber === item._id);
         item.taxDetail = taxDetail;
         return item;
       }

--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -70,12 +70,12 @@ class InvoiceContainer extends Component {
       selectedItems.push(lineItem._id);
 
       // Add every quantity in the row to be refunded
-      const isEdited = editedItems.find(item => item.id === lineItem._id);
+      const isEdited = editedItems.find((item) => item.id === lineItem._id);
 
       const adjustedQuantity = lineItem.quantity - this.state.value;
 
       if (isEdited) {
-        editedItems = editedItems.filter(item => item.id !== lineItem._id);
+        editedItems = editedItems.filter((item) => item.id !== lineItem._id);
         isEdited.refundedTotal = lineItem.variants.price * adjustedQuantity;
         isEdited.refundedQuantity = adjustedQuantity;
         editedItems.push(isEdited);
@@ -102,7 +102,7 @@ class InvoiceContainer extends Component {
         }
       });
       // remove item from edited quantities
-      editedItems = editedItems.filter(item => item.id !== lineItem._id);
+      editedItems = editedItems.filter((item) => item.id !== lineItem._id);
 
       this.setState({
         editedItems,
@@ -150,12 +150,12 @@ class InvoiceContainer extends Component {
   handleInputChange = (event, value, lineItem) => {
     let { editedItems } = this.state;
 
-    const isEdited = editedItems.find(item => item.id === lineItem._id);
+    const isEdited = editedItems.find((item) => item.id === lineItem._id);
 
     const refundedQuantity = lineItem.quantity - value;
 
     if (isEdited) {
-      editedItems = editedItems.filter(item => item.id !== lineItem._id);
+      editedItems = editedItems.filter((item) => item.id !== lineItem._id);
       isEdited.refundedTotal = lineItem.variants.price * refundedQuantity;
       isEdited.refundedQuantity = refundedQuantity;
       if (refundedQuantity !== 0) {

--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -100,6 +100,7 @@ class InvoiceContainer extends Component {
         if (id !== lineItem._id) {
           return id;
         }
+        return;
       });
       // remove item from edited quantities
       editedItems = editedItems.filter((item) => item.id !== lineItem._id);
@@ -675,6 +676,7 @@ const composer = (props, onData) => {
         item.taxDetail = taxDetail;
         return item;
       }
+      return;
     });
   } else {
     uniqueItems = returnItems;

--- a/imports/plugins/core/orders/client/containers/orderDashboardContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderDashboardContainer.js
@@ -130,6 +130,6 @@ const wrapComponent = (Comp) => (
   }
 );
 
-registerComponent("OrderSubscription", OrderSubscription, [ wrapComponent ]);
+registerComponent("OrderSubscription", OrderSubscription, [wrapComponent]);
 
 export default compose(wrapComponent)(OrderSubscription);

--- a/imports/plugins/core/orders/client/containers/orderSubscriptionContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderSubscriptionContainer.js
@@ -19,7 +19,7 @@ function composer(props, onData) {
 
   if (subscription.ready()) {
     const orderSearchResults = OrderSearch.find().fetch();
-    orderSearchResultsIds = orderSearchResults.map(orderSearch => orderSearch._id);
+    orderSearchResultsIds = orderSearchResults.map((orderSearch) => orderSearch._id);
     // checking to ensure search was made and search results are returned
     if (props.searchQuery && Array.isArray(orderSearchResultsIds)) {
       // add matching results from search to query passed to Sortable

--- a/imports/plugins/core/orders/client/containers/orderTableContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderTableContainer.js
@@ -680,6 +680,6 @@ const wrapComponent = (Comp) => (
   }
 );
 
-registerComponent("OrderTable", OrderTable, [ wrapComponent ]);
+registerComponent("OrderTable", OrderTable, [wrapComponent]);
 
 export default compose(wrapComponent)(OrderTable);

--- a/imports/plugins/core/orders/client/containers/orderTableContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderTableContainer.js
@@ -113,9 +113,7 @@ const wrapComponent = (Comp) => (
         // if there are no selected orders, or if there are some orders that have been
         // selected but not all of them, loop through the orders array and return a
         // new array with order ids only, then set the selectedItems array with the orderIds
-        const orderIds = orders.map((order) => {
-          return order._id;
-        });
+        const orderIds = orders.map((order) => order._id);
         this.setState({
           selectedItems: orderIds,
           multipleSelect: true
@@ -189,9 +187,7 @@ const wrapComponent = (Comp) => (
      * @return {null} no return value
      */
     shippingStatusUpdateCall = (selectedOrders, status) => {
-      const filteredSelectedOrders = selectedOrders.filter((order) => {
-        return order.shipping && Object.keys(getShippingInfo(order)).length;
-      });
+      const filteredSelectedOrders = selectedOrders.filter((order) => order.shipping && Object.keys(getShippingInfo(order)).length);
       this.setState({
         isLoading: {
           [status]: true
@@ -582,9 +578,7 @@ const wrapComponent = (Comp) => (
       this.setState({
         renderFlowList: true
       });
-      const selectedOrders = orders.filter((order) => {
-        return selectedOrdersIds.includes(order._id);
-      });
+      const selectedOrders = orders.filter((order) => selectedOrdersIds.includes(order._id));
 
       if (status === "picked") {
         this.pickedShippingStatus(selectedOrders, status);
@@ -609,9 +603,7 @@ const wrapComponent = (Comp) => (
           capturePayment: true
         }
       });
-      const selectedOrders = orders.filter((order) => {
-        return selectedOrdersIds.includes(order._id);
-      });
+      const selectedOrders = orders.filter((order) => selectedOrdersIds.includes(order._id));
 
       let orderCount = 0;
 

--- a/imports/plugins/core/orders/client/containers/orderTableContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderTableContainer.js
@@ -84,6 +84,7 @@ const wrapComponent = (Comp) => (
           if (id !== name) {
             return id;
           }
+          return;
         });
         this.setState({
           selectedItems: updatedSelectedArray

--- a/imports/plugins/core/orders/client/helpers/index.js
+++ b/imports/plugins/core/orders/client/helpers/index.js
@@ -159,9 +159,7 @@ export function filterShippingStatus(filter) {
  * @return {Object} proper billing object to use
  */
 export function getBillingInfo(order) {
-  const billingInfo = order && order.billing && order.billing.find((billing) => {
-    return billing && (billing.shopId === Reaction.getShopId());
-  });
+  const billingInfo = order && order.billing && order.billing.find((billing) => billing && (billing.shopId === Reaction.getShopId()));
   return billingInfo || {};
 }
 
@@ -173,8 +171,6 @@ export function getBillingInfo(order) {
  * @return {Object} proper shipping object to use
  */
 export function getShippingInfo(order) {
-  const shippingInfo = order && order.shipping && order.shipping.find((shipping) => {
-    return shipping && shipping.shopId === Reaction.getShopId();
-  });
+  const shippingInfo = order && order.shipping && order.shipping.find((shipping) => shipping && shipping.shopId === Reaction.getShopId());
   return shippingInfo || {};
 }

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -31,9 +31,7 @@ Template.dashboardOrdersList.helpers({
     return moment(this.createdAt).fromNow();
   },
   shipmentTracking() {
-    const shippingObject = this.shipping.find((shipping) => {
-      return shipping.shopId === Reaction.getShopId();
-    });
+    const shippingObject = this.shipping.find((shipping) => shipping.shopId === Reaction.getShopId());
     return shippingObject.shipmentMethod.tracking;
   },
   shopName() {

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -154,7 +154,7 @@ Template.coreOrderShippingInvoice.events({
       let returnToStock;
       if (isConfirm) {
         returnToStock = false;
-        return Meteor.call("orders/cancelOrder", order, returnToStock, err => {
+        return Meteor.call("orders/cancelOrder", order, returnToStock, (err) => {
           if (err) {
             $(".alert").removeClass("hidden").text(err.message);
           }
@@ -162,7 +162,7 @@ Template.coreOrderShippingInvoice.events({
       }
       if (cancel === "cancel") {
         returnToStock = true;
-        return Meteor.call("orders/cancelOrder", order, returnToStock, err => {
+        return Meteor.call("orders/cancelOrder", order, returnToStock, (err) => {
           if (err) {
             $(".alert").removeClass("hidden").text(err.message);
           }

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -14,9 +14,7 @@ import { getBillingInfo } from "../../helpers";
 // the first credit paymentMethod on the order
 // returns entire payment method
 function orderCreditMethod(order) {
-  const creditMethods = order.billing && order.billing.filter((value) => {
-    return value && value.paymentMethod && value.paymentMethod.method ===  "credit";
-  });
+  const creditMethods = order.billing && order.billing.filter((value) => value && value.paymentMethod && value.paymentMethod.method ===  "credit");
   const creditMethod = creditMethods && creditMethods.find((billing) => {
     billing && billing.shopId === Reaction.getShopId();
   });

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -16,7 +16,7 @@ import { getBillingInfo } from "../../helpers";
 function orderCreditMethod(order) {
   const creditMethods = order.billing && order.billing.filter((value) => value && value.paymentMethod && value.paymentMethod.method ===  "credit");
   const creditMethod = creditMethods && creditMethods.find((billing) => {
-    billing && billing.shopId === Reaction.getShopId();
+    return billing && billing.shopId === Reaction.getShopId();
   });
   return creditMethod || {};
 }

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -15,9 +15,7 @@ import { getBillingInfo } from "../../helpers";
 // returns entire payment method
 function orderCreditMethod(order) {
   const creditMethods = order.billing && order.billing.filter((value) => value && value.paymentMethod && value.paymentMethod.method ===  "credit");
-  const creditMethod = creditMethods && creditMethods.find((billing) => {
-    return billing && billing.shopId === Reaction.getShopId();
-  });
+  const creditMethod = creditMethods && creditMethods.find((billing) => billing && billing.shopId === Reaction.getShopId());
   return creditMethod || {};
 }
 

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -145,7 +145,7 @@ Template.coreOrderShippingTracking.helpers({
         if (orderItem._id === shipmentItem._id) {
           return true;
         }
-        return fa; se;
+        return false;
       });
 
       return fullItem.workflow.status !== "coreOrderItemWorkflow/canceled";
@@ -169,6 +169,8 @@ Template.coreOrderShippingTracking.helpers({
       if (Array.isArray(fullItem.workflow.workflow)) {
         return fullItem.workflow.workflow.includes("coreOrderItemWorkflow/completed");
       }
+
+      return;
     });
 
     return completedItems;

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -145,7 +145,7 @@ Template.coreOrderShippingTracking.helpers({
         if (orderItem._id === shipmentItem._id) {
           return true;
         }
-        return fa;se;
+        return fa; se;
       });
 
       return fullItem.workflow.status !== "coreOrderItemWorkflow/canceled";

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -127,6 +127,7 @@ Template.coreOrderShippingTracking.helpers({
         if (orderItem._id === shipmentItem._id) {
           return true;
         }
+        return false;
       });
 
       return !fullItem.workflow.workflow.includes("coreOrderItemWorkflow/shipped");
@@ -144,6 +145,7 @@ Template.coreOrderShippingTracking.helpers({
         if (orderItem._id === shipmentItem._id) {
           return true;
         }
+        return fa;se;
       });
 
       return fullItem.workflow.status !== "coreOrderItemWorkflow/canceled";
@@ -161,6 +163,7 @@ Template.coreOrderShippingTracking.helpers({
         if (orderItem._id === shipmentItem._id) {
           return true;
         }
+        return false;
       });
 
       if (Array.isArray(fullItem.workflow.workflow)) {

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -169,9 +169,7 @@ class PublishControls extends Component {
       });
 
       // If even one revision has changes we should enable the publish button
-      return diffHasActualChanges.some((element) => {
-        return element === true;
-      });
+      return diffHasActualChanges.some((element) => element === true);
     }
 
     // No revisions, no publishing
@@ -180,9 +178,7 @@ class PublishControls extends Component {
 
   renderChanges() {
     if (this.showDiffs) {
-      const diffs = this.props.revisions.map((revision) => {
-        return <SimpleDiff diff={revision.diff} key={revision._id} />;
-      });
+      const diffs = this.props.revisions.map((revision) => <SimpleDiff diff={revision.diff} key={revision._id} />);
 
       return (
         <div>

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -106,14 +106,14 @@ class PublishControls extends Component {
     const revisions = this.props.revisions;
     if (Array.isArray(revisions) && revisions.length) {
       const primaryDocumentId = this.props.documentIds[0];
-      return revisions.find(revision => revision.documentId === primaryDocumentId);
+      return revisions.find((revision) => revision.documentId === primaryDocumentId);
     }
     return false;
   }
 
   get revisionIds() {
     if (this.hasRevisions) {
-      return this.props.revisions.map(revision => revision._id);
+      return this.props.revisions.map((revision) => revision._id);
     }
     return false;
   }

--- a/imports/plugins/core/revisions/client/containers/settingsContainer.js
+++ b/imports/plugins/core/revisions/client/containers/settingsContainer.js
@@ -56,9 +56,7 @@ RevisionSettingsContainer.propTypes = {
 
 export function handlePublishClick(revisions) {
   if (Array.isArray(revisions)) {
-    const documentIds = revisions.map((revision) => {
-      return revision.documentId;
-    });
+    const documentIds = revisions.map((revision) => revision.documentId);
     Meteor.call("revisions/publish", documentIds);
   }
 }

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -29,7 +29,7 @@ export const ProductRevision = {
 
     if (variants.length > 0) {
       const variantPrices = [];
-      variants.forEach(variant => {
+      variants.forEach((variant) => {
         if (variant.isVisible === true) {
           const range = this.getVariantPriceRange(variant._id);
           if (typeof range === "string") {
@@ -64,7 +64,7 @@ export const ProductRevision = {
 
   getVariantPriceRange(variantId) {
     const children = this.getVariants(variantId);
-    const visibleChildren = children.filter(child => child.isVisible && !child.isDeleted);
+    const visibleChildren = children.filter((child) => child.isVisible && !child.isDeleted);
 
     switch (visibleChildren.length) {
       case 0:
@@ -77,7 +77,7 @@ export const ProductRevision = {
         let priceMin = Number.POSITIVE_INFINITY;
         let priceMax = Number.NEGATIVE_INFINITY;
 
-        visibleChildren.map(child => {
+        visibleChildren.map((child) => {
           if (child.price < priceMin) {
             priceMin = child.price;
           }

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -84,6 +84,7 @@ export const ProductRevision = {
           if (child.price > priceMax) {
             priceMax = child.price;
           }
+          return;
         });
 
         if (priceMin === priceMax) {
@@ -131,6 +132,8 @@ export const ProductRevision = {
       } else if (!revision && product.isVisible) {
         variants.push(product);
       }
+
+      return;
     });
 
     return variants;

--- a/imports/plugins/core/router/client/browserRouter.js
+++ b/imports/plugins/core/router/client/browserRouter.js
@@ -38,21 +38,17 @@ class BrowserRouter extends Component {
 
   handleLocationChange = location => {
     // Find all matching paths
-    let foundPaths = Router.routes.filter((pathObject) => {
-      return matchPath(location.pathname, {
-        path: pathObject.route,
-        exact: true
-      });
-    });
+    let foundPaths = Router.routes.filter((pathObject) => matchPath(location.pathname, {
+      path: pathObject.route,
+      exact: true
+    }));
 
     // If no matching path is found, fetch the not-found route definition
     if (foundPaths.length === 0 && location.pathname !== "not-found") {
-      foundPaths = Router.routes.filter((pathObject) => {
-        return matchPath("/not-found", {
-          path: pathObject.route,
-          exact: true
-        });
-      });
+      foundPaths = Router.routes.filter((pathObject) => matchPath("/not-found", {
+        path: pathObject.route,
+        exact: true
+      }));
     }
 
     // If we have a found path, take the first match

--- a/imports/plugins/core/router/client/browserRouter.js
+++ b/imports/plugins/core/router/client/browserRouter.js
@@ -36,7 +36,7 @@ class BrowserRouter extends Component {
     if (this.unsubscribeFromHistory) this.unsubscribeFromHistory();
   }
 
-  handleLocationChange = location => {
+  handleLocationChange = (location) => {
     // Find all matching paths
     let foundPaths = Router.routes.filter((pathObject) => matchPath(location.pathname, {
       path: pathObject.route,

--- a/imports/plugins/core/router/lib/__tests__/router.spec.js
+++ b/imports/plugins/core/router/lib/__tests__/router.spec.js
@@ -1,9 +1,7 @@
-jest.mock("/lib/collections", () => {
-  return {
-    Packages: {},
-    Shops: {}
-  };
-});
+jest.mock("/lib/collections", () => ({
+  Packages: {},
+  Shops: {}
+}));
 
 import Router from "../router.js";
 

--- a/imports/plugins/core/router/lib/hooks.js
+++ b/imports/plugins/core/router/lib/hooks.js
@@ -64,9 +64,7 @@ const Hooks = {
   run(type, name, constant) {
     const callbacks = this.get(type, name);
     if (typeof callbacks !== "undefined" && !!callbacks.length) {
-      return callbacks.forEach((callback) => {
-        return callback(constant);
-      });
+      return callbacks.forEach((callback) => callback(constant));
     }
     return null;
   }

--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -699,16 +699,14 @@ Router.initPackageRoutes = (options) => {
       // TODO: In the future, sort by priority
       // TODO: Allow duplicated routes with a prefix / suffix / flag
       const uniqRoutes = uniqBy(routeDefinitions.reverse(), "route");
-      const reactRouterRoutes = uniqRoutes.map((route, index) => {
-        return (
-          <Route
-            key={`${route.name}-${index}`}
-            path={route.route}
-            exact={true}
-            render={route.options.component}
-          />
-        );
-      });
+      const reactRouterRoutes = uniqRoutes.map((route, index) => (
+        <Route
+          key={`${route.name}-${index}`}
+          path={route.route}
+          exact={true}
+          render={route.options.component}
+        />
+      ));
 
       // Last route, if no other route is matched, this one will be the not-found view
       // Note: This is last becuase all other routes must at-least attempt a match

--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -265,7 +265,7 @@ Router.go = (path, params, query) => {
 
   // if Router is in a non ready/initialized state yet, wait until it is
   if (!Router.ready()) {
-    Tracker.autorun(routerReadyWaitFor => {
+    Tracker.autorun((routerReadyWaitFor) => {
       if (Router.ready()) {
         routerReadyWaitFor.stop();
         routerGo();
@@ -573,7 +573,7 @@ Router.initPackageRoutes = (options) => {
   // subscription to determine this.
   const shopSub = Meteor.subscribe("shopsCount");
 
-  Tracker.autorun(shopSubWaitFor => {
+  Tracker.autorun((shopSubWaitFor) => {
     if (shopSub.ready()) {
       shopSubWaitFor.stop();
       // using tmeasday:publish-counts

--- a/imports/plugins/core/shipping/client/templates/checkout/shipping.js
+++ b/imports/plugins/core/shipping/client/templates/checkout/shipping.js
@@ -17,13 +17,9 @@ import { Cart } from "/lib/collections";
  * @private
  */
 function uniqObjects(objs) {
-  const jsonBlobs = objs.map((obj) => {
-    return JSON.stringify(obj);
-  });
+  const jsonBlobs = objs.map((obj) => JSON.stringify(obj));
   const uniqueBlobs = _.uniq(jsonBlobs);
-  return uniqueBlobs.map((blob) => {
-    return EJSON.parse(blob);
-  });
+  return uniqueBlobs.map((blob) => EJSON.parse(blob));
 }
 
 // cartShippingQuotes

--- a/imports/plugins/core/taxes/client/settings/custom.js
+++ b/imports/plugins/core/taxes/client/settings/custom.js
@@ -82,9 +82,7 @@ Template.customTaxRates.helpers({
     // helper adds a class to every grid row
     //
     const customRowMetaData = {
-      bodyCssClassName: () =>  {
-        return "tax-grid-row";
-      }
+      bodyCssClassName: () =>  "tax-grid-row"
     };
 
     // add i18n handling to headers

--- a/imports/plugins/core/templates/client/templates/settings.js
+++ b/imports/plugins/core/templates/client/templates/settings.js
@@ -56,9 +56,7 @@ Template.templateSettings.helpers({
 
     // helper adds a class to every grid row
     const customRowMetaData = {
-      bodyCssClassName: () =>  {
-        return "template-grid-row";
-      }
+      bodyCssClassName: () =>  "template-grid-row"
     };
 
     // add i18n handling to headers

--- a/imports/plugins/core/ui-tagnav/client/components/tagGroupBody.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagGroupBody.js
@@ -101,33 +101,31 @@ class TagGroupBody extends Component {
 
   genTagsList(tags, parentTag) {
     if (Array.isArray(tags)) {
-      return tags.map((tag, index) => {
-        return (
-          <Components.TagItem
-            tag={tag}
-            index={index}
-            key={index}
-            data-id={tag._id}
-            editable={this.props.editable}
-            isSelected={this.isSelected}
-            parentTag={parentTag}
-            draggable={true}
-            selectable={true}
-            suggestions={this.state.suggestions}
-            onClearSuggestions={this.handleClearSuggestions}
-            onGetSuggestions={this.handleGetSuggestions}
-            onMove={this.handleMoveTag}
-            onTagInputBlur={this.handleTagSave}
-            onTagMouseOut={this.handleTagMouseOut}
-            onTagMouseOver={this.handleTagMouseOver}
-            onTagRemove={this.props.onTagRemove}
-            onTagSave={this.handleTagSave}
-            onTagSelect={this.onTagSelect}
-            onTagUpdate={this.handleTagUpdate}
-            onTagClick={this.props.onTagClick}
-          />
-        );
-      });
+      return tags.map((tag, index) => (
+        <Components.TagItem
+          tag={tag}
+          index={index}
+          key={index}
+          data-id={tag._id}
+          editable={this.props.editable}
+          isSelected={this.isSelected}
+          parentTag={parentTag}
+          draggable={true}
+          selectable={true}
+          suggestions={this.state.suggestions}
+          onClearSuggestions={this.handleClearSuggestions}
+          onGetSuggestions={this.handleGetSuggestions}
+          onMove={this.handleMoveTag}
+          onTagInputBlur={this.handleTagSave}
+          onTagMouseOut={this.handleTagMouseOut}
+          onTagMouseOver={this.handleTagMouseOver}
+          onTagRemove={this.props.onTagRemove}
+          onTagSave={this.handleTagSave}
+          onTagSelect={this.onTagSelect}
+          onTagUpdate={this.handleTagUpdate}
+          onTagClick={this.props.onTagClick}
+        />
+      ));
     }
   }
 

--- a/imports/plugins/core/ui-tagnav/client/containers/tagNavContainer.js
+++ b/imports/plugins/core/ui-tagnav/client/containers/tagNavContainer.js
@@ -126,6 +126,7 @@ const wrapComponent = (Comp) => (
         if (this.isSelected(tag)) {
           selectedTag = tag;
         }
+        return;
       });
 
       const { tagIds, tagsByKey, isVisible } = nextProps;

--- a/imports/plugins/core/ui-tagnav/client/helpers/tags.js
+++ b/imports/plugins/core/ui-tagnav/client/helpers/tags.js
@@ -25,11 +25,7 @@ export const TagHelpers = {
         }
       }).fetch();
 
-      const subTags = parentTag.relatedTagIds.map((tagId) => {
-        return _.find(tags, (tagObject) => {
-          return tagObject._id === tagId;
-        });
-      });
+      const subTags = parentTag.relatedTagIds.map((tagId) => _.find(tags, (tagObject) => tagObject._id === tagId));
 
       return subTags;
     }
@@ -193,11 +189,9 @@ export const TagHelpers = {
       };
     }
 
-    const tags = Tags.find(selector).map((tag) => {
-      return {
-        label: tag.name
-      };
-    });
+    const tags = Tags.find(selector).map((tag) => ({
+      label: tag.name
+    }));
 
     return tags;
   }

--- a/imports/plugins/core/ui/client/components/alerts/alerts.js
+++ b/imports/plugins/core/ui/client/components/alerts/alerts.js
@@ -5,16 +5,14 @@ import { Components } from "@reactioncommerce/reaction-components";
 const Alerts = ({ alerts, handleAlertRemove, handleAlertSeen }) => (
   Array.isArray(alerts) &&
   <div className="alert-container">
-    {alerts.map((alert) => {
-      return (
-        <Components.Alert
-          alert={alert}
-          key={alert._id}
-          onAlertRemove={handleAlertRemove}
-          onAlertSeen={handleAlertSeen}
-        />
-      );
-    })}
+    {alerts.map((alert) => (
+      <Components.Alert
+        alert={alert}
+        key={alert._id}
+        onAlertRemove={handleAlertRemove}
+        onAlertSeen={handleAlertSeen}
+      />
+    ))}
   </div>
 );
 

--- a/imports/plugins/core/ui/client/components/badge/__tests__/badge.js
+++ b/imports/plugins/core/ui/client/components/badge/__tests__/badge.js
@@ -1,13 +1,11 @@
 /**
  * Mock Translation component import, as it uses Meteor modules we have a hard time testing with Jest
  */
-jest.mock("/imports/plugins/core/ui/client/components", () => {
-  return {
-    Translation(props) {
+jest.mock("/imports/plugins/core/ui/client/components", () => ({
+  Translation(props) {
       return <span>{props.defaultValue}</span>; // eslint-disable-line
-    }
-  };
-});
+  }
+}));
 
 import React from "react";
 import Badge from "../badge";

--- a/imports/plugins/core/ui/client/components/button/buttonSelect.js
+++ b/imports/plugins/core/ui/client/components/button/buttonSelect.js
@@ -127,16 +127,14 @@ class ButtonSelect extends Component {
           </div>
         </div>
         <div className={toggleClassNames}>
-          {nonActiveButtons.map((button, key) => {
-            return (
-              <button
-                className="btn button-item" key={key}
-                type="button"
-                onClick={() => this.handleButtonChange(button)}
-              >
-                <Components.Translation defaultValue={button.name} i18nKey={button.i18nKeyLabel} />
-              </button>);
-          })}
+          {nonActiveButtons.map((button, key) => (
+            <button
+              className="btn button-item" key={key}
+              type="button"
+              onClick={() => this.handleButtonChange(button)}
+            >
+              <Components.Translation defaultValue={button.name} i18nKey={button.i18nKeyLabel} />
+            </button>))}
         </div>
       </div>
     );

--- a/imports/plugins/core/ui/client/components/button/buttonSelect.js
+++ b/imports/plugins/core/ui/client/components/button/buttonSelect.js
@@ -30,7 +30,7 @@ class ButtonSelect extends Component {
 
   handleDefaultState = () => {
     const props = this.props;
-    let defaultButton = props.buttons.filter(button => {
+    let defaultButton = props.buttons.filter((button) => {
       if (button.active === true) {
         return button;
       }
@@ -39,7 +39,7 @@ class ButtonSelect extends Component {
 
     const defaultBgClassNames = classnames({ "button-select": true, [defaultButton.bgColor]: true });
 
-    const defaultNonActiveButtons = props.buttons.filter(button => {
+    const defaultNonActiveButtons = props.buttons.filter((button) => {
       if (button.active === false || button.active === undefined) {
         return button;
       }
@@ -66,7 +66,7 @@ class ButtonSelect extends Component {
   filterButtons = () => {
     const { activeButton, buttons } = this.state;
 
-    const nonActiveButtons = buttons.filter(button => {
+    const nonActiveButtons = buttons.filter((button) => {
       if (button.name !== activeButton) {
         return button;
       }

--- a/imports/plugins/core/ui/client/components/button/buttonSelect.js
+++ b/imports/plugins/core/ui/client/components/button/buttonSelect.js
@@ -34,6 +34,7 @@ class ButtonSelect extends Component {
       if (button.active === true) {
         return button;
       }
+      return;
     });
     defaultButton = defaultButton[0];
 
@@ -43,6 +44,7 @@ class ButtonSelect extends Component {
       if (button.active === false || button.active === undefined) {
         return button;
       }
+      return;
     });
     const currentButton = (
       <Button
@@ -70,6 +72,7 @@ class ButtonSelect extends Component {
       if (button.name !== activeButton) {
         return button;
       }
+      return;
     });
     return this.setState({ nonActiveButtons });
   }

--- a/imports/plugins/core/ui/client/components/button/editButton.js
+++ b/imports/plugins/core/ui/client/components/button/editButton.js
@@ -13,19 +13,17 @@ import IconButton from "./iconButton";
  * @param {Object} props Props passed into component
  * @returns {IconButton} Retruns an IconButton component with pre-configured icons for editing
  */
-const EditButton = (props) => {
-  return (
-    <IconButton
-      icon="fa fa-pencil"
-      onIcon="fa fa-check"
-      toggle={true}
-      primary={true}
-      bezelStyle="solid"
-      kind="round"
-      {...props}
-    />
-  );
-};
+const EditButton = (props) => (
+  <IconButton
+    icon="fa fa-pencil"
+    onIcon="fa fa-check"
+    toggle={true}
+    primary={true}
+    bezelStyle="solid"
+    kind="round"
+    {...props}
+  />
+);
 
 registerComponent("EditButton", EditButton);
 

--- a/imports/plugins/core/ui/client/components/button/visibilityButton.js
+++ b/imports/plugins/core/ui/client/components/button/visibilityButton.js
@@ -12,18 +12,16 @@ import IconButton from "./iconButton";
  * @param {Object} props Props passed into component
  * @returns {IconButton} Retruns an IconButton component with pre-configured icons for visibility
  */
-const VisibilityButton = (props) => {
-  return (
-    <IconButton
-      icon="fa fa-eye-slash"
-      onIcon="fa fa-eye"
-      bezelStyle="solid"
-      primary={true}
-      toggle={true}
-      {...props}
-    />
-  );
-};
+const VisibilityButton = (props) => (
+  <IconButton
+    icon="fa fa-eye-slash"
+    onIcon="fa fa-eye"
+    bezelStyle="solid"
+    primary={true}
+    toggle={true}
+    {...props}
+  />
+);
 
 registerComponent("VisibilityButton", VisibilityButton);
 

--- a/imports/plugins/core/ui/client/components/clickToCopy/__tests__/clickToCopy.js
+++ b/imports/plugins/core/ui/client/components/clickToCopy/__tests__/clickToCopy.js
@@ -1,13 +1,11 @@
 /**
  * Mock Translation component import, as it uses Meteor modules we have a hard time testing with Jest
  */
-jest.mock("/imports/plugins/core/ui/client/components", () => {
-  return {
-    Translation(props) {
+jest.mock("/imports/plugins/core/ui/client/components", () => ({
+  Translation(props) {
       return <span>{props.defaultValue}</span>; // eslint-disable-line
-    }
-  };
-});
+  }
+}));
 
 import React from "react";
 import ClickToCopy from "../clickToCopy";

--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -48,9 +48,7 @@ class Form extends Component {
       if (Array.isArray(objectKeys)) {
         // Use the objectKeys from parent fieldset to generate
         // actual form fields
-        const fieldNames = objectKeys.map((fieldName) => {
-          return `${docPath}.${fieldName}`;
-        });
+        const fieldNames = objectKeys.map((fieldName) => `${docPath}.${fieldName}`);
 
         return this.props.schema.pick(fieldNames).newContext();
       }
@@ -105,9 +103,7 @@ class Form extends Component {
   }
 
   handleChange = (event, value, name) => {
-    const newdoc = update(this.state.doc, name, () => {
-      return value;
-    });
+    const newdoc = update(this.state.doc, name, () => value);
 
     this.setState({
       doc: newdoc
@@ -264,9 +260,9 @@ class Form extends Component {
       }
 
       // Render all fields if none of the options are set above
-      return map(this.schema, (field, key) => { // eslint-disable-line consistent-return
-        return this.renderField({ fieldName: key });
-      });
+      return map(this.schema, (field, key) =>  // eslint-disable-line consistent-return
+        this.renderField({ fieldName: key })
+      );
     }
 
     return null;

--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -186,7 +186,7 @@ class Form extends Component {
           const message = this.state.schema.keyErrorMessage(validationError.name);
           fieldHasError = true;
 
-          helpText = (
+          return helpText = (
             <div className="help-block">
               {message}
             </div>

--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -186,7 +186,7 @@ class Form extends Component {
           const message = this.state.schema.keyErrorMessage(validationError.name);
           fieldHasError = true;
 
-          return helpText = (
+          return helpText === (
             <div className="help-block">
               {message}
             </div>

--- a/imports/plugins/core/ui/client/components/media/mediaGallery.js
+++ b/imports/plugins/core/ui/client/components/media/mediaGallery.js
@@ -104,6 +104,7 @@ class MediaGallery extends Component {
             </Measure>
           );
         }
+        return null;
       });
     }
 

--- a/imports/plugins/core/ui/client/components/media/mediaGallery.js
+++ b/imports/plugins/core/ui/client/components/media/mediaGallery.js
@@ -114,21 +114,19 @@ class MediaGallery extends Component {
 
   renderMediaThumbnails() {
     if (this.hasMedia) {
-      return this.props.media.map((media, index) => {
-        return (
-          <Components.MediaItem
-            editable={this.props.editable}
-            index={index}
-            key={index}
-            revision={media.revision}
-            metadata={media.metadata}
-            onMouseEnter={this.props.onMouseEnterMedia}
-            onMove={this.props.onMoveMedia}
-            onRemoveMedia={this.props.onRemoveMedia}
-            source={media}
-          />
-        );
-      });
+      return this.props.media.map((media, index) => (
+        <Components.MediaItem
+          editable={this.props.editable}
+          index={index}
+          key={index}
+          revision={media.revision}
+          metadata={media.metadata}
+          onMouseEnter={this.props.onMouseEnterMedia}
+          onMove={this.props.onMoveMedia}
+          onRemoveMedia={this.props.onRemoveMedia}
+          source={media}
+        />
+      ));
     }
     return null;
   }

--- a/imports/plugins/core/ui/client/components/metadata/metadata.js
+++ b/imports/plugins/core/ui/client/components/metadata/metadata.js
@@ -36,14 +36,12 @@ class Metadata extends Component {
    */
   renderMetadata() {
     if (this.props.metafields) {
-      return this.props.metafields.map((metadata, index) => {
-        return (
-          <div className="rui meta-item" key={index}>
-            <div className="rui meta-key">{metadata.key}</div>
-            <div className="rui meta-value">{metadata.value}</div>
-          </div>
-        );
-      });
+      return this.props.metafields.map((metadata, index) => (
+        <div className="rui meta-item" key={index}>
+          <div className="rui meta-key">{metadata.key}</div>
+          <div className="rui meta-value">{metadata.value}</div>
+        </div>
+      ));
     }
 
     return null;
@@ -55,18 +53,16 @@ class Metadata extends Component {
    */
   renderMetadataForm() {
     if (this.props.metafields) {
-      return this.props.metafields.map((metadata, index) => {
-        return (
-          <Components.Metafield
-            index={index}
-            key={index}
-            metafield={metadata}
-            onBlur={this.handleMetaSave}
-            onChange={this.handleMetaChange}
-            onRemove={this.handleMetaRemove}
-          />
-        );
-      });
+      return this.props.metafields.map((metadata, index) => (
+        <Components.Metafield
+          index={index}
+          key={index}
+          metafield={metadata}
+          onBlur={this.handleMetaSave}
+          onChange={this.handleMetaChange}
+          onRemove={this.handleMetaRemove}
+        />
+      ));
     }
 
     return null;

--- a/imports/plugins/core/ui/client/components/table/sortableTable.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTable.js
@@ -313,7 +313,7 @@ class SortableTable extends Component {
             }
 
             return {
-              onClick: e => { // eslint-disable-line no-unused-vars
+              onClick: (e) => { // eslint-disable-line no-unused-vars
                 this.handleClick(rowInfo);
               },
               className: this.selectedRowsClassName(rowInfo)

--- a/imports/plugins/core/ui/client/components/table/sortableTable.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTable.js
@@ -143,11 +143,9 @@ class SortableTable extends Component {
     const { columnMetadata } = this.props;
 
     // Add minWidth = undefined to override 100px default set by ReactTable
-    const displayColumns = columnMetadata.map((element) => {
-      return Object.assign({}, element, {
-        minWidth: undefined
-      });
-    });
+    const displayColumns = columnMetadata.map((element) => Object.assign({}, element, {
+      minWidth: undefined
+    }));
 
     return displayColumns;
   }

--- a/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
@@ -101,13 +101,11 @@ class SortableTablePagination extends Component {
                 onChange={e => onPageSizeChange(Number(e.target.value))}
                 value={pageSize}
               >
-                {pageSizeOptions.map((option, i) => {
-                  return (
-                    <option key={i} value={option}>
-                      {option} {this.props.rowsText}
-                    </option>
-                  );
-                })}
+                {pageSizeOptions.map((option, i) => (
+                  <option key={i} value={option}>
+                    {option} {this.props.rowsText}
+                  </option>
+                ))}
               </select>
             </span>}
         </div>

--- a/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
@@ -74,7 +74,7 @@ class SortableTablePagination extends Component {
               ? <div className="-pageJump">
                 <input
                   type={this.state.page === "" ? "text" : "number"}
-                  onChange={e => {
+                  onChange={(e) => {
                     const val = e.target.value;
                     const currentPage = val - 1;
                     if (val === "") {
@@ -84,7 +84,7 @@ class SortableTablePagination extends Component {
                   }}
                   value={this.state.page === "" ? "" : this.state.page + 1}
                   onBlur={this.applyPage}
-                  onKeyPress={e => {
+                  onKeyPress={(e) => {
                     if (e.which === 13 || e.keyCode === 13) {
                       this.applyPage();
                     }
@@ -98,7 +98,7 @@ class SortableTablePagination extends Component {
           {showPageSizeOptions &&
             <span className="select-wrap -pageSizeOptions">
               <select
-                onChange={e => onPageSizeChange(Number(e.target.value))}
+                onChange={(e) => onPageSizeChange(Number(e.target.value))}
                 value={pageSize}
               >
                 {pageSizeOptions.map((option, i) => (

--- a/imports/plugins/core/ui/client/components/tags/tagList.js
+++ b/imports/plugins/core/ui/client/components/tags/tagList.js
@@ -91,29 +91,27 @@ class TagList extends Component {
 
     if (Array.isArray(this.props.tags)) {
       const arrayProps = _.compact(this.props.tags);
-      const tags = arrayProps.map((tag, index) => {
-        return (
-          <div className={classes(tag)} key={index}>
-            <Components.TagItem
-              {...this.props}
-              data-id={tag._id}
-              index={index}
-              key={index}
-              tag={tag}
-              onMove={this.props.onMoveTag}
-              draggable={this.props.draggable}
-              onTagInputBlur={this.handleTagSave}
-              onTagMouseOut={this.handleTagMouseOut}
-              onTagMouseOver={this.handleTagMouseOver}
-              onTagRemove={this.handleTagRemove}
-              onTagSave={this.handleTagSave}
-              onTagUpdate={this.handleTagUpdate}
-              onTagClick={this.handleTagClick}
-            />
-            {this.props.children}
-          </div>
-        );
-      });
+      const tags = arrayProps.map((tag, index) => (
+        <div className={classes(tag)} key={index}>
+          <Components.TagItem
+            {...this.props}
+            data-id={tag._id}
+            index={index}
+            key={index}
+            tag={tag}
+            onMove={this.props.onMoveTag}
+            draggable={this.props.draggable}
+            onTagInputBlur={this.handleTagSave}
+            onTagMouseOut={this.handleTagMouseOut}
+            onTagMouseOver={this.handleTagMouseOver}
+            onTagRemove={this.handleTagRemove}
+            onTagSave={this.handleTagSave}
+            onTagUpdate={this.handleTagUpdate}
+            onTagClick={this.handleTagClick}
+          />
+          {this.props.children}
+        </div>
+      ));
 
       // Render an blank tag for creating new tags
       if (this.props.editable && this.props.enableNewTagForm) {

--- a/imports/plugins/core/ui/client/components/translation/__tests__/translation.js
+++ b/imports/plugins/core/ui/client/components/translation/__tests__/translation.js
@@ -4,15 +4,11 @@ import { shallow } from "enzyme";
 import shallowToJSON from "enzyme-to-json";
 
 
-jest.mock("/client/api", () => {
-  return {
-    i18next: {
-      t: (key, { defaultValue }) => {
-        return defaultValue || key;
-      }
-    }
-  };
-});
+jest.mock("/client/api", () => ({
+  i18next: {
+    t: (key, { defaultValue }) => defaultValue || key
+  }
+}));
 
 
 /**

--- a/imports/plugins/core/ui/client/containers/tagListContainer.js
+++ b/imports/plugins/core/ui/client/containers/tagListContainer.js
@@ -24,11 +24,9 @@ function updateSuggestions(term, { excludeTags }) {
     };
   }
 
-  const tags = Tags.find(selector).map((tag) => {
-    return {
-      label: tag.name
-    };
-  });
+  const tags = Tags.find(selector).map((tag) => ({
+    label: tag.name
+  }));
 
   return tags;
 }

--- a/imports/plugins/core/ui/client/templates/themeDetails/themeDetails.js
+++ b/imports/plugins/core/ui/client/templates/themeDetails/themeDetails.js
@@ -52,14 +52,12 @@ Template.uiThemeDetails.helpers({
     let components = [];
 
     if (theme) {
-      components = theme.components.map((component) => {
-        return {
-          label: i18next.t(`reactionUI.components.${component.name}`, {
-            defaultValue: component.label
-          }),
-          name: component.name
-        };
-      });
+      components = theme.components.map((component) => ({
+        label: i18next.t(`reactionUI.components.${component.name}`, {
+          defaultValue: component.label
+        }),
+        name: component.name
+      }));
     }
 
     return components;

--- a/imports/plugins/core/ui/client/templates/themeEditor/themeEditor.js
+++ b/imports/plugins/core/ui/client/templates/themeEditor/themeEditor.js
@@ -21,9 +21,7 @@ Template.uiThemeEditor.onCreated(function () {
   this.findComponentByName = (name) => {
     const theme = this.state.get("theme");
     if (theme) {
-      return _.find(theme.components, (component) => {
-        return component.name === name;
-      });
+      return _.find(theme.components, (component) => component.name === name);
     }
   };
 
@@ -88,20 +86,16 @@ Template.uiThemeEditor.helpers({
     const stylesObject = instance.state.get("styles");
     const annotations = instance.state.get("annotations") || {};
 
-    const stylesArray = _.map(stylesObject, (declarations, selector) => {
-      return {
-        selector,
-        annotation: annotations[selector] || {
-          label: selector
-        },
-        declarations: _.map(declarations, (value, property) => {
-          return {
-            property,
-            value
-          };
-        })
-      };
-    });
+    const stylesArray = _.map(stylesObject, (declarations, selector) => ({
+      selector,
+      annotation: annotations[selector] || {
+        label: selector
+      },
+      declarations: _.map(declarations, (value, property) => ({
+        property,
+        value
+      }))
+    }));
     return stylesArray;
   },
 
@@ -116,12 +110,10 @@ Template.uiThemeEditor.helpers({
     const theme = instance.state.get("theme");
 
     if (theme) {
-      options = theme.components.map((component) => {
-        return {
-          label: component.label || component.name,
-          value: component.name
-        };
-      });
+      options = theme.components.map((component) => ({
+        label: component.label || component.name,
+        value: component.name
+      }));
     }
 
     return {

--- a/imports/plugins/core/versions/server/migrations/5_update_defaultRoles_to_groups.js
+++ b/imports/plugins/core/versions/server/migrations/5_update_defaultRoles_to_groups.js
@@ -27,7 +27,7 @@ Migrations.add({
         const customPermissions = Meteor.users
           .find({ _id: { $nin: defaultGroupAccounts } })
           .fetch()
-          .map(user => user.roles && user.roles[shop._id]);
+          .map((user) => user.roles && user.roles[shop._id]);
         // sorts the array of permission sets to contain only unique sets to avoid creating groups with same permissions
         const permissionsArray = sortUniqueArray(customPermissions);
         permissionsArray.forEach((permissions, index) => {
@@ -51,13 +51,13 @@ Migrations.add({
     function createDefaultGroupsForShop(shop) {
       let defaultGroupAccounts = [];
       const { defaultRoles, defaultVisitorRole } = shop;
-      let ownerRoles = Roles.getAllRoles().fetch().map(role => role.name);
+      let ownerRoles = Roles.getAllRoles().fetch().map((role) => role.name);
 
       // See detailed comment in `/server/api/core/groups.js`. The code here follows similar pattern.
       ownerRoles = ownerRoles.concat(Reaction.defaultCustomerRoles);
       ownerRoles = _.uniq(ownerRoles);
 
-      const shopManagerRoles = ownerRoles.filter(role => role !== "owner");
+      const shopManagerRoles = ownerRoles.filter((role) => role !== "owner");
       const roles = {
         "shop manager": shopManagerRoles,
         "customer": defaultRoles || Reaction.defaultCustomerRoles,
@@ -136,7 +136,7 @@ Migrations.add({
  * and returns this: [["product", "tag"], ["product", "shop", "tag"], ["shop", "tag"]]
  */
 function sortUniqueArray(multiArray) {
-  const sorted = multiArray.map(x => {
+  const sorted = multiArray.map((x) => {
     if (!x) { return []; }
     return x.sort();
   }).sort();

--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.js
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.js
@@ -183,9 +183,7 @@ Template.shopifySync.events({
     event.preventDefault();
     const form = formEvent.target;
     const optionsNodeList = form.querySelectorAll('input[type="checkbox"]');
-    const optionsList = Array.from(optionsNodeList).map((hook) => {
-      return { name: hook.name, checked: hook.checked };
-    });
+    const optionsList = Array.from(optionsNodeList).map((hook) => ({ name: hook.name, checked: hook.checked }));
     optionsList.forEach((node) => {
       if (node.checked) {
         Meteor.call("synchooks/shopify/addHook", node, (error) => {

--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.js
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.js
@@ -121,7 +121,7 @@ Template.shopifySync.helpers({
     const { settings } = Reaction.getPackageSettings("reaction-connectors-shopify");
     const { synchooks } = settings;
     if (synchooks) {
-      const [ topic, event, syncType ]  = hook.split(":");
+      const [topic, event, syncType]  = hook.split(":");
       const matchingHooks = synchooks.map((synchook) => {
         if (synchook.topic === topic && synchook.event === event && synchook.syncType === syncType) {
           return synchook;

--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.js
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.js
@@ -126,6 +126,7 @@ Template.shopifySync.helpers({
         if (synchook.topic === topic && synchook.event === event && synchook.syncType === syncType) {
           return synchook;
         }
+        return;
       });
       if (matchingHooks.length > 0) {
         return "checked";

--- a/imports/plugins/included/connectors-shopify/server/jobs/order-export.js
+++ b/imports/plugins/included/connectors-shopify/server/jobs/order-export.js
@@ -34,10 +34,10 @@ export default () => {
     const order = Orders.findOne(orderId);
     try {
       exportToShopify(order)
-        .then(exportedOrders => {
+        .then((exportedOrders) => {
           Logger.debug("exported order(s)", exportedOrders);
         })
-        .catch(error => {
+        .catch((error) => {
           Logger.error("Encountered error when exporting to shopify", error);
           if (error.response && error.response.body) {
             Logger.error(error.response.body);

--- a/imports/plugins/included/connectors-shopify/server/methods/export/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/export/orders.js
@@ -153,7 +153,7 @@ function convertAddress(address) {
   convertedAddress.country = address.country;
   convertedAddress.country_code = address.country;
   convertedAddress.name = address.fullName;
-  const [ firstName, ...lastName ] = address.fullName.split(" ");
+  const [firstName, ...lastName] = address.fullName.split(" ");
   convertedAddress.first_name = firstName;
   convertedAddress.last_name = lastName.join(" ");
   convertedAddress.phone = address.phone;

--- a/imports/plugins/included/connectors-shopify/server/methods/export/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/export/orders.js
@@ -45,14 +45,10 @@ function convertOrderToShopifyOrder(doc, index, shopId, existingCustomer = undef
   shopifyOrder.subtotal_price = order.getSubtotalByShop()[shopId];
   shopifyOrder.token = order._id;
   shopifyOrder.total_discounts = order.getDiscountsByShop()[shopId];
-  shopifyOrder.total_line_item_price = order.getItemsByShop()[shopId].reduce((total, item) => {
-    return total + (item.variants.price * item.quantity);
-  }, 0);
+  shopifyOrder.total_line_item_price = order.getItemsByShop()[shopId].reduce((total, item) => total + (item.variants.price * item.quantity), 0);
   shopifyOrder.total_price = order.getTotalByShop()[shopId];
   shopifyOrder.total_tax = order.getTaxesByShop()[shopId];
-  shopifyOrder.total_weight = shopifyOrder.line_items.reduce((sum, item) => {
-    return sum + (item.grams * item.quantity);
-  }, 0);
+  shopifyOrder.total_weight = shopifyOrder.line_items.reduce((sum, item) => sum + (item.grams * item.quantity), 0);
   return shopifyOrder;
 }
 

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -427,7 +427,7 @@ export const methods = {
                           Logger.debug(`Importing ${shopifyProduct.title} ${variant} ${option} options`);
                           shopifyTernaryOptions.forEach((ternaryOption, k) => {
                             // Find the option that nests under our current variant.
-                            const shopifyTernaryOption = shopifyProduct.variants.find((o) => o.option1 === variant && o.option2 === option && o.option3 === ternaryOption);
+                            const shopifyTernaryOption = shopifyProduct.variants.find((o) => o.option1 === variant && o.option2 === option && o.option3 === ternaryOption); // eslint-disable-line max-len
 
                             if (shopifyTernaryOption) {
                               const reactionTernaryOption = createReactionVariantFromShopifyVariant({

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -137,9 +137,7 @@ function createReactionVariantFromShopifyVariant(options) {
  * @return {array} Returns an array of image objects that match the passed shopifyVariantId
  */
 function findVariantImages(shopifyVariantId, images) {
-  return images.filter((imageObj) => {
-    return imageObj.variant_ids.indexOf(shopifyVariantId) !== -1;
-  });
+  return images.filter((imageObj) => imageObj.variant_ids.indexOf(shopifyVariantId) !== -1);
 }
 
 /**
@@ -372,9 +370,7 @@ export const methods = {
                     Logger.debug(`Importing ${shopifyProduct.title} ${variant} options`);
                     shopifyOptions.forEach((option, j) => {
                       // Find the option that nests under our current variant.
-                      const shopifyOption = shopifyProduct.variants.find((o) => {
-                        return o.option1 === variant && o.option2 === option;
-                      });
+                      const shopifyOption = shopifyProduct.variants.find((o) => o.option1 === variant && o.option2 === option);
 
                       if (shopifyOption) {
                         const reactionOption = createReactionVariantFromShopifyVariant({
@@ -431,9 +427,7 @@ export const methods = {
                           Logger.debug(`Importing ${shopifyProduct.title} ${variant} ${option} options`);
                           shopifyTernaryOptions.forEach((ternaryOption, k) => {
                             // Find the option that nests under our current variant.
-                            const shopifyTernaryOption = shopifyProduct.variants.find((o) => {
-                              return o.option1 === variant && o.option2 === option && o.option3 === ternaryOption;
-                            });
+                            const shopifyTernaryOption = shopifyProduct.variants.find((o) => o.option1 === variant && o.option2 === option && o.option3 === ternaryOption);
 
                             if (shopifyTernaryOption) {
                               const reactionTernaryOption = createReactionVariantFromShopifyVariant({

--- a/imports/plugins/included/connectors-shopify/server/methods/sync/hooks.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/sync/hooks.js
@@ -15,7 +15,7 @@ export const methods = {
     if (!Reaction.hasPermission(connectorsRoles)) {
       throw new Meteor.Error("access-denied", "Access Denied");
     }
-    const [ topic, event, syncType ] = hook.name.split(":");
+    const [topic, event, syncType] = hook.name.split(":");
     const hookSetting = { topic, event, syncType };
     return Packages.update({
       "name": "reaction-connectors-shopify",
@@ -45,7 +45,7 @@ export const methods = {
       throw new Meteor.Error("access-denied", "Access Denied");
     }
     check(hook, { name: String, checked: Boolean });
-    const [ topic, event, syncType ] = hook.name.split(":");
+    const [topic, event, syncType] = hook.name.split(":");
     const hookSetting = { topic, event, syncType };
     return Packages.update({ name: "reaction-connectors-shopify", shopId: Reaction.getShopId() },
       { $pull: { "settings.synchooks": hookSetting }

--- a/imports/plugins/included/default-theme/client/favicons.js
+++ b/imports/plugins/included/default-theme/client/favicons.js
@@ -75,8 +75,8 @@ function addTag(type, details) {
 
 
 // add the favicon tags to the <head>
-linkTags.forEach(tag => addTag("link", tag));
-metaTags.forEach(tag => addTag("meta", tag));
+linkTags.forEach((tag) => addTag("link", tag));
+metaTags.forEach((tag) => addTag("meta", tag));
 
 
 // HTML output should look like this...

--- a/imports/plugins/included/discount-codes/client/templates/settings.js
+++ b/imports/plugins/included/discount-codes/client/templates/settings.js
@@ -81,9 +81,7 @@ Template.customDiscountCodes.helpers({
     // helper adds a class to every grid row
     //
     const customRowMetaData = {
-      bodyCssClassName: () =>  {
-        return "discount-codes-grid-row";
-      }
+      bodyCssClassName: () =>  "discount-codes-grid-row"
     };
 
     // add i18n handling to headers

--- a/imports/plugins/included/discount-codes/server/methods/methods.app-test.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.app-test.js
@@ -63,9 +63,7 @@ describe("discount code methods", function () {
       Meteor.call("discounts/codes/apply", cart._id, code.code);
 
       const updatedCart = Cart.findOne({ _id: cart._id });
-      const discountObj = updatedCart.billing.find((billing) => {
-        return billing.paymentMethod && billing.paymentMethod.method === "discount";
-      });
+      const discountObj = updatedCart.billing.find((billing) => billing.paymentMethod && billing.paymentMethod.method === "discount");
       const discountStatus = discountObj && discountObj.paymentMethod && discountObj.paymentMethod.status;
 
       expect(discountStatus).to.equal("created");

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -231,7 +231,7 @@ export const methods = {
       if (discount.transactions) {
         const users = Array.from(discount.transactions, (t) => t.userId);
         const transactionCount = new Map([...new Set(users)].map(
-          x => [x, users.filter(y => y === x).length]
+          (x) => [x, users.filter((y) => y === x).length]
         ));
         const orders = Array.from(discount.transactions, (t) => t.cartId);
         userCount = transactionCount.get(Meteor.userId());

--- a/imports/plugins/included/discount-rates/client/settings/rates.js
+++ b/imports/plugins/included/discount-rates/client/settings/rates.js
@@ -80,9 +80,7 @@ Template.customDiscountRates.helpers({
     // helper adds a class to every grid row
     //
     const customRowMetaData = {
-      bodyCssClassName: () =>  {
-        return "discount-rates-grid-row";
-      }
+      bodyCssClassName: () =>  "discount-rates-grid-row"
     };
 
     // add i18n handling to headers

--- a/imports/plugins/included/jobcontrol/server/jobs/cart.js
+++ b/imports/plugins/included/jobcontrol/server/jobs/cart.js
@@ -47,7 +47,7 @@ export default () => {
       const schedule = (settings.cart.cleanupDurationDays).match(/\d/);// configurable in shop settings
       const olderThan = moment().subtract(Number(schedule[0]), "days")._d;
       const carts = getstaleCarts(olderThan);
-      carts.forEach(cart => {
+      carts.forEach((cart) => {
         const user = Accounts.findOne({ _id: cart.userId });
         if (!user.emails.length) {
           const removeCart = Cart.remove({ userId: user._id });

--- a/imports/plugins/included/jobcontrol/server/jobs/cart.js
+++ b/imports/plugins/included/jobcontrol/server/jobs/cart.js
@@ -34,9 +34,7 @@ Hooks.Events.add("afterCoreInit", () => {
  * @param {Object} olderThan older than date
  * @return {Object} stale carts
  */
-const getstaleCarts = (olderThan) => {
-  return Cart.find({ updatedAt: { $lte: olderThan } }).fetch();
-};
+const getstaleCarts = (olderThan) => Cart.find({ updatedAt: { $lte: olderThan } }).fetch();
 
 export default () => {
   const removeStaleCart = Jobs.processJobs("cart/removeFromCart", {

--- a/imports/plugins/included/jobcontrol/server/jobs/exchangerates.js
+++ b/imports/plugins/included/jobcontrol/server/jobs/exchangerates.js
@@ -104,7 +104,7 @@ export default function () {
       workTimeout: 180 * 1000
     },
     (job, callback) => {
-      Meteor.call("shop/flushCurrencyRate", error => {
+      Meteor.call("shop/flushCurrencyRate", (error) => {
         if (error) {
           if (error.error === "notExists") {
             Logger.error(error.message);

--- a/imports/plugins/included/marketplace/client/components/inviteOwner.js
+++ b/imports/plugins/included/marketplace/client/components/inviteOwner.js
@@ -20,11 +20,9 @@ class InviteOwner extends Component {
     this.setState({ [event.target.name]: event.target.value });
   }
 
-  removeAlert = oldAlert => {
-    return this.setState({
-      alertArray: this.state.alertArray.filter(alert => JSON.stringify(alert) === JSON.stringify(oldAlert))
-    });
-  };
+  removeAlert = oldAlert => this.setState({
+    alertArray: this.state.alertArray.filter(alert => JSON.stringify(alert) === JSON.stringify(oldAlert))
+  });
 
   handleSubmit = (event) => {
     event.preventDefault();

--- a/imports/plugins/included/marketplace/client/components/inviteOwner.js
+++ b/imports/plugins/included/marketplace/client/components/inviteOwner.js
@@ -20,8 +20,8 @@ class InviteOwner extends Component {
     this.setState({ [event.target.name]: event.target.value });
   }
 
-  removeAlert = oldAlert => this.setState({
-    alertArray: this.state.alertArray.filter(alert => JSON.stringify(alert) === JSON.stringify(oldAlert))
+  removeAlert = (oldAlert) => this.setState({
+    alertArray: this.state.alertArray.filter((alert) => JSON.stringify(alert) === JSON.stringify(oldAlert))
   });
 
   handleSubmit = (event) => {

--- a/imports/plugins/included/marketplace/client/components/marketplaceShops.js
+++ b/imports/plugins/included/marketplace/client/components/marketplaceShops.js
@@ -11,19 +11,17 @@ class MarketplaceShops extends Component {
   renderShopsTable() {
     const fields = ["name", "emails", "workflow"];
 
-    const columnMetadata = fields.map((field) => {
-      return {
-        Header: <Components.Translation i18nKey={`marketplaceShops.headers.${field}`} defaultValue={field} />,
-        accessor: field,
-        Cell: (data) => (
-          <Components.MarketplaceShopTableCell
-            data={data}
-            field={field}
-            onWorkflowChange={this.props.onWorkflowChange}
-          />
-        )
-      };
-    });
+    const columnMetadata = fields.map((field) => ({
+      Header: <Components.Translation i18nKey={`marketplaceShops.headers.${field}`} defaultValue={field} />,
+      accessor: field,
+      Cell: (data) => (
+        <Components.MarketplaceShopTableCell
+          data={data}
+          field={field}
+          onWorkflowChange={this.props.onWorkflowChange}
+        />
+      )
+    }));
 
     return (
       <Components.SortableTable

--- a/imports/plugins/included/notifications/client/containers/notification.js
+++ b/imports/plugins/included/notifications/client/containers/notification.js
@@ -19,7 +19,7 @@ function composer(props, onData) {
 const handlers = {
   markAllAsRead(notificationList) {
     notificationList.map((notify) => {
-      Meteor.call("notification/markOneAsRead", notify._id);
+      return Meteor.call("notification/markOneAsRead", notify._id);
     });
   },
   markOneAsRead(id) {

--- a/imports/plugins/included/notifications/client/containers/notification.js
+++ b/imports/plugins/included/notifications/client/containers/notification.js
@@ -18,9 +18,7 @@ function composer(props, onData) {
 
 const handlers = {
   markAllAsRead(notificationList) {
-    notificationList.map((notify) => {
-      return Meteor.call("notification/markOneAsRead", notify._id);
-    });
+    notificationList.map((notify) => Meteor.call("notification/markOneAsRead", notify._id));
   },
   markOneAsRead(id) {
     Meteor.call("notification/markOneAsRead", id);

--- a/imports/plugins/included/notifications/client/containers/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/containers/notificationRoute.js
@@ -7,7 +7,7 @@ import { NotificationRoute } from "../components";
 const handlers = {
   markAllAsRead(notificationList) {
     notificationList.map((notify) => {
-      Meteor.call("notification/markOneAsRead", notify._id);
+      return Meteor.call("notification/markOneAsRead", notify._id);
     });
   },
   markOneAsRead(id) {

--- a/imports/plugins/included/notifications/client/containers/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/containers/notificationRoute.js
@@ -6,9 +6,7 @@ import { NotificationRoute } from "../components";
 
 const handlers = {
   markAllAsRead(notificationList) {
-    notificationList.map((notify) => {
-      return Meteor.call("notification/markOneAsRead", notify._id);
-    });
+    notificationList.map((notify) => Meteor.call("notification/markOneAsRead", notify._id));
   },
   markOneAsRead(id) {
     Meteor.call("notification/markOneAsRead", id);

--- a/imports/plugins/included/payments-stripe/server/methods/stripe.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripe.js
@@ -164,15 +164,13 @@ function buildPaymentMethods(options) {
 
   shopIds.forEach((shopId) => {
     if (transactionsByShopId[shopId]) {
-      const cartItems = cartItemsByShop[shopId].map((item) => {
-        return {
-          _id: item._id,
-          productId: item.productId,
-          variantId: item.variants._id,
-          shopId: shopId,
-          quantity: item.quantity
-        };
-      });
+      const cartItems = cartItemsByShop[shopId].map((item) => ({
+        _id: item._id,
+        productId: item.productId,
+        variantId: item.variants._id,
+        shopId: shopId,
+        quantity: item.quantity
+      }));
 
       // we need to grab this per shop to get the API key
       const packageData = Packages.findOne({

--- a/imports/plugins/included/product-admin/client/components/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/components/productAdmin.js
@@ -214,9 +214,7 @@ class ProductAdmin extends Component {
     );
   }
 
-  isExpanded = (groupName) => {
-    return this.state.expandedCard === groupName;
-  }
+  isExpanded = (groupName) => this.state.expandedCard === groupName
 
   render() {
     return (

--- a/imports/plugins/included/product-admin/client/containers/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/containers/productAdmin.js
@@ -134,12 +134,10 @@ function composer(props, onData) {
       provides: "template",
       templateFor: { $in: ["pdp"] },
       enabled: true
-    }).map((template) => {
-      return {
-        label: template.title,
-        value: template.name
-      };
-    });
+    }).map((template) => ({
+      label: template.title,
+      value: template.name
+    }));
 
     const countries = Countries.find({}).fetch();
 

--- a/imports/plugins/included/product-detail-simple/client/components/priceRange.js
+++ b/imports/plugins/included/product-detail-simple/client/components/priceRange.js
@@ -1,13 +1,11 @@
 import React from "react";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 
-const PriceRange = (props) => {
-  return (
-    <div className="pdp price-range">
-      <Components.Currency {...props} />
-    </div>
-  );
-};
+const PriceRange = (props) => (
+  <div className="pdp price-range">
+    <Components.Currency {...props} />
+  </div>
+);
 
 registerComponent("PriceRange", PriceRange);
 

--- a/imports/plugins/included/product-detail-simple/client/components/productNotFound.js
+++ b/imports/plugins/included/product-detail-simple/client/components/productNotFound.js
@@ -2,19 +2,17 @@ import React from "react";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 import { TranslationProvider } from "/imports/plugins/core/ui/client/providers";
 
-const ProductNotFound = () => {
-  return (
-    <TranslationProvider>
-      <div className="container-fluid-sm">
-        <div className="empty-view-message">
-          <i className="fa fa-barcode" />
-          <Components.Translation defaultValue="Oops" i18nKey="productDetail.notFoundTitle" />
-          <Components.Translation defaultValue="Product Not Found" i18nKey="productDetail.notFoundError" />
-        </div>
+const ProductNotFound = () => (
+  <TranslationProvider>
+    <div className="container-fluid-sm">
+      <div className="empty-view-message">
+        <i className="fa fa-barcode" />
+        <Components.Translation defaultValue="Oops" i18nKey="productDetail.notFoundTitle" />
+        <Components.Translation defaultValue="Product Not Found" i18nKey="productDetail.notFoundError" />
       </div>
-    </TranslationProvider>
-  );
-};
+    </div>
+  </TranslationProvider>
+);
 
 registerComponent("ProductNotFound", ProductNotFound);
 

--- a/imports/plugins/included/product-detail-simple/client/components/variant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variant.js
@@ -121,7 +121,7 @@ class Variant extends Component {
     if (variants) {
       validationStatus = variants.map((variant) => this.validation.validate(variant));
 
-      invalidVariant = validationStatus.filter(status => status.isValid === false);
+      invalidVariant = validationStatus.filter((status) => status.isValid === false);
     }
 
     const selfValidation = this.validation.validate(this.props.variant);

--- a/imports/plugins/included/product-detail-simple/client/components/variant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variant.js
@@ -119,9 +119,7 @@ class Variant extends Component {
     let invalidVariant;
 
     if (variants) {
-      validationStatus = variants.map((variant) => {
-        return this.validation.validate(variant);
-      });
+      validationStatus = variants.map((variant) => this.validation.validate(variant));
 
       invalidVariant = validationStatus.filter(status => status.isValid === false);
     }

--- a/imports/plugins/included/product-detail-simple/client/containers/publish.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/publish.js
@@ -28,7 +28,7 @@ class ProductPublishContainer extends Component {
 
     variants.map((variant) => {
       // update variant
-      Meteor.call("products/updateProductField", variant._id, "isVisible", isProductVisible);
+      return Meteor.call("products/updateProductField", variant._id, "isVisible", isProductVisible);
     });
   }
 

--- a/imports/plugins/included/product-detail-simple/client/containers/publish.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/publish.js
@@ -26,7 +26,7 @@ class ProductPublishContainer extends Component {
       }
     }).fetch();
 
-    variants.map(variant => {
+    variants.map((variant) => {
       // update variant
       Meteor.call("products/updateProductField", variant._id, "isVisible", isProductVisible);
     });

--- a/imports/plugins/included/product-detail-simple/client/containers/publish.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/publish.js
@@ -26,10 +26,10 @@ class ProductPublishContainer extends Component {
       }
     }).fetch();
 
-    variants.map((variant) => {
+    variants.map((variant) =>
       // update variant
-      return Meteor.call("products/updateProductField", variant._id, "isVisible", isProductVisible);
-    });
+      Meteor.call("products/updateProductField", variant._id, "isVisible", isProductVisible)
+    );
   }
 
   handlePublishActions = (event, action, documentIds) => {

--- a/imports/plugins/included/product-detail-simple/client/selectors/variants.js
+++ b/imports/plugins/included/product-detail-simple/client/selectors/variants.js
@@ -11,7 +11,7 @@ export function getChildVariants() {
     }
 
     if (current.ancestors.length === 1) {
-      variants.map(variant => {
+      variants.map((variant) => {
         if (typeof variant.ancestors[1] === "string" &&
           variant.ancestors[1] === current._id &&
           variant.optionTitle &&
@@ -21,7 +21,7 @@ export function getChildVariants() {
       });
     } else {
       // TODO not sure we need this part...
-      variants.map(variant => {
+      variants.map((variant) => {
         if (typeof variant.ancestors[1] === "string" &&
           variant.ancestors.length === current.ancestors.length &&
           variant.ancestors[1] === current.ancestors[1] &&

--- a/imports/plugins/included/product-detail-simple/client/selectors/variants.js
+++ b/imports/plugins/included/product-detail-simple/client/selectors/variants.js
@@ -16,8 +16,9 @@ export function getChildVariants() {
           variant.ancestors[1] === current._id &&
           variant.optionTitle &&
           variant.type !== "inventory") {
-          childVariants.push(variant);
+          return childVariants.push(variant);
         }
+        return;
       });
     } else {
       // TODO not sure we need this part...
@@ -27,8 +28,9 @@ export function getChildVariants() {
           variant.ancestors[1] === current.ancestors[1] &&
           variant.optionTitle
         ) {
-          childVariants.push(variant);
+          return childVariants.push(variant);
         }
+        return;
       });
     }
 

--- a/imports/plugins/included/product-detail-simple/client/selectors/variants.js
+++ b/imports/plugins/included/product-detail-simple/client/selectors/variants.js
@@ -16,7 +16,7 @@ export function getChildVariants() {
           variant.ancestors[1] === current._id &&
           variant.optionTitle &&
           variant.type !== "inventory") {
-          return childVariants.push(variant);
+          childVariants.push(variant);
         }
         return;
       });
@@ -28,7 +28,7 @@ export function getChildVariants() {
           variant.ancestors[1] === current.ancestors[1] &&
           variant.optionTitle
         ) {
-          return childVariants.push(variant);
+          childVariants.push(variant);
         }
         return;
       });

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/productImageGallery.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/productImageGallery.js
@@ -63,7 +63,7 @@ function updateImagePriorities() {
     .map((element, index) => {
       const mediaId = element.getAttribute("data-index");
 
-      Media.update(mediaId, {
+      return Media.update(mediaId, {
         $set: {
           "metadata.priority": index
         }

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantList/variantList.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantList/variantList.js
@@ -124,7 +124,7 @@ Template.variantList.helpers({
       }
 
       if (current.ancestors.length === 1) {
-        variants.map(variant => {
+        variants.map((variant) => {
           if (typeof variant.ancestors[1] === "string" &&
             variant.ancestors[1] === current._id &&
             variant.optionTitle &&
@@ -134,7 +134,7 @@ Template.variantList.helpers({
         });
       } else {
         // TODO not sure we need this part...
-        variants.map(variant => {
+        variants.map((variant) => {
           if (typeof variant.ancestors[1] === "string" &&
             variant.ancestors.length === current.ancestors.length &&
             variant.ancestors[1] === current.ancestors[1] &&

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantList/variantList.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantList/variantList.js
@@ -46,9 +46,7 @@ Template.variantList.onRendered(function () {
         onUpdate() {
           const positions = instance.$(".variant-list-item")
             .toArray()
-            .map((element) => {
-              return element.getAttribute("data-id");
-            });
+            .map((element) => element.getAttribute("data-id"));
 
           Meteor.defer(function () {
             Meteor.call("products/updateVariantsPosition", positions);

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantList/variantList.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantList/variantList.js
@@ -131,6 +131,7 @@ Template.variantList.helpers({
             variant.type !== "inventory") {
             childVariants.push(variant);
           }
+          return;
         });
       } else {
         // TODO not sure we need this part...
@@ -142,6 +143,7 @@ Template.variantList.helpers({
           ) {
             childVariants.push(variant);
           }
+          return;
         });
       }
 

--- a/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
@@ -10,7 +10,7 @@ import { isRevisionControlEnabled } from "/imports/plugins/core/revisions/lib/ap
 import { applyProductRevision } from "/lib/api/products";
 
 function updateVariantProductField(variants, field, value) {
-  return variants.map(variant => {
+  return variants.map((variant) => {
     Meteor.call("products/updateProductField", variant._id, field, value);
   });
 }

--- a/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
@@ -26,17 +26,13 @@ Template.productSettings.onCreated(function () {
     const currentData = Template.currentData();
 
     if (_.isArray(currentData.products)) {
-      const productIds = currentData.products.map((product) => {
-        return product._id;
-      });
+      const productIds = currentData.products.map((product) => product._id);
 
       const products = Products.find({
         _id: {
           $in: productIds
         }
-      }).map((product) => {
-        return applyProductRevision(product);
-      });
+      }).map((product) => applyProductRevision(product));
 
       this.state.set("productIds", productIds);
       this.state.set("products", products);

--- a/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.js
@@ -10,9 +10,7 @@ import { isRevisionControlEnabled } from "/imports/plugins/core/revisions/lib/ap
 import { applyProductRevision } from "/lib/api/products";
 
 function updateVariantProductField(variants, field, value) {
-  return variants.map((variant) => {
-    Meteor.call("products/updateProductField", variant._id, field, value);
-  });
+  return variants.map((variant) => Meteor.call("products/updateProductField", variant._id, field, value));
 }
 
 Template.productSettings.onCreated(function () {

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -9,14 +9,12 @@ class ProductGrid extends Component {
 
   renderProductGridItems = (products) => {
     if (Array.isArray(products)) {
-      return products.map((product, index) => {
-        return (
-          <Components.ProductGridItems
-            {...this.props}
-            product={product} key={index} index={index}
-          />
-        );
-      });
+      return products.map((product, index) => (
+        <Components.ProductGridItems
+          {...this.props}
+          product={product} key={index} index={index}
+        />
+      ));
     }
     return (
       <div className="row">

--- a/imports/plugins/included/product-variant/components/productGridItems.js
+++ b/imports/plugins/included/product-variant/components/productGridItems.js
@@ -66,9 +66,7 @@ class ProductGridItems extends Component {
       if (this.props.isMediumWeight()) {
         return (
           <div className={`product-additional-images ${this.renderVisible()}`}>
-            {this.props.additionalMedia().map((media) => {
-              return <span key={media._id} className="product-image" style={{ backgroundImage: `url('${media.url({ store: "medium" })}')` }} />;
-            })}
+            {this.props.additionalMedia().map((media) => <span key={media._id} className="product-image" style={{ backgroundImage: `url('${media.url({ store: "medium" })}')` }} />)}
             {this.renderOverlay()}
           </div>
         );

--- a/imports/plugins/included/product-variant/components/productGridItems.js
+++ b/imports/plugins/included/product-variant/components/productGridItems.js
@@ -66,7 +66,7 @@ class ProductGridItems extends Component {
       if (this.props.isMediumWeight()) {
         return (
           <div className={`product-additional-images ${this.renderVisible()}`}>
-            {this.props.additionalMedia().map((media) => <span key={media._id} className="product-image" style={{ backgroundImage: `url('${media.url({ store: "medium" })}')` }} />)}
+            {this.props.additionalMedia().map((media) => <span key={media._id} className="product-image" style={{ backgroundImage: `url('${media.url({ store: "medium" })}')` }} />)} // eslint-disable-line max-len
             {this.renderOverlay()}
           </div>
         );

--- a/imports/plugins/included/product-variant/components/variantEdit.js
+++ b/imports/plugins/included/product-variant/components/variantEdit.js
@@ -58,17 +58,15 @@ class VariantEdit extends Component {
     const childVariants = this.props.childVariants;
 
     if (Array.isArray(childVariants)) {
-      return childVariants.map((childVariant, index) => {
-        return (
-          <Components.VariantForm
-            key={index}
-            editFocus={this.props.editFocus}
-            countries={this.props.countries}
-            variant={childVariant}
-            type={"option"}
-          />
-        );
-      });
+      return childVariants.map((childVariant, index) => (
+        <Components.VariantForm
+          key={index}
+          editFocus={this.props.editFocus}
+          countries={this.props.countries}
+          variant={childVariant}
+          type={"option"}
+        />
+      ));
     }
 
     return null;

--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -189,13 +189,9 @@ class VariantForm extends Component {
     }
   }
 
-  handleVariantVisibilityToggle = (variant) => {
-    return this.props.onVisibilityButtonClick(variant);
-  }
+  handleVariantVisibilityToggle = (variant) => this.props.onVisibilityButtonClick(variant)
 
-  isExpanded = (groupName) => {
-    return this.state.expandedCard === groupName;
-  }
+  isExpanded = (groupName) => this.state.expandedCard === groupName
 
   renderTaxCodeField() {
     if (this.props.isProviderEnabled()) {

--- a/imports/plugins/included/product-variant/containers/gridItemControlsContainer.js
+++ b/imports/plugins/included/product-variant/containers/gridItemControlsContainer.js
@@ -32,13 +32,9 @@ const wrapComponent = (Comp) => (
       this.checkValidation();
     }
 
-    hasCreateProductPermission = () => {
-      return Reaction.hasPermission("createProduct");
-    }
+    hasCreateProductPermission = () => Reaction.hasPermission("createProduct")
 
-    hasChanges = () => {
-      return this.props.product.__draft ? true : false;
-    }
+    hasChanges = () => this.props.product.__draft ? true : false
 
     // This method checks validation of the variants of the all the products on the Products grid to
     // check whether all required fields have been submitted before publishing
@@ -60,9 +56,7 @@ const wrapComponent = (Comp) => (
       }
     }
 
-    checked = () => {
-      return this.props.isSelected === true;
-    }
+    checked = () => this.props.isSelected === true
 
     render() {
       return (

--- a/imports/plugins/included/product-variant/containers/gridItemNoticeContainer.js
+++ b/imports/plugins/included/product-variant/containers/gridItemNoticeContainer.js
@@ -45,9 +45,7 @@ const wrapComponent = (Comp) => (
       return true;
     }
 
-    isBackorder = () => {
-      return this.props.product.isBackorder;
-    }
+    isBackorder = () => this.props.product.isBackorder
 
     render() {
       return (

--- a/imports/plugins/included/product-variant/containers/gridPublishContainer.js
+++ b/imports/plugins/included/product-variant/containers/gridPublishContainer.js
@@ -47,7 +47,7 @@ function composer(props, onData) {
   if (Array.isArray(selectedProducts) && selectedProducts.length) {
     productIds = selectedProducts;
   } else if (Array.isArray(products) && products.length) {
-    productIds = products.map(p => p._id);
+    productIds = products.map((p) => p._id);
   }
 
   if (productIds) {

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -119,7 +119,7 @@ const wrapComponent = (Comp) => (
       this.state.productIds.map((productId, index) => {
         const position = { position: index, updatedAt: new Date() };
 
-        Meteor.call("products/updateProductPosition", productId, position, tag, (error) => {
+        return Meteor.call("products/updateProductPosition", productId, position, tag, (error) => {
           if (error) {
             Logger.error(error);
             throw new Meteor.Error("error-occurred", error);

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -44,9 +44,7 @@ const wrapComponent = (Comp) => (
       Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
 
       if (products) {
-        const filteredProducts = _.filter(products, (product) => {
-          return _.includes(selectedProducts, product._id);
-        });
+        const filteredProducts = _.filter(products, (product) => _.includes(selectedProducts, product._id));
 
         if (Reaction.isPreview() === false) {
           Reaction.showActionView({
@@ -85,9 +83,7 @@ const wrapComponent = (Comp) => (
       const products = this.products;
 
       if (products) {
-        const filteredProducts = _.filter(products, (product) => {
-          return _.includes(selectedProducts, product._id);
-        });
+        const filteredProducts = _.filter(products, (product) => _.includes(selectedProducts, product._id));
 
         Reaction.showActionView({
           label: "Grid Settings",

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -119,7 +119,7 @@ const wrapComponent = (Comp) => (
       this.state.productIds.map((productId, index) => {
         const position = { position: index, updatedAt: new Date() };
 
-        Meteor.call("products/updateProductPosition", productId, position, tag, error => {
+        Meteor.call("products/updateProductPosition", productId, position, tag, (error) => {
           if (error) {
             Logger.error(error);
             throw new Meteor.Error("error-occurred", error);

--- a/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
@@ -127,7 +127,7 @@ const wrapComponent = (Comp) => (
 
     additionalProductMedia = () => {
       const variants = ReactionProduct.getVariants(this.props.product._id);
-      const variantIds = variants.map(variant => variant._id);
+      const variantIds = variants.map((variant) => variant._id);
       const mediaArray = Media.find({
         "metadata.productId": this.props.product._id,
         "metadata.variantId": {

--- a/imports/plugins/included/product-variant/containers/productsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainer.js
@@ -79,9 +79,7 @@ const wrapComponent = (Comp) => (
       return false;
     }
 
-    loadMoreProducts = () => {
-      return this.props.canLoadMoreProducts === true;
-    }
+    loadMoreProducts = () => this.props.canLoadMoreProducts === true
 
     loadProducts = (event) => {
       event.preventDefault();
@@ -176,9 +174,7 @@ function composer(props, onData) {
     shopId: { $in: activeShopsIds }
   });
 
-  const products = productCursor.map((product) => {
-    return applyProductRevision(product);
-  });
+  const products = productCursor.map((product) => applyProductRevision(product));
 
   const sortedProducts = ReactionProduct.sortProducts(products, currentTag);
 

--- a/imports/plugins/included/product-variant/containers/productsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainer.js
@@ -166,7 +166,7 @@ function composer(props, onData) {
       { "workflow.status": "active" },
       { _id: Reaction.getPrimaryShopId() }
     ]
-  }).fetch().map(activeShop => activeShop._id);
+  }).fetch().map((activeShop) => activeShop._id);
 
   const productCursor = Products.find({
     ancestors: [],

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -75,9 +75,7 @@ const wrapComponent = (Comp) => (
         "shopId": shopId,
         "registry.provides": "taxCodes",
         "$where": function () {
-          const providers = this.registry.filter((o) => {
-            return o.provides && o.provides.includes("taxCodes");
-          });
+          const providers = this.registry.filter((o) => o.provides && o.provides.includes("taxCodes"));
           const providerName = providers[0].name.split("/")[2];
 
           return this.settings[providerName].enabled;
@@ -220,9 +218,7 @@ const wrapComponent = (Comp) => (
       // If this is not a top-level variant, update top-level inventory policy as well
       if (parent && options && options.length) {
         // Check to see if every variant option inventory policy is true
-        const inventoryPolicy = options.every((option) => {
-          return option.inventoryPolicy === true;
-        });
+        const inventoryPolicy = options.every((option) => option.inventoryPolicy === true);
 
         // If all inventory policies on children are true, update parent to be true
         if (inventoryPolicy === true) {

--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -193,12 +193,12 @@ export function buildOrderSearchRecord(orderId) {
   }
   // get the billing object for the current shop on the order (and not hardcoded [0])
   const shopBilling = order.billing && order.billing.find(
-    billing => billing && billing.shopId === Reaction.getShopId()
+    (billing) => billing && billing.shopId === Reaction.getShopId()
   ) || {};
 
   // get the shipping object for the current shop on the order (and not hardcoded [0])
   const shopShipping = order.shipping.find(
-    shipping => shipping.shopId === Reaction.getShopId()
+    (shipping) => shipping.shopId === Reaction.getShopId()
   ) || {};
 
   orderSearch.billingName = shopBilling.address && shopBilling.address.fullName;
@@ -237,9 +237,9 @@ export function buildOrderSearchRecord(orderId) {
   }
   orderSearch.product = {};
   orderSearch.variants = {};
-  orderSearch.product.title = order.items.map(item => item.product && item.product.title);
-  orderSearch.variants.title = order.items.map(item => item.variants && item.variants.title);
-  orderSearch.variants.optionTitle = order.items.map(item => item.variants && item.variants.optionTitle);
+  orderSearch.product.title = order.items.map((item) => item.product && item.product.title);
+  orderSearch.variants.title = order.items.map((item) => item.variants && item.variants.title);
+  orderSearch.variants.optionTitle = order.items.map((item) => item.variants && item.variants.optionTitle);
 
   OrderSearch.insert(orderSearch);
 }

--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -159,9 +159,7 @@ getResults.accounts = function (searchTerm, facets, maxResults, userId) {
 
 Meteor.publish("SearchResults", function (collection, searchTerm, facets, maxResults = 99) {
   check(collection, String);
-  check(collection, Match.Where((coll) => {
-    return _.includes(supportedCollections, coll);
-  }));
+  check(collection, Match.Where((coll) => _.includes(supportedCollections, coll)));
   check(searchTerm, Match.Optional(String));
   check(facets, Match.OneOf(Array, undefined));
   Logger.debug(`Returning search results on ${collection}. SearchTerm: |${searchTerm}|. Facets: |${facets}|.`);

--- a/imports/plugins/included/shipping-rates/client/templates/settings/rates.js
+++ b/imports/plugins/included/shipping-rates/client/templates/settings/rates.js
@@ -71,9 +71,7 @@ Template.shippingRatesSettings.helpers({
 
     // add shipping-grid-row class
     const customRowMetaData = {
-      bodyCssClassName: () =>  {
-        return "shipping-grid-row";
-      }
+      bodyCssClassName: () =>  "shipping-grid-row"
     };
 
     // add i18n handling to headers

--- a/imports/plugins/included/shipping-shippo/client/settings/carriers.js
+++ b/imports/plugins/included/shipping-shippo/client/settings/carriers.js
@@ -43,9 +43,7 @@ Template.shippoCarriers.helpers({
 
     // add shipping-carriers-grid-row class
     const customRowMetaData = {
-      bodyCssClassName: () =>  {
-        return "shipping-carriers-grid-row";
-      }
+      bodyCssClassName: () =>  "shipping-carriers-grid-row"
     };
 
     // add i18n handling to headers

--- a/imports/plugins/included/shipping-shippo/server/jobs/shippo.js
+++ b/imports/plugins/included/shipping-shippo/server/jobs/shippo.js
@@ -63,7 +63,7 @@ export default function () {
         // which "shippo/fetchTrackingStatusForOrders" need, we use dispatch:run-as-user
         // An alternative way is https://forums.meteor.com/t/cant-set-logged-in-user-for-rest-calls/18656/3
         Meteor.runAsUser(ownerId, () => {
-          Meteor.call("shippo/fetchTrackingStatusForOrders", error => {
+          Meteor.call("shippo/fetchTrackingStatusForOrders", (error) => {
             if (error) {
               job.done(error.toString(), { repeatId: true });
             } else {

--- a/imports/plugins/included/shipping-shippo/server/methods/shippo.js
+++ b/imports/plugins/included/shipping-shippo/server/methods/shippo.js
@@ -55,7 +55,7 @@ function getTotalCartweight(cart) {
 
 // converts the Rates List fetched from the Shippo Api to Reaction Shipping Rates form
 function ratesParser(shippoRates, shippoDocs) {
-  return shippoRates.map(rate => {
+  return shippoRates.map((rate) => {
     const rateAmount = parseFloat(rate.amount);
     // const methodLabel = `${rate.provider} - ${rate.servicelevel_name}`;
     const reactionRate = {
@@ -84,7 +84,7 @@ function ratesParser(shippoRates, shippoDocs) {
 function filterActiveCarriers(carrierList) {
   const activeCarriers = [];
   if (carrierList.results && carrierList.count) {
-    carrierList.results.forEach(carrier => {
+    carrierList.results.forEach((carrier) => {
       if (carrier.active) {
         activeCarriers.push({
           carrier: carrier.carrier, // this is a property of the returned result with value the name of the carrier
@@ -115,7 +115,7 @@ function getApiKey(shopId = Reaction.getShopId()) {
 // Adds Shippo carriers in Shipping Collection (one doc per carrier) for the current Shop
 function addShippoProviders(carriers, shopId = Reaction.getShopId()) {
   let result = true;
-  carriers.forEach(carrier => {
+  carriers.forEach((carrier) => {
     const carrierName = carrier.carrier;
     const carrierLabel = formatCarrierLabel(carrierName);
     const currentResult = Shipping.insert({
@@ -166,11 +166,11 @@ function updateShippoProviders(activeCarriers, shopId = Reaction.getShopId()) {
   });
 
   // Ids of Shippo Carriers that exist currently as docs in Shipping Collection
-  const currentCarriersIds = currentShippoProviders.map(doc => doc.provider.shippoProvider.carrierAccountId);
+  const currentCarriersIds = currentShippoProviders.map((doc) => doc.provider.shippoProvider.carrierAccountId);
 
   const newActiveCarriers = [];
   const unchangedActiveCarriersIds = [];
-  activeCarriers.forEach(carrier => {
+  activeCarriers.forEach((carrier) => {
     const carrierId = carrier.carrierAccountId;
     if (!currentCarriersIds.includes(carrierId)) {
       newActiveCarriers.push(carrier);
@@ -305,7 +305,7 @@ export const methods = {
 
     // For each order get from Shippo the transaction item ,check the tracking and if it has been updated
     let updatingResult = true;
-    shippoOrders.forEach(order => {
+    shippoOrders.forEach((order) => {
       const orderShipment = order.shipping[0];
       const transactionId = orderShipment.shippo.transactionId;
       const transaction = ShippoApi.methods.getTransaction.call({ apiKey, transactionId });

--- a/imports/plugins/included/social/client/components/facebook.js
+++ b/imports/plugins/included/social/client/components/facebook.js
@@ -40,13 +40,11 @@ class FacebookSocialButton extends Component {
     if (window && document) {
       $('<div id="fb-root"></div>').appendTo("body");
 
-      window.fbAsyncInit = () => {
-        return FB.init({
-          appId: this.props.settings.appId,
-          xfbml: true,
-          version: this.props.settings.version || "v2.7"
-        });
-      };
+      window.fbAsyncInit = () => FB.init({
+        appId: this.props.settings.appId,
+        xfbml: true,
+        version: this.props.settings.version || "v2.7"
+      });
       (function (d, s, id) {
         let js = void 0;
         const fjs = d.getElementsByTagName(s)[0];

--- a/imports/plugins/included/taxes-avalara/client/accounts/exemption.js
+++ b/imports/plugins/included/taxes-avalara/client/accounts/exemption.js
@@ -37,12 +37,10 @@ Template.taxSettingsPanel.helpers({
       value: "CUSTOM USER INPUT"
     }];
 
-    const entityCodes = TaxEntityCodes.find().map((entityCode) => {
-      return Object.assign({}, entityCode, {
-        label: entityCode.name,
-        value: entityCode.code
-      });
-    });
+    const entityCodes = TaxEntityCodes.find().map((entityCode) => Object.assign({}, entityCode, {
+      label: entityCode.name,
+      value: entityCode.code
+    }));
     entityCodeList = (entityCodes || []).map((a) => a.code);
     return (entityCodes || []).concat(customOption);
   }

--- a/imports/plugins/included/taxes-avalara/client/settings/avalara.js
+++ b/imports/plugins/included/taxes-avalara/client/settings/avalara.js
@@ -82,9 +82,7 @@ Template.avalaraSettings.helpers({
 
     // helper adds a class to every grid row
     const customRowMetaData = {
-      bodyCssClassName: () =>  {
-        return "log-grid-row";
-      }
+      bodyCssClassName: () =>  "log-grid-row"
     };
 
     // add i18n handling to headers

--- a/imports/plugins/included/taxes-avalara/client/settings/avalara.js
+++ b/imports/plugins/included/taxes-avalara/client/settings/avalara.js
@@ -65,7 +65,7 @@ Template.avalaraSettings.helpers({
   },
 
   logGrid() {
-    const filteredFields = [ "data.request.data.date", "data.request.data.type"];
+    const filteredFields = ["data.request.data.date", "data.request.data.type"];
     const noDataMessage = i18next.t("logGrid.noLogsFound");
     const instance = Template.instance();
 

--- a/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
@@ -4,17 +4,15 @@ import { Cart, Orders } from "/lib/collections";
 import taxCalc from "../methods/taxCalc";
 
 function linesToTaxes(lines) {
-  const taxes = lines.map((line) => {
-    return {
-      lineNumber: line.lineNumber,
-      discountAmount: line.discountAmount,
-      taxable: line.isItemTaxable,
-      tax: line.tax,
-      taxableAmount: line.taxableAmount,
-      taxCode: line.taxCode,
-      details: line.details
-    };
-  });
+  const taxes = lines.map((line) => ({
+    lineNumber: line.lineNumber,
+    discountAmount: line.discountAmount,
+    taxable: line.isItemTaxable,
+    tax: line.tax,
+    taxableAmount: line.taxableAmount,
+    taxCode: line.taxCode,
+    details: line.details
+  }));
   return taxes;
 }
 

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -396,6 +396,7 @@ function cartToSalesOrder(cart) {
           taxCode: item.variants.taxCode
         };
       }
+      return;
     });
     if (cartShipping) {
       lineItems.push({

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -501,6 +501,7 @@ function orderToSalesInvoice(order) {
         taxCode: item.variants.taxCode
       };
     }
+    return;
   });
   if (orderShipping) {
     lineItems.push({

--- a/imports/plugins/included/taxes-taxcloud/server/jobs/taxcodes.js
+++ b/imports/plugins/included/taxes-taxcloud/server/jobs/taxcodes.js
@@ -56,7 +56,7 @@ export default function () {
       workTimeout: 180 * 1000
     },
     (job, callback) => {
-      Meteor.call("taxcloud/getTaxCodes", error => {
+      Meteor.call("taxcloud/getTaxCodes", (error) => {
         if (error) {
           if (error.error === "notConfigured") {
             Logger.warn(error.message);

--- a/imports/plugins/included/ui-search/lib/containers/searchModalContainer.js
+++ b/imports/plugins/included/ui-search/lib/containers/searchModalContainer.js
@@ -106,6 +106,6 @@ const wrapComponent = (Comp) => (
   }
 );
 
-registerComponent("SearchSubscription", SearchSubscription, [ wrapComponent ]);
+registerComponent("SearchSubscription", SearchSubscription, [wrapComponent]);
 
 export default compose(wrapComponent)(SearchSubscription);

--- a/imports/plugins/included/ui-search/lib/helpers/accountsTable.js
+++ b/imports/plugins/included/ui-search/lib/helpers/accountsTable.js
@@ -8,17 +8,13 @@ export default function accountsTable() {
       id: "_id",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.accountId", { defaultValue: "Account ID" }),
-      value: rowData => {
-        return rowData._id;
-      }
+      value: rowData => rowData._id
     },
     {
       id: "shopId",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.shopId", { defaultValue: "Shop ID" }),
-      value: rowData => {
-        return rowData.shopId;
-      }
+      value: rowData => rowData.shopId
     },
     {
       id: "firstName",
@@ -57,17 +53,13 @@ export default function accountsTable() {
       id: "email",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.emails", { defaultValue: "Email" }),
-      value: rowData => {
-        return rowData.emails[0];
-      }
+      value: rowData => rowData.emails[0]
     },
     {
       id: "manageAccount",
       type: DataType.String,
       header: "",
-      value: rowData => {
-        return rowData.emails[0];
-      },
+      value: rowData => rowData.emails[0],
       tdClassName: "account-manage",
       renderer(cellData, { rowData }) {
         return <span data-event-action="manageAccount" data-event-data={rowData._id}>View</span>;

--- a/imports/plugins/included/ui-search/lib/helpers/accountsTable.js
+++ b/imports/plugins/included/ui-search/lib/helpers/accountsTable.js
@@ -8,19 +8,19 @@ export default function accountsTable() {
       id: "_id",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.accountId", { defaultValue: "Account ID" }),
-      value: rowData => rowData._id
+      value: (rowData) => rowData._id
     },
     {
       id: "shopId",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.shopId", { defaultValue: "Shop ID" }),
-      value: rowData => rowData.shopId
+      value: (rowData) => rowData.shopId
     },
     {
       id: "firstName",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.firstName", { defaultValue: "First Name" }),
-      value: rowData => {
+      value: (rowData) => {
         if (rowData.profile) {
           return rowData.profile.firstName;
         }
@@ -31,7 +31,7 @@ export default function accountsTable() {
       id: "lastName",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.lastName", { defaultValue: "Last Name" }),
-      value: rowData => {
+      value: (rowData) => {
         if (rowData.profile) {
           return rowData.profile.lastName;
         }
@@ -42,7 +42,7 @@ export default function accountsTable() {
       id: "phone",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.phone", { defaultValue: "Phone" }),
-      value: rowData => {
+      value: (rowData) => {
         if (rowData.profile) {
           return rowData.profile.phone;
         }
@@ -53,13 +53,13 @@ export default function accountsTable() {
       id: "email",
       type: DataType.String,
       header: i18next.t("search.accountSearchResults.emails", { defaultValue: "Email" }),
-      value: rowData => rowData.emails[0]
+      value: (rowData) => rowData.emails[0]
     },
     {
       id: "manageAccount",
       type: DataType.String,
       header: "",
-      value: rowData => rowData.emails[0],
+      value: (rowData) => rowData.emails[0],
       tdClassName: "account-manage",
       renderer(cellData, { rowData }) {
         return <span data-event-action="manageAccount" data-event-data={rowData._id}>View</span>;

--- a/imports/test-utils/__mocks__/client/api/index.js
+++ b/imports/test-utils/__mocks__/client/api/index.js
@@ -1,5 +1,3 @@
 export const i18next = {
-  t: (key, { defaultValue }) => {
-    return defaultValue || key;
-  }
+  t: (key, { defaultValue }) => defaultValue || key
 };

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -51,11 +51,11 @@ export default {
     const variants = this.getTopVariants(product._id);
     // if we have variants we have a price range.
     // this processing will default on the server
-    const visibileVariant = variants.filter(variant => variant.isVisible === true);
+    const visibileVariant = variants.filter((variant) => variant.isVisible === true);
 
     if (visibileVariant.length > 0) {
       const variantPrices = [];
-      variants.forEach(variant => {
+      variants.forEach((variant) => {
         if (variant.isVisible === true) {
           const range = this.getVariantPriceRange(variant._id);
           if (typeof range === "string") {
@@ -99,7 +99,7 @@ export default {
    */
   getVariantPriceRange(variantId) {
     const children = this.getVariants(variantId);
-    const visibleChildren = children.filter(child => child.isVisible);
+    const visibleChildren = children.filter((child) => child.isVisible);
 
     switch (visibleChildren.length) {
       case 0:
@@ -112,7 +112,7 @@ export default {
         let priceMin = Number.POSITIVE_INFINITY;
         let priceMax = Number.NEGATIVE_INFINITY;
 
-        children.map(child => {
+        children.map((child) => {
           if (child.isVisible === true) {
             if (child.price < priceMin) {
               priceMin = child.price;

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -115,12 +115,13 @@ export default {
         children.map((child) => {
           if (child.isVisible === true) {
             if (child.price < priceMin) {
-              priceMin = child.price;
+              return priceMin = child.price;
             }
             if (child.price > priceMax) {
-              priceMax = child.price;
+              return priceMax = child.price;
             }
           }
+          return;
         });
 
         if (priceMin === priceMax) {

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -115,10 +115,10 @@ export default {
         children.map((child) => {
           if (child.isVisible === true) {
             if (child.price < priceMin) {
-              return priceMin = child.price;
+              priceMin = child.price;
             }
             if (child.price > priceMax) {
-              return priceMax = child.price;
+              priceMax = child.price;
             }
           }
           return;

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -230,7 +230,7 @@ export function isObject(item) {
  */
 export function mergeDeep(target, source) {
   if (isObject(target) && isObject(source)) {
-    Object.keys(source).forEach(key => {
+    Object.keys(source).forEach((key) => {
       if (isObject(source[key])) {
         if (!target[key]) Object.assign(target, { [key]: {} });
         mergeDeep(target[key], source[key]);

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -101,13 +101,9 @@ ReactionProduct.sortProducts = (products, tag) => {
 
   sorted = orderBy(products,
     // Sort by postion for tag
-    (product) => {
-      return product.positions && product.positions[tag] && product.positions[tag].position;
-    },
+    (product) => product.positions && product.positions[tag] && product.positions[tag].position,
     // Then by creation date for tag
-    (product) => {
-      return product.positions && product.positions[tag] && product.positions[tag].createdAt;
-    },
+    (product) => product.positions && product.positions[tag] && product.positions[tag].createdAt,
     // Finally sort by creation date
     "createdAt"
   );
@@ -332,9 +328,7 @@ ReactionProduct.getVariantQuantity = doc => Catalog.getVariantQuantity(doc);
  * @param {String} [id] - product _id
  * @return {Object} Product data
  */
-ReactionProduct.getProduct = (id) => {
-  return Catalog.getProduct(id);
-};
+ReactionProduct.getProduct = (id) => Catalog.getProduct(id);
 
 /**
  * @method getVariants
@@ -345,9 +339,7 @@ ReactionProduct.getProduct = (id) => {
  * @param {String} [type] - type of variant
  * @return {Array} Parent variants or empty array
  */
-ReactionProduct.getVariants = (id, type) => {
-  return Catalog.getVariants(id || ReactionProduct.selectedProductId(), type);
-};
+ReactionProduct.getVariants = (id, type) => Catalog.getVariants(id || ReactionProduct.selectedProductId(), type);
 
 /**
  * @method getSiblings
@@ -360,9 +352,7 @@ ReactionProduct.getVariants = (id, type) => {
  * @param {Boolean} [includeSelf] - include current variant in results
  * @return {Array} Sibling variants or empty array
  */
-ReactionProduct.getSiblings = (variant, type) => {
-  return Catalog.getSiblings(variant, type);
-};
+ReactionProduct.getSiblings = (variant, type) => Catalog.getSiblings(variant, type);
 
 /**
  * @method getVariantParent
@@ -372,9 +362,7 @@ ReactionProduct.getSiblings = (variant, type) => {
  * @param {Object} [variant] - product / variant object
  * @return {Array} Parent variant or empty
  */
-ReactionProduct.getVariantParent = (variant) => {
-  return Catalog.getVariantParent(variant);
-};
+ReactionProduct.getVariantParent = (variant) => Catalog.getVariantParent(variant);
 
 /**
  * @method getTopVariants
@@ -382,9 +370,7 @@ ReactionProduct.getVariantParent = (variant) => {
  * @param {String} [id] - product _id
  * @return {Array} Product top level variants or empty array
  */
-ReactionProduct.getTopVariants = id => {
-  return Catalog.getTopVariants(id || ReactionProduct.selectedProductId());
-};
+ReactionProduct.getTopVariants = id => Catalog.getTopVariants(id || ReactionProduct.selectedProductId());
 
 /**
  * @name getTag
@@ -394,9 +380,7 @@ ReactionProduct.getTopVariants = id => {
  * route name or shop name as default name.
  * @return {String} tag name or shop name
  */
-ReactionProduct.getTag = () => {
-  return getCurrentTag() || getShopName().toLowerCase();
-};
+ReactionProduct.getTag = () => getCurrentTag() || getShopName().toLowerCase();
 
 /**
  * @name getProductsByTag

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -291,7 +291,7 @@ ReactionProduct.checkInventoryVariants = function (parentVariantId) {
  * @param {String} [id] - current variant _Id
  * @return {String} formatted price or price range
  */
-ReactionProduct.getVariantPriceRange = id => Catalog.
+ReactionProduct.getVariantPriceRange = (id) => Catalog.
   getVariantPriceRange(id || ReactionProduct.selectedVariant()._id);
 
 /**
@@ -305,7 +305,7 @@ ReactionProduct.getVariantPriceRange = id => Catalog.
  * @param {String} [id] - current product _id
  * @return {String} formatted price or price range
  */
-ReactionProduct.getProductPriceRange = id => Catalog.
+ReactionProduct.getProductPriceRange = (id) => Catalog.
   getProductPriceRange(id || ReactionProduct.selectedProductId());
 
 /**
@@ -318,7 +318,7 @@ ReactionProduct.getProductPriceRange = id => Catalog.
  * @return {Number} summary of options quantity or top-level variant
  * inventoryQuantity
  */
-ReactionProduct.getVariantQuantity = doc => Catalog.getVariantQuantity(doc);
+ReactionProduct.getVariantQuantity = (doc) => Catalog.getVariantQuantity(doc);
 
 /**
  * @method getProduct
@@ -370,7 +370,7 @@ ReactionProduct.getVariantParent = (variant) => Catalog.getVariantParent(variant
  * @param {String} [id] - product _id
  * @return {Array} Product top level variants or empty array
  */
-ReactionProduct.getTopVariants = id => Catalog.getTopVariants(id || ReactionProduct.selectedProductId());
+ReactionProduct.getTopVariants = (id) => Catalog.getTopVariants(id || ReactionProduct.selectedProductId());
 
 /**
  * @name getTag
@@ -544,7 +544,7 @@ ReactionProduct.cloneProduct = function (productOrArray) {
  */
 ReactionProduct.archiveProduct = function (productOrArray) {
   const products = !_.isArray(productOrArray) ? [productOrArray] : productOrArray;
-  const productIds = _.map(products, product => typeof product === "string" ? product : product._id);
+  const productIds = _.map(products, (product) => typeof product === "string" ? product : product._id);
   let confirmTitle;
   // we have to use so difficult logic with `length` check because of some
   // languages, which have different phrase forms for each of cases.

--- a/lib/api/prop-types.js
+++ b/lib/api/prop-types.js
@@ -46,9 +46,7 @@ PropTypes.arrayOfTags = (props, propName) => {
   check(propName, String);
 
   if (_.isEmpty(props[propName]) === false && _.isArray(props[propName])) {
-    const valid = _.every(props[propName], (tag) => {
-      return TagSchema.validate(tag);
-    });
+    const valid = _.every(props[propName], (tag) => TagSchema.validate(tag));
 
     if (valid === false) {
       return new Error("Objects in array must be of type: Schemas.Tag");

--- a/lib/api/router/metadata.js
+++ b/lib/api/router/metadata.js
@@ -18,9 +18,7 @@ export const MetaData = {
     const keywords = [];
 
     // case helper
-    const titleCase = (param) => {
-      return param.charAt(0).toUpperCase() + param.substring(1);
-    };
+    const titleCase = (param) => param.charAt(0).toUpperCase() + param.substring(1);
 
     // populate meta from shop
     if (shop) {

--- a/lib/collections/schemas/helpers.js
+++ b/lib/collections/schemas/helpers.js
@@ -84,9 +84,7 @@ export function shopDefaultCountry() {
 
       // Find the current shops primary shipping address
       if (shop && shop.addressBook) {
-        const defaultShippingAddress = shop.addressBook.find((address) => {
-          return address.isShippingDefault === true;
-        });
+        const defaultShippingAddress = shop.addressBook.find((address) => address.isShippingDefault === true);
 
         // return the shops country to auto-populate the Country of Origin field in the scheme
         return defaultShippingAddress.country;

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -258,9 +258,7 @@ export const cartOrderTransform = {
    * @returns {Array} Array of Payment Method objects
    */
   getPaymentMethods() {
-    const billingMethods = this.billing.map((method) => {
-      return method.paymentMethod;
-    });
+    const billingMethods = this.billing.map((method) => method.paymentMethod);
     const methodObjects = billingMethods.map((method) => {
       const paymentMethodObject = {
         storedCard: method.storedCard,
@@ -280,9 +278,7 @@ export const cartOrderTransform = {
    * @returns {object} - An object containing the payment methods used on this order excluding duplicates
    */
   getUniquePaymentMethods() {
-    const billingMethods = this.billing.map((method) => {
-      return method.paymentMethod;
-    });
+    const billingMethods = this.billing.map((method) => method.paymentMethod);
     const uniqueMethods = {};
     for (const billingMethod of billingMethods) {
       const key = `${billingMethod.storedCard}${billingMethod.processor}${billingMethod.method}`;
@@ -325,9 +321,7 @@ export const cartOrderTransform = {
           subTotal: subTotalsByShop[shop],
           taxes: taxesByShop[shop],
           items: itemsByShop[shop],
-          quantityTotal: itemsByShop[shop].reduce((qty, item) => {
-            return qty + item.quantity;
-          }, 0),
+          quantityTotal: itemsByShop[shop].reduce((qty, item) => qty + item.quantity, 0),
           shipping: shippingByShop[shop],
           shippingMethod: shipping[0].shipmentMethod
         }

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -170,6 +170,7 @@ export const cartOrderTransform = {
       if (item.invoice) {
         return acc + parseFloat(item.invoice.discounts);
       }
+      return;
     }, 0);
     const cartDiscount = parseFloat(this.discount) || 0;
     const discount = orderDiscounts || cartDiscount || 0;

--- a/lib/selectors/tags.js
+++ b/lib/selectors/tags.js
@@ -9,7 +9,7 @@
  */
 export const getTagIds = (state) => {
   if (Array.isArray(state.tags)) {
-    return state.tags.map(tag => tag._id);
+    return state.tags.map((tag) => tag._id);
   }
 
   return [];

--- a/lib/selectors/variants.js
+++ b/lib/selectors/variants.js
@@ -6,4 +6,4 @@
  * @param  {Array} variants Array of variant objects
  * @return {Array}          Array of variant object IDs
  */
-export const getVariantIds = (variants) => Array.isArray(variants) && variants.map(variant => variant._id);
+export const getVariantIds = (variants) => Array.isArray(variants) && variants.map((variant) => variant._id);

--- a/server/api/core/addDefaultRoles.js
+++ b/server/api/core/addDefaultRoles.js
@@ -23,12 +23,10 @@ function addRolesToUsersInGroups(options) {
 
   const groupsToUpdate = Groups.find(query, { fields: { _id: 1, shopId: 1 } }).fetch();
   // We need a list of groups => shops to determine which users get which updates
-  const groupAndShopIds = groupsToUpdate.map((group) => {
-    return {
-      id: group._id,
-      shopId: group.shopId
-    };
-  });
+  const groupAndShopIds = groupsToUpdate.map((group) => ({
+    id: group._id,
+    shopId: group.shopId
+  }));
 
   // We perform one update for each groupId and return a count of the number of updates performed
   groupAndShopIds.forEach((group) => {

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -73,7 +73,7 @@ export default {
     const registeredPackage = this.Packages[packageInfo.name] = packageInfo;
     return registeredPackage;
   },
-  defaultCustomerRoles: [ "guest", "account/profile", "product", "tag", "index", "cart/checkout", "cart/completed"],
+  defaultCustomerRoles: ["guest", "account/profile", "product", "tag", "index", "cart/checkout", "cart/completed"],
   defaultVisitorRoles: ["anonymous", "guest", "product", "tag", "index", "cart/checkout", "cart/completed"],
   createGroups,
 

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -623,7 +623,7 @@ export default {
         Array.isArray(marketplaceSettings.shops.enabledPackagesByShopTypes)) {
       // Find the correct packages list for this shopType
       const matchingShopType = marketplaceSettings.shops.enabledPackagesByShopTypes.find(
-        EnabledPackagesByShopType => EnabledPackagesByShopType.shopType === shop.shopType);
+        (EnabledPackagesByShopType) => EnabledPackagesByShopType.shopType === shop.shopType);
       if (matchingShopType) {
         enabledPackages = matchingShopType.enabledPackages;
       }

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -883,8 +883,8 @@ export default {
 
     const layouts = [];
     // for each shop, we're loading packages in a unique registry
-    _.each(this.Packages, (config, pkgName) => {
-      return Shops.find().forEach((shop) => {
+    _.each(this.Packages, (config, pkgName) =>
+      Shops.find().forEach((shop) => {
         const shopId = shop._id;
         if (!shopId) return [];
 
@@ -904,15 +904,11 @@ export default {
         // Setting from a fixture file, most likely reaction.json
         let settingsFromFixture;
         if (registryFixtureData) {
-          settingsFromFixture = _.find(registryFixtureData[0], (packageSetting) => {
-            return config.name === packageSetting.name;
-          });
+          settingsFromFixture = _.find(registryFixtureData[0], (packageSetting) => config.name === packageSetting.name);
         }
 
         // Setting already imported into the packages collection
-        const settingsFromDB = _.find(packages, (ps) => {
-          return (config.name === ps.name && shopId === ps.shopId);
-        });
+        const settingsFromDB = _.find(packages, (ps) => (config.name === ps.name && shopId === ps.shopId));
 
         const combinedSettings = merge({}, settingsFromPackage, settingsFromFixture || {}, settingsFromDB || {});
 
@@ -940,8 +936,8 @@ export default {
         // Import package data
         this.Import.package(combinedSettings, shopId);
         return Logger.debug(`Initializing ${shop.name} ${pkgName}`);
-      }); // end shops
-    });
+      }) // end shops
+    );
 
     // helper for removing layout duplicates
     const uniqLayouts = uniqWith(layouts, _.isEqual);
@@ -953,16 +949,14 @@ export default {
     //
     // package cleanup
     //
-    Shops.find().forEach((shop) => {
-      return Packages.find().forEach((pkg) => {
-        // delete registry entries for packages that have been removed
-        if (!_.has(this.Packages, pkg.name)) {
-          Logger.debug(`Removing ${pkg.name}`);
-          return Packages.remove({ shopId: shop._id, name: pkg.name });
-        }
-        return false;
-      });
-    });
+    Shops.find().forEach((shop) => Packages.find().forEach((pkg) => {
+      // delete registry entries for packages that have been removed
+      if (!_.has(this.Packages, pkg.name)) {
+        Logger.debug(`Removing ${pkg.name}`);
+        return Packages.remove({ shopId: shop._id, name: pkg.name });
+      }
+      return false;
+    }));
   },
 
   /**
@@ -1007,10 +1001,10 @@ export default {
     // if we have `_simpleSchemas` (plural), then this is a selector based schema
     if (c2._simpleSchemas) {
       const selectorKeys = Object.keys(selector);
-      const selectorSchema = c2._simpleSchemas.find((schema) => {
+      const selectorSchema = c2._simpleSchemas.find((schema) =>
         // Make sure that every key:value in our selector matches the key:value in the schema selector
-        return selectorKeys.every((key) => selector[key] === schema.selector[key]);
-      });
+        selectorKeys.every((key) => selector[key] === schema.selector[key])
+      );
 
       if (!selectorSchema) {
         Logger.warn(errMsg);

--- a/server/api/core/groups.js
+++ b/server/api/core/groups.js
@@ -66,8 +66,8 @@ export function createGroups(options = {}) {
 function getDefaultGroupRoles() {
   let ownerRoles = Roles
     .getAllRoles().fetch()
-    .map(role => role.name)
-    .filter(role => role !== "anonymous"); // see comment above
+    .map((role) => role.name)
+    .filter((role) => role !== "anonymous"); // see comment above
 
   // Join all other roles with package roles for owner. Owner should have all roles
   // this is needed because of default roles defined in the app that are not in Roles.getAllRoles

--- a/server/api/core/import.js
+++ b/server/api/core/import.js
@@ -490,5 +490,5 @@ Import.indication("provider", Collections.Shipping, 0.2);
 // Bulk.find.upsert() to equal false
 //
 export const Fixture = Object.assign({}, Import, {
-  _upsert: () => { return false; }
+  _upsert: () => false
 });

--- a/server/api/core/rightJoin.js
+++ b/server/api/core/rightJoin.js
@@ -21,17 +21,15 @@ const doRightJoinNoIntersection = (leftSet, rightSet) => {
   } else {
     rightJoin = {};
   }
-  const findRightOnlyProperties = () => {
-    return Object.keys(rightSet).filter(function (key) {
-      if (typeof(rightSet[key]) === "object" &&
+  const findRightOnlyProperties = () => Object.keys(rightSet).filter(function (key) {
+    if (typeof(rightSet[key]) === "object" &&
         !Array.isArray(rightSet[key])) {
-        // Nested objects are always considered
-        return true;
-      }
-      // Array or primitive value
-      return !leftSet.hasOwnProperty(key);
-    });
-  };
+      // Nested objects are always considered
+      return true;
+    }
+    // Array or primitive value
+    return !leftSet.hasOwnProperty(key);
+  });
 
   for (const key of findRightOnlyProperties()) {
     if (typeof(rightSet[key]) === "object") {

--- a/server/api/hooks.js
+++ b/server/api/hooks.js
@@ -30,9 +30,7 @@ Hooks.Events.add = (name, callback) => {
  * @return {Array} array of remaining callbacks
  */
 Hooks.Events.remove = (name, callbackName) => {
-  Hooks.Events[name] = _.reject(Hooks.Events[name], (callback) => {
-    return callback.name === callbackName;
-  });
+  Hooks.Events[name] = _.reject(Hooks.Events[name], (callback) => callback.name === callbackName);
 
   return Hooks.Events;
 };
@@ -50,9 +48,7 @@ Hooks.Events.run = (name, item, constant) => {
 
   // if the hook exists, and contains callbacks to run
   if (typeof callbacks !== "undefined" && !!callbacks.length) {
-    return callbacks.reduce((result, callback) => {
-      return callback(result, constant);
-    }, item);
+    return callbacks.reduce((result, callback) => callback(result, constant), item);
   }
   return item;
 };

--- a/server/imports/fixtures/shops.js
+++ b/server/imports/fixtures/shops.js
@@ -38,7 +38,7 @@ const shop = {
   name: faker.internet.domainName(),
   description: faker.company.catchPhrase(),
   keywords: faker.company.bsAdjective(),
-  addressBook: [ getAddress() ],
+  addressBook: [getAddress()],
   domains: ["localhost"],
   emails: [
     {

--- a/server/methods/accounts/accounts-password.js
+++ b/server/methods/accounts/accounts-password.js
@@ -29,9 +29,7 @@ Meteor.methods({
 
     const emails = _.map(user.emails || [], "address");
 
-    const caseInsensitiveEmail = _.find(emails, (email) => {
-      return email.toLowerCase() === options.email.toLowerCase();
-    });
+    const caseInsensitiveEmail = _.find(emails, (email) => email.toLowerCase() === options.email.toLowerCase());
 
     Reaction.Accounts.sendResetPasswordEmail(user._id, caseInsensitiveEmail);
   }

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -811,7 +811,7 @@ export function sendWelcomeEmail(shopId, userId) {
     return true;
   }
 
-  const defaultEmail = user.emails.find(email => email.provides === "default");
+  const defaultEmail = user.emails.find((email) => email.provides === "default");
   // Encode email address for URI
   const encodedEmailAddress = encodeURIComponent(defaultEmail.address);
   // assign verification url

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -350,9 +350,7 @@ describe("core product methods", function () {
         }).fetch();
         expect(cloneVariants.length).to.equal(3);
         for (let i = 0; i < variants.length; i++) {
-          expect(cloneVariants.some(clonedVariant => {
-            return clonedVariant.title === variants[i].title;
-          })).to.be.ok;
+          expect(cloneVariants.some(clonedVariant => clonedVariant.title === variants[i].title)).to.be.ok;
         }
 
         return done();
@@ -716,9 +714,7 @@ describe("core product methods", function () {
   });
 
   describe("setHandle", () => {
-    beforeEach(() => {
-      return Tags.remove({});
-    });
+    beforeEach(() => Tags.remove({}));
 
     it("should throw 403 error by non admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => false);

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -684,7 +684,7 @@ describe("core product methods", function () {
       Meteor.call("products/removeProductTag", product._id, tag._id);
       const productRevision = Revisions.findOne({
         "documentId": product._id,
-        "workflow.status": { $nin: [ "revision/published" ] }
+        "workflow.status": { $nin: ["revision/published"] }
       });
       expect(productRevision.documentData.hashtags).to.not.contain(tag._id);
       expect(Tags.find().count()).to.equal(1);

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -93,7 +93,7 @@ describe("core product methods", function () {
 
       Meteor.call("products/cloneVariant", product._id, variant[0]._id);
       const variants = Products.find({ ancestors: [product._id] }).fetch();
-      const clonedVariant = variants.filter(v => v._id !== variant[0]._id);
+      const clonedVariant = variants.filter((v) => v._id !== variant[0]._id);
       expect(variant[0]._id).to.not.equal(clonedVariant[0]._id);
       expect(_.isEqual(variant[0].ancestors, clonedVariant[0].ancestors)).to.be.true;
       // expect(variant[0].ancestors).to.equal(clonedVariant[0].ancestors);
@@ -156,7 +156,7 @@ describe("core product methods", function () {
       Meteor.call("products/createVariant", product._id, newVariant);
       Meteor._sleepForMs(500);
       variants = Products.find({ ancestors: [product._id] }).fetch();
-      const createdVariant = variants.filter(v => v._id !== firstVariantId);
+      const createdVariant = variants.filter((v) => v._id !== firstVariantId);
       expect(variants.length).to.equal(2);
       expect(createdVariant[0].title).to.equal("newVariant");
       return done();
@@ -350,7 +350,7 @@ describe("core product methods", function () {
         }).fetch();
         expect(cloneVariants.length).to.equal(3);
         for (let i = 0; i < variants.length; i++) {
-          expect(cloneVariants.some(clonedVariant => clonedVariant.title === variants[i].title)).to.be.ok;
+          expect(cloneVariants.some((clonedVariant) => clonedVariant.title === variants[i].title)).to.be.ok;
         }
 
         return done();

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -287,10 +287,8 @@ function isLowQuantity(variants) {
  * @return {boolean} is backorder allowed or not for a product
  */
 function isBackorder(variants) {
-  return variants.every(variant => {
-    return !variant.inventoryPolicy && variant.inventoryManagement &&
-      variant.inventoryQuantity === 0;
-  });
+  return variants.every(variant => !variant.inventoryPolicy && variant.inventoryManagement &&
+      variant.inventoryQuantity === 0);
 }
 
 /**

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -29,7 +29,7 @@ import { Logger, Reaction } from "/server/api";
  * @return {Array} - return an array
  */
 function updateVariantProductField(variants, field, value) {
-  return variants.map(variant => {
+  return variants.map((variant) => {
     Meteor.call("products/updateProductField", variant._id, field, value);
   });
 }
@@ -252,7 +252,7 @@ function denormalize(id, field) {
  * @return {Boolean} true if summary product quantity is zero.
  */
 function isSoldOut(variants) {
-  return variants.every(variant => {
+  return variants.every((variant) => {
     if (variant.inventoryManagement && variant.inventoryPolicy) {
       return Catalog.getVariantQuantity(variant) <= 0;
     }
@@ -268,7 +268,7 @@ function isSoldOut(variants) {
  * @return {boolean} low quantity or not
  */
 function isLowQuantity(variants) {
-  return variants.some(variant => {
+  return variants.some((variant) => {
     const quantity = Catalog.getVariantQuantity(variant);
     // we need to keep an eye on `inventoryPolicy` too and qty > 0
     if (variant.inventoryManagement && variant.inventoryPolicy && quantity) {
@@ -287,7 +287,7 @@ function isLowQuantity(variants) {
  * @return {boolean} is backorder allowed or not for a product
  */
 function isBackorder(variants) {
-  return variants.every(variant => !variant.inventoryPolicy && variant.inventoryManagement &&
+  return variants.every((variant) => !variant.inventoryPolicy && variant.inventoryManagement &&
       variant.inventoryQuantity === 0);
 }
 
@@ -376,9 +376,9 @@ Meteor.methods({
     // we could use this way in future: http://stackoverflow.com/questions/
     // 9040161/mongo-order-by-length-of-array, by now following are allowed
     // @link https://lodash.com/docs#sortBy
-    const sortedVariants = _.sortBy(variants, doc => doc.ancestors.length);
+    const sortedVariants = _.sortBy(variants, (doc) => doc.ancestors.length);
 
-    return sortedVariants.map(sortedVariant => {
+    return sortedVariants.map((sortedVariant) => {
       const oldId = sortedVariant._id;
       let type = "child";
       const clone = {};
@@ -543,7 +543,7 @@ Meteor.methods({
     // we can't stop after successful denormalization, because we have a
     // case when several fields could be changed in top-level variant
     // before form will be submitted.
-    toDenormalize.forEach(field => {
+    toDenormalize.forEach((field) => {
       if (currentVariant[field] !== variant[field]) {
         denormalize(productId, field);
       }
@@ -594,7 +594,7 @@ Meteor.methods({
     // after variant were removed from product, we need to recalculate all
     // denormalized fields
     const productId = toDelete[0].ancestors[0];
-    toDenormalize.forEach(field => denormalize(productId, field));
+    toDenormalize.forEach((field) => denormalize(productId, field));
 
     return typeof deleted === "number" && deleted > 0;
   },
@@ -620,7 +620,7 @@ Meteor.methods({
 
     if (Array.isArray(productOrArray)) {
       // Reduce to unique shops found among producs in this array
-      const shopIds = productOrArray.map(prod => prod.shopId);
+      const shopIds = productOrArray.map((prod) => prod.shopId);
       const uniqueShopIds = [...new Set(shopIds)];
 
       // For each unique shopId check to make sure that user has permission to clone
@@ -657,7 +657,7 @@ Meteor.methods({
 
     function buildAncestors(ancestors) {
       const newAncestors = [];
-      ancestors.map(oldId => {
+      ancestors.map((oldId) => {
         const pair = getIds(oldId);
         // TODO do we always have newId on this step?
         newAncestors.push(pair[0].newId);
@@ -708,7 +708,7 @@ Meteor.methods({
         type: "variant"
       }).fetch();
       // why we are using `_.sortBy` described in `products/cloneVariant`
-      const sortedVariants = _.sortBy(variants, doc => doc.ancestors.length);
+      const sortedVariants = _.sortBy(variants, (doc) => doc.ancestors.length);
       for (const variant of sortedVariants) {
         const variantNewId = Random.id();
         setId({
@@ -825,7 +825,7 @@ Meteor.methods({
     }).fetch();
 
     const ids = [];
-    productsWithVariants.map(doc => {
+    productsWithVariants.map((doc) => {
       ids.push(doc._id);
     });
 
@@ -1319,7 +1319,7 @@ Meteor.methods({
 
     if (typeof product === "object" && product.title.length > 1) {
       if (variants.length > 0) {
-        variants.forEach(variant => {
+        variants.forEach((variant) => {
           // if this is a top variant with children, we avoid it to check price
           // because we using price of its children
           if (variant.ancestors.length === 1 &&

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -29,9 +29,7 @@ import { Logger, Reaction } from "/server/api";
  * @return {Array} - return an array
  */
 function updateVariantProductField(variants, field, value) {
-  return variants.map((variant) => {
-    return Meteor.call("products/updateProductField", variant._id, field, value);
-  });
+  return variants.map((variant) => Meteor.call("products/updateProductField", variant._id, field, value));
 }
 
 /**
@@ -825,9 +823,7 @@ Meteor.methods({
     }).fetch();
 
     const ids = [];
-    productsWithVariants.map((doc) => {
-      return ids.push(doc._id);
-    });
+    productsWithVariants.map((doc) => ids.push(doc._id));
 
     Products.remove({
       _id: {

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -30,7 +30,7 @@ import { Logger, Reaction } from "/server/api";
  */
 function updateVariantProductField(variants, field, value) {
   return variants.map((variant) => {
-    Meteor.call("products/updateProductField", variant._id, field, value);
+    return Meteor.call("products/updateProductField", variant._id, field, value);
   });
 }
 
@@ -660,7 +660,7 @@ Meteor.methods({
       ancestors.map((oldId) => {
         const pair = getIds(oldId);
         // TODO do we always have newId on this step?
-        newAncestors.push(pair[0].newId);
+        return newAncestors.push(pair[0].newId);
       });
       return newAncestors;
     }
@@ -826,7 +826,7 @@ Meteor.methods({
 
     const ids = [];
     productsWithVariants.map((doc) => {
-      ids.push(doc._id);
+      return ids.push(doc._id);
     });
 
     Products.remove({

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -76,7 +76,7 @@ function getSessionCarts(userId, sessionId, shopId) {
   const allowedCarts = [];
 
   // only anonymous user carts allowed
-  carts.forEach(cart => {
+  carts.forEach((cart) => {
     if (Roles.userIsInRole(cart.userId, "anonymous", shopId)) {
       allowedCarts.push(cart);
     }
@@ -164,7 +164,7 @@ Meteor.methods({
         sessionId} into: ${currentCart._id}`
     );
     // loop through session carts and merge into user cart
-    sessionCarts.forEach(sessionCart => {
+    sessionCarts.forEach((sessionCart) => {
       Logger.debug(
         `merge cart: merge user userId: ${userId}, sessionCart.userId: ${
           sessionCart.userId}, sessionCart id: ${sessionCart._id}`
@@ -189,7 +189,7 @@ Meteor.methods({
         const cartSum = sessionCart.items.concat(currentCart.items);
         const mergedItems = cartSum.reduce((newItems, item) => {
           if (item) {
-            const existingItem = newItems.find(cartItem => cartItem.variants._id === item.variants._id);
+            const existingItem = newItems.find((cartItem) => cartItem.variants._id === item.variants._id);
             if (existingItem) {
               existingItem.quantity += item.quantity;
             } else {
@@ -295,7 +295,7 @@ Meteor.methods({
     // this needed after submitting order, when user receives new cart
     const account = Collections.Accounts.findOne(userId);
     if (account && account.profile && account.profile.addressBook) {
-      account.profile.addressBook.forEach(address => {
+      account.profile.addressBook.forEach((address) => {
         if (address.isBillingDefault) {
           Meteor.call("cart/setPaymentAddress", currentCartId, address);
         }
@@ -360,7 +360,7 @@ Meteor.methods({
     Collections.Products.find({ _id: { $in: [
       productId,
       variantId
-    ] } }).forEach(doc => {
+    ] } }).forEach((doc) => {
       if (doc.type === "simple") {
         product = doc;
       } else {
@@ -386,7 +386,7 @@ Meteor.methods({
     const quantity = quantityProcessing(product, variant, itemQty);
     // performs search of variant inside cart
     const cartVariantExists = cart.items && cart.items
-      .some(item => item.variants._id === variantId);
+      .some((item) => item.variants._id === variantId);
 
     if (cartVariantExists) {
       let modifier = {};

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -94,9 +94,7 @@ function getSessionCarts(userId, sessionId, shopId) {
  */
 function removeShippingAddresses(cart) {
   const cartShipping = cart.shipping;
-  cartShipping.map((sRecord) => {
-    delete sRecord.address;
-  });
+  cartShipping.map((sRecord) => delete sRecord.address);
   Collections.Cart.update({
     _id: cart._id
   }, {
@@ -615,7 +613,7 @@ Meteor.methods({
       const updatedShipping = [];
       cart.shipping.map((shipRecord) => {
         shipRecord.shipmentMethod = method;
-        updatedShipping.push(shipRecord);
+        return updatedShipping.push(shipRecord);
       });
 
       selector = {
@@ -841,6 +839,8 @@ Meteor.methods({
               }
             }
           };
+
+          return;
         });
       }
     }

--- a/server/methods/core/cartToOrder.js
+++ b/server/methods/core/cartToOrder.js
@@ -89,7 +89,7 @@ export function copyCartToOrder(cartId) {
     if (order.shipping.length > 0) {
       const shippingRecords = [];
       order.shipping.map((shippingRecord) => {
-        const billingRecord = order.billing.find(billing => billing.shopId === shippingRecord.shopId);
+        const billingRecord = order.billing.find((billing) => billing.shopId === shippingRecord.shopId);
         shippingRecord.paymentId = billingRecord._id;
         shippingRecord.items = [];
         shippingRecord.items.packed = false;
@@ -132,7 +132,7 @@ export function copyCartToOrder(cartId) {
     };
   }
 
-  order.items = order.items.map(item => {
+  order.items = order.items.map((item) => {
     item.shippingMethod = order.shipping[order.shipping.length - 1];
     item.workflow = {
       status: "new",

--- a/server/methods/core/cartToOrder.js
+++ b/server/methods/core/cartToOrder.js
@@ -96,7 +96,7 @@ export function copyCartToOrder(cartId) {
         shippingRecord.items.shipped = false;
         shippingRecord.items.delivered = false;
         shippingRecord.workflow = { status: "new",  workflow: ["coreOrderWorkflow/notStarted"] };
-        shippingRecords.push(shippingRecord);
+        return shippingRecords.push(shippingRecord);
       });
       order.shipping = shippingRecords;
     }

--- a/server/methods/core/methods.app-test.js
+++ b/server/methods/core/methods.app-test.js
@@ -64,7 +64,7 @@ describe("Server/Core", function () {
       expect(Tags.insert).not.to.have.been.called;
     });
 
-    it("should create new tag", done => {
+    it("should create new tag", (done) => {
       sandbox.stub(Roles, "userIsInRole", () => true);
       sandbox.spy(Tags, "insert");
       expect(Meteor.call("shop/createTag", "testTag", true)).to.be.a("string");

--- a/server/methods/core/orders.app-test.js
+++ b/server/methods/core/orders.app-test.js
@@ -90,7 +90,7 @@ describe("orders test", function () {
   }
 
   function orderCreditMethod(orderData) {
-    const billingRecord = orderData.billing.filter(value => value.paymentMethod.method ===  "credit");
+    const billingRecord = orderData.billing.filter((value) => value.paymentMethod.method ===  "credit");
     const billingObject =  billingRecord.find((billing) => billing.shopId === shopId);
     return billingObject;
   }

--- a/server/methods/core/orders.app-test.js
+++ b/server/methods/core/orders.app-test.js
@@ -80,24 +80,18 @@ describe("orders test", function () {
   }
 
   function billingObjectMethod(orderObject) {
-    const billingObject = orderObject.billing.find((billing) => {
-      return billing.shopId === shopId;
-    });
+    const billingObject = orderObject.billing.find((billing) => billing.shopId === shopId);
     return billingObject;
   }
 
   function shippingObjectMethod(orderObject) {
-    const shippingObject = orderObject.shipping.find((shipping) => {
-      return shipping.shopId === shopId;
-    });
+    const shippingObject = orderObject.shipping.find((shipping) => shipping.shopId === shopId);
     return shippingObject;
   }
 
   function orderCreditMethod(orderData) {
     const billingRecord = orderData.billing.filter(value => value.paymentMethod.method ===  "credit");
-    const billingObject =  billingRecord.find((billing) => {
-      return billing.shopId === shopId;
-    });
+    const billingObject =  billingRecord.find((billing) => billing.shopId === shopId);
     return billingObject;
   }
 

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -27,9 +27,7 @@ import { Logger, Hooks, Reaction } from "/server/api";
  */
 export function orderCreditMethod(order) {
   const creditBillingRecords = order.billing.filter(value => value.paymentMethod.method ===  "credit");
-  const billingRecord = creditBillingRecords.find((billing) => {
-    return billing.shopId === Reaction.getShopId();
-  });
+  const billingRecord = creditBillingRecords.find((billing) => billing.shopId === Reaction.getShopId());
   return billingRecord;
 }
 
@@ -43,9 +41,7 @@ export function orderCreditMethod(order) {
  */
 export function orderDebitMethod(order) {
   const debitBillingRecords = order.billing.filter(value => value.paymentMethod.method ===  "debit");
-  const billingRecord = debitBillingRecords.find((billing) => {
-    return billing.shopId === Reaction.getShopId();
-  });
+  const billingRecord = debitBillingRecords.find((billing) => billing.shopId === Reaction.getShopId());
   return billingRecord;
 }
 
@@ -171,9 +167,7 @@ export const methods = {
     }
 
     // Set the status of the items as picked
-    const itemIds = shipment.items.map((item) => {
-      return item._id;
-    });
+    const itemIds = shipment.items.map((item) => item._id);
 
     const result = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/picked", order, itemIds);
     if (result === 1) {
@@ -211,9 +205,7 @@ export const methods = {
     }
 
     // Set the status of the items as packed
-    const itemIds = shipment.items.map((item) => {
-      return item._id;
-    });
+    const itemIds = shipment.items.map((item) => item._id);
 
     const result = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/packed", order, itemIds);
     if (result === 1) {
@@ -249,9 +241,7 @@ export const methods = {
     }
 
     // Set the status of the items as labeled
-    const itemIds = shipment.items.map((item) => {
-      return item._id;
-    });
+    const itemIds = shipment.items.map((item) => item._id);
 
     const result = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/labeled", order, itemIds);
     if (result === 1) {
@@ -391,9 +381,7 @@ export const methods = {
     paymentMethod = Object.assign(paymentMethod, { amount: Number(paymentMethod.amount) });
     const invoiceTotal = billingRecord.invoice.total;
     const shipment = shippingRecord;
-    const itemIds = shipment.items.map((item) => {
-      return item._id;
-    });
+    const itemIds = shipment.items.map((item) => item._id);
 
     // refund payment to customer
     const paymentMethodId = paymentMethod && paymentMethod.paymentPackageId;
@@ -458,9 +446,7 @@ export const methods = {
 
         const shippingRecord = order.shipping.find(shipping => shipping.shopId === Reaction.getShopId());
         // Set the status of the items as shipped
-        const itemIds = shippingRecord.items.map((item) => {
-          return item._id;
-        });
+        const itemIds = shippingRecord.items.map((item) => item._id);
 
         Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/captured", order, itemIds);
 
@@ -495,9 +481,7 @@ export const methods = {
     let completedItemsResult;
     let completedOrderResult;
 
-    const itemIds = shipment.items.map((item) => {
-      return item._id;
-    });
+    const itemIds = shipment.items.map((item) => item._id);
 
     // TODO: In the future, this could be handled by shipping delivery status
     // REVIEW: This hook seems to run before the shipment has been marked as shipped
@@ -569,16 +553,12 @@ export const methods = {
       Logger.warn("No order email found. No notification sent.");
     }
 
-    const itemIds = shipment.items.map((item) => {
-      return item._id;
-    });
+    const itemIds = shipment.items.map((item) => item._id);
 
     Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/delivered", order, itemIds);
     Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/completed", order, itemIds);
 
-    const isCompleted = order.items.every((item) => {
-      return item.workflow.workflow && item.workflow.workflow.includes("coreOrderItemWorkflow/completed");
-    });
+    const isCompleted = order.items.every((item) => item.workflow.workflow && item.workflow.workflow.includes("coreOrderItemWorkflow/completed"));
 
     Orders.update({
       "_id": order._id,
@@ -963,9 +943,7 @@ export const methods = {
     const order = Orders.findOne(orderId);
     // find the appropriate shipping record by shop
     const shippingRecord = order.shipping.find((sRecord) => sRecord.shopId === shopId);
-    const itemIds = shippingRecord.items.map((item) => {
-      return item._id;
-    });
+    const itemIds = shippingRecord.items.map((item) => item._id);
 
     Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/captured", order, itemIds);
 

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -26,7 +26,7 @@ import { Logger, Hooks, Reaction } from "/server/api";
  * @return {Object} returns entire payment method
  */
 export function orderCreditMethod(order) {
-  const creditBillingRecords = order.billing.filter(value => value.paymentMethod.method ===  "credit");
+  const creditBillingRecords = order.billing.filter((value) => value.paymentMethod.method ===  "credit");
   const billingRecord = creditBillingRecords.find((billing) => billing.shopId === Reaction.getShopId());
   return billingRecord;
 }
@@ -40,7 +40,7 @@ export function orderCreditMethod(order) {
  * @return {Pbject} returns entire payment method
  */
 export function orderDebitMethod(order) {
-  const debitBillingRecords = order.billing.filter(value => value.paymentMethod.method ===  "debit");
+  const debitBillingRecords = order.billing.filter((value) => value.paymentMethod.method ===  "debit");
   const billingRecord = debitBillingRecords.find((billing) => billing.shopId === Reaction.getShopId());
   return billingRecord;
 }
@@ -63,7 +63,7 @@ export function ordersInventoryAdjust(orderId) {
   }
 
   const order = Orders.findOne(orderId);
-  order.items.forEach(item => {
+  order.items.forEach((item) => {
     Products.update({
       _id: item.variants._id
     }, {
@@ -98,7 +98,7 @@ export function ordersInventoryAdjustByShop(orderId, shopId) {
   }
 
   const order = Orders.findOne(orderId);
-  order.items.forEach(item => {
+  order.items.forEach((item) => {
     if (item.shopId === shopId) {
       Products.update({
         _id: item.variants._id
@@ -357,7 +357,7 @@ export const methods = {
     if (!returnToStock) {
       // Run this Product update inline instead of using ordersInventoryAdjust because the collection hooks fail
       // in some instances which causes the order not to cancel
-      order.items.forEach(item => {
+      order.items.forEach((item) => {
         if (Reaction.hasPermission("orders", Meteor.userId(), item.shopId)) {
           Products.update({
             _id: item.variants._id,
@@ -374,8 +374,8 @@ export const methods = {
       });
     }
 
-    const billingRecord = order.billing.find(billing => billing.shopId === Reaction.getShopId());
-    const shippingRecord = order.shipping.find(shipping => shipping.shopId === Reaction.getShopId());
+    const billingRecord = order.billing.find((billing) => billing.shopId === Reaction.getShopId());
+    const shippingRecord = order.shipping.find((shipping) => shipping.shopId === Reaction.getShopId());
 
     let paymentMethod = orderCreditMethod(order).paymentMethod;
     paymentMethod = Object.assign(paymentMethod, { amount: Number(paymentMethod.amount) });
@@ -444,7 +444,7 @@ export const methods = {
       if (result) {
         Meteor.call("workflow/pushOrderWorkflow", "coreOrderWorkflow", "coreProcessPayment", order._id);
 
-        const shippingRecord = order.shipping.find(shipping => shipping.shopId === Reaction.getShopId());
+        const shippingRecord = order.shipping.find((shipping) => shipping.shopId === Reaction.getShopId());
         // Set the status of the items as shipped
         const itemIds = shippingRecord.items.map((item) => item._id);
 
@@ -541,7 +541,7 @@ export const methods = {
 
     this.unblock();
 
-    const shipment = order.shipping.find(shipping => shipping.shopId === Reaction.getShopId());
+    const shipment = order.shipping.find((shipping) => shipping.shopId === Reaction.getShopId());
 
     if (order.email) {
       Meteor.call("orders/sendNotification", order, (err) => {
@@ -1157,7 +1157,7 @@ export const methods = {
         });
       }
       if (result) {
-        refundItems.forEach(refundItem => {
+        refundItems.forEach((refundItem) => {
           orderQuantityAdjust(orderId, refundItem);
         });
 

--- a/server/methods/core/shipping.js
+++ b/server/methods/core/shipping.js
@@ -334,9 +334,7 @@ export const methods = {
     }
 
     let newRates;
-    const didEveryShippingProviderFail = rates.every((shippingMethod) => {
-      return shippingMethod.requestStatus && shippingMethod.requestStatus === "error";
-    });
+    const didEveryShippingProviderFail = rates.every((shippingMethod) => shippingMethod.requestStatus && shippingMethod.requestStatus === "error");
     if (didEveryShippingProviderFail) {
       newRates = [{
         requestStatus: "error",
@@ -344,9 +342,7 @@ export const methods = {
         message: "All requests for shipping methods failed."
       }];
     } else {
-      newRates = rates.filter((shippingMethod) => {
-        return !(shippingMethod.requestStatus) || shippingMethod.requestStatus !== "error";
-      });
+      newRates = rates.filter((shippingMethod) => !(shippingMethod.requestStatus) || shippingMethod.requestStatus !== "error");
     }
 
     Logger.debug("getShippingRates returning rates", rates);

--- a/server/methods/core/shops.app-test.js
+++ b/server/methods/core/shops.app-test.js
@@ -61,16 +61,14 @@ describe("core shop methods", function () {
 
     it("should create new shop for admin for userId and shopObject", function () {
       this.timeout(5000);
-      sandbox.stub(Meteor, "user", () => {
-        return {
-          userId: "12345678",
-          emails: [{
-            address: "user@example.com",
-            provides: "default",
-            verified: true
-          }]
-        };
-      });
+      sandbox.stub(Meteor, "user", () => ({
+        userId: "12345678",
+        emails: [{
+          address: "user@example.com",
+          provides: "default",
+          verified: true
+        }]
+      }));
       const shopId = Random.id();
       Factory.create("account", { _id: "12345678", shopId: shopId });
 

--- a/server/methods/core/workflows/orders.js
+++ b/server/methods/core/workflows/orders.js
@@ -38,9 +38,7 @@ Meteor.methods({
 
     const order = options.order;
 
-    const result = _.every(order.items, (item) => {
-      return _.includes(item.workflow.workflow, "coreOrderItemWorkflow/completed");
-    });
+    const result = _.every(order.items, (item) => _.includes(item.workflow.workflow, "coreOrderItemWorkflow/completed"));
 
     return result;
   }

--- a/server/publications/collections/media.js
+++ b/server/publications/collections/media.js
@@ -44,7 +44,7 @@ Meteor.publish("Media", function (shops) {
   if (RevisionApi.isRevisionControlEnabled()) {
     const revisionHandle = Revisions.find({
       "documentType": "image",
-      "workflow.status": { $nin: [ "revision/published"] }
+      "workflow.status": { $nin: ["revision/published"] }
     }).observe({
       added: (revision) => {
         const media = Media.findOne(revision.documentId);

--- a/server/publications/collections/members-publications.app-test.js
+++ b/server/publications/collections/members-publications.app-test.js
@@ -68,12 +68,12 @@ describe("Account Publications", function () {
       // verify
       const data = cursor.fetch();
       // we expect services will be clean object
-      expect(data.some(_user => {
+      expect(data.some(_user =>
         // we expect two users. First will be without services, second with
         // clean services object
-        return typeof _user.services === "object" &&
-          _.isEqual(_user.services, {});
-      })).to.be.true;
+        typeof _user.services === "object" &&
+          _.isEqual(_user.services, {})
+      )).to.be.true;
     });
   });
 });

--- a/server/publications/collections/members-publications.app-test.js
+++ b/server/publications/collections/members-publications.app-test.js
@@ -68,7 +68,7 @@ describe("Account Publications", function () {
       // verify
       const data = cursor.fetch();
       // we expect services will be clean object
-      expect(data.some(_user =>
+      expect(data.some((_user) =>
         // we expect two users. First will be without services, second with
         // clean services object
         typeof _user.services === "object" &&

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -118,7 +118,7 @@ describe("Publication", function () {
           const data = products[1];
           const expectedTitles = ["My Little Pony", "Shopkins - Peachy"];
 
-          expect(expectedTitles.some(title => title === data.title)).to.be.ok;
+          expect(expectedTitles.some((title) => title === data.title)).to.be.ok;
 
           if (!isDone) {
             isDone = true;
@@ -140,7 +140,7 @@ describe("Publication", function () {
           const expectedTitles = ["Fresh Tomatoes", "Shopkins - Peachy"];
 
           expect(products.length).to.equal(2);
-          expect(expectedTitles.some(title => title === data.title)).to.be.ok;
+          expect(expectedTitles.some((title) => title === data.title)).to.be.ok;
 
           if (isDone === false) {
             isDone = true;
@@ -268,7 +268,7 @@ describe("Publication", function () {
           expect(products.length).to.equal(3);
 
           const data = products[1];
-          expect(["My Little Pony", "Shopkins - Peachy"].some(title => title === data.title)).to.be.ok;
+          expect(["My Little Pony", "Shopkins - Peachy"].some((title) => title === data.title)).to.be.ok;
 
           if (!isDone) {
             isDone = true;

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -117,7 +117,7 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
 
     if (RevisionApi.isRevisionControlEnabled()) {
       const productCursor = Products.find(selector);
-      const productIds = productCursor.map(p => p._id);
+      const productIds = productCursor.map((p) => p._id);
 
       const handle = productCursor.observeChanges({
         added: (id, fields) => {
@@ -211,7 +211,7 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
 
     // Revision control is disabled, but is an admin
     const productCursor = Products.find(selector);
-    const productIds = productCursor.map(p => p._id);
+    const productIds = productCursor.map((p) => p._id);
     const mediaCursor = findProductMedia(this, productIds);
 
     return [
@@ -222,7 +222,7 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
 
   // Everyone else gets the standard, visible products and variants
   const productCursor = Products.find(selector);
-  const productIds = productCursor.map(p => p._id);
+  const productIds = productCursor.map((p) => p._id);
   const mediaCursor = findProductMedia(this, productIds);
 
   return [

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -101,7 +101,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
       { "workflow.status": "active" },
       { _id: Reaction.getPrimaryShopId() }
     ]
-  }).fetch().map(activeShop => activeShop._id);
+  }).fetch().map((activeShop) => activeShop._id);
 
   // if there are filter/params that don't match the schema
   // validate, catch except but return no results
@@ -293,7 +293,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
     const productIds = Products.find(selector, {
       sort: sort,
       limit: productScrollLimit
-    }).map(product => product._id);
+    }).map((product) => product._id);
 
     let newSelector = selector;
 
@@ -455,7 +455,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
   const productIds = Products.find(selector, {
     sort: sort,
     limit: productScrollLimit
-  }).map(product => product._id);
+  }).map((product) => product._id);
 
   let newSelector = { ...selector };
 


### PR DESCRIPTION
Resolves #3566 

Enables the following eslint rules, and fixes and warnings caused by the new rules:

`array-bracket-spacing`
`array-callback-return`
`arrow-body-style`
`arrow-parens`

Please take an extra hard look at these two commits, as I'm not 100% comfortable all the returns are what we want them to be (some `undefined` vs `null`):
https://github.com/reactioncommerce/reaction/pull/3576/commits/37e7d1fdafc692039993320379071a9482518b02
https://github.com/reactioncommerce/reaction/pull/3576/commits/fca582c8c6d31c517c4bd164481b287341d8e715 (there are some fixes to the above commit in this one)

**Notes**

Enabling `array-callback-return` has resulted in many cases where a semi-colon is removed. While it's not explicitly required, in the past we have required them internally, so perhaps something to look into.

Enabling `array-callback-return` has also resulted in a few cases where the line length exceeded our 160 character limit, which in turn produced a new linting error, `max-len`. I've disabled the 160 character limit on these lines, as that seems to be a less important lint rule than `array-callback-return`. I am still seeing this warning here, even though I have the `eslint-disable-line` on the line, so I'm not sure what to do there: `imports/plugins/included/product-variant/components/productGridItems.js 69:1`