### PR TITLE
Fix error when creating/update groups and/or group permissions for non-admin user

### DIFF
--- a/imports/plugins/core/accounts/client/components/editGroup.js
+++ b/imports/plugins/core/accounts/client/components/editGroup.js
@@ -21,6 +21,7 @@ import { groupPermissions } from "../helpers/accountsHelper";
 class EditGroup extends Component {
   static propTypes = {
     accounts: PropTypes.array,
+    canEdit: PropTypes.bool,
     groups: PropTypes.array,
     onChangeGroup: PropTypes.func,
     packages: PropTypes.array,
@@ -156,13 +157,14 @@ class EditGroup extends Component {
         {this.state.groups.map((grp, index) => (
           <div key={index} className={this.groupListClass(grp)}>
             <Components.ListItem label={grp.name} onClick={this.selectGroup(grp)}>
-              <a href="" onClick={this.showForm(grp)} className="fa fa-pencil" />
+              {this.props.canEdit && <a href="" onClick={this.showForm(grp)} className="fa fa-pencil" />}
             </Components.ListItem>
           </div>
         ))}
-        <Components.ListItem label="New Group" i18nKeyLabel="admin.groups.newGroup" onClick={this.showForm()}>
-          <i className="fa fa-plus" />
-        </Components.ListItem>
+        {this.props.canEdit &&
+          <Components.ListItem label="New Group" i18nKeyLabel="admin.groups.newGroup" onClick={this.showForm()}>
+            <i className="fa fa-plus" />
+          </Components.ListItem>}
       </Components.List>
     );
   }
@@ -176,6 +178,7 @@ class EditGroup extends Component {
         permissions={groupPermissions(this.props.packages)}
         group={this.state.selectedGroup}
         updateGroup={this.updateGroup}
+        canEdit={this.props.canEdit}
       />
     );
   };

--- a/imports/plugins/core/accounts/client/components/permissionsList.js
+++ b/imports/plugins/core/accounts/client/components/permissionsList.js
@@ -31,6 +31,7 @@ function removePermissions(current, old) {
 
 class PermissionsList extends Component {
   static propTypes = {
+    canEdit: PropTypes.bool,
     createGroup: PropTypes.func,
     group: PropTypes.object,
     permissions: PropTypes.array,
@@ -87,7 +88,7 @@ class PermissionsList extends Component {
                 label={childPermission.label}
                 switchOn={this.checked(childPermission.permission)}
                 switchName={childPermission.permission}
-                onSwitchChange={this.togglePermission(childPermission)}
+                onSwitchChange={this.props.canEdit && this.togglePermission(childPermission)}
               />
             );
           })}
@@ -106,7 +107,7 @@ class PermissionsList extends Component {
           actionType="switch"
           switchOn={this.checked(permission.name)}
           switchName={permission.name}
-          onSwitchChange={this.togglePermission(permission)}
+          onSwitchChange={this.props.canEdit && this.togglePermission(permission)}
         />
         {this.renderSubPermissions(permission)}
       </div>);

--- a/imports/plugins/core/accounts/client/containers/editGroupContainer.js
+++ b/imports/plugins/core/accounts/client/containers/editGroupContainer.js
@@ -6,10 +6,11 @@ import EditGroup from "../components/editGroup";
 
 const composer = (props, onData) => {
   const shopId = Reaction.getShopId();
+  const canEdit = Reaction.hasPermission("admin", Meteor.userId(), shopId);
   const pkg = Meteor.subscribe("Packages", shopId);
   if (pkg.ready()) {
     const packages = Packages.find({ shopId }).fetch();
-    onData(null, { packages, ...props });
+    onData(null, { packages, canEdit, ...props });
   }
 };
 


### PR DESCRIPTION
Resolves #3649

This PR does prevent an error being displayed when a user without the
role "shop-admin" or "owner" tries to create a new group or tries
to update permissions of an existing group.

It does so by not displaying editing buttons and having the permission
toggles not updating when switching on/off. I.e, they behave like
read-only widgets.
