### PR TITLE
Add CSS class to generic product fields

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/components/productField.js
+++ b/imports/plugins/included/product-detail-simple/client/components/productField.js
@@ -133,7 +133,7 @@ class ProductField extends Component {
     const classNames = classnames({
       pdp: true,
       field: true,
-      [this.fieldName]: this.fieldName
+      [this.fieldName]: !!this.fieldName
     });
 
     if (this.props.element) {

--- a/imports/plugins/included/product-detail-simple/client/components/productField.js
+++ b/imports/plugins/included/product-detail-simple/client/components/productField.js
@@ -130,16 +130,22 @@ class ProductField extends Component {
       return this.renderTextField();
     }
 
+    const classNames = classnames({
+      pdp: true,
+      field: true,
+      [this.fieldName]: this.fieldName
+    });
+
     if (this.props.element) {
       return React.createElement(this.props.element, {
-        className: "pdp field",
+        className: classNames,
         itemProp: this.props.itemProp,
         children: this.value
       });
     }
 
     return (
-      <div className="pdp field">
+      <div className={classNames}>
         {this.value}
       </div>
     );


### PR DESCRIPTION
This PR resolves issue #3608 

It adds an additional class name "fieldname" to the existing ones (pdp, field).

To test:
- Navigate to PDP page
- Inspect the title field with Chrome inspector
- HTML source should contain the field name for fields like title, vendor, description, etc.

![developer_tools_-_http___localhost_3000_product_reaction-mug_and_reaction_mug](https://user-images.githubusercontent.com/1733229/35507813-55b5fcfc-04ee-11e8-97fa-cba90820c79d.jpg)

