### PR TITLE
Fix for shippo calculation error

### DIFF
--- a/imports/plugins/included/shipping-shippo/server/methods/shippo.js
+++ b/imports/plugins/included/shipping-shippo/server/methods/shippo.js
@@ -34,9 +34,9 @@ function createShippoAddress(reactionAddress, email, purpose) {
 // a reaction product's parcel and units of measure for mass and distance
 function createShippoParcel(reactionParcel, cartWeight, reactionMassUnit, reactionDistanceUnit) {
   const shippoParcel = {
-    width: reactionParcel.width || "",
-    length: reactionParcel.length || "",
-    height: reactionParcel.height || "",
+    width: reactionParcel.width || 1,
+    length: reactionParcel.length || 1,
+    height: reactionParcel.height || 1,
     weight: cartWeight,
     distance_unit: reactionDistanceUnit,
     mass_unit: reactionMassUnit


### PR DESCRIPTION
Resolves #3750
Impact: major  
Type: bugfix

## Issue
If a product's length, height or width value was falsy , the Shippo call failed with an validation error. 

## Solution/Change
Dimensions need to be specified as numeric values. Otherwise a
validation error occurs.

Chose default value  of 1 for width, height or length, if not given.

A smaller value would lead to only have USPS Shipping option available in
Shippo, which is prohibitively expensive.

## Breaking changes
none expected

## Testing
1. As an admin, enable Shippo shipping option
2. As a user, checkout with a product that has the dimensions width: 0, length: 0, height: 0
3. Use a US address
4. See different Shipping options appear.
