### PR TITLE
Fixes #3761: NavBar made only once

### DIFF
--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -5,43 +5,61 @@ import { getComponent, registerComponent } from "@reactioncommerce/reaction-comp
 import Blaze from "meteor/gadicc:blaze-react-component";
 import { Template } from "meteor/templating";
 
-const CoreLayout = ({ actionViewIsOpen, structure }) => {
-  const { layoutHeader, layoutFooter, template } = structure || {};
+class CoreLayout extends React.Component {
+  constructor(props) {
+    super(props);
 
-  const pageClassName = classnames({
-    "page": true,
-    "show-settings": actionViewIsOpen
-  });
+    const { structure } = this.props;
+    const { layoutHeader, layoutFooter } = structure || {};
 
-  const headerComponent = layoutHeader && getComponent(layoutHeader);
-  const footerComponent = layoutFooter && getComponent(layoutFooter);
+    const headerComponent = layoutHeader && getComponent(layoutHeader);
+    const footerComponent = layoutFooter && getComponent(layoutFooter);
 
-  let mainNode = null;
-  try {
-    const mainComponent = getComponent(template);
-    mainNode = React.createElement(mainComponent, {});
-  } catch (error) {
-    //  Probe for Blaze template (legacy)
-    if (Template[template]) {
-      mainNode = <Blaze template={template} />;
+    if (headerComponent) {
+      this.headerComponent = React.createElement(headerComponent, {});
+    }
+
+    if (footerComponent) {
+      this.footerComponent = React.createElement(footerComponent, {});
     }
   }
 
-  return (
-    <div className={pageClassName} id="reactionAppContainer">
+  render() {
+    const { actionViewIsOpen, structure } = this.props;
+    const { template } = structure || {};
 
-      {headerComponent && React.createElement(headerComponent, {})}
+    const pageClassName = classnames({
+      "page": true,
+      "show-settings": actionViewIsOpen
+    });
 
-      <Blaze template="cartDrawer" className="reaction-cart-drawer" />
+    let mainNode = null;
+    try {
+      const mainComponent = getComponent(template);
+      mainNode = React.createElement(mainComponent, {});
+    } catch (error) {
+    //  Probe for Blaze template (legacy)
+      if (Template[template]) {
+        mainNode = <Blaze template={template} />;
+      }
+    }
 
-      <main>
-        {mainNode}
-      </main>
+    return (
+      <div className={pageClassName} id="reactionAppContainer">
 
-      {footerComponent && React.createElement(footerComponent, {})}
-    </div>
-  );
-};
+        {this.headerComponent}
+
+        <Blaze template="cartDrawer" className="reaction-cart-drawer" />
+
+        <main>
+          {mainNode}
+        </main>
+
+        {this.footerComponent}
+      </div>
+    );
+  }
+}
 
 CoreLayout.propTypes = {
   actionViewIsOpen: PropTypes.bool,


### PR DESCRIPTION
Resolves #3761  
Impact: minor
Type: bugfix|performance

## Issue
The issue was that the `getComponent` call was making a new component everytime. So the whole component tree from NavBar was being made again.

## Solution
The components are now made in the constructor and are reused in the `render()` this cause the internal checks of React in deciding when to render something again work properly.

## Testing
1. In a mobile browser while on the homepage clicking the shop title/logo should do nothing.

## To really test
1. Before merging this PR
1. Add a `contructor()` or `componentWillUnmount()` [here](https://github.com/reactioncommerce/reaction/blob/release-1.8.0/imports/plugins/core/ui-navbar/client/components/navbar.js#L45)
1. Add a breakpoint inside the constructor/function
1. Click on the brand title on the homepage
1. The code will reach the breakpoint, which mean the component is made again.
1. Merge this PR
1. Again click on the brand title on the homepage
1. The control will not reach the breakpoint, which means the component was not made again.