### PR TITLE
Fixes #3766: Checking for shipping address and billing address

### DIFF
--- a/imports/plugins/core/accounts/client/containers/loginInline.js
+++ b/imports/plugins/core/accounts/client/containers/loginInline.js
@@ -36,7 +36,8 @@ class LoginInlineContainer extends Component {
         userId: Meteor.userId()
       });
       // If there's already a billing and shipping address selected, push beyond address book
-      if (cart && cart.billing[0] && cart.shipping[0]) {
+      if (cart && cart.billing[0] && cart.billing[0].address
+        && cart.shipping[0] && cart.shipping[0].address) {
         Meteor.call("workflow/pushCartWorkflow", "coreCartWorkflow", "checkoutAddressBook");
       }
     });


### PR DESCRIPTION
Resolves #3766  
Impact: minor  
Type: bugfix

## Issue
Only the `billing` and `shipping` object were being checked for existence. It was not checked if they actually had and address or not.
## Solution
Now checking if those object contain the `address` field.

## Testing
1. Visit the site in incognito mode
1. Add something to cart
1. Click on "Continue as Guest"
1. Enter the email
1. Observe no shipping methods are displayed
1. Once you enter your address the shipping methods display as expected.