### PR TITLE
Core translations not added to database

### DIFF
--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -7,7 +7,7 @@ import { Logger, Reaction } from "/server/api";
 const fs = {
   readdir: util.promisify(fsModule.readdir),
   readFile: util.promisify(fsModule.readFile),
-  realpath: util.promisify(fsModule.stat),
+  realpath: util.promisify(fsModule.realpath),
   stat: util.promisify(fsModule.stat)
 };
 


### PR DESCRIPTION
That was a tricky one..

Problem was that core translation files were not in a fresh db.

Closes #3694.

Because of a wrong fs func mapping, the core translation files weren't
found in the filesystem, because realpath executed fs.stats rather than fs.realpath, which resulted in this directory name:

`[object Object]/server/assets/app/data/i18n`

which can't be found in the system.