### PR TITLE
Fixes #3293: Added css to make OR visible

### DIFF
--- a/imports/plugins/core/ui/client/components/divider/divider.js
+++ b/imports/plugins/core/ui/client/components/divider/divider.js
@@ -6,6 +6,11 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
 const Divider = (props) => {
   const { label, i18nKeyLabel } = props;
 
+  const dividerStyle = {
+    height: "auto",
+    background: "none"
+  };
+
   const classes = classnames({
     rui: true,
     separator: true,
@@ -15,7 +20,7 @@ const Divider = (props) => {
 
   if (label) {
     return (
-      <div className={classes} id={props.id}>
+      <div className={classes} id={props.id} style={dividerStyle}>
         <hr />
         <span className="label">
           <Components.Translation defaultValue={label} i18nKey={i18nKeyLabel} />


### PR DESCRIPTION
Fixes #3293 

### To test
1. Run `reaction`
1. Login as admin and activate some social logging feature.
1. Logout
1. Click on the login dropdown, the `OR` should be completely visible as shown in the screenshot below.
<img width="304" alt="screen shot 2018-02-13 at 3 29 48 pm" src="https://user-images.githubusercontent.com/7762605/36144133-1d2e332c-10d3-11e8-8401-ff0c4638a66d.png">
