### PR TITLE
(fix): 3572 Enable and fix eslint rules (7)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -320,7 +320,7 @@
     // "object-property-newline": ["error", { "allowAllPropertiesOnSameLine": true }],
     // "object-shorthand": ["error", "always"],
     // "operator-assignment": ["error", "always"],
-    // "prefer-arrow-callback": ["error", { "allowNamedFunctions": false, "allowUnboundThis": true }],
+    "prefer-arrow-callback": ["error", { "allowNamedFunctions": false, "allowUnboundThis": true }]
     // "prefer-destructuring": ["error", {
     //   "VariableDeclarator": {
     //     "array": false,

--- a/client/modules/core/helpers/apps.js
+++ b/client/modules/core/helpers/apps.js
@@ -109,7 +109,7 @@ export function Apps(optionHash) {
   // For now, the audience checks (after the Package.find call) filters out the registry items based on permissions. But
   // part of the filtering should have been handled by the Package.find call, if the "audience" filter works as it should.
   Packages.find(filter).forEach((app) => {
-    const matchingRegistry = _.filter(app.registry, function (item) {
+    const matchingRegistry = _.filter(app.registry, (item) => {
       const itemFilter = _.cloneDeep(registryFilter);
 
       // check audience permissions only if they exist as part of optionHash and are part of the registry item

--- a/client/modules/core/helpers/layout.js
+++ b/client/modules/core/helpers/layout.js
@@ -15,7 +15,7 @@ import { Template } from "meteor/templating";
  * @param {Object} options - workflow defaults to "coreLayout/coreWorkflow"
  * @returns {Array} returns an array with labels, templates that match workflow
  */
-Template.registerHelper("reactionTemplate", function (options) {
+Template.registerHelper("reactionTemplate", (options) => {
   const shopId = options.hash.shopId || Reaction.getShopId();
   // get shop info, defaults to current
   const Shop = Collections.Shops.findOne(shopId);
@@ -73,7 +73,7 @@ Template.registerHelper("reactionTemplate", function (options) {
   });
 
   //  we can have multiple packages contributing to the layout / workflow
-  packages.forEach(function (reactionPackage) {
+  packages.forEach((reactionPackage) => {
     const layoutWorkflows = _.filter(reactionPackage.layout, options.hash);
     // check the packages for layout workflow templates
     for (layout of layoutWorkflows) {

--- a/client/modules/core/helpers/permissions.js
+++ b/client/modules/core/helpers/permissions.js
@@ -16,7 +16,7 @@ import { Reaction } from "../";
  * @param  {String} checkUserId - optional Meteor.userId, default to current
  * @return {Boolean}
  */
-Template.registerHelper("hasPermission", function (permissions, options) {
+Template.registerHelper("hasPermission", (permissions, options) => {
   // default to checking this.userId
   let userId = Meteor.userId();
   const shopId = Reaction.getShopId();
@@ -37,7 +37,7 @@ Template.registerHelper("hasPermission", function (permissions, options) {
  * @summary check if user has owner access
  * @return {Boolean} return true if owner
  */
-Template.registerHelper("hasOwnerAccess", function () {
+Template.registerHelper("hasOwnerAccess", () => {
   return Reaction.hasOwnerAccess();
 });
 
@@ -46,7 +46,7 @@ Template.registerHelper("hasOwnerAccess", function () {
  * @summary check if user has admin access
  * @return {Boolean} return true if admin
  */
-Template.registerHelper("hasAdminAccess", function () {
+Template.registerHelper("hasAdminAccess", () => {
   return Reaction.hasAdminAccess();
 });
 
@@ -55,7 +55,7 @@ Template.registerHelper("hasAdminAccess", function () {
  * @summary check if user has dashboard access
  * @return {Boolean} return true if user has dashboard permission
  */
-Template.registerHelper("hasDashboardAccess", function () {
+Template.registerHelper("hasDashboardAccess", () => {
   return Reaction.hasDashboardAccess();
 });
 
@@ -64,6 +64,6 @@ Template.registerHelper("hasDashboardAccess", function () {
  * @summary check if guest users are allowed to checkout
  * @return {Boolean} return true if shop has guest checkout enabled
  */
-Template.registerHelper("allowGuestCheckout", function () {
+Template.registerHelper("allowGuestCheckout", () => {
   return Reaction.allowGuestCheckout();
 });

--- a/client/modules/core/helpers/templates.js
+++ b/client/modules/core/helpers/templates.js
@@ -14,11 +14,11 @@ import * as Schemas from "/lib/collections/schemas";
 import { toCamelCase } from "/lib/api";
 
 
-Template.registerHelper("Collections", function () {
+Template.registerHelper("Collections", () => {
   return Collections;
 });
 
-Template.registerHelper("Schemas", function () {
+Template.registerHelper("Schemas", () => {
   return Schemas;
 });
 
@@ -28,7 +28,7 @@ Template.registerHelper("Schemas", function () {
  * @return {Boolean} returns true/null if user has registered
  */
 
-Template.registerHelper("currentUser", function () {
+Template.registerHelper("currentUser", () => {
   if (typeof Reaction === "object") {
     const shopId = Reaction.getShopId();
     const user = Accounts.user();
@@ -49,7 +49,7 @@ Template.registerHelper("currentUser", function () {
  * @summary formats moment.js months into an array for autoform selector
  * @return {Array} returns array of months [value:, label:]
  */
-Template.registerHelper("monthOptions", function (showDefaultOption = true) {
+Template.registerHelper("monthOptions", (showDefaultOption = true) => {
   const label = i18next.t("app.monthOptions", "Choose month");
   const localLocale = tz;
 
@@ -97,7 +97,7 @@ Template.registerHelper("monthOptions", function (showDefaultOption = true) {
  * @summary formats moment.js next 9 years into array for autoform selector
  * @return {Array} returns array of years [value:, label:]
  */
-Template.registerHelper("yearOptions", function (showDefaultOption = true) {
+Template.registerHelper("yearOptions", (showDefaultOption = true) => {
   const label = i18next.t("app.yearOptions", "Choose year");
   const yearOptions = [];
 
@@ -124,7 +124,7 @@ Template.registerHelper("yearOptions", function (showDefaultOption = true) {
  * @summary formats moment.js timezones into array for autoform selector
  * @return {Array} returns array of timezones [value:, label:]
  */
-Template.registerHelper("timezoneOptions", function () {
+Template.registerHelper("timezoneOptions", () => {
   const label = i18next.t("app.timezoneOptions", "Choose timezone");
   const timezoneOptions = [{
     value: "",
@@ -147,7 +147,7 @@ Template.registerHelper("timezoneOptions", function () {
  * @param {String} str - camelcased string
  * @return {String} returns space formatted string
  */
-Template.registerHelper("camelToSpace", function (str) {
+Template.registerHelper("camelToSpace", (str) => {
   const downCamel = str.replace(/\W+/g, "-").replace(/([a-z\d])([A-Z])/g, "$1 $2");
   return downCamel.toLowerCase();
 });
@@ -158,7 +158,7 @@ Template.registerHelper("camelToSpace", function (str) {
  * @param {String} str - string
  * @return {String} returns lowercased string
  */
-Template.registerHelper("toLowerCase", function (str) {
+Template.registerHelper("toLowerCase", (str) => {
   return str.toLowerCase();
 });
 
@@ -168,7 +168,7 @@ Template.registerHelper("toLowerCase", function (str) {
  * @param {String} str - string
  * @return {String} returns uppercased string
  */
-Template.registerHelper("toUpperCase", function (str) {
+Template.registerHelper("toUpperCase", (str) => {
   return str.toUpperCase();
 });
 
@@ -178,7 +178,7 @@ Template.registerHelper("toUpperCase", function (str) {
  * @param {String} str - string
  * @return {String} returns string with first letter capitalized
  */
-Template.registerHelper("capitalize", function (str) {
+Template.registerHelper("capitalize", (str) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 });
 
@@ -188,7 +188,7 @@ Template.registerHelper("capitalize", function (str) {
  * @param {String} str - string
  * @return {String|undefined} returns camelCased string
  */
-Template.registerHelper("toCamelCase", function (str) {
+Template.registerHelper("toCamelCase", (str) => {
   return !!str && toCamelCase(str);
 });
 
@@ -198,7 +198,7 @@ Template.registerHelper("toCamelCase", function (str) {
  * @summary get the shop name
  * @return {String} returns site name
  */
-Template.registerHelper("siteName", function () {
+Template.registerHelper("siteName", () => {
   const shop = Collections.Shops.findOne();
   return typeof shop === "object" && shop.name ? shop.name : "";
 });
@@ -216,7 +216,7 @@ Template.registerHelper("siteName", function () {
  * @param {String} v2 - second variable to compare
  * @return {Boolean} returns true/false
  */
-Template.registerHelper("condition", function (v1, operator, v2) {
+Template.registerHelper("condition", (v1, operator, v2) => {
   switch (operator) {
     case "==":
     case "eq":
@@ -260,7 +260,7 @@ Template.registerHelper("condition", function (v1, operator, v2) {
  * @param {String} v2 - variable two
  * @return {String} returns v1 || v2
  */
-Template.registerHelper("orElse", function (v1, v2) {
+Template.registerHelper("orElse", (v1, v2) => {
   return v1 || v2;
 });
 
@@ -270,9 +270,9 @@ Template.registerHelper("orElse", function (v1, v2) {
  * @param {Object} context - object to parse into key / value
  * @return {Array} returns array[key:,value:]
  */
-Template.registerHelper("key_value", function (context) {
+Template.registerHelper("key_value", (context) => {
   const result = [];
-  _.each(context, function (value, key) {
+  _.each(context, (value, key) => {
     return result.push({
       key: key,
       value: value
@@ -288,7 +288,7 @@ Template.registerHelper("key_value", function (context) {
  * @param {String} text - text
  * @returns {String} returns formatted Spacebars.SafeString
  */
-Template.registerHelper("nl2br", function (text) {
+Template.registerHelper("nl2br", (text) => {
   const nl2br = (text + "").replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, "$1" +
     "<br>" + "$2");
   return new Spacebars.SafeString(nl2br);
@@ -305,7 +305,7 @@ Template.registerHelper("nl2br", function (text) {
  * @param {String} block - hash of moment options, ie: format=""
  * @return {Date} return formatted date
  */
-Template.registerHelper("dateFormat", function (context, block) {
+Template.registerHelper("dateFormat", (context, block) => {
   const f = block.hash.format || "MMM DD, YYYY hh:mm:ss A";
   return moment(context).format(f);
 });
@@ -320,7 +320,7 @@ Template.registerHelper("dateFormat", function (context, block) {
  * @param {String} context - moment context
  * @return {Date} return formatted date
  */
-Template.registerHelper("timeAgo", function (context) {
+Template.registerHelper("timeAgo", (context) => {
   return moment(context).from(new Date());
 });
 
@@ -333,7 +333,7 @@ Template.registerHelper("timeAgo", function (context) {
  * @param {String} pString - plural string ie " thing"
  * @todo adapt to, and use i18next
  */
-Template.registerHelper("pluralize", function (nCount, pString) {
+Template.registerHelper("pluralize", (nCount, pString) => {
   if (nCount === 1) {
     return "1 " + pString;
   }

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -783,7 +783,7 @@ export default {
 
     // valid application
     if (reactionApp) {
-      const settingsData = _.find(reactionApp.registry, function (item) {
+      const settingsData = _.find(reactionApp.registry, (item) => {
         return item.provides && item.provides.includes(provides) && item.template === template;
       });
       return settingsData;
@@ -829,7 +829,7 @@ function createCountryCollection(countries) {
       });
     }
   }
-  countryOptions.sort(function (a, b) {
+  countryOptions.sort((a, b) => {
     if (a.label < b.label) {
       return -1;
     }

--- a/client/modules/core/startup.js
+++ b/client/modules/core/startup.js
@@ -12,11 +12,11 @@ const cookieName = "_RcFallbackLoginToken";
  *  Startup Reaction
  *  Init Reaction client
  */
-Meteor.startup(function () {
+Meteor.startup(() => {
   // init the core
   Reaction.init();
   // initialize anonymous guest users
-  return Tracker.autorun(function () {
+  return Tracker.autorun(() => {
     const userId = Meteor.userId();
 
     if (userId && !isLocalStorageAvailable() && !readCookie(cookieName)) {
@@ -35,7 +35,7 @@ Meteor.startup(function () {
     // TODO: maybe `visibilityState` will be better here
     let loggingIn;
     let sessionId;
-    Tracker.nonreactive(function () {
+    Tracker.nonreactive(() => {
       loggingIn = Accounts.loggingIn();
       sessionId = store("Reaction.session");
     });

--- a/client/modules/core/subscriptions.js
+++ b/client/modules/core/subscriptions.js
@@ -56,7 +56,7 @@ Subscriptions.Media = Subscriptions.Manager.subscribe("Media");
 /**
  * Subscriptions that need to reload on new sessions
  */
-Tracker.autorun(function () {
+Tracker.autorun(() => {
   // we are trying to track both amplify and Session.get here, but the problem
   // is - we can't track amplify. It just not tracked. So, to track amplify we
   // are using dirty hack inside Accounts.loginWithAnonymous method.

--- a/client/modules/i18n/helpers.js
+++ b/client/modules/i18n/helpers.js
@@ -17,7 +17,7 @@ import { formatPriceString } from "./currency";
  * @example {{i18n "accountsTemplate.error" "Invalid Email"}}
  * @return {String} returns i18n translated message
  */
-Template.registerHelper("i18n", function (i18nKey, i18nMessage) {
+Template.registerHelper("i18n", (i18nKey, i18nMessage) => {
   if (!i18nKey || typeof i18nMessage !== "string") {
     Logger.warn("i18n key string required to translate", i18nKey, i18nMessage);
     return "";
@@ -38,7 +38,7 @@ Template.registerHelper("i18n", function (i18nKey, i18nMessage) {
  * @summary Eeturn shop /locale specific currency format (ie: $)
  * @returns {String} return current locale currency symbol
  */
-Template.registerHelper("currencySymbol", function () {
+Template.registerHelper("currencySymbol", () => {
   const locale = Reaction.Locale.get();
   const user = Accounts.findOne({
     _id: Meteor.userId()
@@ -63,7 +63,7 @@ Template.registerHelper("currencySymbol", function () {
  * @param {Boolean} useDefaultShopCurrency - flag for displaying shop's currency in Admin view of PDP
  * @return {String} returns locale formatted and exchange rate converted values
  */
-Template.registerHelper("formatPrice", function (formatPrice, useDefaultShopCurrency) {
+Template.registerHelper("formatPrice", (formatPrice, useDefaultShopCurrency) => {
   localeDep.depend();
   return formatPriceString(formatPrice, useDefaultShopCurrency);
 });

--- a/client/modules/i18n/main.js
+++ b/client/modules/i18n/main.js
@@ -89,7 +89,7 @@ export const localeDep = new Tracker.Dependency();
 export const currencyDep = new Tracker.Dependency();
 
 Meteor.startup(() => {
-  Tracker.autorun(function (c) {
+  Tracker.autorun((c) => {
     let merchantShopsReadyOrSkipped = false;
 
     // Choose shopSubscription based on marketplace settings

--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -38,7 +38,7 @@ Meteor.startup(() => {
   // use tracker autorun to detect language changes
   // this only runs on initial page loaded
   // and when user.profile.lang updates
-  Tracker.autorun(function () {
+  Tracker.autorun(() => {
     if (Reaction.Subscriptions.PrimaryShop.ready() &&
         Reaction.Subscriptions.MerchantShops.ready() &&
         Meteor.user()) {
@@ -86,7 +86,7 @@ Meteor.startup(() => {
         // into i18next resource format
         //
         let resources = {};
-        translations.forEach(function (translation) {
+        translations.forEach((translation) => {
           const resource = {};
           resource[translation.i18n] = translation.translation;
           resources = mergeDeep(resources, resource);
@@ -142,7 +142,7 @@ Meteor.startup(() => {
   // this only runs on initial page loaded
   // and when user.profile.currency updates
   // although it is also triggered when profile updates ( meaning .lang )
-  Tracker.autorun(function () {
+  Tracker.autorun(() => {
     const user = Meteor.user();
 
     if (Reaction.Subscriptions.PrimaryShop.ready() &&

--- a/imports/plugins/core/accounts/client/containers/messages.js
+++ b/imports/plugins/core/accounts/client/containers/messages.js
@@ -18,11 +18,11 @@ const wrapComponent = (Comp) => (
     loginFormMessages = () => {
       let reasons = "";
       if (this.props.messages.info) {
-        this.props.messages.info.forEach(function (info) {
+        this.props.messages.info.forEach((info) => {
           reasons = info.reason;
         });
       } else if (this.props.messages.alerts) {
-        this.props.messages.alerts.forEach(function (alert) {
+        this.props.messages.alerts.forEach((alert) => {
           reasons = alert.reason;
         });
       }

--- a/imports/plugins/core/accounts/client/helpers/templates.js
+++ b/imports/plugins/core/accounts/client/helpers/templates.js
@@ -7,7 +7,7 @@ import * as Collections from "/lib/collections";
 /*
  * registerHelper displayName
  */
-Template.registerHelper("displayName", function (displayUser) {
+Template.registerHelper("displayName", (displayUser) => {
   i18nextDep.depend();
 
   const user = displayUser || Collections.Accounts.findOne(Meteor.userId());

--- a/imports/plugins/core/accounts/client/templates/addressBook/add/add.js
+++ b/imports/plugins/core/accounts/client/templates/addressBook/add/add.js
@@ -93,10 +93,10 @@ AutoForm.hooks({
       this.event.preventDefault();
       const addressBook = $(this.template.firstNode).closest(".address-book");
 
-      Meteor.call("accounts/validateAddress", insertDoc, function (err, res) {
+      Meteor.call("accounts/validateAddress", insertDoc, (err, res) => {
         // if the address is validated OR the address has already been through the validation process, pass it on
         if (res.validated) {
-          Meteor.call("accounts/addressBookAdd", insertDoc, function (error, result) {
+          Meteor.call("accounts/addressBookAdd", insertDoc, (error, result) => {
             if (error) {
               Alerts.toast(i18next.t("addressBookAdd.failedToAddAddress", { err: error.message }), "error");
               that.done(new Error("Failed to add address: ", error));

--- a/imports/plugins/core/accounts/client/templates/addressBook/edit/edit.js
+++ b/imports/plugins/core/accounts/client/templates/addressBook/edit/edit.js
@@ -50,7 +50,7 @@ function setWorkingAddress(address) {
 }
 
 
-Template.addressBookEdit.onRendered(function () {
+Template.addressBookEdit.onRendered(() => {
   const addressState = Session.get("addressState");
   if (addressState.address) {
     setWorkingAddress(addressState.address);

--- a/imports/plugins/core/accounts/client/templates/addressBook/review/review.js
+++ b/imports/plugins/core/accounts/client/templates/addressBook/review/review.js
@@ -85,7 +85,7 @@ Template.addressBookReview.events({
       fieldErrors: {}
     };
     Session.set("addressState", addressState);
-    Meteor.call("accounts/addressBookAdd", address, function (error, result) {
+    Meteor.call("accounts/addressBookAdd", address, (error, result) => {
       if (error) {
         Alerts.toast(i18next.t("addressBookAdd.failedToAddAddress", { err: error.message }), "error");
         return false;

--- a/imports/plugins/core/accounts/client/templates/dropdown/helpers/templates.js
+++ b/imports/plugins/core/accounts/client/templates/dropdown/helpers/templates.js
@@ -6,7 +6,7 @@ import { Reaction, i18next, i18nextDep } from "/client/api";
 /**
  * registerHelper displayName
  */
-Template.registerHelper("displayName", function (displayUser) {
+Template.registerHelper("displayName", (displayUser) => {
   i18nextDep.depend();
 
   const user = displayUser || Accounts.user();

--- a/imports/plugins/core/accounts/client/templates/members/member.js
+++ b/imports/plugins/core/accounts/client/templates/members/member.js
@@ -10,7 +10,7 @@ import { Components } from "@reactioncommerce/reaction-components";
 
 const getPermissionMap = (permissions) => {
   const permissionMap = {};
-  _.each(permissions, function (existing) {
+  _.each(permissions, (existing) => {
     permissionMap[existing.permission] = existing.label;
   });
   return permissionMap;
@@ -72,7 +72,7 @@ Template.memberSettings.helpers({
       shopId: shopId
     });
 
-    packages.forEach(function (pkg) {
+    packages.forEach((pkg) => {
       const permissions = [];
       if (pkg.registry && pkg.enabled) {
         for (const registryItem of pkg.registry) {
@@ -104,7 +104,7 @@ Template.memberSettings.helpers({
           }
         }
         // TODO review this, hardcoded WIP
-        const label = pkg.name.replace("reaction", "").replace(/(-.)/g, function (x) {
+        const label = pkg.name.replace("reaction", "").replace(/(-.)/g, (x) => {
           return " " + x[1].toUpperCase();
         });
 

--- a/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
+++ b/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
@@ -38,7 +38,7 @@ Accounts.onEnrollmentLink((token, done) => {
 /**
  * Accounts Event: onEmailVerificationLink When a user uses an verification link
  */
-Accounts.onEmailVerificationLink(function (token, done) {
+Accounts.onEmailVerificationLink((token, done) => {
   Accounts.verifyEmail(token);
   done();
 });

--- a/imports/plugins/core/checkout/client/components/completedOrder.js
+++ b/imports/plugins/core/checkout/client/components/completedOrder.js
@@ -53,7 +53,7 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
         <div className="order-details-content-title">
           <p><Components.Translation defaultValue="Your Items" i18nKey={"cartCompleted.yourItems"} /></p>
         </div>
-        {shops.map(function (shop) {
+        {shops.map((shop) => {
           const shopKey = Object.keys(shop);
           return (
             <CompletedShopOrders
@@ -95,7 +95,7 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
             <div className="order-details-content-title">
               <p><Components.Translation defaultValue="Payment Method" i18nKey={"cartCompleted.paymentMethod"} /></p>
             </div>
-            {paymentMethods.map(function (paymentMethod) {
+            {paymentMethods.map((paymentMethod) => {
               return <CompletedOrderPaymentMethod key={paymentMethod.key} paymentMethod={paymentMethod} />;
             })}
           </div>

--- a/imports/plugins/core/checkout/client/components/completedShopOrders.js
+++ b/imports/plugins/core/checkout/client/components/completedShopOrders.js
@@ -30,7 +30,7 @@ const CompletedShopOrders = ({ shopName, items, handleDisplayMedia, shippingMeth
         </div>
       </div>
       <div className="order-details-info-box-topless">
-        {items.map(function (item) {
+        {items.map((item) => {
           return <CompletedOrderItem item={item} key={item._id} handleDisplayMedia={handleDisplayMedia} />;
         })}
       </div>

--- a/imports/plugins/core/checkout/client/components/emptyCartDrawer.js
+++ b/imports/plugins/core/checkout/client/components/emptyCartDrawer.js
@@ -7,7 +7,7 @@ import { Reaction } from "/client/api";
 function handleKeepShopping(event) {
   event.stopPropagation();
   event.preventDefault();
-  return $("#cart-drawer-container").fadeOut(300, function () {
+  return $("#cart-drawer-container").fadeOut(300, () => {
     return Reaction.toggleSession("displayCart");
   });
 }

--- a/imports/plugins/core/checkout/client/helpers/cart.js
+++ b/imports/plugins/core/checkout/client/helpers/cart.js
@@ -17,7 +17,7 @@ import { Template } from "meteor/templating";
  * in code: Cart.findOne().getTotal()
  * @return {Object} returns inventory helpers
  */
-Template.registerHelper("cart", function () {
+Template.registerHelper("cart", () => {
   const cartHelpers = {
     /**
      * showCartIconWarning
@@ -71,7 +71,7 @@ Template.registerHelper("cart", function () {
  * @summary gets current cart billing address / payment name
  * @return {String} returns cart.billing[0].fullName
  */
-Template.registerHelper("cartPayerName", function () {
+Template.registerHelper("cartPayerName", () => {
   const cart = Cart.findOne();
   if (cart && cart.billing && cart.billing[0] && cart.billing[0].address && cart.billing[0].address.fullName) {
     const name = cart.billing[0].address.fullName;

--- a/imports/plugins/core/checkout/client/methods/cart.js
+++ b/imports/plugins/core/checkout/client/methods/cart.js
@@ -56,7 +56,7 @@ Meteor.methods({
       };
     }
 
-    Cart.update(selector, update, function (error, result) {
+    Cart.update(selector, update, (error, result) => {
       if (error) {
         Logger.debug(error, "An error occurred saving the order");
         throw new Meteor.Error("An error occurred saving the order", error);

--- a/imports/plugins/core/checkout/client/templates/cartDrawer/cartDrawer.js
+++ b/imports/plugins/core/checkout/client/templates/cartDrawer/cartDrawer.js
@@ -38,7 +38,7 @@ Template.cartDrawer.helpers({
  * openCartDrawer helpers
  *
  */
-Template.openCartDrawer.onRendered(function () {
+Template.openCartDrawer.onRendered(() => {
   /**
    * Add swiper to openCartDrawer
    *
@@ -70,7 +70,7 @@ Template.openCartDrawer.helpers({
   }
 });
 
-Template.emptyCartDrawer.onRendered(function () {
+Template.emptyCartDrawer.onRendered(() => {
   return $("#cart-drawer-container").fadeIn();
 });
 

--- a/imports/plugins/core/checkout/client/templates/cartDrawer/cartItems/cartItems.js
+++ b/imports/plugins/core/checkout/client/templates/cartDrawer/cartItems/cartItems.js
@@ -21,7 +21,7 @@ Template.cartDrawerItems.helpers({
     if (defaultImage) {
       return defaultImage;
     } else if (product) {
-      _.some(product.variants, function (variant) {
+      _.some(product.variants, (variant) => {
         if (variant) {
           defaultImage = Media.findOne({
             "metadata.variantId": variant._id

--- a/imports/plugins/core/checkout/client/templates/cartIcon/cartIcon.js
+++ b/imports/plugins/core/checkout/client/templates/cartIcon/cartIcon.js
@@ -15,7 +15,7 @@ Template.cartIcon.helpers({
 
 Template.cartIcon.events({
   "click .cart-icon"() {
-    return $("#cart-drawer-container").fadeOut(300, function () {
+    return $("#cart-drawer-container").fadeOut(300, () => {
       return Reaction.toggleSession("displayCart");
     });
   }

--- a/imports/plugins/core/checkout/client/templates/checkout/checkout.js
+++ b/imports/plugins/core/checkout/client/templates/checkout/checkout.js
@@ -26,7 +26,7 @@ Template.cartCheckout.helpers({
 });
 
 
-Template.cartCheckout.onCreated(function () {
+Template.cartCheckout.onCreated(() => {
   if (Reaction.Subscriptions.Cart.ready()) {
     const cart = Cart.findOne();
     if (cart && cart.workflow && cart.workflow.status === "new") {

--- a/imports/plugins/core/checkout/client/templates/checkout/review/review.js
+++ b/imports/plugins/core/checkout/client/templates/checkout/review/review.js
@@ -8,7 +8,7 @@ import CartSubTotals from "../../../containers/cartSubTotalContainer";
 * trigger checkoutPayment step on template checkoutReview render
 */
 
-Template.checkoutReview.onRendered(function () {
+Template.checkoutReview.onRendered(() => {
   Meteor.call("workflow/pushCartWorkflow", "coreCartWorkflow", "checkoutReview");
 });
 

--- a/imports/plugins/core/checkout/server/methods/workflow.js
+++ b/imports/plugins/core/checkout/server/methods/workflow.js
@@ -62,14 +62,14 @@ Meteor.methods({
     });
 
     // loop through packages and set the defaultPackageWorkflows
-    packages.forEach(function (reactionPackage) {
+    packages.forEach((reactionPackage) => {
       // todo fix this hack for not filtering nicely
       if (!reactionPackage.layout.layout) {
         const layouts = _.filter(reactionPackage.layout, {
           workflow: workflow
         });
         // for every layout, process the associated workflows
-        _.each(layouts, function (layout) {
+        _.each(layouts, (layout) => {
           // audience is the layout permissions
           if (typeof layout.audience !== "object") {
             const defaultRoles = Groups.findOne({
@@ -110,7 +110,7 @@ Meteor.methods({
     // loop through all shop configured layouts, and their default workflows
     // to determine what the next workflow step should be
     // the cart workflow status while processing is neither true nor false (set to template)
-    _.each(defaultPackageWorkflows, function (workflow, currentStatusIndex) {
+    _.each(defaultPackageWorkflows, (workflow, currentStatusIndex) => {
       if (workflow.template === currentWorkflowStatus) {
         // don't go past the end of the workflow
         if (currentStatusIndex < maxSteps - 1) {

--- a/imports/plugins/core/connectors/client/templates/settings/connectors.js
+++ b/imports/plugins/core/connectors/client/templates/settings/connectors.js
@@ -1,10 +1,5 @@
 import { Template } from "meteor/templating";
 import { Meteor } from "meteor/meteor";
-/*
- * Template connector Helpers
- */
-Template.connectorSettings.onCreated(function () {
-});
 
 Template.connectorSettings.helpers({
   checked(enabled) {

--- a/imports/plugins/core/dashboard/client/templates/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/settings/settings.js
@@ -36,7 +36,7 @@ Template.settingsHeader.helpers({
     });
 
     if (reactionApp) {
-      const settingsData = _.find(reactionApp.registry, function (item) {
+      const settingsData = _.find(reactionApp.registry, (item) => {
         return item.route === Reaction.Router.getRouteName() && item.provides && item.provides.includes("settings");
       });
 

--- a/imports/plugins/core/discounts/client/components/form.js
+++ b/imports/plugins/core/discounts/client/components/form.js
@@ -31,9 +31,9 @@ export default class DiscountForm extends Component {
           // if validationMessage isn't an object with i18n
           // we will display an elliptical that's not
           // actually done here though, just bit of foolery
-          this.timerId = Meteor.setTimeout(function () {
+          this.timerId = Meteor.setTimeout(() => {
             this.setState({ validationMessage: "..." });
-          }.bind(this), 2000);
+          }, 2000);
         }
       });
     }, 800);

--- a/imports/plugins/core/discounts/server/methods/methods.app-test.js
+++ b/imports/plugins/core/discounts/server/methods/methods.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/imports/plugins/core/email/client/components/emailLogs.js
+++ b/imports/plugins/core/email/client/components/emailLogs.js
@@ -20,7 +20,7 @@ class EmailLogs extends Component {
 
     // add i18n handling to headers
     const customColumnMetadata = [];
-    filteredFields.forEach(function (field) {
+    filteredFields.forEach((field) => {
       let colWidth = undefined;
       let colStyle = undefined;
       let colClassName = undefined;

--- a/imports/plugins/core/layout/client/templates/layout/alerts/alerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/alerts.js
@@ -16,7 +16,7 @@ Template.inlineAlert.onRendered(function () {
   const alert = this.data;
   const $node = $(this.firstNode);
 
-  Meteor.defer(function () {
+  Meteor.defer(() => {
     Alerts.collection_.update(alert._id, {
       $set: {
         seen: true
@@ -24,10 +24,10 @@ Template.inlineAlert.onRendered(function () {
     });
   });
 
-  $node.removeClass("hide").hide().fadeIn(alert.options.fadeIn, function () {
+  $node.removeClass("hide").hide().fadeIn(alert.options.fadeIn, () => {
     if (alert.options.autoHide) {
-      Meteor.setTimeout(function () {
-        $node.fadeOut(alert.options.fadeOut, function () {
+      Meteor.setTimeout(() => {
+        $node.fadeOut(alert.options.fadeOut, () => {
           return Alerts.collection_.remove(alert._id);
         });
       }, alert.options.autoHide);

--- a/imports/plugins/core/layout/client/templates/layout/alerts/inlineAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/inlineAlerts.js
@@ -107,7 +107,7 @@ const Alerts = {
           created: -1
         },
         skip: options.alertsLimit - 1
-      }).forEach(function (row) {
+      }).forEach((row) => {
         Alerts.collection_.remove(row._id);
       });
     }

--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -12,7 +12,7 @@ import Alerts from "./inlineAlerts";
  * @module ReactionAlerts
  */
 
-Meteor.startup(function () {
+Meteor.startup(() => {
   sAlert.config({
     effect: "stackslide",
     position: "bottom-left",
@@ -83,7 +83,7 @@ Object.assign(Alerts, {
         if (dismiss === "cancel" || dismiss === "esc" || dismiss === "overlay") {
           messageOrCallback(false, dismiss);
         }
-      }).catch(function (err) {
+      }).catch((err) => {
         if (err === "cancel" || err === "overlay" || err === "timer") {
           return undefined; // Silence error
         }
@@ -104,7 +104,7 @@ Object.assign(Alerts, {
       if (isConfirm === true && typeof callback === "function") {
         callback(isConfirm);
       }
-    }).catch(function (err) {
+    }).catch((err) => {
       if (err === "cancel" || err === "overlay" || err === "timer") {
         return undefined; // Silence error
       }

--- a/imports/plugins/core/layout/client/templates/layout/notFound/notFound.js
+++ b/imports/plugins/core/layout/client/templates/layout/notFound/notFound.js
@@ -1,6 +1,6 @@
 import { Template } from "meteor/templating";
 
-Template.notFound.onCreated(function () {
+Template.notFound.onCreated(() => {
   document.getElementsByTagName("head")[0].insertAdjacentHTML("beforeend", "<meta name='prerender-status-code' content='404'>");
   // todo report not found source
 });

--- a/imports/plugins/core/layout/client/templates/layout/notice/unauthorized.js
+++ b/imports/plugins/core/layout/client/templates/layout/notice/unauthorized.js
@@ -1,6 +1,6 @@
 import { Template } from "meteor/templating";
 
-Template.unauthorized.onCreated(function () {
+Template.unauthorized.onCreated(() => {
   document.getElementsByTagName("head")[0].insertAdjacentHTML("beforeend", "<meta name='prerender-status-code' content='403'>");
   // todo report not found source
 });

--- a/imports/plugins/core/payments/client/checkout/payment/methods.js
+++ b/imports/plugins/core/payments/client/checkout/payment/methods.js
@@ -9,7 +9,7 @@ Template.corePaymentMethods.helpers({
   }
 });
 
-Template.corePaymentMethods.onCreated(function () {
+Template.corePaymentMethods.onCreated(() => {
   const payments = enabledPayments();
   const paymentsEnabled = payments.length;
   // If no payments enabled, show payments settings dashboard

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -613,7 +613,7 @@ Products.before.update(function (userId, product, fieldNames, modifier, options)
   return false;
 });
 
-Products.before.remove(function (userId, product) {
+Products.before.remove((userId, product) => {
   if (RevisionApi.isRevisionControlEnabled() === false) {
     return true;
   }
@@ -663,7 +663,7 @@ Products.before.remove(function (userId, product) {
   return false;
 });
 
-Revisions.after.update(function (userId, revision) {
+Revisions.after.update((userId, revision) => {
   if (RevisionApi.isRevisionControlEnabled() === false) {
     return true;
   }

--- a/imports/plugins/core/router/client/startup.js
+++ b/imports/plugins/core/router/client/startup.js
@@ -7,7 +7,7 @@ import { initBrowserRouter } from "./browserRouter";
 import { Reaction } from "/client/api";
 import { Router } from "../lib";
 
-Meteor.startup(function () {
+Meteor.startup(() => {
   loadRegisteredComponents();
 
   // Subscribe to router required publications
@@ -19,7 +19,7 @@ Meteor.startup(function () {
   const merchantShopSub = Meteor.subscribe("MerchantShops");
   const packageSub = Meteor.subscribe("Packages");
 
-  Tracker.autorun(function () {
+  Tracker.autorun(() => {
     // initialize client routing
     if (
       primaryShopSub.ready() &&

--- a/imports/plugins/core/taxes/client/settings/custom.js
+++ b/imports/plugins/core/taxes/client/settings/custom.js
@@ -89,7 +89,7 @@ Template.customTaxRates.helpers({
 
     // add i18n handling to headers
     const customColumnMetadata = [];
-    filteredFields.forEach(function (field) {
+    filteredFields.forEach((field) => {
       const columnMeta = {
         accessor: field,
         Header: i18next.t(`admin.taxGrid.${field}`)

--- a/imports/plugins/core/taxes/server/methods/methods.app-test.js
+++ b/imports/plugins/core/taxes/server/methods/methods.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/imports/plugins/core/templates/client/templates/settings.js
+++ b/imports/plugins/core/templates/client/templates/settings.js
@@ -63,7 +63,7 @@ Template.templateSettings.helpers({
 
     // add i18n handling to headers
     const customColumnMetadata = [];
-    filteredFields.forEach(function (field) {
+    filteredFields.forEach((field) => {
       const columnMeta = {
         accessor: field, // name of field
         Header: i18next.t(`templateGrid.columns.${field}`) // name to display

--- a/imports/plugins/core/ui-tagnav/client/helpers/tags.js
+++ b/imports/plugins/core/ui-tagnav/client/helpers/tags.js
@@ -91,7 +91,7 @@ export const TagHelpers = {
     }
 
     Meteor.call("shop/updateHeaderTags", tagName, null, parentTagId,
-      function (error) {
+      (error) => {
         if (error) {
           Alerts.toast(i18next.t("productDetail.tagExists"), "error");
         }
@@ -100,7 +100,7 @@ export const TagHelpers = {
 
   updateTag(tagId, tagName, parentTagId) {
     Meteor.call("shop/updateHeaderTags", tagName, tagId, parentTagId,
-      function (error) {
+      (error) => {
         if (error) {
           Alerts.toast(i18next.t("productDetail.tagExists"), "error");
         }

--- a/imports/plugins/core/ui/client/containers/mediaGallery.js
+++ b/imports/plugins/core/ui/client/containers/mediaGallery.js
@@ -209,7 +209,7 @@ function fetchMediaRevisions() {
 
 // resort the media in
 function sortMedia(media) {
-  const sortedMedia = _.sortBy(media, function (m) { return m.metadata.priority;});
+  const sortedMedia = _.sortBy(media, (m) => { return m.metadata.priority;});
   return sortedMedia;
 }
 

--- a/imports/plugins/core/ui/client/containers/tagListContainer.js
+++ b/imports/plugins/core/ui/client/containers/tagListContainer.js
@@ -244,7 +244,7 @@ function composer(props, onData) {
 
   if (props.product) {
     if (_.isArray(props.product.hashtags)) {
-      tags = _.map(props.product.hashtags, function (id) {
+      tags = _.map(props.product.hashtags, (id) => {
         return Tags.findOne(id);
       });
     }

--- a/imports/plugins/core/ui/client/helpers/react-template-helper.js
+++ b/imports/plugins/core/ui/client/helpers/react-template-helper.js
@@ -6,7 +6,7 @@ import { Template } from "meteor/templating";
 import { Blaze } from "meteor/blaze";
 
 // Empty template; logic in `onRendered` below
-Template.React = new Template("Template.React", function () {
+Template.React = new Template("Template.React", () => {
   return [];
 });
 

--- a/imports/plugins/core/ui/client/templates/themeDetails/themeDetails.js
+++ b/imports/plugins/core/ui/client/templates/themeDetails/themeDetails.js
@@ -34,10 +34,6 @@ Template.uiThemeDetails.onCreated(function () {
   });
 });
 
-Template.uiThemeDetails.onRendered(function () {
-
-});
-
 Template.uiThemeDetails.helpers({
   activeClassName(componentName) {
     if (Template.instance().state.equals("selectedComponent", componentName)) {

--- a/imports/plugins/core/versions/server/migrations/9_update_metrics.js
+++ b/imports/plugins/core/versions/server/migrations/9_update_metrics.js
@@ -5,7 +5,7 @@ Migrations.add({
   version: 9,
   up() {
     Shops.find().forEach(
-      function (shop) {
+      (shop) => {
         if (!shop.baseUOM) {
           shop.baseUOM = "oz";
         } else {

--- a/imports/plugins/included/analytics/client/startup.js
+++ b/imports/plugins/included/analytics/client/startup.js
@@ -125,8 +125,8 @@ Reaction.Router.triggers.enter([notifySegment, notifyGoogleAnalytics, notifyMixp
 //
 // Initialize analytics event tracking
 //
-Meteor.startup(function () {
-  Tracker.autorun(function () {
+Meteor.startup(() => {
+  Tracker.autorun(() => {
     const coreAnalytics = Packages.findOne({
       name: "reaction-analytics"
     });
@@ -147,7 +147,7 @@ Meteor.startup(function () {
       if (segmentio.api_key && analytics.invoked === true) {
         analytics.load(segmentio.api_key);
       } else if (!segmentio.api_key && Reaction.hasAdminAccess()) {
-        _.defer(function () {
+        _.defer(() => {
           return Alerts.toast(
             `${i18next.t("admin.settings.segmentNotConfigured")}`,
             "danger", {
@@ -165,7 +165,7 @@ Meteor.startup(function () {
       if (googleAnalytics.api_key) {
         ga("create", googleAnalytics.api_key, "auto");
       } else if (!googleAnalytics.api_key && Reaction.hasAdminAccess()) {
-        _.defer(function () {
+        _.defer(() => {
           return Alerts.toast(
             `${i18next.t("admin.settings.googleAnalyticsNotConfigured")}`,
             "error", {
@@ -184,7 +184,7 @@ Meteor.startup(function () {
       if (mixpanel.api_key) {
         mixpanel.init(mixpanel.api_key);
       } else if (!mixpanel.api_key && Reaction.hasAdminAccess()) {
-        _.defer(function () {
+        _.defer(() => {
           return Alerts.toast(
             `${i18next.t("admin.settings.mixpanelNotConfigured")}`,
             "error", {
@@ -205,10 +205,10 @@ Meteor.startup(function () {
   //
   // analytics event processing
   //
-  return $(document.body).click(function (e) {
+  return $(document.body).click((e) => {
     let $targets = $(e.target).closest("*[data-event-action]");
     $targets = $targets.parents("*[data-event-action]").add($targets);
-    return $targets.each(function (index, element) {
+    return $targets.each((index, element) => {
       const $element = $(element);
       const analyticsEvent = {
         eventType: "event",

--- a/imports/plugins/included/connectors-shopify/server/endpoints/webhooks.js
+++ b/imports/plugins/included/connectors-shopify/server/endpoints/webhooks.js
@@ -41,7 +41,7 @@ function verifyWebhook(req) {
   return true;
 }
 
-Reaction.Endpoints.add("post", "/webhooks/shopify/orders-create", function (req, res) {
+Reaction.Endpoints.add("post", "/webhooks/shopify/orders-create", (req, res) => {
   // We'll move the code that's in the orders-updated hook into here once it's functional
   // easier to iterate in that hook for now.
   Reaction.Endpoints.sendResponse(res);

--- a/imports/plugins/included/discount-codes/client/templates/settings.js
+++ b/imports/plugins/included/discount-codes/client/templates/settings.js
@@ -88,7 +88,7 @@ Template.customDiscountCodes.helpers({
 
     // add i18n handling to headers
     const customColumnMetadata = [];
-    filteredFields.forEach(function (field) {
+    filteredFields.forEach((field) => {
       const columnMeta = {
         accessor: field,
         Header: i18next.t(`admin.discountGrid.${field}`)

--- a/imports/plugins/included/discount-codes/server/hooks/orders.js
+++ b/imports/plugins/included/discount-codes/server/hooks/orders.js
@@ -5,7 +5,7 @@ import { MethodHooks } from "/server/api";
 // this hook runs before a cart is converted to an order
 // it looks at any discounts that have been applied to the cart
 // and updates the discount document with a transaction history
-MethodHooks.before("cart/copyCartToOrder", function (options) {
+MethodHooks.before("cart/copyCartToOrder", (options) => {
   const cartId = options.arguments[0];
   const cart = Cart.findOne(cartId);
   // record that discounts have been applied to order

--- a/imports/plugins/included/discount-codes/server/methods/methods.app-test.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { Factory } from "meteor/dburles:factory";

--- a/imports/plugins/included/discount-rates/client/settings/rates.js
+++ b/imports/plugins/included/discount-rates/client/settings/rates.js
@@ -87,7 +87,7 @@ Template.customDiscountRates.helpers({
 
     // add i18n handling to headers
     const customColumnMetadata = [];
-    filteredFields.forEach(function (field) {
+    filteredFields.forEach((field) => {
       const columnMeta = {
         accessor: field,
         Header: i18next.t(`admin.discountGrid.${field}`)

--- a/imports/plugins/included/discount-rates/server/methods/methods.app-test.js
+++ b/imports/plugins/included/discount-rates/server/methods/methods.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
+++ b/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/imports/plugins/included/inventory/server/methods/inventory.app-test.js
+++ b/imports/plugins/included/inventory/server/methods/inventory.app-test.js
@@ -1,4 +1,5 @@
-/* eslint dot-notation: 0 */
+/* eslint dot-notation:0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { Products, Inventory }  from "/lib/collections";

--- a/imports/plugins/included/marketplace/client/templates/becomeSellerButton/becomeSellerButton.js
+++ b/imports/plugins/included/marketplace/client/templates/becomeSellerButton/becomeSellerButton.js
@@ -4,7 +4,7 @@ import { Reaction, i18next } from "/client/api";
 
 Template.becomeSellerButton.events({
   "click [data-event-action='button-click-become-seller']": function () {
-    Meteor.call("shop/createShop", Meteor.userId(), function (error, response) {
+    Meteor.call("shop/createShop", Meteor.userId(), (error, response) => {
       if (error) {
         const errorMessage = i18next.t("marketplace.errorCannotCreateShop", { defaultValue: "Could not create shop for current user {{user}}" });
         return Alerts.toast(`${errorMessage} ${error}`, "error");

--- a/imports/plugins/included/marketplace/server/publications.js
+++ b/imports/plugins/included/marketplace/server/publications.js
@@ -39,7 +39,7 @@ Meteor.publish("SellerShops", function (shopIds) {
       }
     });
 
-    this.onStop(function () {
+    this.onStop(() => {
       sellerShopsObserver.stop();
     });
   };
@@ -57,7 +57,7 @@ Meteor.publish("SellerShops", function (shopIds) {
         this.removed("SellerShops", document._id);
       }
     });
-    this.onStop(function () {
+    this.onStop(() => {
       ownedSellerShopObserver.stop();
     });
   };

--- a/imports/plugins/included/notifications/server/hooks/notification.js
+++ b/imports/plugins/included/notifications/server/hooks/notification.js
@@ -23,7 +23,7 @@ const sendNotificationToAdmin = (adminId) => {
   return Meteor.call("notification/send", adminId, type, url, sms);
 };
 
-MethodHooks.after("cart/copyCartToOrder", function (options) {
+MethodHooks.after("cart/copyCartToOrder", (options) => {
   const userId = Meteor.userId();
   const type = "newOrder";
   const prefix = Reaction.getShopPrefix();

--- a/imports/plugins/included/payments-authnet/client/checkout/authnet.js
+++ b/imports/plugins/included/payments-authnet/client/checkout/authnet.js
@@ -74,7 +74,7 @@ AutoForm.addHooks("authnet-payment-form", {
     };
 
     // Submit for processing
-    AuthNet.authorize(cardInfo, paymentInfo, function (error, transaction) {
+    AuthNet.authorize(cardInfo, paymentInfo, (error, transaction) => {
       if (error || !transaction) {
         handleAuthNetSubmitError(error);
         uiEnd(tpl, "Resubmit payment");

--- a/imports/plugins/included/payments-authnet/server/methods/authnet.js
+++ b/imports/plugins/included/payments-authnet/server/methods/authnet.js
@@ -43,19 +43,19 @@ function getSettings(settings, ref, valueName) {
   return undefined;
 }
 
-const ValidCardNumber = Match.Where(function (x) {
+const ValidCardNumber = Match.Where((x) => {
   return /^[0-9]{14,16}$/.test(x);
 });
 
-const ValidExpireMonth = Match.Where(function (x) {
+const ValidExpireMonth = Match.Where((x) => {
   return /^[0-9]{1,2}$/.test(x);
 });
 
-const ValidExpireYear = Match.Where(function (x) {
+const ValidExpireYear = Match.Where((x) => {
   return /^[0-9]{4}$/.test(x);
 });
 
-const ValidCVV = Match.Where(function (x) {
+const ValidCVV = Match.Where((x) => {
   return /^[0-9]{3,4}$/.test(x);
 });
 
@@ -204,7 +204,7 @@ function priorAuthCaptureTransaction(transId, amount, service) {
     refTransId: transId
   };
   // This call returns a Promise to the cb so we need to use Promise.await
-  const transactionRequest = service.sendTransactionRequest.call(service, body, function (trans) {
+  const transactionRequest = service.sendTransactionRequest.call(service, body, (trans) => {
     return trans;
   });
   return Promise.await(transactionRequest);
@@ -216,7 +216,7 @@ function voidTransaction(transId, service) {
     refTransId: transId
   };
   // This call returns a Promise to the cb so we need to use Promise.await
-  const transactionRequest = service.sendTransactionRequest.call(service, body, function (trans) {
+  const transactionRequest = service.sendTransactionRequest.call(service, body, (trans) => {
     return trans;
   });
   return Promise.await(transactionRequest);

--- a/imports/plugins/included/payments-braintree/client/checkout/braintree.js
+++ b/imports/plugins/included/payments-braintree/client/checkout/braintree.js
@@ -60,7 +60,7 @@ function submitToBrainTree(doc, template) {
   Braintree.authorize(cardData, {
     total: cartTotal,
     currency: currencyCode
-  }, function (error, results) {
+  }, (error, results) => {
     let paymentMethod;
     submitting = false;
     if (error) {

--- a/imports/plugins/included/payments-braintree/server/methods/braintreeApi.js
+++ b/imports/plugins/included/payments-braintree/server/methods/braintreeApi.js
@@ -100,7 +100,7 @@ BraintreeApi.apiCall.paymentSubmit = function (paymentSubmitDetails) {
   paymentObj.creditCard = parseCardData(paymentSubmitDetails.cardData);
   paymentObj.amount = paymentSubmitDetails.paymentData.total;
   const fut = new Future();
-  gateway.transaction.sale(paymentObj, Meteor.bindEnvironment(function (error, result) {
+  gateway.transaction.sale(paymentObj, Meteor.bindEnvironment((error, result) => {
     if (error) {
       fut.return({
         saved: false,
@@ -117,7 +117,7 @@ BraintreeApi.apiCall.paymentSubmit = function (paymentSubmitDetails) {
         response: result
       });
     }
-  }, function (error) {
+  }, (error) => {
     Reaction.Events.warn(error);
   }));
 
@@ -132,7 +132,7 @@ BraintreeApi.apiCall.captureCharge = function (paymentCaptureDetails) {
   const fut = new Future();
 
   if (amount === accounting.toFixed(0, 2)) {
-    gateway.transaction.void(transactionId, function (error, result) {
+    gateway.transaction.void(transactionId, (error, result) => {
       if (error) {
         fut.return({
           saved: false,
@@ -144,12 +144,12 @@ BraintreeApi.apiCall.captureCharge = function (paymentCaptureDetails) {
           response: result
         });
       }
-    }, function (e) {
+    }, (e) => {
       Logger.warn(e);
     });
     return fut.wait();
   }
-  gateway.transaction.submitForSettlement(transactionId, amount, Meteor.bindEnvironment(function (error, result) {
+  gateway.transaction.submitForSettlement(transactionId, amount, Meteor.bindEnvironment((error, result) => {
     if (error) {
       fut.return({
         saved: false,
@@ -161,7 +161,7 @@ BraintreeApi.apiCall.captureCharge = function (paymentCaptureDetails) {
         response: result
       });
     }
-  }, function (e) {
+  }, (e) => {
     Logger.warn(e);
   }));
 
@@ -174,7 +174,7 @@ BraintreeApi.apiCall.createRefund = function (refundDetails) {
   const amount = refundDetails.amount;
   const gateway = getGateway();
   const fut = new Future();
-  gateway.transaction.refund(transactionId, amount, Meteor.bindEnvironment(function (error, result) {
+  gateway.transaction.refund(transactionId, amount, Meteor.bindEnvironment((error, result) => {
     if (error) {
       fut.return({
         saved: false,
@@ -198,7 +198,7 @@ BraintreeApi.apiCall.createRefund = function (refundDetails) {
         response: result
       });
     }
-  }, function (e) {
+  }, (e) => {
     Logger.fatal(e);
   }));
   return fut.wait();

--- a/imports/plugins/included/payments-braintree/server/methods/braintreeapi-methods-refund.app-test.js
+++ b/imports/plugins/included/payments-braintree/server/methods/braintreeapi-methods-refund.app-test.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";

--- a/imports/plugins/included/payments-example/client/checkout/example.js
+++ b/imports/plugins/included/payments-example/client/checkout/example.js
@@ -64,7 +64,7 @@ AutoForm.addHooks("example-payment-form", {
     Example.authorize(form, {
       total: Cart.findOne().getTotal(),
       currency: Shops.findOne().currency
-    }, function (error, transaction) {
+    }, (error, transaction) => {
       submitting = false;
       let paymentMethod;
       if (error) {

--- a/imports/plugins/included/payments-example/server/methods/example-payment-methods.app-test.js
+++ b/imports/plugins/included/payments-example/server/methods/example-payment-methods.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";

--- a/imports/plugins/included/payments-example/server/methods/example.js
+++ b/imports/plugins/included/payments-example/server/methods/example.js
@@ -15,19 +15,19 @@ function luhnValid(x) {
   }, 0) % 10 === 0;
 }
 
-const ValidCardNumber = Match.Where(function (x) {
+const ValidCardNumber = Match.Where((x) => {
   return /^[0-9]{13,16}$/.test(x) && luhnValid(x);
 });
 
-const ValidExpireMonth = Match.Where(function (x) {
+const ValidExpireMonth = Match.Where((x) => {
   return /^[0-9]{1,2}$/.test(x);
 });
 
-const ValidExpireYear = Match.Where(function (x) {
+const ValidExpireYear = Match.Where((x) => {
   return /^[0-9]{4}$/.test(x);
 });
 
-const ValidCVV = Match.Where(function (x) {
+const ValidCVV = Match.Where((x) => {
   return /^[0-9]{3,4}$/.test(x);
 });
 

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/express/checkoutButton.js
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/express/checkoutButton.js
@@ -27,7 +27,7 @@ function checkout() {
     return undefined;
   }
 
-  return Meteor.call("getExpressCheckoutToken", cart._id, function (error, token) {
+  return Meteor.call("getExpressCheckoutToken", cart._id, (error, token) => {
     if (error) {
       const msg = (error !== null ? error.error : void 0) || i18next.t("checkoutPayment.processingError", "There was a problem with your payment.");
       Alerts.add(msg, "danger", {
@@ -55,7 +55,7 @@ function expressCheckoutSettingsValid(settings) {
  * @return {undefined} no return value
  */
 Template.paypalCheckoutButton.onCreated(function () {
-  Meteor.call("getExpressCheckoutSettings", function (error, expressCheckoutSettings) {
+  Meteor.call("getExpressCheckoutSettings", (error, expressCheckoutSettings) => {
     if (!error) {
       return Session.set("expressCheckoutSettings", expressCheckoutSettings);
     }

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.js
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.js
@@ -87,7 +87,7 @@ AutoForm.addHooks("paypal-payment-form", {
     PayPal.authorize(form, {
       total: Cart.findOne().getTotal(),
       currency: Shops.findOne().currency
-    }, function (error, transaction) {
+    }, (error, transaction) => {
       submitting = false; // todo: check scope
       if (error) {
         handlePaypalSubmitError(error);

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/return/done.js
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/return/done.js
@@ -44,7 +44,7 @@ function buildPaymentMethod(result, status, mode) {
   return paymentMethod;
 }
 
-Template.paypalDone.onRendered(function () {
+Template.paypalDone.onRendered(() => {
   $(".paypal-done-error").hide();
 });
 
@@ -61,7 +61,7 @@ Template.paypalDone.onCreated(function () {
   const prefix = Reaction.getShopPrefix();
   this.checkoutUrl = `${prefix}/cart/checkout`;
   // wait for cart to be ready
-  Tracker.autorun(function (c) {
+  Tracker.autorun((c) => {
     if (Reaction.Subscriptions.Cart.ready()) {
       const cart = Cart.findOne();
       if (!cart) {
@@ -71,7 +71,7 @@ Template.paypalDone.onCreated(function () {
       c.stop();
       if (Session.get("expressToken") !== token) {
         Session.set("expressToken", token);
-        Meteor.call("confirmPaymentAuthorization", cart._id, token, payerId, function (error, result) {
+        Meteor.call("confirmPaymentAuthorization", cart._id, token, payerId, (error, result) => {
           if (error) {
             if (isDuplicate(error)) {
               Reaction.Router.go("cart/completed", {}, {
@@ -96,7 +96,7 @@ Template.paypalDone.onCreated(function () {
             }
             const paymentMethod = buildPaymentMethod(result, status, mode);
 
-            Meteor.call("cart/submitPayment", paymentMethod, function (payError, payResult) {
+            Meteor.call("cart/submitPayment", paymentMethod, (payError, payResult) => {
               if (!payResult && payError) {
                 Logger.warn(payError, "Error received during submitting Payment via Paypal");
                 showError(payError);

--- a/imports/plugins/included/payments-paypal/server/methods/express.js
+++ b/imports/plugins/included/payments-paypal/server/methods/express.js
@@ -335,7 +335,7 @@ export const methods = {
 function parseResponse(response) {
   const result = {};
   const pieces = response.content.split("&");
-  pieces.forEach(function (piece) {
+  pieces.forEach((piece) => {
     const subpieces = piece.split("=");
     const decodedResult = result[subpieces[0]] = decodeURIComponent(subpieces[1]);
     return decodedResult;

--- a/imports/plugins/included/payments-paypal/server/methods/payflowpro-methods-refund.app-test.js
+++ b/imports/plugins/included/payments-paypal/server/methods/payflowpro-methods-refund.app-test.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";

--- a/imports/plugins/included/payments-stripe/client/settings/authorize.js
+++ b/imports/plugins/included/payments-stripe/client/settings/authorize.js
@@ -3,7 +3,7 @@ import { Template } from "meteor/templating";
 import { Reaction, Router, i18next } from "client/api";
 import { Components } from "@reactioncommerce/reaction-components";
 
-Template.stripeConnectAuthorize.onCreated(function () {
+Template.stripeConnectAuthorize.onCreated(() => {
   const shopId = Reaction.Router.getQueryParam("state");
   const authCode = Reaction.Router.getQueryParam("code");
   const error = Reaction.Router.getQueryParam("error");

--- a/imports/plugins/included/payments-stripe/server/methods/stripe-payment-create-charges.app-test.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripe-payment-create-charges.app-test.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: 0 */
+/* eslint prefer-arrow-callback:0 */
 import nock from "nock";
 
 import { Meteor } from "meteor/meteor";

--- a/imports/plugins/included/payments-stripe/server/methods/stripe.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripe.js
@@ -279,7 +279,7 @@ export const methods = {
       // and waits for the promise to resolve
       const customer = Promise.await(stripe.customers.create({
         email: customerEmail
-      }).then(function (cust) {
+      }).then((cust) => {
         const customerCard = stripe.customers.createSource(cust.id, { source: { ...card, object: "card" } });
         return customerCard;
       }));

--- a/imports/plugins/included/payments-stripe/server/methods/stripeapi-methods-capture.app-test.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripeapi-methods-capture.app-test.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: 0 */
+/* eslint prefer-arrow-callback:0 */
 import nock from "nock";
 import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";

--- a/imports/plugins/included/payments-stripe/server/methods/stripeapi-methods-refund.app-test.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripeapi-methods-refund.app-test.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: 0 */
+/* eslint prefer-arrow-callback:0 */
 import nock from "nock";
 import { Meteor } from "meteor/meteor";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/imports/plugins/included/payments-stripe/server/methods/stripeapi-methods-refundlist.app-test.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripeapi-methods-refundlist.app-test.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: 0 */
+/* eslint prefer-arrow-callback:0 */
 import nock from "nock";
 import { Meteor } from "meteor/meteor";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/imports/plugins/included/product-admin/client/containers/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/containers/productAdmin.js
@@ -110,7 +110,7 @@ function composer(props, onData) {
 
   if (product) {
     if (_.isArray(product.hashtags)) {
-      tags = _.map(product.hashtags, function (id) {
+      tags = _.map(product.hashtags, (id) => {
         return Tags.findOne(id);
       });
     }

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
@@ -299,7 +299,7 @@ function composer(props, onData) {
     if (product) {
       let tags;
       if (_.isArray(product.hashtags)) {
-        tags = _.map(product.hashtags, function (id) {
+        tags = _.map(product.hashtags, (id) => {
           return Tags.findOne(id);
         });
       }

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/edit.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/edit.js
@@ -99,6 +99,6 @@ Template.productDetailField.events({
  * productDetailEdit onRendered
  */
 
-Template.productDetailEdit.onRendered(function () {
+Template.productDetailEdit.onRendered(() => {
   return autosize($("textarea"));
 });

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/productImageGallery.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/productImageGallery.js
@@ -39,7 +39,7 @@ function uploadHandler(event) {
   // will have a chance to be displayed
   const toGrid = variant.ancestors.length >= 1;
 
-  return FS.Utility.eachFile(event, function (file) {
+  return FS.Utility.eachFile(event, (file) => {
     const fileObj = new FS.File(file);
     fileObj.metadata = {
       ownerId: userId,

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantList/variantList.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantList/variantList.js
@@ -50,7 +50,7 @@ Template.variantList.onRendered(function () {
               return element.getAttribute("data-id");
             });
 
-          Meteor.defer(function () {
+          Meteor.defer(() => {
             Meteor.call("products/updateVariantsPosition", positions);
           });
 

--- a/imports/plugins/included/product-variant/containers/variantEditContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantEditContainer.js
@@ -21,7 +21,7 @@ const wrapComponent = (Comp) => (
     };
 
     handleCreateNewChildVariant(variant) {
-      Meteor.call("products/createVariant", variant._id, function (error, result) {
+      Meteor.call("products/createVariant", variant._id, (error, result) => {
         if (error) {
           Alerts.alert({
             text: i18next.t("productDetailEdit.addVariantFail", { title: variant.title }),

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -90,7 +90,7 @@ const wrapComponent = (Comp) => (
         taxCodeProvider: provider.name
       });
 
-      codes.forEach(function (code) {
+      codes.forEach((code) => {
         taxCodesArray.push({
           value: code.taxCode,
           label: `${code.taxCode} | ${code.label}`
@@ -150,7 +150,7 @@ const wrapComponent = (Comp) => (
             isDeleted: !this.state.isDeleted
           });
           const id = variant._id;
-          Meteor.call("products/deleteVariant", id, function (error, result) {
+          Meteor.call("products/deleteVariant", id, (error, result) => {
             if (result && ReactionProduct.selectedVariantId() === id) {
               return ReactionProduct.setCurrentVariant(null);
             }
@@ -166,7 +166,7 @@ const wrapComponent = (Comp) => (
         return;
       }
       Meteor.call("products/cloneVariant", productId, variant._id,
-        function (error, result) {
+        (error, result) => {
           if (error) {
             Alerts.alert({
               text: i18next.t("productDetailEdit.cloneVariantFail", { title }),

--- a/imports/plugins/included/search-mongo/server/jobs/buildSearchCollections.js
+++ b/imports/plugins/included/search-mongo/server/jobs/buildSearchCollections.js
@@ -82,7 +82,7 @@ export default function () {
     },
     (job, callback) => {
       Logger.debug("(re)build ProductSearch collection running");
-      buildProductSearch(function (error) {
+      buildProductSearch((error) => {
         if (error) {
           job.done(error.toString(), { repeatId: true });
           callback();
@@ -103,7 +103,7 @@ export default function () {
     },
     (job, callback) => {
       Logger.debug("(re)build ProductSearch index running");
-      rebuildProductSearchIndex(function (error) {
+      rebuildProductSearchIndex((error) => {
         if (error) {
           job.done(error.toString(), { repeatId: true });
           callback();
@@ -124,7 +124,7 @@ export default function () {
     },
     (job, callback) => {
       Logger.debug("(re)build OrderSearch index running");
-      buildOrderSearch(function (error) {
+      buildOrderSearch((error) => {
         if (error) {
           job.done(error.toString(), { repeatId: true });
           callback();
@@ -145,7 +145,7 @@ export default function () {
     },
     (job, callback) => {
       Logger.debug("(re)build AccountSearch index running");
-      buildAccountSearch(function (error) {
+      buildAccountSearch((error) => {
         if (error) {
           job.done(error.toString(), { repeatId: true });
           callback();

--- a/imports/plugins/included/search-mongo/server/publications/searchresults.app-test.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import faker from "faker";
 import { Factory } from "meteor/dburles:factory";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/imports/plugins/included/shipping-rates/client/templates/settings/rates.js
+++ b/imports/plugins/included/shipping-rates/client/templates/settings/rates.js
@@ -78,7 +78,7 @@ Template.shippingRatesSettings.helpers({
 
     // add i18n handling to headers
     const customColumnMetadata = [];
-    filteredFields.forEach(function (field) {
+    filteredFields.forEach((field) => {
       const columnMeta = {
         accessor: field,
         Header: i18next.t(`admin.shippingGrid.${field}`)

--- a/imports/plugins/included/shipping-rates/server/hooks/hooks.js
+++ b/imports/plugins/included/shipping-rates/server/hooks/hooks.js
@@ -120,7 +120,7 @@ function getShippingRates(previousQueryResults, cart) {
 
   const shippingCollection = Shipping.find(selector);
   const initialNumOfRates = rates.length;
-  shippingCollection.forEach(function (doc) {
+  shippingCollection.forEach((doc) => {
     const _results = [];
     for (const method of doc.methods) {
       if (!method.enabled) {

--- a/imports/plugins/included/shipping-shippo/client/settings/carriers.js
+++ b/imports/plugins/included/shipping-shippo/client/settings/carriers.js
@@ -50,7 +50,7 @@ Template.shippoCarriers.helpers({
 
     // add i18n handling to headers
     const customColumnMetadata = [];
-    filteredFields.forEach(function (field) {
+    filteredFields.forEach((field) => {
       let colWidth = undefined;
       let colStyle = undefined;
       let colClassName = undefined;

--- a/imports/plugins/included/shipping-shippo/server/hooks/rates.js
+++ b/imports/plugins/included/shipping-shippo/server/hooks/rates.js
@@ -59,7 +59,7 @@ function getShippingRates(previousQueryResults, cart) {
   const shippingCollection = Shipping.find(selector);
   const shippoDocs = {};
   if (shippingCollection) {
-    shippingCollection.forEach(function (doc) {
+    shippingCollection.forEach((doc) => {
       // If provider is from Shippo, put it in an object to get rates dynamically(shippoApi) for all of them after.
       if (doc.provider.shippoProvider) {
         shippoDocs[doc.provider.shippoProvider.carrierAccountId] = doc;

--- a/imports/plugins/included/shipping-shippo/server/hooks/tracking.js
+++ b/imports/plugins/included/shipping-shippo/server/hooks/tracking.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { MethodHooks } from "/server/api";
 
-MethodHooks.before("shipping/status/refresh", function (options) {
+MethodHooks.before("shipping/status/refresh", (options) => {
   const orderId = options.arguments[0];
   Meteor.call("shippo/confirmShippingMethodForOrder",  orderId);
 });

--- a/imports/plugins/included/social/client/templates/social.js
+++ b/imports/plugins/included/social/client/templates/social.js
@@ -5,7 +5,7 @@ import { Packages } from "/lib/collections";
 
 Template.reactionSocial.onCreated(function () {
   const self = this;
-  return this.autorun(function () {
+  return this.autorun(() => {
     const subscription = Reaction.Subscriptions.Packages;
     if (subscription.ready()) {
       const socialSettings = Packages.findOne({

--- a/imports/plugins/included/taxes-avalara/client/accounts/exemption.js
+++ b/imports/plugins/included/taxes-avalara/client/accounts/exemption.js
@@ -66,7 +66,7 @@ Template.taxSettingsPanel.events({
   }
 });
 
-Template.taxSettingsPanel.onCreated(function () {
+Template.taxSettingsPanel.onCreated(() => {
   const avalaraPackage = Packages.findOne({
     name: "taxes-avalara",
     shopId: Reaction.getShopId()

--- a/imports/plugins/included/taxes-avalara/client/settings/avalara.js
+++ b/imports/plugins/included/taxes-avalara/client/settings/avalara.js
@@ -89,7 +89,7 @@ Template.avalaraSettings.helpers({
 
     // add i18n handling to headers
     const customColumnMetadata = [];
-    filteredFields.forEach(function (field) {
+    filteredFields.forEach((field) => {
       const columnMeta = {
         accessor: field,
         Header: i18next.t(`logGrid.columns.${field}`)
@@ -147,7 +147,7 @@ Template.avalaraSettings.events({
     const formData = AutoForm.getFormValues(formId);
     const settings = _.get(formData, "insertDoc.settings.avalara");
 
-    Meteor.call("avalara/testCredentials", settings, function (error, result) {
+    Meteor.call("avalara/testCredentials", settings, (error, result) => {
       if (error && error.message) {
         return Alerts.toast(`${i18next.t("settings.testCredentialsFailed")} ${error.message}`, "error");
       }

--- a/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
@@ -27,7 +27,7 @@ MethodHooks.after("taxes/calculate", (options) => {
   Logger.debug("Avalara triggered on taxes/calculate for cartId:", cartId);
 
   if (pkg && pkg.settings.avalara.enabled && pkg.settings.avalara.performTaxCalculation) {
-    taxCalc.estimateCart(cartToCalc, function (result) {
+    taxCalc.estimateCart(cartToCalc, (result) => {
       // we don't use totalTax, that just tells us we have a valid tax calculation
       if (result && !result.error && typeof result.totalTax === "number" && result.lines) {
         const taxes = linesToTaxes(result.lines);
@@ -51,7 +51,7 @@ MethodHooks.after("cart/copyCartToOrder", (options) => {
   if (pkg && pkg.settings.avalara.enabled && pkg.settings.avalara.performTaxCalculation) {
     const cartId = options.arguments[0];
     const order = Orders.findOne({ cartId: cartId });
-    taxCalc.recordOrder(order, function (result) {
+    taxCalc.recordOrder(order, (result) => {
       if (result) {
         Logger.info(`Order ${order._id} recorded with Avalara`);
       }
@@ -66,7 +66,7 @@ MethodHooks.after("orders/refunds/create", (options) => {
     const orderId = options.arguments[0];
     const order = Orders.findOne(orderId);
     const refundAmount = options.arguments[2];
-    taxCalc.reportRefund(order, refundAmount, function (result) {
+    taxCalc.reportRefund(order, refundAmount, (result) => {
       if (result) {
         Logger.info(`Refund for order ${order._id} recorded with Avalara`);
       }

--- a/imports/plugins/included/taxes-avalara/server/jobs/cleanup.js
+++ b/imports/plugins/included/taxes-avalara/server/jobs/cleanup.js
@@ -52,7 +52,7 @@ export default function () {
     },
     (job, callback) => {
       Logger.debug("Avalara log cleanup running");
-      cleanupAvalaraJobs(function (error) {
+      cleanupAvalaraJobs((error) => {
         if (error) {
           job.done(error.toString(), { repeatId: true });
           callback();

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -341,7 +341,7 @@ taxCalc.testCredentials = function (credentials, testCredentials = false) {
             Meteor.call("logging/logError", "avalara",  { error });
           }
         } else if (res && Array.isArray(res)) {
-          res.forEach(function (code) {
+          res.forEach((code) => {
             Meteor.call("taxes/insertTaxCodes", Reaction.getShopId(), code, "taxes-avalara", (err) => {
               if (err) {
                 throw new Meteor.Error("error-occurred", "Error populating TaxCodes collection", err);

--- a/imports/plugins/included/taxes-taxcloud/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-taxcloud/server/hooks/hooks.js
@@ -10,7 +10,7 @@ import { Shops, Cart, Packages } from "/lib/collections";
 // tax methods precendence is determined by
 // load order of plugins
 //
-MethodHooks.after("taxes/calculate", function (options) {
+MethodHooks.after("taxes/calculate", (options) => {
   const result = options.result || {};
   let origin = {};
 
@@ -97,7 +97,7 @@ MethodHooks.after("taxes/calculate", function (options) {
               }
             };
 
-            HTTP.post(url, request, function (error, response) {
+            HTTP.post(url, request, (error, response) => {
               let taxRate = 0;
               // ResponseType 3 is a successful call.
               if (!error && response.data.ResponseType === 3) {

--- a/imports/plugins/included/taxes-taxcloud/server/methods/methods.js
+++ b/imports/plugins/included/taxes-taxcloud/server/methods/methods.js
@@ -16,9 +16,9 @@ Meteor.methods({
     const taxCodes = HTTP.get(TAXCODE_SRC);
 
     if (taxCodes) {
-      taxCodes.data.tic_list.forEach(function (code) {
+      taxCodes.data.tic_list.forEach((code) => {
         if (code.tic.children) {
-          code.tic.children.forEach(function (child) {
+          code.tic.children.forEach((child) => {
             taxCodeArray.push(child.tic);
           });
         }

--- a/imports/plugins/included/taxes-taxjar/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-taxjar/server/hooks/hooks.js
@@ -2,7 +2,7 @@ import { Reaction, Logger, MethodHooks } from "/server/api";
 import { Packages } from "/lib/collections";
 
 // // Meteor.after to call after
-MethodHooks.after("taxes/calculate", function (options) {
+MethodHooks.after("taxes/calculate", (options) => {
   const result = options.result || {};
   const pkg = Packages.findOne({
     name: "taxes-taxjar",

--- a/lib/api/files.js
+++ b/lib/api/files.js
@@ -23,11 +23,11 @@ function _copyStoreData(fileObj, storeName, sourceKey, callback) {
   const readStream = storage.adapter.createReadStreamForFileKey(sourceKey);
   const writeStream = storage.adapter.createWriteStreamForFileKey(destinationKey);
 
-  writeStream.once("stored", function (result) {
+  writeStream.once("stored", (result) => {
     callback(null, result.fileKey);
   });
 
-  writeStream.once("error", function (error) {
+  writeStream.once("error", (error) => {
     callback(error);
   });
 

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -166,10 +166,10 @@ export function getSlug(slugString) {
 export function toCamelCase(needscamels) {
   let s;
   s = needscamels.replace(/([^a-zA-Z0-9_\- ])|^[_0-9]+/g, "").trim().toLowerCase();
-  s = s.replace(/([ -]+)([a-zA-Z0-9])/g, function (a, b, c) {
+  s = s.replace(/([ -]+)([a-zA-Z0-9])/g, (a, b, c) => {
     return c.toUpperCase();
   });
-  s = s.replace(/([0-9]+)([a-zA-Z])/g, function (a, b, c) {
+  s = s.replace(/([0-9]+)([a-zA-Z])/g, (a, b, c) => {
     return b + c.toUpperCase();
   });
   return s;

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -516,7 +516,7 @@ ReactionProduct.toggleVisibility = function (productOrArray) {
 ReactionProduct.cloneProduct = function (productOrArray) {
   const products = !Array.isArray(productOrArray) ? [productOrArray] : productOrArray;
 
-  return Meteor.call("products/cloneProduct", products, function (error, result) {
+  return Meteor.call("products/cloneProduct", products, (error, result) => {
     if (error) {
       Alerts.add(error, "danger", { placement: "productGridItem" });
       throw new Meteor.Error("error-occurred", error);
@@ -579,7 +579,7 @@ ReactionProduct.archiveProduct = function (productOrArray) {
     confirmButtonText: "Archive"
   }, (isConfirm) => {
     if (isConfirm) {
-      Meteor.call("products/archiveProduct", productIds, function (error, result) {
+      Meteor.call("products/archiveProduct", productIds, (error, result) => {
         let title;
         if (error) {
           title = products.length === 1 ?

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -318,7 +318,7 @@ export const cartOrderTransform = {
       return shopItems;
     }, {});
 
-    const shopObjects = Object.keys(itemsByShop).map(function (shop) {
+    const shopObjects = Object.keys(itemsByShop).map((shop) => {
       return {
         [shop]: {
           name: Shops.findOne(shop).name,

--- a/server/api/core/addDefaultRoles.app-test.js
+++ b/server/api/core/addDefaultRoles.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Factory } from "meteor/dburles:factory";
 import { sinon } from "meteor/practicalmeteor:sinon";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/server/api/core/endpoints.js
+++ b/server/api/core/endpoints.js
@@ -39,7 +39,7 @@ Endpoints.routes = [];
 let connectRouter;
 
 // Register as a middleware
-WebApp.connectHandlers.use(Meteor.bindEnvironment(connectRoute(function (router) {
+WebApp.connectHandlers.use(Meteor.bindEnvironment(connectRoute((router) => {
   connectRouter = router;
 })));
 
@@ -69,7 +69,7 @@ Endpoints.ErrorMiddleware = {
   }
 };
 
-Meteor.startup(function () {
+Meteor.startup(() => {
   errorMiddlewares.forEach((errorMiddleware) => {
     const errorMiddlewareFn = errorMiddleware.map((maybeFn) => {
       if (_.isFunction(maybeFn)) {
@@ -114,14 +114,14 @@ Endpoints.add = function (method, path, handler) {
     path: slashedPath
   });
 
-  connectRouter[method.toLowerCase()](path, function (req, res, next) {
+  connectRouter[method.toLowerCase()](path, (req, res, next) => {
     // Set headers on response
     const headerKeys = Object.keys(responseHeaders);
     headerKeys.forEach((key) => {
       res.setHeader(key, responseHeaders[key]);
     });
 
-    Fiber(function () {
+    Fiber(() => {
       try {
         handler(req, res, next);
       } catch (error) {

--- a/server/api/core/import.js
+++ b/server/api/core/import.js
@@ -121,7 +121,7 @@ Import.commit = function (collection) {
 
   // Only commit if the buffer isn't empty (otherwise it'll throw).
   if (this._count[name]) {
-    this.buffer(collection).execute(function (error, result) {
+    this.buffer(collection).execute((error, result) => {
       // Inserted document counts don't affect the modified document count, so we
       // throw everything together.
       const nImported = result.nModified + result.nInserted + result.nUpserted;

--- a/server/api/core/rightJoin.js
+++ b/server/api/core/rightJoin.js
@@ -22,7 +22,7 @@ const doRightJoinNoIntersection = (leftSet, rightSet) => {
     rightJoin = {};
   }
   const findRightOnlyProperties = () => {
-    return Object.keys(rightSet).filter(function (key) {
+    return Object.keys(rightSet).filter((key) => {
       if (typeof(rightSet[key]) === "object" &&
         !Array.isArray(rightSet[key])) {
         // Nested objects are always considered

--- a/server/api/core/templates.app-test.js
+++ b/server/api/core/templates.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import React from "react";
 import { expect } from "meteor/practicalmeteor:chai";
 import Reaction from "./";

--- a/server/api/geocoder.js
+++ b/server/api/geocoder.js
@@ -54,7 +54,7 @@ GeoCoder.prototype.geocode = function geoCoderGeocode(address, callback) {
   let geoCallback = callback;
   let geoAddress = address;
   if (geoCallback) {
-    geoCallback = Meteor.bindEnvironment(geoCallback, function (error) {
+    geoCallback = Meteor.bindEnvironment(geoCallback, (error) => {
       if (error) throw error;
     });
     gc(geoAddress, this.options, geoCallback);
@@ -76,7 +76,7 @@ function rv(lat, lng, options, callback) {
 GeoCoder.prototype.reverse = function geoCoderReverse(lat, lng, callback) {
   let geoCallback = callback;
   if (geoCallback) {
-    geoCallback = Meteor.bindEnvironment(geoCallback, function (error) {
+    geoCallback = Meteor.bindEnvironment(geoCallback, (error) => {
       if (error) throw error;
     });
     rv(lat, lng, this.options, geoCallback);
@@ -117,7 +117,7 @@ GeoCoder.prototype.geoip = function geoCoderGeocode(address, callback) {
   let geoCallback = callback;
   let geoAddress = address;
   if (geoCallback) {
-    geoCallback = Meteor.bindEnvironment(geoCallback, function (error) {
+    geoCallback = Meteor.bindEnvironment(geoCallback, (error) => {
       if (error) throw error;
     });
     gi(geoAddress, this.options, geoCallback);

--- a/server/api/method-hooks.js
+++ b/server/api/method-hooks.js
@@ -182,7 +182,7 @@ MethodHooks.after = function (methodName, afterFunction) {
  * @return {String} - returns transformed data
  */
 MethodHooks.beforeMethods = function (dict) {
-  _.each(dict, function (v, k) {
+  _.each(dict, (v, k) => {
     MethodHooks.before(k, v);
   });
 };
@@ -193,7 +193,7 @@ MethodHooks.beforeMethods = function (dict) {
  * @return {String} - returns transformed data
  */
 MethodHooks.afterMethods = function (dict) {
-  _.each(dict, function (v, k) {
+  _.each(dict, (v, k) => {
     MethodHooks.after(k, v);
   });
 };

--- a/server/imports/fixtures/fixtures.app-test.js
+++ b/server/imports/fixtures/fixtures.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Factory } from "meteor/dburles:factory";
 import { check, Match } from "meteor/check";

--- a/server/methods/accounts/accounts-validation.app-test.js
+++ b/server/methods/accounts/accounts-validation.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { expect } from "meteor/practicalmeteor:chai";
 

--- a/server/methods/accounts/accounts.app-test.js
+++ b/server/methods/accounts/accounts.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import _ from  "lodash";
 import { Meteor } from "meteor/meteor";
 import { Factory } from "meteor/dburles:factory";

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -160,7 +160,7 @@ function getValidator() {
   }
   // If there are two, we default to the one that is not the Reaction one
   if (geoCoders.length === 2) {
-    geoCoder = _.filter(geoCoders, function (coder) {
+    geoCoder = _.filter(geoCoders, (coder) => {
       return !_.includes(coder.name, "reaction");
     })[0];
   }
@@ -435,7 +435,7 @@ export function addressBookUpdate(address, accountUserId, type) {
   const account = Accounts.findOne({
     userId: userId
   });
-  const oldAddress = account.profile.addressBook.find(function (addr) {
+  const oldAddress = account.profile.addressBook.find((addr) => {
     return addr._id === address._id;
   });
 

--- a/server/methods/accounts/serviceConfiguration.js
+++ b/server/methods/accounts/serviceConfiguration.js
@@ -20,7 +20,7 @@ Meteor.methods({
     check(fields, Array);
     const dataToSave = {};
 
-    _.each(fields, function (field) {
+    _.each(fields, (field) => {
       dataToSave[field.property] = field.value;
     });
 

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -1,5 +1,6 @@
-/* eslint dot-notation: 0 */
-/* eslint no-loop-func: 0 */
+/* eslint dot-notation:0 */
+/* eslint no-loop-func:0 */
+/* eslint prefer-arrow-callback:0 */
 import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -175,7 +175,7 @@ function createHandle(productHandle, productId) {
 function copyMedia(newId, variantOldId, variantNewId) {
   Media.find({
     "metadata.variantId": variantOldId
-  }).forEach(function (fileObj) {
+  }).forEach((fileObj) => {
     // Copy File and insert directly, bypasing revision control
     copyFile(fileObj, {
       productId: newId,

--- a/server/methods/core/cart-create.app-test.js
+++ b/server/methods/core/cart-create.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Random } from "meteor/random";

--- a/server/methods/core/cart-merge.app-test.js
+++ b/server/methods/core/cart-merge.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Factory } from "meteor/dburles:factory";
 import { Random } from "meteor/random";

--- a/server/methods/core/cart-remove.app-test.js
+++ b/server/methods/core/cart-remove.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Random } from "meteor/random";

--- a/server/methods/core/groups.app-test.js
+++ b/server/methods/core/groups.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Factory } from "meteor/dburles:factory";

--- a/server/methods/core/hooks/cart.js
+++ b/server/methods/core/hooks/cart.js
@@ -5,7 +5,7 @@ import { Logger, MethodHooks } from "/server/api";
 import "../cart";
 
 // // Meteor.after to call after
-MethodHooks.after("cart/submitPayment", function (options) {
+MethodHooks.after("cart/submitPayment", (options) => {
   // TODO: REVIEW WITH AARON - this is too late to fail. We need to copy cart to order either way at this point
   // if cart/submit had an error we won't copy cart to Order
   // and we'll throw an error.

--- a/server/methods/core/hooks/shop.js
+++ b/server/methods/core/hooks/shop.js
@@ -2,7 +2,7 @@ import { Logger, MethodHooks } from "/server/api";
 // this needed to keep correct loading order. Methods should be loaded before hooks
 import "../shop";
 
-MethodHooks.after("shop/createTag", function (options) {
+MethodHooks.after("shop/createTag", (options) => {
   if (options.error) {
     Logger.warn("Failed to add new tag:", options.error.reason);
     return options.error;

--- a/server/methods/core/methods.app-test.js
+++ b/server/methods/core/methods.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { Factory } from "meteor/dburles:factory";

--- a/server/methods/core/orders.app-test.js
+++ b/server/methods/core/orders.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import accounting from "accounting-js";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";

--- a/server/methods/core/packages-update.app-test.js
+++ b/server/methods/core/packages-update.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Match } from "meteor/check";
 import { Factory } from "meteor/dburles:factory";

--- a/server/methods/core/registry.js
+++ b/server/methods/core/registry.js
@@ -36,7 +36,7 @@ export const methods = {
     dataToSave[setting] = {};
     const currentPackage = Packages.findOne(packageId);
 
-    _.each(fields, function (field) {
+    _.each(fields, (field) => {
       dataToSave[setting][field.property] = field.value;
     });
 

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -220,7 +220,7 @@ Meteor.methods({
     }
 
     // localeCurrency is an array of allowed currencies
-    _.each(localeCurrency, function (currency) {
+    _.each(localeCurrency, (currency) => {
       let exchangeRate;
       if (shop.currencies[currency]) {
         result.currency = shop.currencies[currency];
@@ -362,7 +362,7 @@ Meteor.methods({
 
         const exchangeRates = rateResults.data.rates;
 
-        _.each(shopCurrencies, function (currencyConfig, currencyKey) {
+        _.each(shopCurrencies, (currencyConfig, currencyKey) => {
           if (exchangeRates[currencyKey] !== undefined) {
             const rateUpdate = {
               // this needed for shop/flushCurrencyRates Method
@@ -418,7 +418,7 @@ Meteor.methods({
     const now = new Date();
 
     if (now < updatedAt) { // todo remove this line. its for tests
-      _.each(shop.currencies, function (currencyConfig, currencyKey) {
+      _.each(shop.currencies, (currencyConfig, currencyKey) => {
         const rate = `currencies.${currencyKey}.rate`;
 
         if (typeof currencyConfig.rate === "number") {

--- a/server/methods/core/shops.app-test.js
+++ b/server/methods/core/shops.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
 import { expect } from "meteor/practicalmeteor:chai";

--- a/server/methods/translations.app-test.js
+++ b/server/methods/translations.app-test.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Factory } from "meteor/dburles:factory";
 import { Roles } from "meteor/alanning:roles";

--- a/server/publications/collections/cart-publications.app-test.js
+++ b/server/publications/collections/cart-publications.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
 import { Factory } from "meteor/dburles:factory";

--- a/server/publications/collections/cart.js
+++ b/server/publications/collections/cart.js
@@ -68,7 +68,7 @@ Meteor.publish("Cart", function (sessionId, userId) {
 });
 
 
-Meteor.publish("CartImages", function (cartItems) {
+Meteor.publish("CartImages", (cartItems) => {
   check(cartItems, Array);
 
   // Ensure each of these are unique
@@ -100,7 +100,7 @@ Meteor.publish("CartImages", function (cartItems) {
   return productImages;
 });
 
-Meteor.publish("CartItemImage", function (cartItem) {
+Meteor.publish("CartItemImage", (cartItem) => {
   check(cartItem, Match.Optional(Object));
   const productId = cartItem.productId;
 

--- a/server/publications/collections/members-publications.app-test.js
+++ b/server/publications/collections/members-publications.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { Factory } from "meteor/dburles:factory";

--- a/server/publications/collections/orders-publications.app-test.js
+++ b/server/publications/collections/orders-publications.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
 import { check, Match } from "meteor/check";

--- a/server/publications/collections/packages.js
+++ b/server/publications/collections/packages.js
@@ -125,7 +125,7 @@ Meteor.publish("Packages", function (shopId) {
         }
       });
 
-      self.onStop(function () {
+      self.onStop(() => {
         observer.stop();
       });
     }

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -1,4 +1,5 @@
 /* eslint dot-notation: 0 */
+/* eslint prefer-arrow-callback:0 */
 import { Random } from "meteor/random";
 import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";

--- a/server/publications/collections/reactiveAggregate.js
+++ b/server/publications/collections/reactiveAggregate.js
@@ -88,7 +88,7 @@ export function ReactiveAggregate(pub, collection, pipeline, options) {
     }
 
     // add and update documents on the client
-    collection.aggregate(pipeline).forEach(function (doc) {
+    collection.aggregate(pipeline).forEach((doc) => {
       if (!pub._ids[doc._id]) {
         pub.added(pubOptions.clientCollection, doc._id, doc);
       } else {
@@ -125,7 +125,7 @@ export function ReactiveAggregate(pub, collection, pipeline, options) {
   pub.ready();
 
   // stop observing the cursor when the client unsubscribes
-  pub.onStop(function () {
+  pub.onStop(() => {
     handle.stop();
   });
 }

--- a/server/publications/collections/sessions.js
+++ b/server/publications/collections/sessions.js
@@ -12,7 +12,7 @@ import { Reaction } from "/server/api";
 
 export const ServerSessions = new Mongo.Collection("Sessions");
 
-Meteor.publish("Sessions", function (sessionId) {
+Meteor.publish("Sessions", (sessionId) => {
   check(sessionId, Match.OneOf(String, null));
   const created = new Date().getTime();
   let newSessionId;

--- a/server/publications/collections/shops.js
+++ b/server/publications/collections/shops.js
@@ -3,7 +3,7 @@ import { Reaction } from "/server/api";
 import { Shops } from "/lib/collections";
 
 // We should be able to publish just the enabled languages/currencies/
-Meteor.publish("PrimaryShop", function () {
+Meteor.publish("PrimaryShop", () => {
   return Shops.find({
     shopType: "primary"
   }, {

--- a/server/publications/collections/themes.js
+++ b/server/publications/collections/themes.js
@@ -6,6 +6,6 @@ import { Themes } from "/lib/collections";
  * @returns {Object} thtmes - themes cursor
  */
 
-Meteor.publish("Themes", function () {
+Meteor.publish("Themes", () => {
   return Themes.find({});
 });

--- a/server/publications/collections/translations.js
+++ b/server/publications/collections/translations.js
@@ -16,7 +16,7 @@ import { Reaction } from "/server/api";
  * @returns { Object } returns Translations
  * @todo like to see the langages validated more with a schema
  */
-Meteor.publish("Translations", function (languages) {
+Meteor.publish("Translations", (languages) => {
   check(languages, Match.OneOf(String, Array));
   const shopId = Reaction.getShopId();
   const shopLanguage = Shops.findOne(shopId).language;

--- a/server/security/collections.js
+++ b/server/security/collections.js
@@ -184,7 +184,7 @@ export default function () {
   /*
    * apply download permissions to file collections
    */
-  _.each([Media], function (fsCollection) {
+  _.each([Media], (fsCollection) => {
     return fsCollection.allow({
       download: function () {
         return true;

--- a/server/startup/accounts.js
+++ b/server/startup/accounts.js
@@ -12,7 +12,7 @@ export default function () {
    * http://docs.meteor.com/#/full/accounts_validateloginattempt
    */
 
-  Accounts.validateLoginAttempt(function (attempt) {
+  Accounts.validateLoginAttempt((attempt) => {
     if (!attempt.allowed) {
       return false;
     }
@@ -31,7 +31,7 @@ export default function () {
 
     if (loginEmail && loginEmail === adminEmail) {
       // filter out the matching login email from any existing emails
-      const userEmail = _.filter(attempt.user.emails, function (email) {
+      const userEmail = _.filter(attempt.user.emails, (email) => {
         return email.address === loginEmail;
       });
 
@@ -49,7 +49,7 @@ export default function () {
    * creates a login type "anonymous"
    * default for all unauthenticated visitors
    */
-  Accounts.registerLoginHandler(function (options) {
+  Accounts.registerLoginHandler((options) => {
     if (!options.anonymous) return {};
 
     const stampedToken = Accounts._generateStampedLoginToken();

--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -51,7 +51,7 @@ export function loadTranslation(source) {
  * @return {Boolean} false if assets weren't loaded
  */
 export function loadTranslations(sources) {
-  sources.forEach(function (source) {
+  sources.forEach((source) => {
     loadTranslation(source);
   });
 }
@@ -70,7 +70,7 @@ export function loadCoreTranslations() {
   const i18nFolder = `${meteorPath}/server/assets/app/data/i18n/`;
 
   if (directoryExists(i18nFolder)) {
-    fs.readdir(i18nFolder, Meteor.bindEnvironment(function (err, files) {
+    fs.readdir(i18nFolder, Meteor.bindEnvironment((err, files) => {
       if (err) throw new Meteor.Error("No translations found for import.", err);
       for (const file of files) {
         if (~file.indexOf("json")) {


### PR DESCRIPTION
Resolves #3572 

This PR enables and fixes errors/warnings caused by `prefer-arrow-callback`

**Note:**
- I've disabled this rule in all the test files because Mocha recommends not using arrow functions https://mochajs.org/#arrow-functions. 
- Reason being arrow functions lexically bind `this` and cannot access the Mocha context. So, for example `this.timeout(1000);` would not work using arrow functions

**Reviewer on PR:** You might find it easier reviewing using my commits .. I made changes per folder and commited them as such.