### PR TITLE
docs: add link to Contributing Guide in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,6 @@
 # Contributing
 
-At Reaction Commerce, we're dedicated to the open source community. In fact, we've designed our entire platform and business to grow from the passion and creativity that an open source community ignites. We've already attracted a small, dedicated team of open source contributors, and there's always room for more. If you'd like to join us, here's how to get started:
+At Reaction Commerce, we're dedicated to the open source community. In fact, we've designed our entire platform and business to grow from the passion and creativity that an open source community ignites. We've already attracted a small, dedicated team of open source contributors, and there's always room for more. 
 
-**Step 1:**  If you haven't already, get Reaction running locally:
+If you'd like to join us, check out our detailed [Contributing Guide](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction).
 
-```sh
-curl https://install.meteor.com | /bin/sh
-git clone https://github.com/reactioncommerce/reaction.git
-cd reaction
-reaction
-```
-
-**Step 2:**
-
-Explore the interface and the code to give you a good overview of the product and a sense for what's already built. Keep an eye out for bugs and interface issues, as well as features you'd like to see created.
-
-**Step 3:**
-
-Explore the [GitHub issues already open on our main repo](https://github.com/reactioncommerce/reaction/issues) and our [GitHub project boards](https://github.com/reactioncommerce/reaction/projects). If you find something you want to work on, let us know right there in the comments. [`Pull Requests Encouraged`](https://github.com/reactioncommerce/reaction/issues?q=is%3Aissue+is%3Aopen+label%3Apull-requests-encouraged) and [`Verified Reproducible`](https://github.com/reactioncommerce/reaction/issues?q=is%3Aopen+is%3Aissue+label%3Averified-reproducible) labeled issues are a great place to start.
-
-If you are interested in a specific aspect of the project but aren't sure where to begin, feel free to ask. Start small and open up a dialogue with us. This will help to get your contributions accepted easily.
-
-**Step 4:**
-
-Let us know how we can make the contribution process easier. We want to find the best ways to support you.
-
-## Pull Requests
-
-[Create a pull request](https://help.github.com/articles/creating-a-pull-request/) to propose and collaborate on changes to Reaction. These changes are proposed in a PR branch, and are reviewed before merge acceptance into `master` for release.
-
--   Should reference an issue if one exists, or provide detailed information on the goal of the PR.
--   Pass both [acceptance tests and unit testing](https://docs.reactioncommerce.com/reaction-docs/master/testing-reaction). New functionality should include new tests.
--   Lint and adhere to the [Reaction style guide](https://docs.reactioncommerce.com/reaction-docs/master/styleguide).
--   Contributors should review the CLA.
--   Code reviewed before merge acceptance.


### PR DESCRIPTION
Resolves unreported
Impact: **minor**
Type: **chore**

## Issue
We recently merged @mikemurray's PR to update the contributing guidelines for submitting a PR to the Reaction docs. https://github.com/reactioncommerce/reaction-docs/pull/465. Instead of having to update CONTRIBUTING.md and the Contributing Guide 

## Solution
Updates reaction's CONTRIBUTING.md to link to docs.

## Breaking changes
n/a

## Testing
Test that the link works
