### PR TITLE
Fixes #2286: Remove currency formatting

### DIFF
--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -5,7 +5,6 @@ import _ from "lodash";
 import Velocity from "velocity-animate";
 import "velocity-animate/velocity.ui";
 import { Components } from "@reactioncommerce/reaction-components";
-import { formatPriceString } from "/client/api";
 
 const fieldNames = [
   "title",
@@ -406,8 +405,8 @@ class VariantForm extends Component {
               <div className="col-sm-6">
                 <Components.TextField
                   i18nKeyLabel="productVariant.price"
-                  i18nKeyPlaceholder={formatPriceString("0.00")}
-                  placeholder={formatPriceString("0.00")}
+                  i18nKeyPlaceholder="0.00"
+                  placeholder="0.00"
                   label="Price"
                   name="price"
                   ref="priceInput"
@@ -423,8 +422,8 @@ class VariantForm extends Component {
               <div className="col-sm-6">
                 <Components.TextField
                   i18nKeyLabel="productVariant.compareAtPrice"
-                  i18nKeyPlaceholder={formatPriceString("0.00")}
-                  placeholder={formatPriceString("0.00")}
+                  i18nKeyPlaceholder="0.00"
+                  placeholder="0.00"
                   label="Compare At Price"
                   name="compareAtPrice"
                   ref="compareAtPriceInput"
@@ -642,8 +641,8 @@ class VariantForm extends Component {
               <div className="col-sm-6">
                 <Components.TextField
                   i18nKeyLabel="productVariant.price"
-                  i18nKeyPlaceholder={formatPriceString("0.00")}
-                  placeholder={formatPriceString("0.00")}
+                  i18nKeyPlaceholder="0.00"
+                  placeholder="0.00"
                   label="Price"
                   name="price"
                   ref="priceInput"
@@ -661,8 +660,8 @@ class VariantForm extends Component {
               <div className="col-sm-6">
                 <Components.TextField
                   i18nKeyLabel="productVariant.compareAtPrice"
-                  i18nKeyPlaceholder={formatPriceString("0.00")}
-                  placeholder={formatPriceString("0.00")}
+                  i18nKeyPlaceholder="0.00"
+                  placeholder="0.00"
                   label="Compare At Price"
                   name="compareAtPrice"
                   ref="compareAtPriceInput"


### PR DESCRIPTION
Resolves #2286   
Impact: minor  
Type: bugfix

## Issue
The currency input were formatted inconsistently.

## Solution
This PR removes the currency formatting from the placeholders

## Testing
1. Create a product
1. For a variant enter a price and an MSRP
1. Observe the price and MSRP are not formatted as currency.
