### PR TITLE
(refactor)(performance)(fix): Audit Product Images and update to always use optimized versions

### DIFF
--- a/imports/plugins/core/checkout/client/components/completedOrderItem.js
+++ b/imports/plugins/core/checkout/client/components/completedOrderItem.js
@@ -9,22 +9,21 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
  * @property {Function} handleDisplayMedia - a function for displaying the proper product image
  * @return {Node} React node containing each line item on an order
  */
-const CompletedOrderItem = ({ item, handleDisplayMedia }) => {
-  let image;
-  if (handleDisplayMedia(item)) {
-    image = handleDisplayMedia(item).url();
-  } else {
-    image = "/resources/placeholder.gif";
-  }
-  return (
-    <div className="row order-details-line">
-      <div className="order-details-media"><img src={image} alt="" /></div>
-      <div className="order-details-title">{item.product.title}<p>{item.variants.title}</p></div>
-      <div className="order-details-quantity"><span>{item.quantity}</span></div>
-      <div className="order-details-price"><Components.Currency amount={item.variants.price} /></div>
+const CompletedOrderItem = ({ item, handleDisplayMedia }) => (
+  <div className="row order-details-line">
+    <div className="order-details-media">
+      <Components.ProductImage
+        item={item}
+        displayMedia={handleDisplayMedia}
+        size="small"
+        badge={false}
+      />
     </div>
-  );
-};
+    <div className="order-details-title">{item.product.title}<p>{item.variants.title}</p></div>
+    <div className="order-details-quantity"><span>{item.quantity}</span></div>
+    <div className="order-details-price"><Components.Currency amount={item.variants.price} /></div>
+  </div>
+);
 
 
 CompletedOrderItem.propTypes = {

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -6,6 +6,7 @@ import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { formatPriceString, Reaction } from "/client/api";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
+import ProductImage from "./productImage";
 
 /**
  * @file LineItems React Component for displaying the actionable data on the invoice section on the orders sideview
@@ -60,12 +61,13 @@ class LineItems extends Component {
     const { displayMedia } = this.props;
 
     if (displayMedia(uniqueItem)) {
-      // Return thumbnail version of image
-      const rawMedia = displayMedia(uniqueItem).url();
-      const thumbnailMedia = `${rawMedia}?store=thumbnail`;
-
       return (
-        <img src={thumbnailMedia} alt="" />
+        <ProductImage
+          item={uniqueItem}
+          displayMedia={displayMedia}
+          size="small"
+          badge={false}
+        />
       );
     }
     return (

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -60,8 +60,12 @@ class LineItems extends Component {
     const { displayMedia } = this.props;
 
     if (displayMedia(uniqueItem)) {
+      // Return thumbnail version of image
+      const rawMedia = displayMedia(uniqueItem).url();
+      const thumbnailMedia = `${rawMedia}?store=thumbnail`;
+
       return (
-        <img src={displayMedia(uniqueItem).url()} alt="" />
+        <img src={thumbnailMedia} alt="" />
       );
     }
     return (

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -64,7 +64,7 @@ class LineItems extends Component {
         <Components.ProductImage
           item={uniqueItem}
           displayMedia={displayMedia}
-          size="small"
+          size="thumbnail"
           badge={false}
         />
       );

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -6,7 +6,6 @@ import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { formatPriceString, Reaction } from "/client/api";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
-import ProductImage from "./productImage";
 
 /**
  * @file LineItems React Component for displaying the actionable data on the invoice section on the orders sideview
@@ -62,7 +61,7 @@ class LineItems extends Component {
 
     if (displayMedia(uniqueItem)) {
       return (
-        <ProductImage
+        <Components.ProductImage
           item={uniqueItem}
           displayMedia={displayMedia}
           size="small"

--- a/imports/plugins/core/orders/client/components/orderTable.js
+++ b/imports/plugins/core/orders/client/components/orderTable.js
@@ -125,7 +125,7 @@ class OrderTable extends Component {
                 <Components.ProductImage
                   item={item}
                   displayMedia={displayMedia}
-                  size="small"
+                  size="thumbnail"
                   badge={true}
                 />
               </div>

--- a/imports/plugins/core/orders/client/components/orderTable.js
+++ b/imports/plugins/core/orders/client/components/orderTable.js
@@ -4,12 +4,11 @@ import Avatar from "react-avatar";
 import classnames from "classnames/dedupe";
 import { formatPriceString, i18next } from "/client/api";
 import { Orders } from "/lib/collections";
-import { withMoment } from "@reactioncommerce/reaction-components";
+import { Components, withMoment } from "@reactioncommerce/reaction-components";
 import { Badge, ClickToCopy, Icon, Translation, Checkbox, Loading, SortableTable } from "@reactioncommerce/reaction-ui";
 import { getOrderRiskBadge, getOrderRiskStatus, getBillingInfo, getShippingInfo } from "../helpers";
 import OrderTableColumn from "./orderTableColumn";
 import OrderBulkActionsBar from "./orderBulkActionsBar";
-import ProductImage from "./productImage";
 
 
 const classNames = {
@@ -123,7 +122,7 @@ class OrderTable extends Component {
           {order.items.map((item, i) => (
             <div className="order-item" key={i}>
               <div className="order-item-media">
-                <ProductImage
+                <Components.ProductImage
                   item={item}
                   displayMedia={displayMedia}
                   size="small"

--- a/imports/plugins/core/orders/client/components/productImage.js
+++ b/imports/plugins/core/orders/client/components/productImage.js
@@ -31,7 +31,12 @@ class ProductImage extends Component {
     let mediaUrl;
 
     if (displayMedia(item)) {
-      mediaUrl = displayMedia(item).url();
+      const rawMediaUrl = displayMedia(item).url();
+      mediaUrl = rawMediaUrl;
+
+      if (size) {
+        mediaUrl = `${rawMediaUrl}?source=${size}`;
+      }
     } else {
       mediaUrl = "/resources/placeholder.gif";
     }

--- a/imports/plugins/core/orders/client/components/productImage.js
+++ b/imports/plugins/core/orders/client/components/productImage.js
@@ -36,7 +36,7 @@ class ProductImage extends Component {
       mediaUrl = rawMediaUrl;
 
       if (size) {
-        mediaUrl = `${rawMediaUrl}?store=${size}`;
+        mediaUrl = `${rawMediaUrl}&store=${size}`;
       }
     } else {
       mediaUrl = "/resources/placeholder.gif";

--- a/imports/plugins/core/orders/client/components/productImage.js
+++ b/imports/plugins/core/orders/client/components/productImage.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { registerComponent } from "@reactioncommerce/reaction-components";
 import { Badge } from "@reactioncommerce/reaction-ui";
 
 
@@ -61,5 +62,7 @@ class ProductImage extends Component {
     );
   }
 }
+
+registerComponent("ProductImage", ProductImage);
 
 export default ProductImage;

--- a/imports/plugins/core/orders/client/components/productImage.js
+++ b/imports/plugins/core/orders/client/components/productImage.js
@@ -36,7 +36,7 @@ class ProductImage extends Component {
       mediaUrl = rawMediaUrl;
 
       if (size) {
-        mediaUrl = `${rawMediaUrl}?source=${size}`;
+        mediaUrl = `${rawMediaUrl}?store=${size}`;
       }
     } else {
       mediaUrl = "/resources/placeholder.gif";

--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -61,6 +61,30 @@ class InvoiceContainer extends Component {
     });
   };
 
+  handleDisplayMedia = (item) => {
+    const variantId = item.variants._id;
+    const { productId } = item;
+
+    const variantImage = Media.findOne({
+      "metadata.variantId": variantId,
+      "metadata.productId": productId
+    });
+
+    if (variantImage) {
+      return variantImage;
+    }
+
+    const defaultImage = Media.findOne({
+      "metadata.productId": productId,
+      "metadata.priority": 0
+    });
+
+    if (defaultImage) {
+      return defaultImage;
+    }
+    return false;
+  }
+
   handleItemSelect = (lineItem) => {
     let { selectedItems, editedItems } = this.state;
 

--- a/imports/plugins/core/orders/client/index.js
+++ b/imports/plugins/core/orders/client/index.js
@@ -19,3 +19,5 @@ import "./templates/workflow/workflow.js";
 
 import "./templates/orders.html";
 import "./templates/orders.js";
+
+export { ProductImage } from "./components/productImage";

--- a/imports/plugins/core/ui/client/components/media/media.js
+++ b/imports/plugins/core/ui/client/components/media/media.js
@@ -83,12 +83,17 @@ class MediaItem extends Component {
     return this.props.defaultSource || "/resources/placeholder.gif";
   }
 
-  get source() {
-    if (typeof this.props.source === "object" && this.props.source) {
-      return this.props.source.url() || this.defaultSource;
+  renderSource = (size) => {
+    let sourceSize = "&store=large";
+    if (size) {
+      sourceSize = `&store=${size}`;
     }
 
-    return this.props.source || this.defaultSource;
+    if (typeof this.props.source === "object" && this.props.source) {
+      return `${this.props.source.url()}${sourceSize}` || `${this.defaultSource}${sourceSize}`;
+    }
+
+    return `${this.props.source}${sourceSize}` || `${this.defaultSource}${sourceSize}`;
   }
 
   renderImage() {
@@ -98,14 +103,14 @@ class MediaItem extends Component {
           smallImage: {
             width: this.props.mediaWidth,
             height: this.props.mediaHeight,
-            src: this.source
+            src: this.renderSource("large")
           },
           imageClassName: "img-responsive",
           fadeDurationInMs: 150,
           hoverDelayInMs: 200,
           pressDuration: 300,
           largeImage: {
-            src: this.source,
+            src: this.renderSource("large"),
             width: this.props.mediaWidth * 2,
             height: this.props.mediaHeight * 2
           },
@@ -122,7 +127,7 @@ class MediaItem extends Component {
       <img
         alt=""
         className="img-responsive"
-        src={this.source}
+        src={this.renderSource("small")}
       />
     );
   }

--- a/imports/plugins/core/ui/client/components/media/media.js
+++ b/imports/plugins/core/ui/client/components/media/media.js
@@ -127,7 +127,7 @@ class MediaItem extends Component {
       <img
         alt=""
         className="img-responsive"
-        src={this.renderSource("small")}
+        src={this.renderSource("large")}
       />
     );
   }

--- a/imports/plugins/included/default-theme/client/styles/cart/checkout.less
+++ b/imports/plugins/included/default-theme/client/styles/cart/checkout.less
@@ -230,7 +230,6 @@
 .order-details-media {
   width: 40px;
   height: 40px;
-  border: solid 1px #cccccc;
   margin: 5px;
 
   img {
@@ -391,4 +390,3 @@
     border: 0;
   }
 }
-

--- a/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.html
@@ -110,7 +110,7 @@
     >
       <div class="order-item-media">
         {{#with media}}
-          <img src="{{url store='large'}}">
+          <img src="{{url store='thumbnail'}}">
         {{else}}
           <img src="/resources/placeholder.gif">
         {{/with}}


### PR DESCRIPTION
Resolves #3637
Impact: minor
Type: fix + refactor + performance

## Issue
Throughout the Reaction application, product images in various locations were being displayed at their full resolution, instead of their optimized versions (`large`, `medium`, `small`, `thumbnail`). It seems only the cart and Product grid are correctly using optimized versions, all other product images are using the raw uploaded image.

## Solution
This PR updates all product images throughout the application to use the optimized versions. In addition, this PR also updates the order fulfillment workflow, and the order confirmation screen, to use our `ProductImage` component, instead of just using a regular <img /> tag.

## Breaking changes
- None

## Testing
1. Login as an administrator, and create one or more products (or update the basic reaction product) to have at least two different variants with images, and one without an image.
2. Open the inspector, and inspect the element of the product image everywhere you see it:

**On the Product Grid, with all three sizes of PDP options**

![sweet_tee_s](https://user-images.githubusercontent.com/4482263/36127439-41ed4728-1012-11e8-811e-fd0c07db407c.png)
![sweet_tee_s](https://user-images.githubusercontent.com/4482263/36127452-52ae0836-1012-11e8-8edb-7a1d8956423a.png)
![sweet_tee_s](https://user-images.githubusercontent.com/4482263/36127459-5ea8471e-1012-11e8-85ea-2e2633767ea7.png)

**On the Grid Settings Dashboard**

![sweet_tee_s](https://user-images.githubusercontent.com/4482263/36127474-7c7578b6-1012-11e8-996a-3ba9a87fb5cb.png)

**On the PDP, both on the larger Media Gallery, and the smaller Options / Variant images**

![sweet_tee_s](https://user-images.githubusercontent.com/4482263/36127487-9e284fce-1012-11e8-804b-641bcf83570a.png)

**Add all product variants to your cart, and inspect the cart images**

![blank_image_and_blank_image](https://user-images.githubusercontent.com/4482263/36127509-b6e8110c-1012-11e8-9cb0-6b81a34ce54f.png)

**Make an order with all product variants, and inspect the order Confirmation screen**

![blank_image](https://user-images.githubusercontent.com/4482263/36127519-c9e31ff4-1012-11e8-8c4e-4a9342497e25.png)

**On the orders dashboard, open up the larger view and inspect the images on the large list view**

![blank_image](https://user-images.githubusercontent.com/4482263/36127534-ebfc9c32-1012-11e8-9310-c3934c012f4d.png)

**Open up the Orders fulfillment screen, and inspect the images in that flow both on the "normal" invoice, and also on the "checkable" invoice**
![blank_image](https://user-images.githubusercontent.com/4482263/36127569-0b066df6-1013-11e8-9259-384d287ba12f.png)
![blank_image](https://user-images.githubusercontent.com/4482263/36127575-14bad60c-1013-11e8-8070-41ba954a3b11.png)

