### PR TITLE
fix: update action view size handling to fix shipping settings cutoff

### DIFF
--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -19,6 +19,7 @@ import { getComponent } from "@reactioncommerce/reaction-components";
 const getStyles = (props) => {
   const minWidth = Math.min(props.viewportWidth, 400);
   let viewSize = minWidth;
+  let viewMaxSize = "400px";
   const actionView = props.actionView || {};
   const provides = actionView.provides || [];
   // legacy provides could be a string, is an array since 1.5.0, check for either.
@@ -27,6 +28,7 @@ const getStyles = (props) => {
                     (provides.includes("shortcut") && actionView.container === "dashboard");
   if (isBigView) {
     viewSize = "90vw";
+    viewMaxSize = "100%";
   }
 
   if (actionView.meta && actionView.meta.actionView) {
@@ -36,12 +38,15 @@ const getStyles = (props) => {
 
     if (isSmView) {
       viewSize = `${minWidth}px`;
+      viewMaxSize = `${minWidth}px`;
     }
     if (isMdView) {
       viewSize = "50vw";
+      viewMaxSize = "50vw";
     }
     if (isLgView) {
       viewSize = "90vw";
+      viewMaxSize = "90vw";
     }
   }
 
@@ -51,17 +56,25 @@ const getStyles = (props) => {
 
   return {
     base: {
-      display: "flex",
-      flexDirection: "row",
-      height: "100vh",
-      position: "relative",
-      width: viewSize,
-      boxShadow: isBigView ? "0 0 40px rgba(0,0,0,.1)" : "",
-      flex: "0 0 auto",
-      backgroundColor: "white",
-      overflow: "hidden",
-      transition: "width 300ms cubic-bezier(0.455, 0.03, 0.515, 0.955))",
-      zIndex: 1050
+      "display": "flex",
+      "flexDirection": "row",
+      "height": "100vh",
+      "position": "relative",
+      "width": viewSize,
+      "maxWidth": viewMaxSize,
+      "boxShadow": isBigView ? "0 0 40px rgba(0,0,0,.1)" : "",
+      "flex": "0 0 auto",
+      "backgroundColor": "white",
+      "overflow": "hidden",
+      "transition": "width 300ms cubic-bezier(0.455, 0.03, 0.515, 0.955))",
+      "zIndex": 1050,
+      "@media only screen and (max-width: 949px)": {
+        width: "auto",
+        maxWidth: "100%"
+      },
+      "@media only screen and (max-width: 767px)": {
+        maxWidth: "100%"
+      }
     },
     header: {
       display: "flex",
@@ -86,9 +99,14 @@ const getStyles = (props) => {
       WebkitOverflowScrolling: "touch"
     },
     masterViewPanel: {
-      display: "flex",
-      flexDirection: "column",
-      flex: "1 1 auto"
+      "display": "flex",
+      "flexDirection": "column",
+      "flex": "1 1 auto",
+      "maxWidth": viewMaxSize,
+      "@media only screen and (max-width: 949px)": {
+        width: "100vw",
+        maxWidth: "100%"
+      }
     },
     masterView: {
       flex: "1 1 auto",
@@ -100,7 +118,7 @@ const getStyles = (props) => {
       "display": "flex",
       "flexDirection": "column",
       "flex": "1 1 auto",
-      "maxWidth": "400px",
+      "maxWidth": viewMaxSize,
       "height": "100vh",
       "backgroundColor": "white",
       "borderRight": "1px solid #ccc",


### PR DESCRIPTION
Resolves #3756   
Impact: critical
Type: bugfix

## Issue

Fixes issues where content in the action view will be cut-off horizontally at various viewport sizes.

This is happening due to the lack max widths on containers, allowing them to overflow the action view.

**To reproduce**
1. Use the 1.8.0 branch
1. Sign in as admin
1. Open the shipping settings panel
1. Enable shippo with valid credentials
1. Refresh methods
1. See the right side of the table is cut off

## Solution

1. Inspected elements to determine that it was the action view that was allowing content to overflow.
1. Added max widths at various action view sizes and viewport breakpoints to prevent overflow.

## Breaking changes

none

## Testing

**Test 1**
1. As an admin open the shipping settings at desktop size
2. Enable shippo with valid credentials and refresh methods
3. A table of available shipping methods should be visible, and not cutoff to the right
4. Resize the window from desktop -> tablet -> phone
5. Content should not be cut off at any size

**Test 2**
1. As an admin open other settings panels
2. Content should not be cut off at various viewport sizes