### PR TITLE
(fix): Add permission checks to template method and publication

### DIFF
--- a/imports/plugins/core/layout/server/publications/templates.js
+++ b/imports/plugins/core/layout/server/publications/templates.js
@@ -20,9 +20,20 @@ Meteor.publish("Templates", function (query, options) {
       return this.ready();
     }
 
+    // Check that this user has templates permissions for the active shop
+    if (!Reaction.hasPermission("reaction-templates", Meteor.userId(), shopId)) {
+      return this.ready();
+    }
+
     // append shopId to query
     countSelector.shopId = shopId;
     findSelector.shopId = shopId;
+  } else {
+    // Shop specific templates are not enabled
+    // Check that this user has templates permissions for the primary shop
+    if (!Reaction.hasPermission("reaction-templates", Meteor.userId(), Reaction.getPrimaryShopId())) {
+      return this.ready();
+    }
   }
 
   // If we aren't using merchantTemplates, we'll share templates with the primary shop

--- a/imports/plugins/core/layout/server/publications/templates.js
+++ b/imports/plugins/core/layout/server/publications/templates.js
@@ -20,20 +20,9 @@ Meteor.publish("Templates", function (query, options) {
       return this.ready();
     }
 
-    // Check that this user has templates permissions for the active shop
-    if (!Reaction.hasPermission("reaction-templates", Meteor.userId(), shopId)) {
-      return this.ready();
-    }
-
     // append shopId to query
     countSelector.shopId = shopId;
     findSelector.shopId = shopId;
-  } else {
-    // Shop specific templates are not enabled
-    // Check that this user has templates permissions for the primary shop
-    if (!Reaction.hasPermission("reaction-templates", Meteor.userId(), Reaction.getPrimaryShopId())) {
-      return this.ready();
-    }
   }
 
   // If we aren't using merchantTemplates, we'll share templates with the primary shop

--- a/imports/plugins/core/templates/server/methods.js
+++ b/imports/plugins/core/templates/server/methods.js
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
+import { Reaction } from "/server/api";
 import { Templates } from "/lib/collections";
 
 /**
@@ -23,13 +24,19 @@ export const methods = {
   "templates/email/update": function (templateId, doc) {
     check(templateId, String);
     check(doc, Object);
-    // TODO: add permissions
-    // if (!Reaction.hasPermission("shipping")) {
-    //   throw new Meteor.Error(403, "Access Denied");
-    // }
+
+    const shopId = Reaction.getShopId();
+    const userId = Meteor.userId();
+
+    // Check that this user has permission to update templates for the active shop
+    if (!Reaction.hasPermission("reaction-templates", userId, shopId)) {
+      throw new Meteor.Error(403, "Access Denied");
+    }
+
     return Templates.update({
       _id: templateId,
-      type: "email"
+      type: "email",
+      shopId: shopId // Ensure that the template we're attempting to update is owned by the active shop.
     }, {
       $set: {
         title: doc.title,

--- a/imports/plugins/core/templates/server/methods.js
+++ b/imports/plugins/core/templates/server/methods.js
@@ -30,7 +30,7 @@ export const methods = {
 
     // Check that this user has permission to update templates for the active shop
     if (!Reaction.hasPermission("reaction-templates", userId, shopId)) {
-      throw new Meteor.Error(403, "Access Denied");
+      throw new Meteor.Error("access-denied", "Access Denied");
     }
 
     return Templates.update({


### PR DESCRIPTION
Adds permission checks to the `template/email/update` server method.

I've tested and verified that as an admin you can still view and modify email templates.
I've also tested and verified that users without the `reaction-templates` role for the primary shop cannot view or subscribe to the templates, and cannot modify them.

We currently _do not_ use shop specific templates, the default marketplace install of Reaction disables template editing for shops and uses the primary shop's templates for all emails. I've added this code to be compatible with marketplace shops, but it's not enabled right now anyway, and there's not a great way to test that.

**To test:**
1. Verify that as the admin user or user with the `reaction-templates` role you can still view and modify templates.
2. As an unauthenticated user. (incognito window works)
3. Attempt to subscribe to the templates publication, verify that you are not sent any template documents.
4. Attempt to modify a template by calling the `template/email/update` method from the client console. Verify that you are not able to do so successfully.

![image](https://user-images.githubusercontent.com/1203639/35468148-98f311dc-02d5-11e8-8ed4-d631bdf3afc0.png)