### PR TITLE
perf: remove meteor and babel-preset-react from babel presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7722,6 +7722,11 @@
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
         "public-encrypt": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
@@ -7859,6 +7864,11 @@
           "requires": {
             "inherits": "2.0.1"
           }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vm-browserify": {
           "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -192,10 +192,7 @@
         }
       ]
     ],
-    "presets": [
-      "meteor",
-      "@babel/preset-react"
-    ]
+    "presets": []
   },
   "jest": {
     "moduleNameMapper": {


### PR DESCRIPTION
Resolves unreported issue with slow build times
Impact: critical
Type: performance

## Issue
Since updating to Meteor 1.6.1 we've seen long initial build times, in the 8-15 minute range. 

## Solution
This PR removes `meteor` and `@babel/preset-react` from the babel presets array in our `package.json` file leaving it empty. @aldeed suggested that these presets may not be necessary because they are included by default. 

The best theory we've got is that perhaps meteor is compiling everything twice when these presets are included in the package.json file.

Testing fresh `reaction init` => `meteor npm install` => `reaction run` startups with these two presets removed in comparison with the base release-1.8.0 branch revealed a significant improvement in build time when we remove these presets.
In my tests using `METEOR_PROFILE=1` I saw the build time go from `Total: 536,607 ms (Build App)` to `Total: 160,783 ms (Build App)` when removing the presets.

## Breaking changes
N/A

## Testing
1. Initialize a fresh copy of Reaction: `reaction init fresh`
2. Checkout this branch `git checkout perf-meteor-1.6.1-build-time` | compare with `release-1.8.0`
3. install dependencies: `meteor npm install`
4. Start reaction with profiling enabled `METEOR_PROFILE=1 reaction run`

To test the difference, compare this branch with the `release-1.8.0` branch
