### PR TITLE
Fix: Email verification link for admin user

### DIFF
--- a/server/api/core/accounts/password.js
+++ b/server/api/core/accounts/password.js
@@ -172,7 +172,9 @@ export function sendVerificationEmail(userId, email) {
   });
 
   const shopName = Reaction.getShopName();
-  const url = Accounts.urls.verifyEmail(token);
+
+  const encodedEmailAddress = encodeURIComponent(address);
+  const url = `${Meteor.absoluteUrl()}account/profile/verify?email=${encodedEmailAddress}`;
 
   const dataForEmail = {
     // Reaction Information
@@ -289,7 +291,9 @@ export function sendUpdatedVerificationEmail(userId, email) {
   });
 
   const shopName = Reaction.getShopName();
-  const url = Accounts.urls.verifyEmail(token);
+
+  const encodedEmailAddress = encodeURIComponent(address);
+  const url = `${Meteor.absoluteUrl()}account/profile/verify?email=${encodedEmailAddress}`;
 
   const dataForEmail = {
     // Reaction Information


### PR DESCRIPTION
This PR resoves issue #3714


Resolves #3714  
Impact: minor  
Type: bugfix

## Issue
When pasting the verification link into the browser's address bar, the index route loads. There's no visual feedback or anything that signals the user if the verification process was successful or not.
In fact, the verfication does not happen at all, because the email address is still unverified in database.

## Solution
The previously used hash URL did not seem to work at all. It just redirects to the
index route and leaves the verified fields in database in false state.

The fix is to use the verification URL that's used for other users as well. This will provide visual feedback and set the verified fields in db to true.


## Breaking changes
none expected


## Testing
1) Clone reaction
2) export REACTION_SECURE_DEFAULT_ADMIN=true 
3) reaction reset -n && reaction
4) Watch out in console window for something along the lines
```
  ***************************************************
            IMPORTANT! EMAIL VERIFICATION LINK

             Email sending is not configured.

    Go to the following URL to verify email: hpwgdbe3@localhost

    http://localhost:3000/account/profile/verify?email=testing%40reactioncommerce.com
    ***************************************************
```

5) copy the link adress and paste it in the browser window
6) A verification success notification should be displayed.
6) Browse mongodb. Both Accounts and Users collection shoud show the verified email addresses. You should see the following values: `Accounts.emails.$.verified : true` and `Users.emails.$.verified: true`
