### PR TITLE
feat: Enable eslint space-unary-ops

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -337,11 +337,11 @@
     // "prefer-spread": "error",
     // "prefer-template": "error",
     // "rest-spread-spacing": ["error", "never"],
-    // "space-unary-ops": ["error", {
-    //   "words": true,
-    //   "nonwords": false,
-    //   "overrides": {}
-    // }],
+    "space-unary-ops": ["error", {
+      "words": true,
+      "nonwords": false,
+      "overrides": {}
+    }],
     // "template-curly-spacing": "error"
   }
 }

--- a/imports/plugins/included/taxes-taxcloud/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-taxcloud/server/hooks/hooks.js
@@ -74,7 +74,7 @@ MethodHooks.after("taxes/calculate", function (options) {
                   Price: items.variants.price,
                   Qty: items.quantity
                 };
-                index ++;
+                index++;
                 cartItems.push(item);
               }
             }

--- a/server/api/core/rightJoin.js
+++ b/server/api/core/rightJoin.js
@@ -23,7 +23,7 @@ const doRightJoinNoIntersection = (leftSet, rightSet) => {
   }
   const findRightOnlyProperties = () => {
     return Object.keys(rightSet).filter(function (key) {
-      if (typeof(rightSet[key]) === "object" &&
+      if (typeof (rightSet[key]) === "object" &&
         !Array.isArray(rightSet[key])) {
         // Nested objects are always considered
         return true;
@@ -34,9 +34,9 @@ const doRightJoinNoIntersection = (leftSet, rightSet) => {
   };
 
   for (const key of findRightOnlyProperties()) {
-    if (typeof(rightSet[key]) === "object") {
+    if (typeof (rightSet[key]) === "object") {
       // subobject or array
-      if (leftSet.hasOwnProperty(key) && (typeof(leftSet[key]) !== "object" ||
+      if (leftSet.hasOwnProperty(key) && (typeof (leftSet[key]) !== "object" ||
            Array.isArray(leftSet[key]) !== Array.isArray(rightSet[ key ]))) {
         // This is not expected!
         throw new Error(


### PR DESCRIPTION
Part of #3573 

Enables eslint's `space-unary-ops`, and fixes the lint issues in a few files.

Changes:
- `a ++` becomes `a++`.
- `typeof(Boolean(a))` becomes `typeof (Boolean(a))`

This shouldn't cause any breaking change. 