### PR TITLE
(fix): Cart image & Remove cart icon alignment fixes

### DIFF
--- a/imports/plugins/core/checkout/client/components/cartItems.js
+++ b/imports/plugins/core/checkout/client/components/cartItems.js
@@ -50,6 +50,7 @@ class CartItems extends Component {
         <Components.IconButton
           icon="fa fa-times fa-lg remove-cart-item"
           onClick={this.removalClick}
+          kind="removeItem"
         />
         <a href={pdpPath(item)}
           data-event-action="product-click"

--- a/imports/plugins/core/ui/client/components/button/iconButton.js
+++ b/imports/plugins/core/ui/client/components/button/iconButton.js
@@ -19,6 +19,12 @@ const IconButton = ({ icon, onIcon, ...otherProps }) => {
       "icon-only": true,
       "status-badge": true
     });
+  } else if (otherProps.kind === "removeItem") {
+    buttonClassName = classnames({
+      "icon-only": true,
+      "variant-edit": true,
+      "remove-item-aria-container": true
+    });
   } else {
     buttonClassName = classnames({
       "icon-only": true,

--- a/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
+++ b/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
@@ -39,7 +39,7 @@
     top: 0px;
     .right(0px);
     color: @gray;
-    background-color: @alert-warning-bg;
+    background-color: @black15;
     padding: 5px;
     border-radius: 50%;
     z-index: 99;

--- a/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
+++ b/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
@@ -28,10 +28,16 @@
     white-space: pre-wrap;
   }
 
-  .remove-cart-item {
+  .remove-item-aria-container {
     position: absolute;
     top: -8px;
     .right(-8px);
+  }
+
+  .remove-cart-item {
+    position: absolute;
+    top: 0px;
+    .right(0px);
     color: @gray;
     background-color: @alert-warning-bg;
     border: 2px solid @gray;

--- a/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
+++ b/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
@@ -30,8 +30,8 @@
 
   .remove-cart-item {
     position: absolute;
-    top: 8px;
-    .right(8px);
+    top: -8px;
+    .right(-8px);
     color: @gray;
     background-color: @alert-warning-bg;
     border: 2px solid @gray;

--- a/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
+++ b/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
@@ -39,8 +39,7 @@
     top: 0px;
     .right(0px);
     color: @gray;
-    background-color: @alert-warning-bg;
-    border: 2px solid @gray;
+    border: 1px solid @gray;
     padding: 5px;
     border-radius: 50%;
     z-index: 99;

--- a/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
+++ b/imports/plugins/included/default-theme/client/styles/cart/cartItems.less
@@ -39,7 +39,7 @@
     top: 0px;
     .right(0px);
     color: @gray;
-    border: 1px solid @gray;
+    background-color: @alert-warning-bg;
     padding: 5px;
     border-radius: 50%;
     z-index: 99;


### PR DESCRIPTION
Resolves #3668 | Resolves #3667 
Impact: minor
Type: bugfix

## Issue
We are seeing some alignment issues on items inside the cart - the item image overlaps the checkout button, and the remove from cart button is also out of place.

## Solution
Add correct positioning, via CSS, so that the items are aligned as they should be.

## Breaking changes
None

## Testing
1. Add items to the cart
2. See that the item images do not overlap the checkout button, and that the remove from cart `X` is in the top right corner