### PR TITLE
(fix): substitute "-" for "/" when tagging docker image

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -16,7 +16,7 @@ docker build \
   -t "${DOCKER_NAMESPACE}:${SHA1}" .
 
 # Get tags and apply them to our Docker image
-"${__dir}/docker-tags.sh" "${SHA1}" "${CIRCLE_BRANCH}" | xargs -t -I % \
+"${__dir}/docker-tags.sh" "${SHA1}" "${CIRCLE_BRANCH}" | sed 's/\//-/g' | xargs -t -I % \
   docker tag "${DOCKER_NAMESPACE}:${SHA1}" "${DOCKER_NAMESPACE}:%"
 
 # run the container and wait for it to boot

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -27,5 +27,5 @@ docker push "${DOCKER_NAMESPACE}:${SHA1}"
 
 # Push remaining tags (git tags, branch, "latest" if applicable)
 echo "Pushing remaining tags"
-"${__dir}/docker-tags.sh" "${SHA1}" "${CIRCLE_BRANCH}" | xargs -t -I % \
+"${__dir}/docker-tags.sh" "${SHA1}" "${CIRCLE_BRANCH}" | sed 's/\//-/g' | xargs -t -I % \
   docker push "${DOCKER_NAMESPACE}:%"


### PR DESCRIPTION
Resolves unreported issue
Impact: critical
Type: bugfix

## Issue

Looking at https://github.com/reactioncommerce/reaction/pull/3723 and https://github.com/reactioncommerce/reaction/pull/3348 it seems that CircleCI is adding a tag "pull/pullNumber" to any PR that is from a fork. When that gets converted to a docker tag, it breaks the build because `/` is not a valid character in a docker tag.

See: https://docs.docker.com/engine/reference/commandline/tag/#usage
> A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.

## Solution
This resolves the problem by replacing the `/` with `-` in the build script where we tag docker images. It uses `sed` to perform the replacement and pipes the replaced output into `xargs`

## Breaking changes
N/A

## Testing
I've used a branch name with slashes for this PR so that it emulates the issue we've been seeing.

1. Verify that this branch builds correctly
2. Verify that the docker image gets tagged with the modified branch name (`spencer-fix-docker-tag-script` in this case) - see https://hub.docker.com/r/reactioncommerce/reaction/tags/
