### PR TITLE
(refactor): remove kadira:dochead meteor package and add needed functions to a core plugin

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -62,7 +62,6 @@ cfs:ui
 dispatch:run-as-user
 juliancwirko:s-alert
 juliancwirko:s-alert-stackslide
-kadira:dochead
 matb33:collection-hooks
 meteorhacks:ssr
 meteorhacks:subs-manager

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -89,7 +89,6 @@ jquery@1.11.10
 juliancwirko:postcss@1.2.0
 juliancwirko:s-alert@3.2.0
 juliancwirko:s-alert-stackslide@3.1.3
-kadira:dochead@1.5.0
 launch-screen@1.1.1
 less@2.7.11
 livedata@1.0.18

--- a/client/modules/core/index.js
+++ b/client/modules/core/index.js
@@ -5,6 +5,7 @@ import * as Utils from "./helpers/utils";
 import { Subscriptions } from "./subscriptions";
 
 import Log from "/client/modules/logger";
+import { DOM } from "/imports/plugins/core/dom/client";
 import { Router } from "/client/modules/router";
 
 import * as Collections from "/lib/collections";
@@ -18,6 +19,7 @@ export const Reaction = Object.assign(
   Utils,
   { Subscriptions },
   { Log },
+  { DOM },
   { Router },
   { Collections },
   { Schemas }

--- a/imports/plugins/core/dom/client/dom.js
+++ b/imports/plugins/core/dom/client/dom.js
@@ -1,5 +1,3 @@
-// import { Tracker } from "meteor/tracker";
-
 /**
  * @file Exposes the DOM object used to manipulate the document.
  *  NOTE: this functions are only meant to be used on the client.

--- a/imports/plugins/core/dom/client/dom.js
+++ b/imports/plugins/core/dom/client/dom.js
@@ -10,7 +10,7 @@
 const DOM = {};
 
 /*
- * Adds meta tags to the <head> of the document
+ * Sets/adds a meta tag to the document head
  * @param {Object} attributes - key/value pairs for tag attributes
  * @return {undefined} no return value
   */
@@ -26,6 +26,7 @@ DOM.setMetaTag = (attributes) => {
 
   // Otherwise, create a new meta tag element
   const newMetaTag = document.createElement("meta");
+
   newMetaTag.setAttribute("name", attributes.name);
   newMetaTag.setAttribute("content", attributes.content);
   // This attribute will be used to remove meta tags on route changes.
@@ -33,6 +34,23 @@ DOM.setMetaTag = (attributes) => {
 
   // Append to document head
   document.head.appendChild(newMetaTag);
+};
+
+/*
+ * Adds a link tags to the document head
+ * @param {Object} attributes - key/value pairs for tag attributes
+ * @return {undefined} no return value
+  */
+DOM.addLinkTag = (attributes) => {
+  const newLinkTag = document.createElement("link");
+
+  for (const key in attributes) {
+    if ({}.hasOwnProperty.call(attributes, key)) {
+      newLinkTag.setAttribute(key, attributes[key]);
+    }
+  }
+
+  document.head.appendChild(newLinkTag);
 };
 
 /**

--- a/imports/plugins/core/dom/client/dom.js
+++ b/imports/plugins/core/dom/client/dom.js
@@ -1,0 +1,50 @@
+// import { Tracker } from "meteor/tracker";
+
+/**
+ * @file Exposes the DOM object used to manipulate the document.
+ *  NOTE: this functions are only meant to be used on the client.
+ * @author Will Lopez
+ * @namespace DOM
+ */
+
+const DOM = {};
+
+/*
+ * Adds meta tags to the <head> of the document
+ * @param {Object} attributes - key/value pairs for tag attributes
+ * @return {undefined} no return value
+  */
+DOM.setMetaTag = (attributes) => {
+  const currentMetaTag = document.querySelector(`meta[name="${attributes.name}"]`);
+
+  // If tag exists, just update its content attribute
+  if (currentMetaTag) {
+    currentMetaTag.setAttribute("content", attributes.content);
+    currentMetaTag.setAttribute("data-metatag", "1");
+    return;
+  }
+
+  // Otherwise, create a new meta tag element
+  const newMetaTag = document.createElement("meta");
+  newMetaTag.setAttribute("name", attributes.name);
+  newMetaTag.setAttribute("content", attributes.content);
+  // This attribute will be used to remove meta tags on route changes.
+  newMetaTag.setAttribute("data-metatag", "1");
+
+  // Append to document head
+  document.head.appendChild(newMetaTag);
+};
+
+/**
+ * Removes document head tags
+ *
+ * @returns {undefined} no return value
+ */
+DOM.removeDocHeadAddedTags = () => {
+  const elements = document.querySelectorAll('[data-metatag="1"]');
+  for (const element of elements) {
+    element.parentNode.removeChild(element);
+  }
+};
+
+export default DOM;

--- a/imports/plugins/core/dom/client/index.js
+++ b/imports/plugins/core/dom/client/index.js
@@ -1,0 +1,3 @@
+export { default as DOM } from "./dom";
+
+

--- a/imports/test-utils/__mocks__/meteor/kadira:dochead.js
+++ b/imports/test-utils/__mocks__/meteor/kadira:dochead.js
@@ -1,5 +1,0 @@
-export const DocHead = {
-  addMeta: () => {},
-  removeDocHeadAddedTags: () => {},
-  setTitle: () => {}
-};

--- a/lib/api/router/metadata.js
+++ b/lib/api/router/metadata.js
@@ -13,7 +13,8 @@ export const MetaData = {
     const shop = Shops.findOne(getShopId());
     const meta = [];
     let title = "";
-    const keywords = [];
+    let description = "";
+    let keywords = [];
 
     // case helper
     const titleCase = (param) => {
@@ -23,18 +24,12 @@ export const MetaData = {
     // populate meta from shop
     if (shop) {
       // shop defaults
-      if (shop && shop.description) {
-        Reaction.DOM.setMetaTag({
-          name: "description",
-          content: shop.description.substring(0, 160)
-        });
+      if (shop.description) {
+        description = shop.description.substring(0, 160);
       }
 
-      if (shop && shop.keywords) {
-        Reaction.DOM.setMetaTag({
-          name: "keywords",
-          content: shop.keywords.toString()
-        });
+      if (shop.keywords) {
+        keywords.push(shop.keywords.toString());
       }
 
       // set title defaults
@@ -84,31 +79,34 @@ export const MetaData = {
         Reaction.DOM.removeDocHeadAddedTags();
 
         if (product.description) {
-          Reaction.DOM.setMetaTag({
-            name: "description",
-            content: product.description.substring(0, 160)
-          });
+          description = product.description.substring(0, 160);
         }
 
         if (product && product.metafields) {
+          // Clear shop keywords, to make keywords specific to this product page.
+          keywords = [];
           for (const key of product.metafields) {
             keywords.push(key.value);
           }
         }
-
-        if (keywords) {
-          Reaction.DOM.setMetaTag({
-            name: "keywords",
-            content: keywords.toString()
-          });
-        }
       }
-
-      // set site defaults
-      document.title = title;
-      MetaData.title = title;
-      MetaData.meta = meta;
-      return meta;
     } // end shop
+
+    Reaction.DOM.setMetaTag({
+      name: "description",
+      content: description
+    });
+
+    Reaction.DOM.setMetaTag({
+      name: "keywords",
+      content: keywords ? keywords.toString() : ""
+    });
+
+    // set site defaults
+    document.title = title;
+    MetaData.title = title;
+    MetaData.meta = meta;
+
+    return meta;
   } // end update
 };

--- a/lib/api/router/metadata.js
+++ b/lib/api/router/metadata.js
@@ -1,5 +1,4 @@
-import { DocHead } from "meteor/kadira:dochead";
-import { ReactionProduct, getShopId } from "/lib/api";
+import { ReactionProduct, getShopId, Reaction } from "/lib/api";
 import { Shops, SellerShops } from "/lib/collections";
 
 /**
@@ -25,14 +24,14 @@ export const MetaData = {
     if (shop) {
       // shop defaults
       if (shop && shop.description) {
-        DocHead.addMeta({
+        Reaction.DOM.setMetaTag({
           name: "description",
           content: shop.description.substring(0, 160)
         });
       }
 
       if (shop && shop.keywords) {
-        DocHead.addMeta({
+        Reaction.DOM.setMetaTag({
           name: "keywords",
           content: shop.keywords.toString()
         });
@@ -82,10 +81,10 @@ export const MetaData = {
       //  product details
       if (params && params.handle && product) {
         // discard defaults
-        DocHead.removeDocHeadAddedTags();
+        Reaction.DOM.removeDocHeadAddedTags();
 
         if (product.description) {
-          DocHead.addMeta({
+          Reaction.DOM.setMetaTag({
             name: "description",
             content: product.description.substring(0, 160)
           });
@@ -98,7 +97,7 @@ export const MetaData = {
         }
 
         if (keywords) {
-          DocHead.addMeta({
+          Reaction.DOM.setMetaTag({
             name: "keywords",
             content: keywords.toString()
           });
@@ -106,7 +105,7 @@ export const MetaData = {
       }
 
       // set site defaults
-      DocHead.setTitle(title);
+      document.title = title;
       MetaData.title = title;
       MetaData.meta = meta;
       return meta;


### PR DESCRIPTION
This PR removes the kadira:dochead meteor package, and adds a core plugins to provide the necessary functionality. A new namespace named `Reaction.DOM` is added to provide functions to manipulate the document.

In particular, `Reaction.DOM.setMetaTag` is used to add meta tags.

**Testing Procedure**
- Login as a shop administrator
- Click on the "Shop" link
- Under general add a description and keywords
- Reload page and use the inspect element to verify that meta tags were added

