### PR TITLE
Fixes #3530: Zip is optional

### DIFF
--- a/lib/collections/schemas/address.js
+++ b/lib/collections/schemas/address.js
@@ -3,6 +3,14 @@ import { SimpleSchema } from "meteor/aldeed:simple-schema";
 import { registerSchema } from "@reactioncommerce/reaction-collections";
 import { Metafield } from "./metafield";
 
+const withoutCodeCountries = ["AO", "AG", "AW", "BS", "BZ", "BJ", "BW",
+  "BF", "BI", "CM", "CF", "KM", "CG", "CD", "CK", "CI", "DJ",
+  "DM", "GQ", "ER", "FJ", "TF", "GM", "GH", "GD", "GN", "GY",
+  "HK", "IE", "JM", "KE", "KI", "MO", "MW", "ML", "MR", "MU",
+  "MS", "NR", "AN", "NU", "KP", "PA", "QA", "RW", "KN", "LC",
+  "ST", "SA", "SC", "SL", "SB", "SO", "SR", "SY", "TZ", "TL",
+  "TK", "TO", "TT", "TV", "UG", "AE", "VU", "YE", "ZW"];
+
 /**
  * @name Address
  * @memberof schemas
@@ -61,7 +69,17 @@ export const Address = new SimpleSchema({
   },
   postal: {
     label: "ZIP/Postal Code",
-    type: String
+    type: String,
+    optional: true,
+    custom() {
+      const country = this.field("country");
+      if (country && country.value) {
+        if (!withoutCodeCountries.includes(country.value) && !this.value) {
+          return "required";
+        }
+      }
+      return true;
+    }
   },
   country: {
     type: String,


### PR DESCRIPTION
Fixes #3530 

### To test
1. Run `reaction`
1. Add the example product to the cart.
1. On the checkout form select country as India, and enter all the details except Zip code.
1. Notice the error that "Zip code is required"
1. Now change the country to Qatar
1. Again try to add the address with Zip code. 
1. Observe that the address will get added now.

Used the list of countries that don't have a zip code from [here](https://gist.github.com/kennwilson/3902548) (except South Africa which now has zip codes mostly everywhere.)