### PR TITLE
Fix: Product url should open product detail page when user clicks on an item in the cart drawer

### DIFF
--- a/imports/plugins/core/checkout/client/containers/cartDrawerContainer.js
+++ b/imports/plugins/core/checkout/client/containers/cartDrawerContainer.js
@@ -41,7 +41,6 @@ const handlers = {
       });
 
       ReactionProduct.setCurrentVariant(productItem.variants._id);
-      Session.set(`variant-form-${productItem.variants._id}`, true);
     }
   },
 

--- a/imports/plugins/core/checkout/client/containers/cartDrawerContainer.js
+++ b/imports/plugins/core/checkout/client/containers/cartDrawerContainer.js
@@ -6,6 +6,7 @@ import { Meteor } from "meteor/meteor";
 import { Cart, Media } from "/lib/collections";
 import { Reaction } from "/client/api";
 import CartDrawer from "../components/cartDrawer";
+import { ReactionProduct } from "/lib/api";
 
 // event handlers to pass in as props
 const handlers = {
@@ -38,6 +39,9 @@ const handlers = {
         handle: productItem.productId,
         variantId: productItem.variants._id
       });
+
+      ReactionProduct.setCurrentVariant(productItem.variants._id);
+      Session.set(`variant-form-${productItem.variants._id}`, true);
     }
   },
 


### PR DESCRIPTION
Resolves #3660  
Impact: major  
Type: bugfix

## Issue
When clicking on a product in the cart drawer the corresponding product detail page is not loaded, only the URL changes.

## Solution
Set the currently selected variant like this: `ReactionProduct.setCurrentVariant(productItem.variants._id);`
when a user clicks on a variant in the cart.



## Testing
1. Add two different variants to the cart
2. Click on the cart icon to open the cart drawer
3. Click on the first variant and verify that the product detail information shows the clicked variant as selected.
4. Click on the second variant and verify that the product detail information shows the clicked variant as selected.
More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
