### PR TITLE
Fix: import/export eslint rule issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -271,7 +271,16 @@
     // "dot-location": ["error", "property"],
     // "function-paren-newline": ["error", "multiline"],
     "import/export": "error",
-    // "import/first": ["error", "absolute-first"],
+    "import/order": ["error", {
+      "groups": [
+        "builtin",
+        "external",
+        "internal",
+        "parent",
+        "sibling",
+        "index"
+      ]
+    }]
     // "import/newline-after-import": "error",
     // "import/no-duplicates": "error",
     // "import/no-mutable-exports": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -271,16 +271,16 @@
     // "dot-location": ["error", "property"],
     // "function-paren-newline": ["error", "multiline"],
     "import/export": "error",
-    "import/order": ["error", {
-      "groups": [
-        "builtin",
-        "external",
-        "internal",
-        "parent",
-        "sibling",
-        "index"
-      ]
-    }]
+    // "import/order": ["error", {
+    //   "groups": [
+    //     "builtin",
+    //     "external",
+    //     "internal",
+    //     "parent",
+    //     "sibling",
+    //     "index"
+    //   ]
+    // }]
     // "import/newline-after-import": "error",
     // "import/no-duplicates": "error",
     // "import/no-mutable-exports": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -270,7 +270,7 @@
     // "computed-property-spacing": ["error", "never"],
     // "dot-location": ["error", "property"],
     // "function-paren-newline": ["error", "multiline"],
-    // "import/export": "error",
+    "import/export": "error",
     // "import/first": ["error", "absolute-first"],
     // "import/newline-after-import": "error",
     // "import/no-duplicates": "error",

--- a/imports/plugins/core/ui/client/components/index.js
+++ b/imports/plugins/core/ui/client/components/index.js
@@ -1,5 +1,3 @@
-// export ButtonGroup from "./buttonGroup/buttonGroup";
-
 export { Alerts, Alert } from "./alerts";
 export { App } from "./app";
 export { default as Icon } from "./icon/icon";

--- a/imports/plugins/core/ui/client/containers/index.js
+++ b/imports/plugins/core/ui/client/containers/index.js
@@ -1,7 +1,7 @@
 export { default as EditContainer } from "./edit";
-export { default as Alerts } from "./alerts";
-export { default as App } from "./appContainer";
-export { default as ReactionAvatar } from "./avatar";
+export { default as AlertContainer } from "./alerts";
+export { default as AppContainer } from "./appContainer";
+export { default as ReactionAvatarContainer } from "./avatar";
 export { default as SortableItem } from "./sortableItem";
 export { default as MediaGalleryContainer } from "./mediaGallery";
 export { default as TagListContainer } from "./tagListContainer";

--- a/imports/plugins/included/payments-braintree/server/index.js
+++ b/imports/plugins/included/payments-braintree/server/index.js
@@ -1,4 +1,2 @@
 import "./i18n";
 import "./methods/braintree";
-
-export * from "./methods/braintree";

--- a/imports/plugins/included/product-detail-simple/client/index.js
+++ b/imports/plugins/included/product-detail-simple/client/index.js
@@ -23,7 +23,7 @@ import {
 } from "./containers";
 
 import {
-  Alerts,
+  AlertContainer,
   MediaGalleryContainer
 } from "/imports/plugins/core/ui/client/containers";
 
@@ -34,7 +34,7 @@ registerComponent("ProductField", ProductField);
 registerComponent("ProductTags", ProductTags);
 registerComponent("ProductMetadata", ProductMetadata);
 registerComponent("PriceRange", PriceRange);
-registerComponent("AlertContainer", Alerts);
+registerComponent("AlertContainer", AlertContainer);
 registerComponent("VariantList", VariantList);
 registerComponent("MediaGalleryContainer", MediaGalleryContainer);
 registerComponent("SocialContainer", SocialContainer);

--- a/imports/plugins/included/search-mongo/server/jobs/index.js
+++ b/imports/plugins/included/search-mongo/server/jobs/index.js
@@ -1,3 +1,1 @@
 import "./buildSearchCollections";
-
-export * from "./buildSearchCollections";

--- a/lib/collections/schemas/payments.js
+++ b/lib/collections/schemas/payments.js
@@ -202,13 +202,13 @@ export const Invoice = new SimpleSchema({
 registerSchema("Invoice", Invoice);
 
 /**
- * @name Currency
+ * @name CurrencyExchangeRate
  * @type {SimpleSchema}
  * @memberof schemas
  * @property {String} userCurrency, default value: `"USD"`
  * @property {Number} exchangeRate optional
  */
-export const Currency = new SimpleSchema({
+export const CurrencyExchangeRate = new SimpleSchema({
   userCurrency: {
     type: String,
     optional: true,
@@ -221,7 +221,7 @@ export const Currency = new SimpleSchema({
   }
 });
 
-registerSchema("Currency", Currency);
+registerSchema("CurrencyExchangeRate", CurrencyExchangeRate);
 
 /**
  * @name Payment
@@ -231,7 +231,7 @@ registerSchema("Currency", Currency);
  * @property {Address} address optional
  * @property {PaymentMethod} paymentMethod optional
  * @property {Invoice} invoice optional
- * @property {Currency} currency optional
+ * @property {CurrencyExchangeRate} currency optional
  * @property {String} shopId optional
  */
 export const Payment = new SimpleSchema({
@@ -254,7 +254,7 @@ export const Payment = new SimpleSchema({
     optional: true
   },
   currency: {
-    type: Currency,
+    type: CurrencyExchangeRate,
     optional: true
   },
   shopId: {


### PR DESCRIPTION
Resolves part 1/8 of #3568 

Biggest change here is having to rename 3 exports from `imports/plugins/core/ui/client/containers/index.js`

Alerts => AlertContainer
  This was a breaking change and I had to change productDetailSimple as well

App => AppContainer
ReactionAvatar => ReactionAvatarContainer


I also had to rename the Currency schema exported from `lib/collections/schemas/payments.js` but it does not appear that schema was used outside of that file.

Breaking this PR out from the rest of the eslint updates in my issue because these should be reviewed a little more intentionally.
