### PR TITLE
Fixes 3487: Css to make whole title clickable

### DIFF
--- a/imports/plugins/core/dashboard/client/index.js
+++ b/imports/plugins/core/dashboard/client/index.js
@@ -12,6 +12,7 @@ import "./templates/settings/settings.html";
 import "./templates/settings/settings.js";
 
 import "./templates/shop/settings/settings.html";
+import "./templates/shop/settings/settings.less";
 import "./templates/shop/settings/settings.js";
 
 import "./templates/dashboard.html";

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.less
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.less
@@ -1,0 +1,13 @@
+#shopSettingsAccordian {
+    .panel-heading {
+        padding: 0px;
+    }
+    div > a {
+        padding: 15px 20px 15px 20px;
+        display: inline-block;
+        width: 100%;
+    }
+    .panel-controls {
+        padding-right: 15px;
+    }
+}


### PR DESCRIPTION
Fix for #3487

### To test
1. Run `reaction`.
1. Open Shops from the Action menu.
1. Click anywhere outside the area shown in the pic, dropdown will open
<img width="400" alt="screen shot 2018-01-15 at 7 55 58 pm" src="https://user-images.githubusercontent.com/7762605/34946832-5deba004-fa2e-11e7-9004-ebb1e8c4315e.png">
1. Check for all the titles in the Shops sub-menu. It should work for all.
