### PR TITLE
Fix warnings after turning on eslint prefer-destructuring

### DIFF
--- a/client/modules/core/helpers/apps.js
+++ b/client/modules/core/helpers/apps.js
@@ -50,7 +50,6 @@ export function Apps(optionHash) {
   let key;
   const reactionApps = [];
   let options = {};
-  let shopType;
 
   // allow for object or option.hash
   if (optionHash) {
@@ -67,11 +66,8 @@ export function Apps(optionHash) {
   }
 
   // Get the shop to determine shopType
-  const shop = Shops.findOne({ _id: options.shopId });
-  if (shop) {
-    shopType = shop.shopType;
-  }
-
+  const shop = Shops.findOne({ _id: options.shopId }) || {};
+  const { shopType } = shop;
 
   // remove audience permissions for owner (still needed here for older/legacy calls)
   if (Reaction.hasOwnerAccess() && options.audience) {

--- a/client/modules/core/helpers/permissions.js
+++ b/client/modules/core/helpers/permissions.js
@@ -18,18 +18,18 @@ import { Reaction } from "../";
  */
 Template.registerHelper("hasPermission", function (permissions, options) {
   // default to checking this.userId
-  let userId = Meteor.userId();
+  const loggedInUser = Meteor.userId();
   const shopId = Reaction.getShopId();
   // we don't necessarily need to check here
   // as these same checks and defaults are
   // also performed in Reaction.hasPermission
   if (typeof options === "object") {
     if (options.hash.userId) {
-      userId = options.hash.userId;
-      return Reaction.hasPermission(permissions, userId, shopId);
+      const { userId } = options.hash;
+      return Reaction.hasPermission(permissions, userId || loggedInUser, shopId);
     }
   }
-  return Reaction.hasPermission(permissions, userId, shopId);
+  return Reaction.hasPermission(permissions, loggedInUser, shopId);
 });
 
 /**

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -91,10 +91,9 @@ export default {
 
     // Listen for active shop change
     return Tracker.autorun(() => {
-      let domain;
       let shop;
       if (this.Subscriptions.MerchantShops.ready()) {
-        domain = Meteor.absoluteUrl().split("/")[2].split(":")[0];
+        const [ domain ] = Meteor.absoluteUrl().split("/")[2].split(":");
 
         // if we don't have an active shopId, try to retreive it from the userPreferences object
         // and set the shop from the storedShopId
@@ -278,8 +277,7 @@ export default {
    * @return {Boolean} Boolean - true if has dashboard access for any shop
    */
   hasDashboardAccessForAnyShop(options = { user: Meteor.user(), permissions: ["owner", "admin", "dashboard"] }) {
-    const user = options.user;
-    const permissions = options.permissions;
+    const { user, permissions } = options;
 
     if (!user || !user.roles) {
       return false;
@@ -390,7 +388,7 @@ export default {
     const user = Meteor.user();
 
     if (user) {
-      const profile = Meteor.user().profile;
+      const { profile } = Meteor.user();
       if (profile && profile.preferences && profile.preferences[packageName] && profile.preferences[packageName][preference]) {
         return profile.preferences[packageName][preference];
       }
@@ -766,7 +764,7 @@ export default {
     this.Router.watchPathChange();
     const currentRouteName = this.Router.getRouteName();
     const currentRoute = this.Router.current();
-    const template = currentRoute.route.options.template;
+    const { template } = currentRoute.route.options;
     // find registry entries for routeName
     const reactionApp = Packages.findOne({
       "registry.name": currentRouteName,

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -93,7 +93,9 @@ export default {
     return Tracker.autorun(() => {
       let shop;
       if (this.Subscriptions.MerchantShops.ready()) {
-        const [ domain ] = Meteor.absoluteUrl().split("/")[2].split(":");
+        // get domain (e.g localhost) from absolute url (e.g http://localhost:3000/)
+        const [ , , host ] = Meteor.absoluteUrl().split("/");
+        const [ domain ] = host.split(":");
 
         // if we don't have an active shopId, try to retreive it from the userPreferences object
         // and set the shop from the storedShopId

--- a/imports/plugins/core/accounts/client/containers/userOrdersListContainer.js
+++ b/imports/plugins/core/accounts/client/containers/userOrdersListContainer.js
@@ -10,7 +10,7 @@ const handlers = {};
 
 handlers.handleDisplayMedia = (item) => {
   const variantId = item.variants._id;
-  const productId = item.productId;
+  const { productId } = item;
 
   const variantImage = Media.findOne({
     "metadata.variantId": variantId,
@@ -34,7 +34,7 @@ handlers.handleDisplayMedia = (item) => {
 
 function composer(props, onData) {
   // Get user order from props
-  const orders = props.orders;
+  const { orders } = props;
   const allOrdersInfo = [];
   let isProfilePage = false;
 

--- a/imports/plugins/core/accounts/client/helpers/helpers.js
+++ b/imports/plugins/core/accounts/client/helpers/helpers.js
@@ -56,7 +56,7 @@ export function getUserAvatar(currentUser) {
   const account = Collections.Accounts.findOne(user._id);
   // first we check picture exists. Picture has higher priority to display
   if (account && account.profile && account.profile.picture) {
-    const picture = account.profile.picture;
+    const { picture } = account.profile;
 
     return (
       <Components.ReactionAvatar

--- a/imports/plugins/core/accounts/client/templates/profile/profile.js
+++ b/imports/plugins/core/accounts/client/templates/profile/profile.js
@@ -102,7 +102,7 @@ Template.accountProfile.helpers({
   ReactionAvatar() {
     const account = Collections.Accounts.findOne({ _id: Meteor.userId() });
     if (account && account.profile && account.profile.picture) {
-      const picture = account.profile.picture;
+      const { picture } = account.profile;
       return {
         component: Components.ReactionAvatar,
         currentUser: true,

--- a/imports/plugins/core/checkout/client/containers/completedOrderContainer.js
+++ b/imports/plugins/core/checkout/client/containers/completedOrderContainer.js
@@ -11,7 +11,7 @@ const handlers = {};
 
 handlers.handleDisplayMedia = (item) => {
   const variantId = item.variants._id;
-  const productId = item.productId;
+  const { productId } = item;
 
   const variantImage = Media.findOne({
     "metadata.variantId": variantId,

--- a/imports/plugins/core/components/lib/composer/compose.js
+++ b/imports/plugins/core/components/lib/composer/compose.js
@@ -92,7 +92,7 @@ export default function compose(dataLoader, options = {}) {
       }
 
       render() {
-        const props = this.props;
+        const { props } = this;
         const { data, error } = this.state;
 
         if (error) {

--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -4,12 +4,10 @@ import { Roles } from "meteor/alanning:roles";
 import { Accounts, Groups } from "/lib/collections";
 import { composeWithTracker } from "./composer";
 
-let Reaction;
+let { Reaction } = require("/client/api");
 
-if (Meteor.isClient) {
-  Reaction = require("/client/api").Reaction;
-} else {
-  Reaction = require("/server/api").Reaction;
+if (!Meteor.isClient) {
+  Reaction = require("/server/api");
 }
 
 

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -58,7 +58,7 @@ function composer(props, onData) {
 
     for (const item of registryItems) {
       if (Reaction.hasPermission(item.route, Meteor.userId())) {
-        let icon = item.icon;
+        let { icon } = item;
         if (!item.icon && item.provides && item.provides.includes("settings")) {
           icon = "gear";
         }

--- a/imports/plugins/core/dashboard/client/templates/import/import.js
+++ b/imports/plugins/core/dashboard/client/templates/import/import.js
@@ -6,7 +6,7 @@ import { Media, Products } from "/lib/collections";
 function uploadHandler(event) {
   const shopId = Reaction.getShopId();
   const userId = Meteor.userId();
-  const files = event.target.files.files;
+  const { files } = event.target.files;
 
   for (let i = 0; i < files.length; i++) {
     const parts = files[i].name.split(".");

--- a/imports/plugins/core/dashboard/client/templates/packages/grid/package.js
+++ b/imports/plugins/core/dashboard/client/templates/packages/grid/package.js
@@ -13,7 +13,7 @@ Template.gridPackage.helpers({
    */
   cardProps() {
     const instance = Template.instance();
-    const data = instance.data;
+    const { data } = instance;
     const apps = Reaction.Apps({
       provides: "settings",
       name: data.package.packageName

--- a/imports/plugins/core/discounts/server/hooks/cart.js
+++ b/imports/plugins/core/discounts/server/hooks/cart.js
@@ -16,7 +16,7 @@ import { Cart } from "/lib/collections";
 Cart.after.update((userId, cart, fieldNames) => {
   const trigger = ["discount", "billing", "shipping"];
   if (cart) {
-    let discount = cart.discount;
+    let { discount } = cart;
     for (const field of fieldNames) {
       if (indexOf(trigger, field) !== -1) {
         discount = Meteor.call("discounts/calculate", cart);

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -98,7 +98,7 @@ export const methods = {
         if (billing.paymentMethod) {
           const discount = Discounts.findOne(billing.paymentMethod.id);
           if (discount && discount.calculation) {
-            const processor = billing.paymentMethod.processor;
+            const { processor } = billing.paymentMethod;
             const calculation = discount.calculation.method;
             // we're using processor/calculation
             // as a convention that can be easily

--- a/imports/plugins/core/i18n/client/containers/languageDropdown.js
+++ b/imports/plugins/core/i18n/client/containers/languageDropdown.js
@@ -36,7 +36,7 @@ const composer = (props, onData) => {
           language.translation = "languages." + language.label.toLowerCase();
           // appending a helper to let us know this
           // language is currently selected
-          const profile = Meteor.user().profile;
+          const { profile } = Meteor.user();
           if (profile && profile.lang) {
             if (profile.lang === language.i18n) {
               currentLanguage = profile.lang;

--- a/imports/plugins/core/i18n/client/containers/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/containers/localizationSettings.js
@@ -79,7 +79,7 @@ function composer(props, onData) {
     }
   }
 
-  const currencies = shop.currencies;
+  const { currencies } = shop;
   const currencyList = [];
   const currencyOptions = [];
   for (const currency in currencies) {
@@ -108,7 +108,7 @@ function composer(props, onData) {
   }
 
 
-  const unitsOfMeasure = Shops.findOne().unitsOfMeasure;
+  const { unitsOfMeasure } = Shops.findOne();
   const uomOptions = [];
   if (Array.isArray(unitsOfMeasure)) {
     for (const measure of unitsOfMeasure) {
@@ -119,7 +119,7 @@ function composer(props, onData) {
     }
   }
 
-  const unitsOfLength = Shops.findOne().unitsOfLength;
+  const { unitsOfLength } = Shops.findOne();
   const uolOptions = [];
   if (Array.isArray(unitsOfLength)) {
     for (const length of unitsOfLength) {

--- a/imports/plugins/core/layout/lib/reactionLayout.js
+++ b/imports/plugins/core/layout/lib/reactionLayout.js
@@ -42,7 +42,7 @@ class ReactionLayout extends Component {
           }
 
           if (this.checkElementPermissions(child)) {
-            let component = child.component;
+            let { component } = child;
 
             try {
               if (typeof child.component === "string") {

--- a/imports/plugins/core/logging/server/publications.js
+++ b/imports/plugins/core/logging/server/publications.js
@@ -20,7 +20,7 @@ Meteor.publish("Logs", function (query, options) {
     return this.ready();
   }
 
-  const logType = query.logType;
+  const { logType } = query;
   if (Roles.userIsInRole(this.userId, ["admin", "owner"])) {
     Counts.publish(this, "logs-count", Logs.find({ shopId, logType }));
     return Logs.find({ shopId, logType }, { sort: { date: 1 } });

--- a/imports/plugins/core/orders/client/components/orderSearch.js
+++ b/imports/plugins/core/orders/client/components/orderSearch.js
@@ -33,7 +33,7 @@ class OrderSearch extends Component {
    * @return {null} -
    */
   handleChange = (event) => {
-    const value = event.target.value;
+    const { value } = event.target;
 
     this.setState({
       value

--- a/imports/plugins/core/orders/client/components/orderSummary.js
+++ b/imports/plugins/core/orders/client/components/orderSummary.js
@@ -15,7 +15,7 @@ class OrderSummary extends Component {
   }
 
   badgeStatus() {
-    const order = this.props.order;
+    const { order } = this.props;
     const orderStatus = order && order.workflow && order.workflow.status;
 
     if (orderStatus === "new") {

--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -186,7 +186,7 @@ class InvoiceContainer extends Component {
    */
   handleDisplayMedia = (item) => {
     const variantId = item.variants._id;
-    const productId = item.productId;
+    const { productId } = item;
 
     const variantImage = Media.findOne({
       "metadata.variantId": variantId,
@@ -218,7 +218,7 @@ class InvoiceContainer extends Component {
   }
 
   hasRefundingEnabled() {
-    const order = this.state.order;
+    const { order } = this.state;
     const orderBillingInfo = getBillingInfo(order);
     const paymentMethodId = orderBillingInfo.paymentMethod && orderBillingInfo.paymentMethod.paymentPackageId;
     const paymentMethodName = orderBillingInfo.paymentMethod && orderBillingInfo.paymentMethod.paymentSettingsKey;
@@ -232,7 +232,7 @@ class InvoiceContainer extends Component {
   handleApprove = (event) => {
     event.preventDefault();
 
-    const order = this.state.order;
+    const { order } = this.state;
     approvePayment(order);
   }
 
@@ -243,7 +243,7 @@ class InvoiceContainer extends Component {
       isCapturing: true
     });
 
-    const order = this.state.order;
+    const { order } = this.state;
     capturePayments(order, () => {
       this.setState({
         isCapturing: false
@@ -253,7 +253,7 @@ class InvoiceContainer extends Component {
 
   handleCancelPayment = (event) => {
     event.preventDefault();
-    const order = this.state.order;
+    const { order } = this.state;
     const invoiceTotal = getBillingInfo(order).invoice && getBillingInfo(order).invoice.total;
     const currencySymbol = this.state.currency.symbol;
 
@@ -303,12 +303,12 @@ class InvoiceContainer extends Component {
     event.preventDefault();
 
     const currencySymbol = this.state.currency.symbol;
-    const order = this.state.order;
+    const { order } = this.state;
     const paymentMethod = orderCreditMethod(order) && orderCreditMethod(order).paymentMethod;
     const orderTotal = paymentMethod && paymentMethod.amount;
     const discounts = paymentMethod && paymentMethod.discounts;
     const refund = value;
-    const refunds = this.state.refunds;
+    const { refunds } = this.state;
     const refundTotal = refunds && Array.isArray(refunds) && refunds.reduce((acc, item) => acc + parseFloat(item.amount), 0);
 
     let adjustedTotal;
@@ -356,7 +356,7 @@ class InvoiceContainer extends Component {
   handleRefundItems = () => {
     const paymentMethod = orderCreditMethod(this.state.order) && orderCreditMethod(this.state.order).paymentMethod;
     const orderMode = paymentMethod && paymentMethod.mode;
-    const order = this.state.order;
+    const { order } = this.state;
 
     // Check if payment is yet to be captured approve and capture first before return
     if (orderMode === "authorize") {
@@ -519,7 +519,7 @@ function approvePayment(order) {
     + paymentMethod.invoice.taxes
     , 2);
 
-  const discount = order.discount;
+  const { discount } = order;
   // TODO: review Discount cannot be greater than original total price
   // logic is probably not valid any more. Discounts aren't valid below 0 order.
   if (discount > orderTotal) {
@@ -607,8 +607,7 @@ function capturePayments(order, onCancel) {
 }
 
 const composer = (props, onData) => {
-  const order = props.order;
-  const refunds = props.refunds;
+  const { order, refunds } = props;
 
   const shopBilling = getBillingInfo(order);
   const creditMethod = orderCreditMethod(order);

--- a/imports/plugins/core/orders/client/containers/orderDashboardContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderDashboardContainer.js
@@ -17,7 +17,7 @@ const wrapComponent = (Comp) => (
     }
 
     filterDates = (startDate, endDate) => {
-      const query = this.state.query;
+      const { query } = this.state;
 
       if (startDate && endDate) {
         // generate time for start and end of day
@@ -43,7 +43,7 @@ const wrapComponent = (Comp) => (
 
     filterWorkflowStatus = (event, value) => {
       const query = filterWorkflowStatus(value);
-      const shippingFilter = this.state.shippingFilter;
+      const { shippingFilter } = this.state;
       if (this.state.query.createdAt) {
         query.createdAt = this.state.query.createdAt;
       }
@@ -60,7 +60,7 @@ const wrapComponent = (Comp) => (
 
     filterShippingStatus = (event, value) => {
       const query = filterShippingStatus(value);
-      const workflowFilter = this.state.workflowFilter;
+      const { workflowFilter } = this.state;
 
       if (this.state.query.createdAt) {
         query.createdAt = this.state.query.createdAt;
@@ -78,8 +78,7 @@ const wrapComponent = (Comp) => (
 
     clearFilter = (filterString) => {
       let query;
-      let shippingFilter = this.state.shippingFilter;
-      let workflowFilter = this.state.workflowFilter;
+      let { shippingFilter, workflowFilter } = this.state;
 
       if (filterString === "workflow") {
         workflowFilter = "";

--- a/imports/plugins/core/orders/client/containers/orderSubscriptionContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderSubscriptionContainer.js
@@ -15,7 +15,7 @@ class OrderSubscription extends Component {
 function composer(props, onData) {
   const subscription = Meteor.subscribe("SearchResults", "orders", props.searchQuery);
   let orderSearchResultsIds;
-  const query = props.query;
+  const { query } = props;
 
   if (subscription.ready()) {
     const orderSearchResults = OrderSearch.find().fetch();

--- a/imports/plugins/core/orders/client/containers/orderSummaryContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderSummaryContainer.js
@@ -36,7 +36,7 @@ class OrderSummaryContainer extends Component {
   }
 
   shipmentStatus = () => {
-    const order = this.props.order;
+    const { order } = this.props;
     const shipment = getShippingInfo(this.props.order);
 
     if (shipment.delivered) {

--- a/imports/plugins/core/orders/client/containers/orderTableContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderTableContainer.js
@@ -158,7 +158,7 @@ const wrapComponent = (Comp) => (
      */
     handleDisplayMedia = (item) => {
       const variantId = item.variants._id;
-      const productId = item.productId;
+      const { productId } = item;
 
       const variantImage = Media.findOne({
         "metadata.variantId": variantId,

--- a/imports/plugins/core/orders/client/helpers/index.js
+++ b/imports/plugins/core/orders/client/helpers/index.js
@@ -31,12 +31,9 @@ export function getOrderRiskBadge(riskLevel) {
  * @return {string} label - risklevel value (if risklevel is not normal)
  */
 export function getOrderRiskStatus(order) {
-  let riskLevel;
   const billingForShop = order.billing.find((billing) => billing.shopId === Reaction.getShopId());
-
-  if (billingForShop && billingForShop.paymentMethod && billingForShop.paymentMethod.riskLevel) {
-    riskLevel = billingForShop.paymentMethod.riskLevel;
-  }
+  const paymentMethod = (billingForShop && billingForShop.paymentMethod) || {};
+  const { riskLevel } = paymentMethod;
 
   // normal transactions do not need to be flagged
   if (riskLevel === "normal") {

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -123,7 +123,7 @@ Template.coreOrderShippingInvoice.events({
     const order = instance.state.get("order");
     const invoiceTotal = getBillingInfo(order).invoice && getBillingInfo(order).invoice.total;
     const currencySymbol = instance.state.get("currency").symbol;
-    const paymentMethod = getBillingInfo(order).paymentMethod;
+    const { paymentMethod } = getBillingInfo(order);
 
     Meteor.subscribe("Packages", Reaction.getShopId());
     const packageId = paymentMethod && paymentMethod.paymentPackageId;

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -54,7 +54,7 @@ Template.coreOrderShippingTracking.events({
     });
 
     // send notification to order owner
-    const userId = template.order.userId;
+    const { userId } = template.order;
     const type = "orderShipped";
     const prefix = Reaction.getShopPrefix();
     const url = `${prefix}/notifications`;
@@ -87,7 +87,7 @@ Template.coreOrderShippingTracking.events({
     event.stopPropagation();
 
     const currentData = Template.currentData();
-    const order = template.order;
+    const { order } = template;
     const shipment = currentData.fulfillment;
     const tracking = event.target.trackingNumber.value;
 
@@ -106,7 +106,7 @@ Template.coreOrderShippingTracking.events({
 
 Template.coreOrderShippingTracking.helpers({
   printableLabels() {
-    const order = Template.instance().order;
+    const { order } = Template.instance();
     const shipment = getShippingInfo(order);
 
     if (shipment) {
@@ -120,7 +120,7 @@ Template.coreOrderShippingTracking.helpers({
   },
   isShipped() {
     const currentData = Template.currentData();
-    const order = Template.instance().order;
+    const { order } = Template.instance();
 
     const shippedItems = currentData.fulfillment && currentData.fulfillment.items.every((shipmentItem) => {
       const fullItem = order.items.find((orderItem) => {
@@ -137,7 +137,7 @@ Template.coreOrderShippingTracking.helpers({
 
   isNotCanceled() {
     const currentData = Template.currentData();
-    const order = Template.instance().order;
+    const { order } = Template.instance();
 
     const canceledItems = currentData.fulfillment && currentData.fulfillment.items.every((shipmentItem) => {
       const fullItem = order.items.find((orderItem) => {
@@ -154,7 +154,7 @@ Template.coreOrderShippingTracking.helpers({
 
   isCompleted() {
     const currentData = Template.currentData();
-    const order = Template.instance().order;
+    const { order } = Template.instance();
 
     const completedItems = currentData.fulfillment && currentData.fulfillment.items.every((shipmentItem) => {
       const fullItem = order.items.find((orderItem) => {
@@ -179,7 +179,7 @@ Template.coreOrderShippingTracking.helpers({
     // TODO: future proof by not using flatRates, but rather look for editable:true
     if (settings && settings.flatRates.enabled === true) {
       const template = Template.instance();
-      const order = template.order;
+      const { order } = template;
       const shipment = getShippingInfo(order);
       const editing = template.showTrackingEditForm.get();
       let view = false;
@@ -197,11 +197,11 @@ Template.coreOrderShippingTracking.helpers({
     return Template.instance().order;
   },
   shipment() {
-    const order = Template.instance().order;
+    const { order } = Template.instance();
     return getShippingInfo(order);
   },
   shipmentReady() {
-    const order = Template.instance().order;
+    const { order } = Template.instance();
     const shipment = getShippingInfo(order);
     const shipmentWorkflow = shipment.workflow;
 


### PR DESCRIPTION
Part of `prefer-destructuring` which is part of #3573

This is the first of a group of PRs to enable `prefer-destructuring` eslint rule. This can be merged as is (when approved).

Some features to check (based on the files touched):
- `reactionApps`: This is used in a number of places, e,g the main dropdown menu, test that nothing breaks around there
- Template helper hasPermission: Used in blaze, e.g [here](https://github.com/reactioncommerce/reaction/blob/master/imports/plugins/core/accounts/client/templates/dashboard/dashboard.html#L2) as a wrapper around accounts dashboard template. 
- Localisation panel in dashboard, specifically units of measures
- Orders panel & invoiceContainer in Orders dashboard side panel