### PR TITLE
Fix 3815 Don't use `default` for moment in invoice

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/pdf.js
+++ b/imports/plugins/core/orders/client/templates/list/pdf.js
@@ -49,7 +49,7 @@ Template.completedPDFLayout.helpers({
     return null;
   },
   dateFormat(context, block) {
-    const moment = Template.instance().moment.default;
+    const { moment } = Template.instance();
     moment.locale(Reaction.Locale.get().language);
     const f = block.hash.format || "MMM DD, YYYY hh:mm:ss A";
     return moment(context).format(f);


### PR DESCRIPTION
Resolves #3815 
Impact: critical  
Type: bugfix

## Issue
`moment` was coming up `undefined` because we were looking for `moment.default`

## Solution

Just use the root `moment` object returned by the import

## Breaking changes
None

## Testing
1. Add a product to cart and complete an order
1. Approve and Capture the order
1. Click on "Print Invoice"
1. Observe that the date is shown and there is no error in the console

