### PR TITLE
Fix 3767 Add metadata on route change

### DIFF
--- a/imports/plugins/core/router/client/browserRouter.js
+++ b/imports/plugins/core/router/client/browserRouter.js
@@ -118,6 +118,7 @@ class BrowserRouter extends Component {
       Router.Hooks.run("onEnter", "GLOBAL", routeData);
       Router.Hooks.run("onEnter", currentRoute.name, routeData);
     }
+    MetaData.init(routeData);
   }
 
   render() {


### PR DESCRIPTION
Resolves #3767 and #3732
Impact: minor  
Type: bugfix

## Issue
`MetaData.init was not being called by the Hook, and when it was being called it didn't call with the correct data.

## Solution
Add a call to `MetaData.init` to `handleLocationChange` which has all the data MetaData.init needs.

## Breaking changes
None. Bugfix for regression

## Testing
1. Start the app as either a logged in user or anonymous
1. Notice that the Metadata (title and description) for the home page is set correctly
1. Add an item to cart and go to checkout
1. Notice that the title are now set to the route name


