### PR TITLE
Add missing address2 details

### DIFF
--- a/imports/plugins/core/checkout/client/components/completedOrder.js
+++ b/imports/plugins/core/checkout/client/components/completedOrder.js
@@ -82,7 +82,7 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
                   <div className="order-details-info-box-content">
                     <p>
                       {shipment.address.fullName}<br/>
-                      {shipment.address.address1}<br/>
+                      {shipment.address.address1} {shipment.address.address2}<br/>
                       {shipment.address.city}, {shipment.address.region} {shipment.address.postal} {shipment.address.country}
                     </p>
                   </div>

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -760,7 +760,7 @@ export const methods = {
         order,
         billing: {
           address: {
-            address: `${address.address1}${address.address2 ? ' ' + address.address2 : ''}`,
+            address: `${address.address1}${address.address2 ? " " + address.address2 : ""}`,
             city: address.city,
             region: address.region,
             postal: address.postal
@@ -781,7 +781,7 @@ export const methods = {
           tracking,
           carrier,
           address: {
-            address: `${shippingAddress.address1}${shippingAddress.address2 ? ' ' + shippingAddress.address2 : ''}`,
+            address: `${shippingAddress.address1}${shippingAddress.address2 ? " " + shippingAddress.address2 : ""}`,
             city: shippingAddress.city,
             region: shippingAddress.region,
             postal: shippingAddress.postal

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -760,7 +760,7 @@ export const methods = {
         order,
         billing: {
           address: {
-            address: address.address1,
+            address: `${address.address1}${address.address2 ? ' ' + address.address2 : ''}`,
             city: address.city,
             region: address.region,
             postal: address.postal
@@ -781,7 +781,7 @@ export const methods = {
           tracking,
           carrier,
           address: {
-            address: shippingAddress.address1,
+            address: `${shippingAddress.address1}${shippingAddress.address2 ? ' ' + shippingAddress.address2 : ''}`,
             city: shippingAddress.city,
             region: shippingAddress.region,
             postal: shippingAddress.postal


### PR DESCRIPTION
Closes #3601

When providing an address on the order page, the form has two address
fields.  However, when you enter details in the second address field
(address2) those details are not included in the order confirmation or
the order confirmation email.

This commit updates both to correctly include the full address details.

Note that if we don't check for the existence of address.address2 and
shippingAddress.address2 in server/methods/core/orders.js then we'll
see undefined for address2 in the contents of the e-mail.
