### PR TITLE
Fix #3720:  Added space to Taxcloud notice

### DIFF
--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -27,7 +27,7 @@ const TaxCloudSettingsForm = (props) => {
     <div className="rui taxcloud-settings-form">
       {!settings.taxcloud.apiLoginId &&
         <div className="alert alert-info">
-          <Components.Translation defaultValue="Add API Login ID to enable" i18nkey="admin.taxSettings.taxcloudCredentials" />
+          <Components.Translation defaultValue="Add API Login ID to enable " i18nkey="admin.taxSettings.taxcloudCredentials" />
           <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
         </div>
       }

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -27,7 +27,7 @@ const TaxCloudSettingsForm = (props) => {
     <div className="rui taxcloud-settings-form">
       {!settings.taxcloud.apiLoginId &&
         <div className="alert alert-info">
-          <Components.Translation 
+          <Components.Translation
             defaultValue="Add API Login ID to enable"
             i18nKey="admin.taxSettings.taxcloudCredentials" />&nbsp;
           <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>

--- a/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
+++ b/imports/plugins/included/taxes-taxcloud/client/components/taxCloudSettingsForm.js
@@ -27,7 +27,9 @@ const TaxCloudSettingsForm = (props) => {
     <div className="rui taxcloud-settings-form">
       {!settings.taxcloud.apiLoginId &&
         <div className="alert alert-info">
-          <Components.Translation defaultValue="Add API Login ID to enable " i18nkey="admin.taxSettings.taxcloudCredentials" />
+          <Components.Translation 
+            defaultValue="Add API Login ID to enable"
+            i18nKey="admin.taxSettings.taxcloudCredentials" />&nbsp;
           <a href="https://www.taxcloud.com/" target="_blank">TaxCloud</a>
         </div>
       }

--- a/imports/plugins/included/taxes-taxjar/client/settings/taxjar.html
+++ b/imports/plugins/included/taxes-taxjar/client/settings/taxjar.html
@@ -1,7 +1,7 @@
 <template name="taxJarSettings">
   {{#unless packageData.settings.taxjar.apiLoginId}}
   <div class="alert alert-info">
-    <span data-i18n="admin.taxSettings.taxjarCredentials">Add API Login ID to enable </span>
+    <span data-i18n="admin.taxSettings.taxjarCredentials">Add API Login ID to enable</span>&nbsp;
     <a href="https://www.taxjar.com/" target="_blank">TaxJar</a>
   </div>
   {{/unless}}

--- a/imports/plugins/included/taxes-taxjar/client/settings/taxjar.html
+++ b/imports/plugins/included/taxes-taxjar/client/settings/taxjar.html
@@ -1,7 +1,7 @@
 <template name="taxJarSettings">
   {{#unless packageData.settings.taxjar.apiLoginId}}
   <div class="alert alert-info">
-    <span data-i18n="admin.taxSettings.taxjarCredentials">Add API Login ID to enable</span>
+    <span data-i18n="admin.taxSettings.taxjarCredentials">Add API Login ID to enable </span>
     <a href="https://www.taxjar.com/" target="_blank">TaxJar</a>
   </div>
   {{/unless}}


### PR DESCRIPTION
This is a fix for Issue #3720 

There is now a space in the message after the word enable.

<img width="432" alt="screen shot 2018-02-11 at 1 12 32 pm" src="https://user-images.githubusercontent.com/5836953/36068611-4b485ba4-0f2d-11e8-96ac-77195fa3970b.png">


