### PR TITLE
Fixes #2292: Sending the text to G+

### DIFF
--- a/imports/plugins/included/social/client/components/googleplus.js
+++ b/imports/plugins/included/social/client/components/googleplus.js
@@ -28,6 +28,7 @@ export function getGooglePlusMeta(props) {
       content: media
     });
   }
+  return meta;
 }
 
 class GooglePlusSocialButton extends Component {
@@ -40,11 +41,14 @@ class GooglePlusSocialButton extends Component {
   }
 
   get url() {
-    const { props } = this;
-    const preferredUrl = props.url || location.origin + location.pathname;
-    const url = encodeURIComponent(preferredUrl);
-    const href = `https://plus.google.com/share?url=${url}`;
-
+    const { url, settings } = this.props;
+    const { description } = this.props.settings;
+    const preferredUrl = url || location.origin + location.pathname;
+    const encodedUrl = encodeURIComponent(preferredUrl);
+    let href = `https://plus.google.com/share?url=${encodedUrl}`;
+    if (settings.description) {
+      href += `&text=${description}`;
+    }
     return href;
   }
 
@@ -83,8 +87,10 @@ class GooglePlusSocialButton extends Component {
 
 GooglePlusSocialButton.propTypes = {
   altIcon: PropTypes.bool,
+  settings: PropTypes.object,
   showText: PropTypes.bool,
-  size: PropTypes.string
+  size: PropTypes.string,
+  url: PropTypes.string
 };
 
 export default GooglePlusSocialButton;


### PR DESCRIPTION
Resolves #2292  
Impact: minor  
Type: bugfix

## Issue
The description was not being sent to the Google API.

## Solution
Added `text` as URL parameter while calling Google API.

## Testing
1. Configure G+ sharing in Dashboard
1. Create a product
1. Add a message to the G+ sharing
1. Publish
1. Click on G+ message
1. Observe that this message is used