### PR TITLE
Fix 2882: Remove methods deprecated in 1.5

### DIFF
--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -330,53 +330,5 @@ export const cartOrderTransform = {
     // because shipping records are not stored by shop
     const sortedShopObjects = _.sortBy(shopObjects, (shopObject) => shopObject.name);
     return sortedShopObjects;
-  },
-  /**
-   * @method cartCount
-   * @deprecated since version 1.5
-   * @returns {Number} - Return total quantity for this cart/order
-   */
-  cartCount() {
-    return this.getCount();
-  },
-  /**
-   * @method cartShipping
-   * @deprecated since version 1.5
-   * @returns {Number} - Return overall shipping total
-   */
-  cartShipping() {
-    return this.getShippingTotal();
-  },
-  /**
-   * @method cartSubtotal
-   * @deprecated since version 1.5
-   * @returns {*|Number} - Returns the cart subtotal
-   */
-  cartSubTotal() {
-    return this.getSubTotal();
-  },
-  /**
-   * @method cartTaxes
-   * @deprecated since version 1.5
-   * @returns {Number} Returns taxes for this cart
-   */
-  cartTaxes() {
-    return this.getTaxTotal();
-  },
-  /**
-   * @method cartDiscounts
-   * @deprecated since version 1.5
-   * @returns {Number} Returns the discount percentage for this order
-   */
-  cartDiscounts() {
-    return this.getDiscounts();
-  },
-  /**
-   * @method cartTotal
-   * @deprecated since version 1.5
-   * @returns {Number} Returns the total for the cart
-   */
-  cartTotal() {
-    return this.getTotal();
   }
 };


### PR DESCRIPTION
**Resolves** #2882
**Impact**: breaking
**Type**: chore

## Issue
Some of the methods in the cart/order were deprecated in 1.5 to make them no longer cart specific. 

## Solution
This removes those deprecated methods now that one version has passed


## Breaking changes
Anybody using these methods should will need to adjust their code to use the new methods


## Testing
1. This should have no impact since these methods were no longer used but double-checking that checkout still works would probably still be helpful.

