### PR TITLE
(refactor): 3574 fix eslint and ARIA issues for notifications

### DIFF
--- a/imports/plugins/core/ui/client/components/list/listItem.js
+++ b/imports/plugins/core/ui/client/components/list/listItem.js
@@ -28,6 +28,14 @@ class ListItem extends Component {
     }
   }
 
+  handleOnKeyUp = (event) => {
+    // keyCode 32 (spacebar)
+    // keyCode 13 (enter/return)
+    if (event.keyCode === 32 || event.keyCode === 13) {
+      this.handleClick(event);
+    }
+  }
+
   handleSwitchChange = (event, isChecked, name) => {
     event.preventDefault();
     event.stopPropagation();
@@ -144,7 +152,13 @@ class ListItem extends Component {
     }, this.props.listItemClassName);
 
     return (
-      <div className={listItemClassName} onClick={this.handleClick}>
+      <div
+        className={listItemClassName}
+        onClick={this.handleClick}
+        onKeyUp={this.handleOnKeyUp}
+        role="button"
+        tabIndex={0}
+      >
         {this.renderIcon()}
         {this.renderContent()}
         {this.renderAction()}

--- a/imports/plugins/included/notifications/client/components/notificationDropdown.js
+++ b/imports/plugins/included/notifications/client/components/notificationDropdown.js
@@ -1,98 +1,13 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import moment from "moment";
-import { registerComponent } from "@reactioncommerce/reaction-components";
-import { Link } from "@reactioncommerce/reaction-router";
-import { Reaction } from "/client/api";
+import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 
-class NotificationDropdown extends Component {
-  constructor(props) {
-    super(props);
-    this.prefix = Reaction.getShopPrefix();
-    this.renderNoNotifications = this.renderNoNotifications.bind(this);
-    this.renderDropdownHead = this.renderDropdownHead.bind(this);
-    this.handleClick = this.handleClick.bind(this);
-  }
-
-  renderNoNotifications(notifyArr) {
-    if (notifyArr.length <= 0) {
-      return (
-        <li className="notification">
-          <div className="media">
-            <div className="media-body">
-              <strong className="notification-title" data-i18n="notifications.body.noNotifications">No notifications yet</strong>
-            </div>
-          </div>
-        </li>
-      );
-    }
-    return null;
-  }
-
-  handleClick(notify) {
-    if (notify.type === "forAdmin") {
-      const actionViewData = Reaction.Apps({
-        name: "reaction-orders",
-        provides: "dashboard"
-      });
-      Reaction.showActionView(actionViewData);
-    } else {
-      Reaction.Router.go(notify.url);
-    }
-
-    const { markOneAsRead } = this.props;
-    return markOneAsRead(notify._id);
-  }
-
-  renderDropdownHead() {
-    const { notificationList, unread, markAllAsRead } = this.props;
-    return (
-      <div className="dropdown-toolbar">
-        <div className="dropdown-toolbar-actions">
-          <a onClick={() => { markAllAsRead(notificationList); }} data-i18n="notifications.body.markAllAsRead"> Mark all as read</a>
-        </div>
-        <h3 className="dropdown-toolbar-title"><span data-i18n="notifications.body.recent">Recent</span> ({unread})</h3>
-      </div>
-    );
-  }
-
-  render() {
-    const { notificationList } = this.props;
-    return (
-      <div className="notify-bar">
-        { this.renderDropdownHead() }
-        <ul className="dropdown-notify notifications">
-          { this.renderNoNotifications(notificationList) }
-          { notificationList.map((notify, key) => {
-            const timeNow = moment(notify.timeSent).fromNow();
-            const read = `notification ${notify.status}`;
-            const i18n = `notifications.messages.${notify.type}`;
-            return (
-              <li className={read} key={key}>
-                <a onClick={() => {
-                  this.handleClick(notify);
-                }}
-                >
-                  <div className="media">
-                    <div className="media-body">
-                      <strong className="notification-title" data-i18n={i18n}>{notify.message}</strong>
-                      <div className="notification-meta">
-                        <small className="timestamp">{timeNow}</small>
-                      </div>
-                    </div>
-                  </div>
-                </a>
-              </li>
-            );
-          })}
-        </ul>
-        <div className="dropdown-footer text-center">
-          <Link to="/notifications" data-i18n="notifications.body.viewAll">View All</Link>
-        </div>
-      </div>
-    );
-  }
-}
+const NotificationDropdown = (props) => (
+  <Components.NotificationRoute
+    {...props}
+    showViewAll={true}
+  />
+);
 
 NotificationDropdown.propTypes = {
   markAllAsRead: PropTypes.func.isRequired,

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import moment from "moment";
 import { Reaction } from "/client/api";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
+import { Link } from "@reactioncommerce/reaction-router";
 
 class NotificationRoute extends Component {
   handleNoNotifications = (notifyArr) => {
@@ -86,6 +87,11 @@ class NotificationRoute extends Component {
             );
           })}
         </div>
+        {this.props.showViewAll &&
+          <div className="dropdown-footer text-center">
+            <Link to="/notifications" data-i18n="notifications.body.viewAll">View All</Link>
+          </div>
+        }
       </div>
     );
   }
@@ -95,6 +101,7 @@ NotificationRoute.propTypes = {
   markAllAsRead: PropTypes.func,
   markOneAsRead: PropTypes.func,
   notificationList: PropTypes.array,
+  showViewAll: PropTypes.bool,
   unread: PropTypes.number
 };
 

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -68,21 +68,21 @@ class NotificationRoute extends Component {
             const read = `notification ${notify.status}`;
             const i18n = `notifications.messages.${notify.type}`;
             return (
-              <li className={read} key={key}>
-                <a onClick={() => {
-                  this.handleClick(notify);
-                }}
-                >
-                  <div className="media">
-                    <div className="media-body">
-                      <strong className="notification-title" data-i18n={i18n}>{notify.message}</strong>
-                      <div className="notification-meta">
-                        <small className="timestamp">{timeNow}</small>
-                      </div>
+              <Components.ListItem
+                key={key}
+                listItemClassName={read}
+                onClick={this.handleClick}
+                value={notify}
+              >
+                <div className="media">
+                  <div className="media-body">
+                    <strong className="notification-title" data-i18n={i18n}>{notify.message}</strong>
+                    <div className="notification-meta">
+                      <small className="timestamp">{timeNow}</small>
                     </div>
                   </div>
-                </a>
-              </li>
+                </div>
+              </Components.ListItem>
             );
           })}
         </div>

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -5,15 +5,7 @@ import { Reaction } from "/client/api";
 
 
 class NotificationRoute extends Component {
-  constructor(props) {
-    super(props);
-
-    this.handleNoNotifications = this.handleNoNotifications.bind(this);
-    this.renderDropdownHead = this.renderDropdownHead.bind(this);
-    this.handleClick = this.handleClick.bind(this);
-  }
-
-  handleNoNotifications(notifyArr) {
+  handleNoNotifications = (notifyArr) => {
     if (notifyArr.length <= 0) {
       return (
         <li className="notification">
@@ -28,7 +20,7 @@ class NotificationRoute extends Component {
     return null;
   }
 
-  handleClick(notify) {
+  handleClick = (event, notify) => {
     if (notify.type === "forAdmin") {
       const actionViewData = Reaction.Apps({
         name: "reaction-orders",

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -44,6 +44,7 @@ class NotificationRoute extends Component {
     const { unread } = this.props;
     return (
       <div className="dropdown-toolbar">
+        <h3 className="dropdown-toolbar-title"><span data-i18n="notifications.body.recent">Recent</span> ({unread})</h3>
         <div className="dropdown-toolbar-actions">
           <Components.Button
             label={"Mark all as read"}
@@ -51,7 +52,6 @@ class NotificationRoute extends Component {
             onClick={this.handleMarkAllAsRead}
           />
         </div>
-        <h3 className="dropdown-toolbar-title"><span data-i18n="notifications.body.recent">Recent</span> ({unread})</h3>
       </div>
     );
   }

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -89,4 +89,6 @@ NotificationRoute.propTypes = {
   unread: PropTypes.number
 };
 
+registerComponent("NotificationRoute", NotificationRoute);
+
 export default NotificationRoute;

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -35,12 +35,21 @@ class NotificationRoute extends Component {
     return markOneAsRead(notify._id);
   }
 
+  handleMarkAllAsRead = () => {
+    const { notificationList, markAllAsRead } = this.props;
+    markAllAsRead(notificationList);
+  }
+
   renderDropdownHead() {
-    const { notificationList, unread, markAllAsRead } = this.props;
+    const { unread } = this.props;
     return (
       <div className="dropdown-toolbar">
         <div className="dropdown-toolbar-actions">
-          <a onClick={() => { markAllAsRead(notificationList); }} data-i18n="notifications.body.markAllAsRead"> Mark all as read</a>
+          <Components.Button
+            label={"Mark all as read"}
+            i18nKeyLabel={"notifications.body.markAllAsRead"}
+            onClick={this.handleMarkAllAsRead}
+          />
         </div>
         <h3 className="dropdown-toolbar-title"><span data-i18n="notifications.body.recent">Recent</span> ({unread})</h3>
       </div>

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -52,7 +52,7 @@ class NotificationRoute extends Component {
     return (
       <div className="notify-bar">
         { this.renderDropdownHead() }
-        <ul className="dropdown-notify notifications">
+        <div className="dropdown-notify notifications">
           { this.handleNoNotifications(notificationList) }
           { notificationList.map((notify, key) => {
             const timeNow = moment(notify.timeSent).fromNow();
@@ -76,7 +76,7 @@ class NotificationRoute extends Component {
               </li>
             );
           })}
-        </ul>
+        </div>
       </div>
     );
   }

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import moment from "moment";
 import { Reaction } from "/client/api";
-
+import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 
 class NotificationRoute extends Component {
   handleNoNotifications = (notifyArr) => {

--- a/imports/plugins/included/notifications/client/styles/dropdown.css
+++ b/imports/plugins/included/notifications/client/styles/dropdown.css
@@ -129,6 +129,9 @@ html:not(.rtl) .dropdown .notify-drop.dropdown-menu {
   display: block;
 }
 .dropdown-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   padding-top: 6px;
   padding-left: 20px;
   padding-right: 20px;


### PR DESCRIPTION
Part of #3574

The notifications dropdown required some substantial changes to bring it in line with Aria compliance due to updated eslint rules.

### To Test
- As any user, add products to cart and checkout
- After checkout is completed, return the home age and check the alerts in navigation bar
- The alert drop-down should look close to the same design as it used to but now be fully tabbable and (spacebar/enter) should work on most links. The same should be true for the `/notifications` page.

**Note** Circle CI test will fail as this is a small part of the `mm-3574-eslint-9` branch and more linting issues are being worked on there. The PR merges back into that branch when approved.