### PR TITLE
Fixes #3805: remove spinner before mounting

### DIFF
--- a/imports/plugins/core/accounts/client/components/updatePasswordOverlay.js
+++ b/imports/plugins/core/accounts/client/components/updatePasswordOverlay.js
@@ -29,6 +29,10 @@ class UpdatePasswordOverlay extends Component {
     this.handleCancel = this.handleCancel.bind(this);
   }
 
+  async componentWillMount() {
+    await this.setState({ showSpinner: false });
+  }
+
   componentWillReceiveProps() {
     this.setState({ showSpinner: false });
   }


### PR DESCRIPTION
Resolves #3805  
Impact: major  
Type: bugfix

## Issue
The spinner was not turned off while mounting the component and so it was present forever
## Solution
Changing the state in sync(to prevent extra rendering) to remove the spinner.

## Testing
1. Use branch `release-1.8.0`
2. invite a user to become a shop manager from the accounts screen
3. Follow that link in a new session (incognito or similar)
4. Observer no spinner
6. Input your password and see that your account is created