### PR TITLE
(fix): PDP placeholde image display

### DIFF
--- a/imports/plugins/core/ui/client/components/media/media.js
+++ b/imports/plugins/core/ui/client/components/media/media.js
@@ -84,29 +84,36 @@ class MediaItem extends Component {
   }
 
   renderSource = (size) => {
+    // Set source to be default image
+    let source = this.defaultSource;
+
+    // Set default source size to `large`
     let sourceSize = "&store=large";
-    let source;
+    // If size is provided, set that sourse to that size
     if (size) {
       sourceSize = `&store=${size}`;
     }
 
-    if (typeof this.props.source === "object" && this.props.source) {
-      if (this.props.source.url()) {
+    // If a source was provided, use it
+    if (this.props.source) {
+      if (typeof this.props.source == "object" && this.props.source.url()) {
         source = `${this.props.source.url()}${sourceSize}`;
       } else {
-        source = `${this.defaultSource}`;
+        source = `${this.props.source}${sourceSize}`;
       }
-      return source;
-    }
-
-    if (this.props.source) {
-      source = `${this.props.source}${sourceSize}`;
-    } else {
-      source = `${this.defaultSource}`;
     }
 
     return source;
   }
+
+
+
+
+
+
+
+
+
 
   renderImage() {
     if (this.props.zoomable && !this.props.editable) {

--- a/imports/plugins/core/ui/client/components/media/media.js
+++ b/imports/plugins/core/ui/client/components/media/media.js
@@ -106,15 +106,6 @@ class MediaItem extends Component {
     return source;
   }
 
-
-
-
-
-
-
-
-
-
   renderImage() {
     if (this.props.zoomable && !this.props.editable) {
       return (

--- a/imports/plugins/core/ui/client/components/media/media.js
+++ b/imports/plugins/core/ui/client/components/media/media.js
@@ -85,15 +85,27 @@ class MediaItem extends Component {
 
   renderSource = (size) => {
     let sourceSize = "&store=large";
+    let source;
     if (size) {
       sourceSize = `&store=${size}`;
     }
 
     if (typeof this.props.source === "object" && this.props.source) {
-      return `${this.props.source.url()}${sourceSize}` || `${this.defaultSource}${sourceSize}`;
+      if (this.props.source.url()) {
+        source = `${this.props.source.url()}${sourceSize}`;
+      } else {
+        source = `${this.defaultSource}`;
+      }
+      return source;
     }
 
-    return `${this.props.source}${sourceSize}` || `${this.defaultSource}${sourceSize}`;
+    if (this.props.source) {
+      source = `${this.props.source}${sourceSize}`;
+    } else {
+      source = `${this.defaultSource}`;
+    }
+
+    return source;
   }
 
   renderImage() {


### PR DESCRIPTION
Impact: major  
Type: bugfix

## Issue
Placeholder images were not showing up on the PDP. This issue was cause by a line of code that was pre-emptively adding a `&store=size` to the end of a URL in an `||` check. Because the `&store=size` was always added, the first part of the `||` check would never be `null` / `undefinded`, and would never fall back to the second part of the `||` check, which was where the placeholder image was loaded. 

## Solution
Re-write the checks to only add the size after an initial source was checked, not during the initial source check.

## Breaking changes
None


## Testing
1. Visit the Product Grid and the PDP as both an anonymous and Admin user
2. See that the placeholder image is shown if no product image is available.
3. See that the correct image is shown, with the correct `&store=size` being loaded