### PR TITLE
Update pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,25 @@
-<!-- Thanks so much for your PR, your contribution is appreciated! -->
+Resolves #issueNumber  
+Impact: breaking|critical|major|minor  
+Type: feature|bugfix|performance|test|style|refactor|docs|chore
 
-Please provide the following information to help us approve your PR. Failure to provide this
-information may result in your PR being closed without comment.
+## Issue
+Description of the issue this PR is solving, why it's happening, and how to reproduce it. This may differ from the original ticket as you now have more information at your disposal.
 
-- [ ] Clearly explain what your PR is trying to accomplish. A link to an issue is best
-- [ ] Provide us detailed instructions on how we can test your PR
+## Solution
 
+Summarize your solution to the problem. Please include short descriptions of any solutions you tested before arriving at your final solution. This will help reviewers know why you decided to solve this problem in this particular way and will speed up the review process.
+
+## Breaking changes
+If you have a breaking changes, list them here, otherwise list none.
+
+Examples of breaking changes include changing file names, moving files, deleting files, renaming functions or exports, or changes to code which might cause previous versions of Reaction or third-party code not to work as expected.
+
+Note any work that you did to mitigate the effect of any breaking changes such as creating migrations, deprecation warnings, etc.
+
+
+## Testing
+1. List the steps needed for testing your change in this section.
+2. Assume that testers already know how to start the app, and do the basic setup tasks.
+3. Be detailed enough that someone can work through it without being too granular
+
+More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 


### PR DESCRIPTION
Resolves unreported
Impact: **minor**
Type: **chore**

## Issue
We recently merged @mikemurray's PR to update the contributing guidelines for submitting a PR to the Reaction docs. https://github.com/reactioncommerce/reaction-docs/pull/465. We need to update our PR template in `reactioncommerce/reaction` to fit the new guide.

## Solution
Updates the PR template to match the template listed in the docs.

## Breaking changes
n/a

## Testing
Check that the included PR template matches the updated contributing docs