### PR TITLE
(wip)(refactor): Convert Products collection hooks to Hooks.Events

### DIFF
--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -274,7 +274,7 @@ Media.files.before.remove((userId, media) => {
   return true;
 });
 
-Hooks.Events.add("beforeProductInsert", (product) => {
+Hooks.Events.add("verifyProductInsert", (product) => {
   if (RevisionApi.isRevisionControlEnabled() === false) {
     return true;
   }
@@ -295,7 +295,7 @@ Hooks.Events.add("beforeProductInsert", (product) => {
 
   // Prevent this product from being created if a parent product / varaint ancestor is deleted.
   //
-  // This will prevent cases where a parent variant hase been deleted and a user tries to create a
+  // This will prevent cases where a parent variant has been deleted and a user tries to create a
   // child variant. You cannot create the child variant becuase the parent will no longer exist when
   // changes have been published; resulting in a broken inheretence and UI
   const productHasAncestors = Array.isArray(product.ancestors);

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -330,8 +330,9 @@ Hooks.Events.add("verifyProductInsert", (product) => {
   }
 });
 
-Hooks.Events.add("beforeProductUpdate", (userId, product, modifier, options) => {
-  console.log("modifier", modifier);
+Hooks.Events.add("beforeProductUpdate", (bla) => {
+  const { userId, modifier, options, product } = { ...bla };
+  console.log( "userId", userId, "modifier", modifier, "options", options);
   if (RevisionApi.isRevisionControlEnabled() === false) {
     return true;
   }

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -611,7 +611,7 @@ Products.before.update(function (userId, product, fieldNames, modifier, options)
   return false;
 });
 
-Products.before.remove((userId, product) => {
+Hooks.Events.add("beforeProductRemove", (product) => {
   if (RevisionApi.isRevisionControlEnabled() === false) {
     return true;
   }

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { diff } from "deep-diff";
 import { Meteor } from "meteor/meteor";
 import { Products, Revisions, Tags, Media } from "/lib/collections";
-import { Logger } from "/server/api";
+import { Hooks, Logger } from "/server/api";
 import { RevisionApi } from "../lib/api";
 import { getSlug } from "/lib/api";
 
@@ -274,8 +274,7 @@ Media.files.before.remove((userId, media) => {
   return true;
 });
 
-
-Products.before.insert((userId, product) => {
+Hooks.Events.add("beforeProductInsert", (product) => {
   if (RevisionApi.isRevisionControlEnabled() === false) {
     return true;
   }
@@ -330,7 +329,6 @@ Products.before.insert((userId, product) => {
     });
   }
 });
-
 
 Products.before.update(function (userId, product, fieldNames, modifier, options) {
   if (RevisionApi.isRevisionControlEnabled() === false) {

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -330,7 +330,8 @@ Hooks.Events.add("verifyProductInsert", (product) => {
   }
 });
 
-Products.before.update(function (userId, product, fieldNames, modifier, options) {
+Hooks.Events.add("beforeProductUpdate", (userId, product, modifier, options) => {
+  console.log("modifier", modifier);
   if (RevisionApi.isRevisionControlEnabled() === false) {
     return true;
   }
@@ -371,7 +372,7 @@ Products.before.update(function (userId, product, fieldNames, modifier, options)
       throw new Meteor.Error("unable-to-delete-variant", "Unable to delete product variant");
     }
   }
-
+  console.log("this.args[0]", this.args[0]);
   const originalSelector = this.args[0];
 
   if (!productRevision) {

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -330,9 +330,8 @@ Hooks.Events.add("verifyProductInsert", (product) => {
   }
 });
 
-Hooks.Events.add("beforeProductUpdate", (bla) => {
-  const { userId, modifier, options, product } = { ...bla };
-  console.log( "userId", userId, "modifier", modifier, "options", options);
+Hooks.Events.add("beforeProductUpdate", (productUpdateArgs) => {
+  const { product, modifier, options } = { ...productUpdateArgs };
   if (RevisionApi.isRevisionControlEnabled() === false) {
     return true;
   }
@@ -373,8 +372,8 @@ Hooks.Events.add("beforeProductUpdate", (bla) => {
       throw new Meteor.Error("unable-to-delete-variant", "Unable to delete product variant");
     }
   }
-  console.log("this.args[0]", this.args[0]);
-  const originalSelector = this.args[0];
+
+  const originalSelector = { _id: product._id };
 
   if (!productRevision) {
     Logger.debug(`No revision found for product ${product._id}. Creating new revision`);
@@ -411,7 +410,7 @@ Hooks.Events.add("beforeProductUpdate", (bla) => {
     }
   };
 
-  if (options.publish === true || (product.workflow && product.workflow.status === "product/publish")) {
+  if (options && options.publish === true || (product.workflow && product.workflow.status === "product/publish")) {
     // Maybe mark the revision as published
 
     Logger.debug(`Publishing revison for product ${product._id}.`);

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Products, Media, Revisions, Packages } from "/lib/collections";
-import { Logger } from "/server/api";
+import { Hooks, Logger } from "/server/api";
 
 export function updateSettings(settings) {
   check(settings, Object);
@@ -115,7 +115,11 @@ Meteor.methods({
       for (const revision of revisions) {
         if (!revision.documentType || revision.documentType === "product") {
           previousDocuments.push(Products.findOne(revision.documentId));
-
+          Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(revision.documentId), {
+            $set: revision.documentData
+          }, {
+            publish: true
+          });
           const res = Products.update({
             _id: revision.documentId
           }, {

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -115,11 +115,17 @@ Meteor.methods({
       for (const revision of revisions) {
         if (!revision.documentType || revision.documentType === "product") {
           previousDocuments.push(Products.findOne(revision.documentId));
-          Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(revision.documentId), {
-            $set: revision.documentData
-          }, {
-            publish: true
-          });
+          const productUpdateArgs = {
+            product: Products.findOne(revision.documentId),
+            modifier: {
+              $set: revision.documentData
+            },
+            options: {
+              publish: true
+            }
+          };
+
+          Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
           const res = Products.update({
             _id: revision.documentId
           }, {

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -133,6 +133,7 @@ Meteor.methods({
           }, {
             publish: true
           });
+          Hooks.Events.run("afterProductUpdate", productUpdateArgs);
           updatedDocuments += res;
         } else if (revision.documentType === "image") {
           if (revision.changeType === "insert") {

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -125,8 +125,11 @@ Meteor.methods({
             },
             fieldNames: Object.keys(revision.documentData)
           };
+          console.log("productsID", productUpdateArgs.product);
 
           Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+          Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
+
           const res = Products.update({
             _id: revision.documentId
           }, {

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -122,7 +122,8 @@ Meteor.methods({
             },
             options: {
               publish: true
-            }
+            },
+            fieldNames: Object.keys(revision.documentData)
           };
 
           Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -134,6 +135,7 @@ Meteor.methods({
             publish: true
           });
           Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+          Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
           updatedDocuments += res;
         } else if (revision.documentType === "image") {
           if (revision.changeType === "insert") {

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -125,7 +125,6 @@ Meteor.methods({
             },
             fieldNames: Object.keys(revision.documentData)
           };
-          console.log("productsID", productUpdateArgs.product);
 
           Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
           Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -317,9 +317,9 @@ export const methods = {
             const reactionProduct = createReactionProductFromShopifyProduct({ shopifyProduct, shopId, hashtags });
 
             // Call product insert `before` hook
-            Hooks.Events.run("beforeProductInsert", reactionProduct);
             // Insert product, save id
             const reactionProductId = Products.insert(reactionProduct, { selector: { type: "simple" }, publish: true });
+            Hooks.Events.run("verifyProductInsert", reactionProduct);
             // Call product insert `after` hook
             Hooks.Events.run("afterProductInsert", reactionProduct);
             Hooks.Events.run("afterProductInsertSearch", reactionProduct);
@@ -368,9 +368,9 @@ export const methods = {
                     shopId
                   });
 
-                  Hooks.Events.run("beforeProductInsert", reactionVariant);
                   // insert the Reaction variant
                   const reactionVariantId = Products.insert(reactionVariant, { publish: true });
+                  Hooks.Events.run("verifyProductInsert", reactionVariant);
                   Hooks.Events.run("afterProductInsert", reactionProduct);
                   Hooks.Events.run("afterProductInsertSearch", reactionProduct);
                   ids.push(reactionVariantId);
@@ -393,8 +393,8 @@ export const methods = {
                           shopId
                         });
 
-                        Hooks.Events.run("beforeProductInsert", reactionOption);
                         const reactionOptionId = Products.insert(reactionOption, { type: "variant" });
+                        Hooks.Events.run("verifyProductInsert", reactionOption);
                         Hooks.Events.run("afterProductInsert", reactionProduct);
                         Hooks.Events.run("afterProductInsertSearch", reactionProduct);
                         ids.push(reactionOptionId);
@@ -455,8 +455,8 @@ export const methods = {
                                 shopId
                               });
 
-                              Hooks.Events.run("beforeProductInsert", reactionTernaryOption);
                               const reactionTernaryOptionId = Products.insert(reactionTernaryOption, { type: "variant" });
+                              Hooks.Events.run("verifyProductInsert", reactionTernaryOption);
                               Hooks.Events.run("afterProductInsert", reactionProduct);
                               Hooks.Events.run("afterProductInsertSearch", reactionProduct);
                               ids.push(reactionTernaryOptionId);

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -560,6 +560,7 @@ export const methods = {
               fieldNames: ["price", "isSoldOut", "isBackorder"]
             };
             Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+            Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
 
             Products.update({
               _id: reactionProductId

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -547,6 +547,14 @@ export const methods = {
             } else {
               price.range = `${price.max}`;
             }
+            Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(reactionProductId), {
+              $set: {
+                price,
+                isSoldOut,
+                isBackorder
+              }
+            }, { selector: { type: "simple" }, publish: true });
+
             Products.update({
               _id: reactionProductId
             }, {

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -556,7 +556,8 @@ export const methods = {
                   isBackorder
                 }
               },
-              options: { selector: { type: "simple" }, publish: true }
+              options: { selector: { type: "simple" }, publish: true },
+              fieldNames: ["price", "isSoldOut", "isBackorder"]
             };
             Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
@@ -570,6 +571,7 @@ export const methods = {
               }
             }, { selector: { type: "simple" }, publish: true });
             Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+            Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 
             Logger.debug(`Product ${shopifyProduct.title} added`);
           } else { // product already exists check

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -320,6 +320,10 @@ export const methods = {
             Hooks.Events.run("beforeProductInsert", reactionProduct);
             // Insert product, save id
             const reactionProductId = Products.insert(reactionProduct, { selector: { type: "simple" }, publish: true });
+            // Call product insert `after` hook
+            Hooks.Events.run("afterProductInsert", reactionProduct);
+            Hooks.Events.run("afterProductInsertSearch", reactionProduct);
+
             ids.push(reactionProductId);
 
             // Save the primary image to the grid and as priority 0
@@ -367,6 +371,8 @@ export const methods = {
                   Hooks.Events.run("beforeProductInsert", reactionVariant);
                   // insert the Reaction variant
                   const reactionVariantId = Products.insert(reactionVariant, { publish: true });
+                  Hooks.Events.run("afterProductInsert", reactionProduct);
+                  Hooks.Events.run("afterProductInsertSearch", reactionProduct);
                   ids.push(reactionVariantId);
 
                   // If we have shopify options, create reaction options
@@ -389,6 +395,8 @@ export const methods = {
 
                         Hooks.Events.run("beforeProductInsert", reactionOption);
                         const reactionOptionId = Products.insert(reactionOption, { type: "variant" });
+                        Hooks.Events.run("afterProductInsert", reactionProduct);
+                        Hooks.Events.run("afterProductInsertSearch", reactionProduct);
                         ids.push(reactionOptionId);
                         Logger.debug(`Imported ${shopifyProduct.title} ${variant}/${option}`);
 
@@ -449,6 +457,8 @@ export const methods = {
 
                               Hooks.Events.run("beforeProductInsert", reactionTernaryOption);
                               const reactionTernaryOptionId = Products.insert(reactionTernaryOption, { type: "variant" });
+                              Hooks.Events.run("afterProductInsert", reactionProduct);
+                              Hooks.Events.run("afterProductInsertSearch", reactionProduct);
                               ids.push(reactionTernaryOptionId);
                               Logger.debug(`Imported ${shopifyProduct.title} ${variant}/${option}/${ternaryOption}`);
 

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -2,7 +2,7 @@
 import Shopify from "shopify-api-node";
 import { Job } from "meteor/vsivsi:job-collection";
 import { Meteor } from "meteor/meteor";
-import { Logger, Reaction } from "/server/api";
+import { Hooks, Logger, Reaction } from "/server/api";
 import { check, Match } from "meteor/check";
 import { Products, Jobs, Tags } from "/lib/collections";
 import { getApiInfo } from "../api/api";
@@ -316,6 +316,8 @@ export const methods = {
             // Setup reaction product
             const reactionProduct = createReactionProductFromShopifyProduct({ shopifyProduct, shopId, hashtags });
 
+            // Call product insert `before` hook
+            Hooks.Events.run("beforeProductInsert", reactionProduct);
             // Insert product, save id
             const reactionProductId = Products.insert(reactionProduct, { selector: { type: "simple" }, publish: true });
             ids.push(reactionProductId);
@@ -362,6 +364,7 @@ export const methods = {
                     shopId
                   });
 
+                  Hooks.Events.run("beforeProductInsert", reactionVariant);
                   // insert the Reaction variant
                   const reactionVariantId = Products.insert(reactionVariant, { publish: true });
                   ids.push(reactionVariantId);
@@ -384,6 +387,7 @@ export const methods = {
                           shopId
                         });
 
+                        Hooks.Events.run("beforeProductInsert", reactionOption);
                         const reactionOptionId = Products.insert(reactionOption, { type: "variant" });
                         ids.push(reactionOptionId);
                         Logger.debug(`Imported ${shopifyProduct.title} ${variant}/${option}`);
@@ -443,6 +447,7 @@ export const methods = {
                                 shopId
                               });
 
+                              Hooks.Events.run("beforeProductInsert", reactionTernaryOption);
                               const reactionTernaryOptionId = Products.insert(reactionTernaryOption, { type: "variant" });
                               ids.push(reactionTernaryOptionId);
                               Logger.debug(`Imported ${shopifyProduct.title} ${variant}/${option}/${ternaryOption}`);

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -569,6 +569,7 @@ export const methods = {
                 isBackorder
               }
             }, { selector: { type: "simple" }, publish: true });
+            Hooks.Events.run("afterProductUpdate", productUpdateArgs);
 
             Logger.debug(`Product ${shopifyProduct.title} added`);
           } else { // product already exists check

--- a/imports/plugins/included/connectors-shopify/server/methods/import/products.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/products.js
@@ -547,13 +547,18 @@ export const methods = {
             } else {
               price.range = `${price.max}`;
             }
-            Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(reactionProductId), {
-              $set: {
-                price,
-                isSoldOut,
-                isBackorder
-              }
-            }, { selector: { type: "simple" }, publish: true });
+            const productUpdateArgs = {
+              product: Products.findOne(reactionProductId),
+              modifier: {
+                $set: {
+                  price,
+                  isSoldOut,
+                  isBackorder
+                }
+              },
+              options: { selector: { type: "simple" }, publish: true }
+            };
+            Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
             Products.update({
               _id: reactionProductId

--- a/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
@@ -70,6 +70,7 @@ export const methods = {
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
       // adjust inventory for variant and push an event into the eventLog
       Products.update({
         _id: variant._id

--- a/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
@@ -53,16 +53,22 @@ export const methods = {
       // return the one with the longest list of ancestors
       const variant = findBottomVariant(variantsWithShopifyId);
 
-      Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(variant._id), {
-        $inc: { inventoryQuantity: (lineItem.quantity * -1) },
-        $push: {
-          eventLog: {
-            title: "Product inventory updated by Shopify webhook",
-            type: "update-webhook",
-            description: `Shopify order created which caused inventory to be reduced by ${lineItem.quantity}`
+      const productUpdateArgs = {
+        product: Products.findOne(variant._id),
+        modifier: {
+          $inc: { inventoryQuantity: (lineItem.quantity * -1) },
+          $push: {
+            eventLog: {
+              title: "Product inventory updated by Shopify webhook",
+              type: "update-webhook",
+              description: `Shopify order created which caused inventory to be reduced by ${lineItem.quantity}`
+            }
           }
-        }
-      }, { selector: { type: "variant" } });
+        },
+        options: { selector: { type: "variant" } }
+      };
+
+      Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
       // adjust inventory for variant and push an event into the eventLog
       Products.update({
         _id: variant._id

--- a/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
@@ -65,7 +65,8 @@ export const methods = {
             }
           }
         },
-        options: { selector: { type: "variant" } }
+        options: { selector: { type: "variant" } },
+        fieldNames: ["inventoryQuantity", "eventLog"]
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -83,6 +84,7 @@ export const methods = {
         }
       }, { selector: { type: "variant" } });
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
     });
   }
 };

--- a/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
@@ -82,6 +82,7 @@ export const methods = {
           }
         }
       }, { selector: { type: "variant" } });
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
     });
   }
 };

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Cart, Products, Orders } from "/lib/collections";
-import { Logger } from "/server/api";
+import { Hooks, Logger } from "/server/api";
 import { registerInventory } from "../methods/inventory";
 
 /**
@@ -45,14 +45,14 @@ Cart.before.update((userId, cart, fieldNames, modifier) => {
  * after variant were removed
  * @fires `inventory/remove` Method
  */
-Products.after.remove((userId, doc) => {
-  if (doc.type === "variant") {
+Hooks.Events.add("afterProductVariantRemove", (product) => {
+  if (product.type === "variant") {
     const variantItem = {
-      productId: doc.ancestors[0],
-      variantId: doc._id,
-      shopId: doc.shopId
+      productId: product.ancestors[0],
+      variantId: product._id,
+      shopId: product.shopId
     };
-    Logger.debug(`remove inventory variants for variant: ${doc._id
+    Logger.debug(`remove inventory variants for variant: ${product._id
     }, call inventory/remove`);
     Meteor.call("inventory/remove", variantItem);
   }

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -1,5 +1,5 @@
 import { Meteor } from "meteor/meteor";
-import { Cart, Products, Orders } from "/lib/collections";
+import { Cart, Orders } from "/lib/collections";
 import { Hooks, Logger } from "/server/api";
 import { registerInventory } from "../methods/inventory";
 
@@ -61,11 +61,12 @@ Hooks.Events.add("afterProductVariantRemove", (product) => {
 //
 // after product update
 //
-Products.after.update((userId, doc, fieldNames, modifier) => {
+Hooks.Events.add("afterProductUpdate", (productUpdateArgs) => {
+  const { product, modifier } = { ...productUpdateArgs };
   // product update can't affect on inventory, so we don't manage this cases
   // we should keep in mind that returning false within hook prevents other
   // hooks to be run
-  if (doc.type !== "variant") return false;
+  if (product.type !== "variant") return false;
 
   // check if modifier is set and $pull and $push are undefined. This need
   // because anyway on every create or delete operation we have additionally
@@ -77,7 +78,7 @@ Products.after.update((userId, doc, fieldNames, modifier) => {
     }
     modifier.$set.updatedAt = new Date();
     // triggers inventory adjustment
-    Meteor.call("inventory/adjust", doc);
+    Meteor.call("inventory/adjust", product);
   }
 });
 

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -85,11 +85,11 @@ Products.after.update((userId, doc, fieldNames, modifier) => {
  * after insert
  * @summary should fires on create new variants, on clones products/variants
  */
-Products.after.insert((userId, doc) => {
-  if (doc.type !== "variant") {
+Hooks.Events.add("afterProductInsert", (product) => {
+  if (product.type !== "variant") {
     return false;
   }
-  registerInventory(doc);
+  registerInventory(product);
 });
 
 function markInventoryShipped(doc) {

--- a/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
+++ b/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
@@ -36,7 +36,7 @@ describe("Inventory Hooks", function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    Products.direct.remove({});
+    Products.remove({});
     const { product, variant } = addProductSingleVariant();
     cart = createCart(product._id, variant._id);
     resetInventory();

--- a/imports/plugins/included/search-mongo/server/hooks/search.js
+++ b/imports/plugins/included/search-mongo/server/hooks/search.js
@@ -82,9 +82,9 @@ Products.after.update((userId, doc, fieldNames) => {
  * after insert
  * @summary should fires on create new variants, on clones products/variants
  */
-Products.after.insert((userId, doc) => {
-  if (ProductSearch && !Meteor.isAppTest && doc.type === "simple") {
-    const productId = doc._id;
+Hooks.Events.add("afterProductInsertSearch", (product) => {
+  if (ProductSearch && !Meteor.isAppTest && product.type === "simple") {
+    const productId = product._id;
     buildProductSearchRecord(productId);
     Logger.debug(`Added product ${productId} to ProductSearch`);
   }

--- a/imports/plugins/included/search-mongo/server/hooks/search.js
+++ b/imports/plugins/included/search-mongo/server/hooks/search.js
@@ -68,9 +68,7 @@ Hooks.Events.add("afterProductUpdateSearchRebuild", (productUpdateArgs) => {
   if (ProductSearch && !Meteor.isAppTest && product.type === "simple") {
     const productId = product._id;
     const { fieldSet } = getSearchParameters();
-    console.log("fieldSet", fieldSet);
     const modifiedFields = _.intersection(fieldSet, fieldNames);
-    console.log("modified", modifiedFields);
     if (modifiedFields.length) {
       Logger.debug(`Rewriting search record for ${product.title}`);
       ProductSearch.remove(productId);

--- a/imports/plugins/included/search-mongo/server/hooks/search.js
+++ b/imports/plugins/included/search-mongo/server/hooks/search.js
@@ -3,7 +3,7 @@ import { Meteor } from "meteor/meteor";
 import { Products, ProductSearch, Orders, OrderSearch, Accounts, AccountSearch } from "/lib/collections";
 import { getSearchParameters,
   buildProductSearchRecord, buildOrderSearchRecord, buildAccountSearchRecord } from "../methods/searchcollections";
-import { Logger } from "/server/api";
+import { Hooks, Logger } from "/server/api";
 
 Accounts.after.insert((userId, doc) => {
   if (AccountSearch && !Meteor.isAppTest) {
@@ -50,9 +50,9 @@ Orders.after.update((userId, doc) => {
 /**
  * if product is removed, remove product search record
  */
-Products.after.remove((userId, doc) => {
-  if (ProductSearch && !Meteor.isAppTest && doc.type === "simple") {
-    const productId = doc._id;
+Hooks.Events.add("afterProductRemove", (product) => {
+  if (ProductSearch && !Meteor.isAppTest && product.type === "simple") {
+    const productId = product._id;
     ProductSearch.remove(productId);
     Logger.debug(`Removed product ${productId} from ProductSearch collection`);
   }

--- a/server/methods/accounts/accounts.app-test.js
+++ b/server/methods/accounts/accounts.app-test.js
@@ -37,7 +37,7 @@ describe("Account Meteor method ", function () {
     Cart.direct.remove({});
     Accounts.direct.remove({});
     Orders.direct.remove({});
-    Products.direct.remove({});
+    Products.remove({});
     Shops.direct.remove({});
     if (sandbox) {
       sandbox.restore();

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -1091,6 +1091,7 @@ describe("core product methods", function () {
     it("should let admin toggle product revision visibility", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
+      console.log("product in test", product, "revisions", Revisions.findOne({ documentId: product._id }));
       let productRevision = Revisions.findOne({ documentId: product._id });
       const isVisible = productRevision.documentData.isVisible;
       expect(() => Meteor.call("products/publishProduct", product._id)).to.not.throw(Meteor.Error, /Access Denied/);

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -1091,7 +1091,6 @@ describe("core product methods", function () {
     it("should let admin toggle product revision visibility", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
-      console.log("product in test", product, "revisions", Revisions.findOne({ documentId: product._id }));
       let productRevision = Revisions.findOne({ documentId: product._id });
       const isVisible = productRevision.documentData.isVisible;
       expect(() => Meteor.call("products/publishProduct", product._id)).to.not.throw(Meteor.Error, /Access Denied/);

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -39,7 +39,7 @@ describe("core product methods", function () {
       removeStub = sinon.stub(Products._hookAspects.remove.after[0], "aspect");
       insertStub = sinon.stub(Products._hookAspects.insert.after[0], "aspect");
     }
-    Products.direct.remove({});
+    Products.remove({});
   });
 
   after(function () {
@@ -294,7 +294,7 @@ describe("core product methods", function () {
     // cloning hierarchy, so the only way to track that will be cleaning
     // collection on before each test.
     beforeEach(function () {
-      return Products.direct.remove({});
+      return Products.remove({});
     });
 
     it("should throw 403 error by non admin", function () {

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -176,7 +176,7 @@ describe("core product methods", function () {
       expect(updateProductSpy).to.not.have.been.called;
     });
 
-    it("should not update individual variant by admin passing in full object", function (done) {
+    it.only("should not update individual variant by admin passing in full object", function (done) {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
       let variant = Products.find({ ancestors: [product._id] }).fetch()[0];

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -176,7 +176,7 @@ describe("core product methods", function () {
       expect(updateProductSpy).to.not.have.been.called;
     });
 
-    it.only("should not update individual variant by admin passing in full object", function (done) {
+    it("should not update individual variant by admin passing in full object", function (done) {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
       let variant = Products.find({ ancestors: [product._id] }).fetch()[0];

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -588,7 +588,7 @@ Meteor.methods({
     const toDelete = Products.find(selector).fetch();
     // out if nothing to delete
     if (!Array.isArray(toDelete) || toDelete.length === 0) return false;
-
+    Hooks.Events.run("beforeProductRemove", selector);
     const deleted = Products.remove(selector);
 
     // after variant were removed from product, we need to recalculate all
@@ -834,6 +834,7 @@ Meteor.methods({
 
     const ids = [];
     productsWithVariants.map(doc => {
+      Hooks.Events.run("beforeProductRemove", doc);
       ids.push(doc._id);
     });
 

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -549,12 +549,30 @@ Meteor.methods({
     }
 
     const newVariant = Object.assign({}, currentVariant, variant);
-    Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(variant._id), {
-      $set: newVariant // newVariant already contain `type` property, so we
-      // do not need to pass it explicitly
-    }, {
-      validate: false
-    });
+    // const userId = Meteor.userId();
+    // const modifier = {
+    //   $set: newVariant // newVariant already contain `type` property, so we
+    //   // do not need to pass it explicitly
+    // };
+    // const options = {
+    //   validate: false
+    // };
+
+    const args = {
+      product: newVariant,
+      userId: Meteor.userId(),
+      modifier: {
+        $set: newVariant // newVariant already contain `type` property, so we
+        // do not need to pass it explicitly
+      },
+      options: {
+        validate: false
+      }
+    };
+
+    console.log("in the run", args);
+
+    Hooks.Events.run("beforeProductUpdate", args);
     const variantUpdateResult = Products.update({
       _id: variant._id
     }, {

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -6,7 +6,7 @@ import { Meteor } from "meteor/meteor";
 import { copyFile, ReactionProduct } from "/lib/api";
 import { ProductRevision as Catalog } from "/imports/plugins/core/revisions/server/hooks";
 import { Media, Products, Revisions, Tags } from "/lib/collections";
-import { Logger, Reaction } from "/server/api";
+import { Hooks, Logger, Reaction } from "/server/api";
 
 /* eslint new-cap: 0 */
 /* eslint no-loop-func: 0 */
@@ -428,6 +428,7 @@ Meteor.methods({
 
       let newId;
       try {
+        Hooks.Events.run("beforeProductInsert", clone);
         newId = Products.insert(clone, { validate: false });
         Logger.debug(`products/cloneVariant: created ${type === "child" ? "sub child " : ""}clone: ${
           clone._id} from ${variantId}`);
@@ -494,6 +495,7 @@ Meteor.methods({
       flushQuantity(parentId);
     }
 
+    Hooks.Events.run("beforeProductInsert", assembledVariant);
     Products.insert(assembledVariant);
     Logger.debug(`products/createVariant: created variant: ${newVariantId} for ${parentId}`);
 
@@ -699,6 +701,7 @@ Meteor.methods({
           newProduct._id
         );
       }
+      Hooks.Events.run("beforeProductInsert", newProduct);
       result = Products.insert(newProduct, { validate: false });
       results.push(result);
 
@@ -726,6 +729,7 @@ Meteor.methods({
         delete newVariant.createdAt;
         delete newVariant.publishedAt; // TODO can variant have this param?
 
+        Hooks.Events.run("beforeProductInsert", newVariant);
         result = Products.insert(newVariant, { validate: false });
         copyMedia(productNewId, variant._id, variantNewId);
         results.push(result);
@@ -756,6 +760,7 @@ Meteor.methods({
       if (!product.shopId || !Reaction.hasPermission("createProduct", this.userId, product.shopId)) {
         throw new Meteor.Error("invalid-parameter", "Product should have a valid shopId");
       }
+      Hooks.Events.run("beforeProductInsert", product);
       return Products.insert(product);
     }
 
@@ -765,6 +770,7 @@ Meteor.methods({
       validate: false
     });
 
+    Hooks.Events.run("beforeProductInsert", newId);
     Products.insert({
       ancestors: [newId],
       price: 0.00,

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -428,8 +428,8 @@ Meteor.methods({
 
       let newId;
       try {
-        Hooks.Events.run("beforeProductInsert", clone);
         newId = Products.insert(clone, { validate: false });
+        Hooks.Events.run("verifyProductInsert", clone);
         Hooks.Events.run("afterProductInsert", clone);
         Hooks.Events.run("afterProductInsertSearch", clone);
         Logger.debug(`products/cloneVariant: created ${type === "child" ? "sub child " : ""}clone: ${
@@ -497,8 +497,8 @@ Meteor.methods({
       flushQuantity(parentId);
     }
 
-    Hooks.Events.run("beforeProductInsert", assembledVariant);
     Products.insert(assembledVariant);
+    Hooks.Events.run("verifyProductInsert", assembledVariant);
     Hooks.Events.run("afterProductInsert", assembledVariant);
     Hooks.Events.run("afterProductInsertSearch", assembledVariant);
     Logger.debug(`products/createVariant: created variant: ${newVariantId} for ${parentId}`);
@@ -707,8 +707,8 @@ Meteor.methods({
           newProduct._id
         );
       }
-      Hooks.Events.run("beforeProductInsert", newProduct);
       result = Products.insert(newProduct, { validate: false });
+      Hooks.Events.run("verifyProductInsert", newProduct);
       Hooks.Events.run("afterProductInsert", newProduct);
       Hooks.Events.run("afterProductInsertSearch", newProduct);
       results.push(result);
@@ -737,8 +737,8 @@ Meteor.methods({
         delete newVariant.createdAt;
         delete newVariant.publishedAt; // TODO can variant have this param?
 
-        Hooks.Events.run("beforeProductInsert", newVariant);
         result = Products.insert(newVariant, { validate: false });
+        Hooks.Events.run("verifyProductInsert", newVariant);
         Hooks.Events.run("afterProductInsert", newVariant);
         Hooks.Events.run("afterProductInsertSearch", newVariant);
         copyMedia(productNewId, variant._id, variantNewId);
@@ -770,8 +770,8 @@ Meteor.methods({
       if (!product.shopId || !Reaction.hasPermission("createProduct", this.userId, product.shopId)) {
         throw new Meteor.Error("invalid-parameter", "Product should have a valid shopId");
       }
-      Hooks.Events.run("beforeProductInsert", product);
       const newProductId = Products.insert(product);
+      Hooks.Events.run("verifyProductInsert", product);
       Hooks.Events.run("afterProductInsert", product);
       Hooks.Events.run("afterProductInsertSearch", product);
       return newProductId;
@@ -783,16 +783,24 @@ Meteor.methods({
       validate: false
     });
 
-    Hooks.Events.run("beforeProductInsert", newId);
-    Products.insert({
+    const newProduct = Products.findOne(newId);
+
+    Hooks.Events.run("verifyProductInsert", newProduct);
+    Hooks.Events.run("afterProductInsert", newProduct);
+    Hooks.Events.run("afterProductInsertSearch", newProduct);
+
+    const variantId = Products.insert({
       ancestors: [newId],
       price: 0.00,
       title: "",
       type: "variant" // needed for multi-schema
     });
 
-    Hooks.Events.run("afterProductInsert", newId);
-    Hooks.Events.run("afterProductInsertSearch", newId);
+    const variant = Products.findOne(variantId);
+
+    Hooks.Events.run("verifyProductInsert", variant);
+    Hooks.Events.run("afterProductInsert", variant);
+    Hooks.Events.run("afterProductInsertSearch", variant);
     return newId;
   },
 

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -590,6 +590,8 @@ Meteor.methods({
     if (!Array.isArray(toDelete) || toDelete.length === 0) return false;
     Hooks.Events.run("beforeProductRemove", selector);
     const deleted = Products.remove(selector);
+    Hooks.Events.run("afterProductRemove", selector);
+    Hooks.Events.run("afterProductVariantRemove", selector);
 
     // after variant were removed from product, we need to recalculate all
     // denormalized fields
@@ -842,6 +844,11 @@ Meteor.methods({
       _id: {
         $in: ids
       }
+    });
+
+    productsWithVariants.map(doc => {
+      Hooks.Events.run("afterProductRemove", doc);
+      Hooks.Events.run("afterProductVariantRemove", doc);
     });
 
     const numRemoved = Revisions.find({

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -250,6 +250,8 @@ function denormalize(id, field) {
   };
 
   Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+  Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
+
   Products.update(id, {
     $set: update
   }, {
@@ -344,6 +346,7 @@ function flushQuantity(id) {
   };
 
   Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+  Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
 
   const updatedProduct = Products.update({
     _id: id
@@ -583,6 +586,8 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
+
     const variantUpdateResult = Products.update({
       _id: variant._id
     }, {
@@ -644,10 +649,11 @@ Meteor.methods({
     const toDelete = Products.find(selector).fetch();
     // out if nothing to delete
     if (!Array.isArray(toDelete) || toDelete.length === 0) return false;
-    Hooks.Events.run("beforeProductRemove", selector);
+
+    Hooks.Events.run("beforeProductRemove", variant);
     const deleted = Products.remove(selector);
-    Hooks.Events.run("afterProductRemove", selector);
-    Hooks.Events.run("afterProductVariantRemove", selector);
+    Hooks.Events.run("afterProductRemove", variant);
+    Hooks.Events.run("afterProductVariantRemove", variant);
 
     // after variant were removed from product, we need to recalculate all
     // denormalized fields
@@ -910,20 +916,17 @@ Meteor.methods({
 
     const ids = [];
     productsWithVariants.map(doc => {
-      Hooks.Events.run("beforeProductRemove", doc);
       ids.push(doc._id);
     });
 
+    Hooks.Events.run("beforeProductRemove", product);
     Products.remove({
       _id: {
         $in: ids
       }
     });
-
-    productsWithVariants.map(doc => {
-      Hooks.Events.run("afterProductRemove", doc);
-      Hooks.Events.run("afterProductVariantRemove", doc);
-    });
+    Hooks.Events.run("afterProductRemove", product);
+    Hooks.Events.run("afterProductVariantRemove", product);
 
     const numRemoved = Revisions.find({
       "documentId": {
@@ -1024,6 +1027,8 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
+
     try {
       result = Products.update(_id, {
         $set: update
@@ -1106,6 +1111,7 @@ Meteor.methods({
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
 
       const updatedProduct = Products.update(productId, {
         $push: {
@@ -1145,6 +1151,7 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
 
     const updatedProduct = Products.update(productId, {
       $push: {
@@ -1196,6 +1203,7 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
 
     Products.update(productId, {
       $pull: {
@@ -1237,6 +1245,7 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
     Products.update(product._id, { $set: { handle, type: "simple" } });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
     Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
@@ -1285,6 +1294,7 @@ Meteor.methods({
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
       Products.update(product._id, getSet(handle));
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
       Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
@@ -1307,7 +1317,7 @@ Meteor.methods({
         modifier: getSet(currentProductHandle)
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
-
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
       Products.update(currentProduct._id, getSet(currentProductHandle));
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
       Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
@@ -1317,6 +1327,7 @@ Meteor.methods({
       modifier: getSet(tag.slug)
     };
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
     Products.update(product._id, getSet(tag.slug));
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
     Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
@@ -1369,6 +1380,7 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
     const updatedProduct = Products.update({
       _id: productId
     }, {
@@ -1418,6 +1430,7 @@ Meteor.methods({
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
       Products.update(id, {
         $set: { index }
       }, {
@@ -1469,7 +1482,7 @@ Meteor.methods({
         fieldNames: ["metafields"]
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
-
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
       const updatedProduct = Products.update({
         _id: productId,
         metafields: meta
@@ -1498,7 +1511,7 @@ Meteor.methods({
         fieldNames: ["metafields"]
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
-
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
       const updatedProduct = Products.update({
         _id: productId
       }, {
@@ -1528,6 +1541,7 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
     // adds metadata
     const updatedProduct = Products.update({
       _id: productId
@@ -1574,7 +1588,7 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
-
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
     const updatedProduct = Products.update({
       _id: productId,
       type
@@ -1664,7 +1678,7 @@ Meteor.methods({
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
-
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
       const res = Products.update(product._id, {
         $set: {
           isVisible: !product.isVisible
@@ -1722,7 +1736,7 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
-
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
     const res = Products.update(productId, {
       $set: {
         isVisible: !product.isVisible

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -249,7 +249,6 @@ function denormalize(id, field) {
   };
 
   Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
-
   Products.update(id, {
     $set: update
   }, {
@@ -257,6 +256,7 @@ function denormalize(id, field) {
       type: "simple"
     }
   });
+  Hooks.Events.run("afterProductUpdate", productUpdateArgs);
 }
 
 /**
@@ -342,7 +342,7 @@ function flushQuantity(id) {
 
   Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
-  return Products.update({
+  const updatedProduct = Products.update({
     _id: id
   }, {
     $set: {
@@ -353,6 +353,9 @@ function flushQuantity(id) {
       type: "variant"
     }
   });
+  Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+
+  return updatedProduct;
 }
 
 Meteor.methods({
@@ -583,6 +586,7 @@ Meteor.methods({
     }, {
       validate: false
     });
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
 
     const productId = currentVariant.ancestors[0];
     // we need manually check is these fields were updated?
@@ -1022,6 +1026,7 @@ Meteor.methods({
     } catch (e) {
       throw new Meteor.Error("server-error", e.message);
     }
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
 
     // If we get a result from the product update,
     // meaning the update went past revision control,
@@ -1093,13 +1098,15 @@ Meteor.methods({
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
-      return Products.update(productId, {
+      const updatedProduct = Products.update(productId, {
         $push: {
           hashtags: existingTag._id
         }
       }, {
         selector: { type: "simple" }
       });
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      return updatedProduct;
     } else if (tagId) {
       return Tags.update(tagId, { $set: newTag });
     }
@@ -1127,7 +1134,7 @@ Meteor.methods({
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
-    return Products.update(productId, {
+    const updatedProduct = Products.update(productId, {
       $push: {
         hashtags: newTagId
       }
@@ -1136,6 +1143,8 @@ Meteor.methods({
         type: "simple"
       }
     });
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    return updatedProduct;
   },
 
   /**
@@ -1180,6 +1189,7 @@ Meteor.methods({
     }, {
       selector: { type: "simple" }
     });
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
   },
 
   /**
@@ -1210,7 +1220,7 @@ Meteor.methods({
     };
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
     Products.update(product._id, { $set: { handle, type: "simple" } });
-
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
     return handle;
   },
 
@@ -1253,9 +1263,10 @@ Meteor.methods({
         product,
         modifier: getSet(handle)
       };
-      Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
+      Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
       Products.update(product._id, getSet(handle));
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
 
       return handle;
     }
@@ -1277,6 +1288,7 @@ Meteor.methods({
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
       Products.update(currentProduct._id, getSet(currentProductHandle));
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
     }
     productUpdateArgs = {
       product,
@@ -1284,6 +1296,7 @@ Meteor.methods({
     };
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
     Products.update(product._id, getSet(tag.slug));
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
 
     return tag.slug;
   },
@@ -1332,7 +1345,7 @@ Meteor.methods({
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
-    return Products.update({
+    const updatedProduct = Products.update({
       _id: productId
     }, {
       $set: {
@@ -1343,6 +1356,8 @@ Meteor.methods({
         type: "simple" // for multi-schema
       }
     });
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    return updatedProduct;
   },
 
   /**
@@ -1381,6 +1396,7 @@ Meteor.methods({
       }, {
         selector: { type: "variant" }
       });
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
       Logger.debug(`Variant ${id} position was updated to index ${index}`);
     });
   },
@@ -1424,7 +1440,7 @@ Meteor.methods({
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
-      return Products.update({
+      const updatedProduct = Products.update({
         _id: productId,
         metafields: meta
       }, {
@@ -1434,6 +1450,8 @@ Meteor.methods({
       }, {
         selector: { type: "simple" }
       });
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      return updatedProduct;
     } else if (typeof meta === "number") {
       const productUpdateArgs = {
         product,
@@ -1448,7 +1466,7 @@ Meteor.methods({
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
-      return Products.update({
+      const updatedProduct = Products.update({
         _id: productId
       }, {
         $set: {
@@ -1457,6 +1475,8 @@ Meteor.methods({
       }, {
         selector: { type: "simple" }
       });
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      return updatedProduct;
     }
 
     const productUpdateArgs = {
@@ -1473,7 +1493,7 @@ Meteor.methods({
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
     // adds metadata
-    return Products.update({
+    const updatedProduct = Products.update({
       _id: productId
     }, {
       $addToSet: {
@@ -1482,6 +1502,8 @@ Meteor.methods({
     }, {
       selector: { type: "simple" }
     });
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    return updatedProduct;
   },
 
   /**
@@ -1514,12 +1536,14 @@ Meteor.methods({
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
-    return Products.update({
+    const updatedProduct = Products.update({
       _id: productId,
       type
     }, {
       $pull: { metafields }
     });
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    return updatedProduct;
   },
 
   /**
@@ -1606,6 +1630,8 @@ Meteor.methods({
       }, {
         selector: { type: "simple" }
       });
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+
       // update product variants visibility
       updateVariantProductField(variants, "isVisible", !product.isVisible);
       // if collection updated we return new `isVisible` state
@@ -1662,6 +1688,7 @@ Meteor.methods({
         type: product.type
       }
     });
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
 
     if (Array.isArray(product.ancestors) && product.ancestors.length) {
       const updateId = product.ancestors[0] || product._id;

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -430,6 +430,8 @@ Meteor.methods({
       try {
         Hooks.Events.run("beforeProductInsert", clone);
         newId = Products.insert(clone, { validate: false });
+        Hooks.Events.run("afterProductInsert", clone);
+        Hooks.Events.run("afterProductInsertSearch", clone);
         Logger.debug(`products/cloneVariant: created ${type === "child" ? "sub child " : ""}clone: ${
           clone._id} from ${variantId}`);
       } catch (error) {
@@ -497,6 +499,8 @@ Meteor.methods({
 
     Hooks.Events.run("beforeProductInsert", assembledVariant);
     Products.insert(assembledVariant);
+    Hooks.Events.run("afterProductInsert", assembledVariant);
+    Hooks.Events.run("afterProductInsertSearch", assembledVariant);
     Logger.debug(`products/createVariant: created variant: ${newVariantId} for ${parentId}`);
 
     return newVariantId;
@@ -705,6 +709,8 @@ Meteor.methods({
       }
       Hooks.Events.run("beforeProductInsert", newProduct);
       result = Products.insert(newProduct, { validate: false });
+      Hooks.Events.run("afterProductInsert", newProduct);
+      Hooks.Events.run("afterProductInsertSearch", newProduct);
       results.push(result);
 
       // cloning variants
@@ -733,6 +739,8 @@ Meteor.methods({
 
         Hooks.Events.run("beforeProductInsert", newVariant);
         result = Products.insert(newVariant, { validate: false });
+        Hooks.Events.run("afterProductInsert", newVariant);
+        Hooks.Events.run("afterProductInsertSearch", newVariant);
         copyMedia(productNewId, variant._id, variantNewId);
         results.push(result);
       }
@@ -763,7 +771,10 @@ Meteor.methods({
         throw new Meteor.Error("invalid-parameter", "Product should have a valid shopId");
       }
       Hooks.Events.run("beforeProductInsert", product);
-      return Products.insert(product);
+      const newProductId = Products.insert(product);
+      Hooks.Events.run("afterProductInsert", product);
+      Hooks.Events.run("afterProductInsertSearch", product);
+      return newProductId;
     }
 
     const newId = Products.insert({
@@ -780,6 +791,8 @@ Meteor.methods({
       type: "variant" // needed for multi-schema
     });
 
+    Hooks.Events.run("afterProductInsert", newId);
+    Hooks.Events.run("afterProductInsertSearch", newId);
     return newId;
   },
 

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -245,7 +245,8 @@ function denormalize(id, field) {
       selector: {
         type: "simple"
       }
-    }
+    },
+    fieldNames: Object.keys(update)
   };
 
   Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -257,6 +258,7 @@ function denormalize(id, field) {
     }
   });
   Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+  Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 }
 
 /**
@@ -337,7 +339,8 @@ function flushQuantity(id) {
       selector: {
         type: "variant"
       }
-    }
+    },
+    fieldNames: ["inventoryQuantity"]
   };
 
   Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -354,6 +357,7 @@ function flushQuantity(id) {
     }
   });
   Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+  Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 
   return updatedProduct;
 }
@@ -574,7 +578,8 @@ Meteor.methods({
       },
       options: {
         validate: false
-      }
+      },
+      fieldNames: Object.keys(newVariant)
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -587,6 +592,7 @@ Meteor.methods({
       validate: false
     });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 
     const productId = currentVariant.ancestors[0];
     // we need manually check is these fields were updated?
@@ -1013,7 +1019,8 @@ Meteor.methods({
       },
       options: {
         selector: { type }
-      }
+      },
+      fieldNames: Object.keys(update)
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1027,6 +1034,7 @@ Meteor.methods({
       throw new Meteor.Error("server-error", e.message);
     }
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 
     // If we get a result from the product update,
     // meaning the update went past revision control,
@@ -1093,7 +1101,8 @@ Meteor.methods({
         },
         options: {
           selector: { type: "simple" }
-        }
+        },
+        fieldNames: ["hashtags"]
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1106,6 +1115,8 @@ Meteor.methods({
         selector: { type: "simple" }
       });
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
       return updatedProduct;
     } else if (tagId) {
       return Tags.update(tagId, { $set: newTag });
@@ -1129,7 +1140,8 @@ Meteor.methods({
         selector: {
           type: "simple"
         }
-      }
+      },
+      fieldNames: Object.keys("hashtags")
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1144,6 +1156,8 @@ Meteor.methods({
       }
     });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
     return updatedProduct;
   },
 
@@ -1177,7 +1191,8 @@ Meteor.methods({
       },
       options: {
         selector: { type: "simple" }
-      }
+      },
+      fieldNames: ["hashtags"]
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1190,6 +1205,7 @@ Meteor.methods({
       selector: { type: "simple" }
     });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
   },
 
   /**
@@ -1216,11 +1232,15 @@ Meteor.methods({
 
     const productUpdateArgs = {
       product,
-      modifier: { $set: { handle, type: "simple" } }
+      modifier: { $set: { handle, type: "simple" } },
+      fieldNames: ["handle", "type"]
     };
+
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
     Products.update(product._id, { $set: { handle, type: "simple" } });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
     return handle;
   },
 
@@ -1267,6 +1287,7 @@ Meteor.methods({
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
       Products.update(product._id, getSet(handle));
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 
       return handle;
     }
@@ -1289,6 +1310,7 @@ Meteor.methods({
 
       Products.update(currentProduct._id, getSet(currentProductHandle));
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
     }
     productUpdateArgs = {
       product,
@@ -1297,6 +1319,7 @@ Meteor.methods({
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
     Products.update(product._id, getSet(tag.slug));
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 
     return tag.slug;
   },
@@ -1341,7 +1364,8 @@ Meteor.methods({
           [updatedAt]: new Date(),
           type: "simple" // for multi-schema
         }
-      }
+      },
+      fieldNames: ["type", position, pinned, weight, updatedAt]
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1357,6 +1381,8 @@ Meteor.methods({
       }
     });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
     return updatedProduct;
   },
 
@@ -1387,7 +1413,8 @@ Meteor.methods({
         },
         options: {
           selector: { type: "variant" }
-        }
+        },
+        fieldNames: ["index"]
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1397,6 +1424,8 @@ Meteor.methods({
         selector: { type: "variant" }
       });
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
       Logger.debug(`Variant ${id} position was updated to index ${index}`);
     });
   },
@@ -1436,7 +1465,8 @@ Meteor.methods({
         },
         options: {
           selector: { type: "simple" }
-        }
+        },
+        fieldNames: ["metafields"]
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
@@ -1451,6 +1481,8 @@ Meteor.methods({
         selector: { type: "simple" }
       });
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
       return updatedProduct;
     } else if (typeof meta === "number") {
       const productUpdateArgs = {
@@ -1462,7 +1494,8 @@ Meteor.methods({
         },
         options: {
           selector: { type: "simple" }
-        }
+        },
+        fieldNames: ["metafields"]
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
@@ -1476,6 +1509,8 @@ Meteor.methods({
         selector: { type: "simple" }
       });
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
       return updatedProduct;
     }
 
@@ -1488,7 +1523,8 @@ Meteor.methods({
       },
       options: {
         selector: { type: "simple" }
-      }
+      },
+      fieldNames: ["metafields"]
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1503,6 +1539,8 @@ Meteor.methods({
       selector: { type: "simple" }
     });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
     return updatedProduct;
   },
 
@@ -1531,7 +1569,8 @@ Meteor.methods({
 
     const productUpdateArgs = {
       product,
-      modifier: { $pull: { metafields } }
+      modifier: { $pull: { metafields } },
+      fieldNames: ["metafields"]
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1543,6 +1582,8 @@ Meteor.methods({
       $pull: { metafields }
     });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
+
     return updatedProduct;
   },
 
@@ -1618,7 +1659,8 @@ Meteor.methods({
         },
         options: {
           selector: { type: "simple" }
-        }
+        },
+        fieldNames: ["isVisible"]
       };
 
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1631,6 +1673,7 @@ Meteor.methods({
         selector: { type: "simple" }
       });
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 
       // update product variants visibility
       updateVariantProductField(variants, "isVisible", !product.isVisible);
@@ -1674,7 +1717,8 @@ Meteor.methods({
         selector: {
           type: product.type
         }
-      }
+      },
+      fieldNames: ["isVisible"]
     };
 
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
@@ -1689,6 +1733,7 @@ Meteor.methods({
       }
     });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
 
     if (Array.isArray(product.ancestors) && product.ancestors.length) {
       const updateId = product.ancestors[0] || product._id;

--- a/server/methods/core/cart-merge.app-test.js
+++ b/server/methods/core/cart-merge.app-test.js
@@ -19,16 +19,8 @@ describe("Merge Cart function ", function () {
   let originals;
   let sandbox;
   let pushCartWorkflowStub;
-  let cartHookStub;
-  let productHookStub;
 
   before(function () {
-    // We are mocking inventory hooks, because we don't need them here, but
-    if (Array.isArray(Collections.Products._hookAspects.remove.after) &&
-      Collections.Products._hookAspects.remove.after.length) {
-      cartHookStub = sinon.stub(Collections.Cart._hookAspects.update.after[0], "aspect");
-      productHookStub = sinon.stub(Collections.Products._hookAspects.remove.after[0], "aspect");
-    }
     originals = {
       mergeCart: Meteor.server.method_handlers["cart/mergeCart"],
       copyCartToOrder: Meteor.server.method_handlers["cart/copyCartToOrder"],
@@ -48,8 +40,6 @@ describe("Merge Cart function ", function () {
 
   after(function () {
     pushCartWorkflowStub.restore();
-    cartHookStub.restore();
-    productHookStub.restore();
   });
 
   beforeEach(function () {

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -80,7 +80,8 @@ export function ordersInventoryAdjust(orderId) {
         selector: {
           type: "variant"
         }
-      }
+      },
+      fieldNames: ["inventoryQuantity"]
     };
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
@@ -97,6 +98,7 @@ export function ordersInventoryAdjust(orderId) {
       }
     });
     Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+    Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
   });
 }
 
@@ -133,7 +135,8 @@ export function ordersInventoryAdjustByShop(orderId, shopId) {
           selector: {
             type: "variant"
           }
-        }
+        },
+        fieldNames: ["inventoryQuantity"]
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
@@ -150,6 +153,7 @@ export function ordersInventoryAdjustByShop(orderId, shopId) {
         }
       });
       Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+      Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
     }
   });
 }
@@ -412,7 +416,8 @@ export const methods = {
             options: {
               bypassCollection2: true,
               publish: true
-            }
+            },
+            fieldNames: ["inventoryQuantity"]
           };
           Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
@@ -428,6 +433,7 @@ export const methods = {
             publish: true
           });
           Hooks.Events.run("afterProductUpdate", productUpdateArgs);
+          Hooks.Events.run("afterProductUpdateSearchRebuild", productUpdateArgs);
         }
       });
     }

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -96,6 +96,7 @@ export function ordersInventoryAdjust(orderId) {
         type: "variant"
       }
     });
+    Hooks.Events.run("afterProductUpdate", productUpdateArgs);
   });
 }
 
@@ -148,6 +149,7 @@ export function ordersInventoryAdjustByShop(orderId, shopId) {
           type: "variant"
         }
       });
+      Hooks.Events.run("afterProductUpdate", productUpdateArgs);
     }
   });
 }
@@ -425,6 +427,7 @@ export const methods = {
             bypassCollection2: true,
             publish: true
           });
+          Hooks.Events.run("afterProductUpdate", productUpdateArgs);
         }
       });
     }

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -68,6 +68,17 @@ export function ordersInventoryAdjust(orderId) {
 
   const order = Orders.findOne(orderId);
   order.items.forEach(item => {
+    Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(item.variants._id), {
+      $inc: {
+        inventoryQuantity: -item.quantity
+      }
+    }, {
+      publish: true,
+      selector: {
+        type: "variant"
+      }
+    });
+
     Products.update({
       _id: item.variants._id
     }, {
@@ -104,6 +115,17 @@ export function ordersInventoryAdjustByShop(orderId, shopId) {
   const order = Orders.findOne(orderId);
   order.items.forEach(item => {
     if (item.shopId === shopId) {
+      Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(item.variants._id), {
+        $inc: {
+          inventoryQuantity: -item.quantity
+        }
+      }, {
+        publish: true,
+        selector: {
+          type: "variant"
+        }
+      });
+
       Products.update({
         _id: item.variants._id
       }, {
@@ -368,6 +390,15 @@ export const methods = {
       // in some instances which causes the order not to cancel
       order.items.forEach(item => {
         if (Reaction.hasPermission("orders", Meteor.userId(), item.shopId)) {
+          Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(item.variants._id), {
+            $inc: {
+              inventoryQuantity: -item.quantity
+            }
+          }, {
+            bypassCollection2: true,
+            publish: true
+          });
+
           Products.update({
             _id: item.variants._id,
             shopId: item.shopId

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -84,6 +84,7 @@ export function ordersInventoryAdjust(orderId) {
       fieldNames: ["inventoryQuantity"]
     };
     Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+    Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
 
     Products.update({
       _id: item.variants._id
@@ -139,6 +140,7 @@ export function ordersInventoryAdjustByShop(orderId, shopId) {
         fieldNames: ["inventoryQuantity"]
       };
       Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+      Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
 
       Products.update({
         _id: item.variants._id
@@ -420,6 +422,7 @@ export const methods = {
             fieldNames: ["inventoryQuantity"]
           };
           Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
+          Hooks.Events.run("beforeProductUpdatePositions", productUpdateArgs);
 
           Products.update({
             _id: item.variants._id,

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -68,16 +68,21 @@ export function ordersInventoryAdjust(orderId) {
 
   const order = Orders.findOne(orderId);
   order.items.forEach(item => {
-    Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(item.variants._id), {
-      $inc: {
-        inventoryQuantity: -item.quantity
+    const productUpdateArgs = {
+      product: Products.findOne(item.variants._id),
+      modifier: {
+        $inc: {
+          inventoryQuantity: -item.quantity
+        }
+      },
+      options: {
+        publish: true,
+        selector: {
+          type: "variant"
+        }
       }
-    }, {
-      publish: true,
-      selector: {
-        type: "variant"
-      }
-    });
+    };
+    Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
     Products.update({
       _id: item.variants._id
@@ -115,16 +120,21 @@ export function ordersInventoryAdjustByShop(orderId, shopId) {
   const order = Orders.findOne(orderId);
   order.items.forEach(item => {
     if (item.shopId === shopId) {
-      Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(item.variants._id), {
-        $inc: {
-          inventoryQuantity: -item.quantity
+      const productUpdateArgs = {
+        product: Products.findOne(item.variants._id),
+        modifier: {
+          $inc: {
+            inventoryQuantity: -item.quantity
+          }
+        },
+        options: {
+          publish: true,
+          selector: {
+            type: "variant"
+          }
         }
-      }, {
-        publish: true,
-        selector: {
-          type: "variant"
-        }
-      });
+      };
+      Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
       Products.update({
         _id: item.variants._id
@@ -390,14 +400,19 @@ export const methods = {
       // in some instances which causes the order not to cancel
       order.items.forEach(item => {
         if (Reaction.hasPermission("orders", Meteor.userId(), item.shopId)) {
-          Hooks.Events.run("beforeProductUpdate", Meteor.userId(), Products.findOne(item.variants._id), {
-            $inc: {
-              inventoryQuantity: -item.quantity
+          const productUpdateArgs = {
+            product: Products.findOne(item.variants._id),
+            modifier: {
+              $inc: {
+                inventoryQuantity: -item.quantity
+              }
+            },
+            options: {
+              bypassCollection2: true,
+              publish: true
             }
-          }, {
-            bypassCollection2: true,
-            publish: true
-          });
+          };
+          Hooks.Events.run("beforeProductUpdate", productUpdateArgs);
 
           Products.update({
             _id: item.variants._id,

--- a/server/publications/collections/orders-publications.app-test.js
+++ b/server/publications/collections/orders-publications.app-test.js
@@ -19,8 +19,6 @@ Fixtures();
 describe("Order Publication", function () {
   const shop = getShop();
   let sandbox;
-  let productRemoveStub;
-  let productInsertStub;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
@@ -30,22 +28,6 @@ describe("Order Publication", function () {
   afterEach(function () {
     sandbox.restore();
     Collections.Orders.direct.remove();
-  });
-
-  before(function () {
-    // We are mocking inventory hooks, because we don't need them here, but
-    // if you want to do a real stress test, you could try to comment out
-    // this spyOn lines. This is needed only for ./reaction test. In one
-    // package test this is ignoring.
-    if (Array.isArray(Collections.Products._hookAspects.remove.after) && Collections.Products._hookAspects.remove.after.length) {
-      productRemoveStub = sinon.stub(Collections.Products._hookAspects.remove.after[0], "aspect");
-      productInsertStub = sinon.stub(Collections.Products._hookAspects.insert.after[0], "aspect");
-    }
-  });
-
-  after(function () {
-    productRemoveStub.restore();
-    productInsertStub.restore();
   });
 
   describe("Orders", () => {

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -42,7 +42,7 @@ describe("Publication", function () {
     };
 
     beforeEach(function () {
-      Collections.Products.direct.remove({});
+      Collections.Products.remove({});
 
       // a product with price range A, and not visible
       Collections.Products.insert({

--- a/server/startup/packages.js
+++ b/server/startup/packages.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { Products } from "/lib/collections";
+import { Hooks } from "/server/api";
 
 export default function () {
   /**
@@ -13,7 +13,8 @@ export default function () {
    * before product update
    */
   // TODO: review this.  not sure this does what it was intended to
-  Products.before.update((userId, product, fieldNames, modifier) => {
+  Hooks.Events.add("beforeProductUpdatePositions", (productUpdateArgs) => {
+    const { fieldNames, modifier } = productUpdateArgs;
     let updatedAt;
     // handling product positions updates
     if (_.indexOf(fieldNames, "positions") !== -1) {


### PR DESCRIPTION
Resolves #3634

Use `Hooks.Events` for Products related hooks.

### Changes made
1.  `products.before.insert`: 
      - **Hooks.Events.add("verifyProductInsert"..)** 
2. `products.after.insert`: 
      - **Hooks.Events.add("afterProductInsert", (product)..)**
      - **Hooks.Events.add("afterProductInsertSearch", (product)..) **
3. `products.before.remove`:
     - **Hooks.Events.add("beforeProductRemove", (product)..)**
4. `products.after.remove`:
     - **Hooks.Events.add("afterProductVariantRemove", (product)..)**
     - **Hooks.Events.add("afterProductRemove", (product)..)**
5. `products.before.update`:
     - **Hooks.Events.add("beforeProductUpdate", (productUpdateArgs)..)**
6. `products.after.update`:
     - **Hooks.Events.add("afterProductUpdate", (productUpdateArgs)..)**
     - **Hooks.Events.add("afterProductUpdateSearchRebuild", (productUpdateArgs)..)**

Search: `imports/plugins/included/search-mongo/server/hooks/search.js`: No tests for this hook. You need to test this manually to make sure it works.

How to test
- Update product
- Make sure the search record has been rebuilt if the fields modified are part of the ones watched 

