### PR TITLE
Fixes 3499: Add  css to truncate

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/dashboard/accounts.less
+++ b/imports/plugins/included/default-theme/client/styles/dashboard/accounts.less
@@ -116,6 +116,9 @@
         }
         .btn {
           padding: 0 5%;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       }
       .created-at {


### PR DESCRIPTION
Resolves #3499   
Impact: minor  
Type: style

## Issue
Long group name not truncated

## Solution
Added css to add ellipsis on long group name

## Testing
1. Create a group with a longer name
1. Select a user to change groups
1. Select the group with the long name
1. Observe that the name overflows the box
Screenshot of the fixed issue -> 
<img width="1098" alt="screen shot 2018-02-14 at 5 52 37 pm" src="https://user-images.githubusercontent.com/7762605/36204283-af387bb4-11b0-11e8-97ee-ed3dd77bc50b.png">
