### PR TITLE
(Fix 3811) Fix can't change localization values

### DIFF
--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -7,7 +7,8 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
 class Form extends Component {
   static defaultProps = {
     autoSave: false,
-    renderFromFields: false
+    renderFromFields: false,
+    fieldsProp: {}
   }
 
   /**


### PR DESCRIPTION
Resolves #3811 
Impact: critical
Type: bugfix

## Issue

Some improvement to the form control added a `fieldProps` property which allows you to override some behaviors. The current version expects this to always be there, but existing dashboard panels that use this library were not passing this in because it didn't exist before

## Solution

Add an empty object to the `defaultProps`

## Breaking changes
None

## Testing
1. Go to localization settings in the dashboard
1. Observe that you can now change these settings

