### PR TITLE
Fix for 3709 Display orderId instead of cartId

### DIFF
--- a/imports/plugins/core/accounts/client/components/ordersList.js
+++ b/imports/plugins/core/accounts/client/components/ordersList.js
@@ -30,7 +30,6 @@ class OrdersList extends Component {
                 key={orderKey}
                 shops={order.shops}
                 order={order.order}
-                orderId={order.orderId}
                 orderSummary={order.orderSummary}
                 paymentMethods={order.paymentMethods}
                 productImages={order.productImages}

--- a/imports/plugins/core/checkout/client/components/completedOrder.js
+++ b/imports/plugins/core/checkout/client/components/completedOrder.js
@@ -10,7 +10,6 @@ import AddEmail from "./addEmail";
  * @summary Displays a summary/information about the order the user has just completed
  * @param {Object} props - React PropTypes
  * @property {Object} order - An object representing the order
- * @property {String} orderID - the unique identifier of the order
  * @property {Array} shops - An Array contains information broken down by shop
  * @property {Object} orderSummary - An object containing the items making up the order summary
  * @property {Array} paymentMethod - An array of paymentMethod objects
@@ -18,7 +17,7 @@ import AddEmail from "./addEmail";
  * @property {Booleam} isProfilePage - A boolean value that checks if current page is user profile page
  * @return {Node} React node containing the top-level component for displaying the completed order/receipt page
  */
-const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, handleDisplayMedia, isProfilePage }) => {
+const CompletedOrder = ({ order, shops, orderSummary, paymentMethods, handleDisplayMedia, isProfilePage }) => {
   if (!order) {
     return (
       <Components.NotFound
@@ -32,13 +31,13 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
   let headerText;
 
   if (isProfilePage) {
-    headerText = (<p className="order-id"><strong>Order ID </strong>{orderId}</p>);
+    headerText = (<p className="order-id"><strong>Order ID </strong>{order._id}</p>);
   } else {
     headerText = (
       <div className="order-details-header">
         {/* This is the left side / main content */}
         <h3><Components.Translation defaultValue="Thank You" i18nKey={"cartCompleted.thankYou"} /></h3>
-        <p><strong>Order ID </strong>{orderId}</p>
+        <p><strong>Order ID </strong>{order._id}</p>
         {/* show a different message depending on whether we have an email or not */}
         <AddEmail order={order} orderEmail={order.email} />
         {/* This is the left side / main content*/}
@@ -111,7 +110,6 @@ CompletedOrder.propTypes = {
   handleDisplayMedia: PropTypes.func,
   isProfilePage: PropTypes.bool,
   order: PropTypes.object,
-  orderId: PropTypes.string,
   orderSummary: PropTypes.object,
   paymentMethods: PropTypes.array,
   shops: PropTypes.array

--- a/imports/plugins/core/checkout/client/containers/completedOrderContainer.js
+++ b/imports/plugins/core/checkout/client/containers/completedOrderContainer.js
@@ -40,13 +40,13 @@ function composer(props, onData) {
   // I think this is a bug in SubscriptionManager but that should be revisited later
   const sessionId = Session.get("sessionId");
   Reaction.Subscriptions.Cart = Reaction.Subscriptions.Manager.subscribe("Cart", sessionId, Meteor.userId());
-  const orderId = Reaction.Router.getQueryParam("_id");
-  const orderSub = Meteor.subscribe("CompletedCartOrder", Meteor.userId(), orderId);
+  const cartId = Reaction.Router.getQueryParam("_id");
+  const orderSub = Meteor.subscribe("CompletedCartOrder", Meteor.userId(), cartId);
 
   if (orderSub.ready()) {
     const order = Orders.findOne({
       userId: Meteor.userId(),
-      cartId: orderId
+      cartId
     });
 
     if (order) {
@@ -69,7 +69,6 @@ function composer(props, onData) {
           isProfilePage: false,
           shops: order.getShopSummary(),
           order,
-          orderId,
           orderSummary,
           paymentMethods: order.getUniquePaymentMethods(),
           productImages


### PR DESCRIPTION
Closes #3709 

### To test 
1. As an admin, set up products, shipping, and payment methods.
1. As an anonymous user, add a product to cart and checkout.
1. Complete the checkout process
1. On the confirmation page, enter an email address if you are presented so you get a confirmation email.
1. Take note of the order id on the confirmation page. This id should be correct.
1. In the confirmation email, observe the same order id.
1. As an admin, view the order in the order dashboard.