### PR TITLE
refactor: Dynamic load SMS pkgs to make server startup faster

### DIFF
--- a/imports/plugins/included/sms/server/methods/sms.js
+++ b/imports/plugins/included/sms/server/methods/sms.js
@@ -1,9 +1,23 @@
-import Twilio from "twilio";
-import Nexmo from "nexmo";
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Sms, Accounts } from "/lib/collections";
 import { Reaction, Logger } from "/server/api";
+
+// We lazy load these in order to shave a few seconds off the time
+// it takes Meteor to start/restart the app.
+let Twilio;
+async function lazyLoadTwilio() {
+  if (Twilio) return;
+  const mod = await import("twilio");
+  Twilio = mod.default;
+}
+
+let Nexmo;
+async function lazyLoadNexmo() {
+  if (Nexmo) return;
+  const mod = await import("nexmo");
+  Nexmo = mod.default;
+}
 
 /**
  * @file Meteor methods for SMS. Run these methods using `Meteor.call()`.
@@ -58,38 +72,37 @@ Meteor.methods({
       }
     }
 
-    if (phone) {
-      const smsSettings = Sms.findOne({ shopId });
+    if (!phone) return;
 
-      if (smsSettings) {
-        const { apiKey, apiToken, smsPhone, smsProvider } = smsSettings;
-        if (smsProvider === "twilio") {
-          Logger.debug("choose twilio");
-          const client = new Twilio(apiKey, apiToken);
-          client.messages.create({
-            to: phone,
-            from: smsPhone,
-            body: message
-          }, (err) => {
-            if (err) {
-              return Logger.error(err);
-            }
-          });
-          return;
+    const smsSettings = Sms.findOne({ shopId });
+    if (!smsSettings) return;
+
+    const { apiKey, apiToken, smsPhone, smsProvider } = smsSettings;
+    if (smsProvider === "twilio") {
+      Logger.debug("choose twilio");
+      Promise.await(lazyLoadTwilio());
+      const client = new Twilio(apiKey, apiToken);
+      client.messages.create({
+        to: phone,
+        from: smsPhone,
+        body: message
+      }, (err) => {
+        if (err) {
+          return Logger.error(err);
         }
-        if (smsProvider === "nexmo") {
-          Logger.debug("choose nexmo");
-          const client = new Nexmo({
-            apiKey,
-            apiSecret: apiToken
-          });
-          client.message.sendSms(smsPhone, phone, message, {}, (err) => {
-            if (err) {
-              return Logger.error(err);
-            }
-          });
+      });
+      return;
+    }
+
+    if (smsProvider === "nexmo") {
+      Logger.debug("choose nexmo");
+      Promise.await(lazyLoadNexmo());
+      const client = new Nexmo({ apiKey, apiSecret: apiToken });
+      client.message.sendSms(smsPhone, phone, message, {}, (err) => {
+        if (err) {
+          return Logger.error(err);
         }
-      }
+      });
     }
   }
 });

--- a/imports/plugins/included/sms/server/methods/sms.js
+++ b/imports/plugins/included/sms/server/methods/sms.js
@@ -98,10 +98,16 @@ Meteor.methods({
       Logger.debug("choose nexmo");
       Promise.await(lazyLoadNexmo());
       const client = new Nexmo({ apiKey, apiSecret: apiToken });
-      client.message.sendSms(smsPhone, phone, message, {}, (err) => {
+      client.message.sendSms(smsPhone, phone, message, (err, result) => {
         if (err) {
-          return Logger.error(err);
+          Logger.error("Nexmo error", err);
         }
+
+        if (result && Array.isArray(result.messages) && result.messages[0]["error-text"]) {
+          Logger.error("Nexmo error sending sms", result.messages[0]["error-text"]);
+        }
+
+        Logger.debug(JSON.stringify(result));
       });
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13803,119 +13803,19 @@
       }
     },
     "nexmo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/nexmo/-/nexmo-2.0.2.tgz",
-      "integrity": "sha1-Flsgr3sKVmiQcUt+v1O+ZF8Flv0=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nexmo/-/nexmo-2.2.0.tgz",
+      "integrity": "sha512-7D/QVyQakLJ8M40hANSvINzswK/3XWfml0hY7Ce2pwn5Kinu5UL5i5+nobnvvftoi0mv1Sx288+fmVEqJkh0Mw==",
       "requires": {
         "jsonwebtoken": "7.4.3",
+        "request": "2.83.0",
         "uuid": "2.0.3"
       },
       "dependencies": {
-        "base64url": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-          "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-        },
-        "buffer-equal-constant-time": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-        },
-        "ecdsa-sig-formatter": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-          "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
-          "requires": {
-            "base64url": "2.0.0",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "isemail": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-        },
-        "joi": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-          "requires": {
-            "hoek": "2.16.3",
-            "isemail": "1.2.0",
-            "moment": "2.19.3",
-            "topo": "1.1.0"
-          }
-        },
-        "jsonwebtoken": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
-          "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
-          "requires": {
-            "joi": "6.10.1",
-            "jws": "3.1.4",
-            "lodash.once": "4.1.1",
-            "ms": "2.0.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "jwa": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-          "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
-          "requires": {
-            "base64url": "2.0.0",
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.9",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "jws": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-          "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
-          "requires": {
-            "base64url": "2.0.0",
-            "jwa": "1.1.5",
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "lodash.once": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "topo": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
         "uuid": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "meteor-node-stubs": "^0.3.2",
     "moment": "^2.19.3",
     "moment-timezone": "^0.5.14",
-    "nexmo": "^2.0.2",
+    "nexmo": "^2.2.0",
     "nock": "^9.1.3",
     "node-geocoder": "^3.21.1",
     "node-loggly-bulk": "^2.2.0",


### PR DESCRIPTION
When profiling Meteor, 2-3 seconds of start/restart time is spent requiring the Twilio and Nexmo packages. I moved these into dynamic imports, which means startup is faster but the first method call for each provider will be slower. This seems like a good tradeoff.

### Testing

1. Run with `METEOR_PROFILE=1 meteor` command and notice in the `Top leaves:` list at the very end that `require("twilio")` and `require("nexmo")` are no longer listed because they don't happen during startup.
1. Log in as the default admin user, or any admin user.
1. Enter a real phone number (yours) for the user on the user profile form (add default address)
1. In admin dashboard > SMS settings, choose Twilio and enter Twilio credentials and a Twilio phone number that is owned by that account and has SMS enabled.
1. In the Chrome console, enter `Meteor.call("sms/send", "TEST", Meteor.userId(), ReactionCore._shopId.get(), console.log.bind(console))`. Verify that your phone number receives the text in a few seconds.
1. In admin dashboard > SMS settings, switch to Nexmo and test that the same way.

I tested Twilio with my own account but did not test Nexmo. I'm not sure if we have some testing credentials we usually use.