### PR TITLE
Fixes #3762: Add placeholder media

### DIFF
--- a/imports/plugins/core/ui/client/components/media/mediaGallery.js
+++ b/imports/plugins/core/ui/client/components/media/mediaGallery.js
@@ -119,7 +119,11 @@ class MediaGallery extends Component {
     }
 
     return (
-      <Components.MediaItem />
+      <Components.MediaItem
+        source={"/resources/placeholder.gif"}
+        mediaHeight={height}
+        mediaWidth={width}
+      />
     );
   }
 


### PR DESCRIPTION
Resolves #3762   
Impact: minor  
Type: bugfix

## Issue
The case when there was no image, we were displaying a empty image

## Solution
Added the placeholder image in place of the empty image.

## Testing
1. Go to PDP for the "Basic Reaction Product"(edit mode off or not logged in state)
1. Observe that the placeholder image is visible