### PR TITLE
Add sentence requesting images for UIX PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,14 @@
 Resolves #issueNumber  
-Impact: breaking|critical|major|minor  
-Type: feature|bugfix|performance|test|style|refactor|docs|chore
+Impact: **breaking|critical|major|minor**  
+Type: **feature|bugfix|performance|test|style|refactor|docs|chore**
 
 ## Issue
 Description of the issue this PR is solving, why it's happening, and how to reproduce it. This may differ from the original ticket as you now have more information at your disposal.
 
 ## Solution
-
 Summarize your solution to the problem. Please include short descriptions of any solutions you tested before arriving at your final solution. This will help reviewers know why you decided to solve this problem in this particular way and will speed up the review process.
+
+If you're solving a UIX related issue, please attach screen-caps or gifs showing how your solution differs from the issue.
 
 ## Breaking changes
 If you have a breaking changes, list them here, otherwise list none.


### PR DESCRIPTION
Resolves unreported issue  
Impact: **minor**  
Type: **chore**

## Issue
Described in this comment https://github.com/reactioncommerce/reaction/pull/3737#issuecomment-365330533

I'd like to see before/after images included in the pull request when we're making changes to a UI element to make design reviews a little more simple.

## Solution
This PR updates the pull request template to add a sentence to the `Solution` section
> If you're solving a UIX related issue, please attach screen-caps or gifs showing how your solution differs from the issue.

This PR also updates the top section of the PR template to **bold** the `impact` and `type` definitions for a PR.

## Breaking changes
No breaking changes

## Testing
1. Check for spelling or grammatical errors or weird phrasings in the included sentence.
