### PR TITLE
Fix error when switching table layout in order dashboard

### DIFF
--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -44,10 +44,10 @@ export function withMoment(component) {
   return lifecycle({
     componentDidMount() {
       import("moment")
-        .then(moment => {
+        .then((moment) => {
           moment.locale(Reaction.Locale.get().language);
           this.setState({
-            moment: moment.default
+            moment
           });
         })
         .catch((error) => {
@@ -70,7 +70,7 @@ export function withMomentTimezone(component) {
   return lifecycle({
     componentDidMount() {
       import("moment-timezone")
-        .then(moment => {
+        .then((moment) => {
           this.setState({
             momentTimezone: moment.tz
           });

--- a/imports/plugins/core/orders/client/components/orderTable.js
+++ b/imports/plugins/core/orders/client/components/orderTable.js
@@ -100,7 +100,9 @@ class OrderTable extends Component {
         <div className="order-totals">
           <span className="order-data order-data-date">
             <strong>Date: </strong>
-            {moment(order.createdAt).fromNow()} | {moment(order.createdAt).format("MM/D/YYYY")}
+            {(moment && moment(order.createdAt).fromNow()) || order.createdAt.toLocaleString()}
+            &nbsp;|&nbsp;
+            {(moment && moment(order.createdAt).format("MM/D/YYYY")) || order.createdAt.toLocaleString()}
           </span>
 
           <span className="order-data order-data-id">


### PR DESCRIPTION
Resolves #3760
Impact: major
Type: bugfix

## Issue
As an admin it's not possible to switch the table layout in the order dashboard.

## Solution/Changes
- The withMoment higherOrderComponent would always return undefined,
    because there's no property default on the moment object

- Render getLocaleString() on the date object until moment gets
    available (async)

## Breaking changes
none expected

## Testing
1. create a order and checkout
2. As an admin, go to the order dashboard
3. Switch table layout
4. It should work without error


![localhost_3000](https://user-images.githubusercontent.com/1733229/36302455-d3199f32-1308-11e8-9c40-a59ac978a6ec.jpg)
