### PR TITLE
Don't rerender on failed sign in,

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { Accounts } from "meteor/accounts-base";
 import { Meteor } from "meteor/meteor";
 import { Session } from "meteor/session";
 import { check } from "meteor/check";
@@ -250,7 +251,11 @@ export default {
     // a user logging, as we'll check again
     // when everything is ready
     //
-    if (Meteor.loggingIn() === false) {
+    let loggingIn;
+    Tracker.nonreactive(() => {
+      loggingIn = Accounts.loggingIn();
+    });
+    if (loggingIn === false) {
       //
       // this userId check happens because when logout
       // occurs it takes a few cycles for a new anonymous user


### PR DESCRIPTION
or to be more specific: Don't re-render during logging in.

Closes #2328

Don't let changes to Accounts._loggingIn invalidate the computation
hasPermission() in main.js. This is done through making Accounts.loggingIn
nonreactive.

This should not prevent the re-run of hasPermission in general, because
whenever Meteor.userId() changes, it's called anyway. It just saves us
from running hasPermissions redundantly and too early (the moment the
user is about to sign in).

NOTE: The re-render would not happen if trying to sign in with wrong credentials via NavBar anyway, because it presumably doesn't involve hasPermission(). It rather happens when trying to sign in with wrong credentials during first checkout step.