### PR TITLE
(fix): restore remove from cart functionality

### DIFF
--- a/imports/plugins/core/checkout/client/components/cartItems.js
+++ b/imports/plugins/core/checkout/client/components/cartItems.js
@@ -20,12 +20,19 @@ class CartItems extends Component {
     }
   }
 
+  removalClick = (event) => {
+    event.preventDefault();
+
+    if (typeof this.props.handleRemoveItem === "function") {
+      this.props.handleRemoveItem(event, this.props.item);
+    }
+  }
+
   render() {
     const {
       handleLowInventory,
       pdpPath,
       handleImage,
-      handleRemoveItem,
       item
     } = this.props;
 
@@ -42,7 +49,7 @@ class CartItems extends Component {
         }
         <Components.IconButton
           icon="fa fa-times fa-lg remove-cart-item"
-          onClick={handleRemoveItem}
+          onClick={this.removalClick}
         />
         <a href={pdpPath(item)}
           data-event-action="product-click"

--- a/imports/plugins/core/checkout/client/containers/cartDrawerContainer.js
+++ b/imports/plugins/core/checkout/client/containers/cartDrawerContainer.js
@@ -53,11 +53,11 @@ const handlers = {
     }
   },
 
-  handleRemoveItem(event) {
+  handleRemoveItem(event, item) {
     event.stopPropagation();
     event.preventDefault();
-    const currentCartItemId = event.target.getAttribute("id");
-    $(`#${currentCartItemId}`).fadeOut(500, () => Meteor.call("cart/removeFromCart", currentCartItemId));
+    const cartItemElement = $(event.target).closest(".cart-drawer-swiper-slide");
+    cartItemElement.fadeOut(500, () => Meteor.call("cart/removeFromCart", item._id));
   },
 
   handleCheckout() {


### PR DESCRIPTION
Resolves #3669 

Impact: **critical**
 
## Issue
Unable to remove items from cart in `release-1.8.0`
 
In #3582 changes were made to the IconButton used to remove items from the cart. This change replaced an `<i>` which had an `id` attribute with a React component which did not include the `id` attribute. The `handleRemoveItem` method was not updated and relied on the `id`. 

https://github.com/reactioncommerce/reaction/commit/5056c6b07798cc31fa523dbad1c6016f830dd680

## Solution
 
1. Add an intermediate `removalClick` class function to the `CartItems` component
1. Call `this.props.handleRemoveItem` from that function with the current item
1. Update the `handleRemoveItem` event handler to remove the item passed in and fade out the closest cart item to the target.
  
## Testing
 
1. Make sure you can remove items from the cart

