### PR TITLE
Fixes #3784: Edit address when already present

### DIFF
--- a/imports/plugins/core/accounts/client/templates/addressBook/review/review.js
+++ b/imports/plugins/core/accounts/client/templates/addressBook/review/review.js
@@ -85,17 +85,31 @@ Template.addressBookReview.events({
       fieldErrors: {}
     };
     Session.set("addressState", addressState);
-    Meteor.call("accounts/addressBookAdd", address, (error, result) => {
-      if (error) {
-        Alerts.toast(i18next.t("addressBookAdd.failedToAddAddress", { err: error.message }), "error");
-        return false;
-      }
-      if (result) {
-        const addressBook = $(instance.firstNode).closest(".address-book");
-        addressBook.trigger($.Event("showMainView"));
-        return true;
-      }
-    });
+    if (address._id) {
+      Meteor.call("accounts/addressBookUpdate", address, (error, result) => {
+        if (error) {
+          Alerts.toast(i18next.t("addressBookEdit.somethingWentWrong", { err: error.message }), "error");
+          return false;
+        }
+        if (result) {
+          const addressBook = $(instance.firstNode).closest(".address-book");
+          addressBook.trigger($.Event("showMainView"));
+          return true;
+        }
+      });
+    } else {
+      Meteor.call("accounts/addressBookAdd", address, (error, result) => {
+        if (error) {
+          Alerts.toast(i18next.t("addressBookAdd.failedToAddAddress", { err: error.message }), "error");
+          return false;
+        }
+        if (result) {
+          const addressBook = $(instance.firstNode).closest(".address-book");
+          addressBook.trigger($.Event("showMainView"));
+          return true;
+        }
+      });
+    }
   },
   "click [data-event-action=cancelAddressEdit]"() {
     // set address back to original value before edits


### PR DESCRIPTION
Resolves #3784  
Impact: minor  
Type: bugfix

## Issue
The review process assumed that it will always get address before the address was saved in the DB.

## Solution
If the review process get's a address that has been already added to the DB, just update it

## Testing
1. Enable Avalara w/ valid credentials
1. As an anonymous user, add a product to your cart and proceed to checkout.
1. Enter an address and approve it's validation
1. Click the edit "pencil" icon for that address and then click save without making any changes
1. Approve the address validation
1. Observe that the address is not duplicated
