### PR TITLE
(fix: 3783) Discount codes limits are not honored

### DIFF
--- a/imports/plugins/core/discounts/client/components/list.js
+++ b/imports/plugins/core/discounts/client/components/list.js
@@ -74,17 +74,13 @@ function composer(props, onData) {
   });
 
   const listItems = [];
-  for (const billing of currentCart.billing) {
-    if (billing.paymentMethod && billing.paymentMethod.processor === "code") {
-      listItems.push({
-        id: billing._id,
-        code: billing.paymentMethod.code,
-        discount: billing.paymentMethod.amount
-      });
-      // Found discount payment method. break here for good measure, just in case there's another "code" payment method.
-      // Which I think can happen only if "cart/submitPayment" is executed multiple times, e.g. if DDP connection broke.
-      break;
-    }
+  const listItem = currentCart.billing.find((element) => element.paymentMethod && element.paymentMethod.processor === "code");
+  if (listItem) {
+    listItems.push({
+      id: listItem._id,
+      code: listItem.paymentMethod.code,
+      discount: listItem.paymentMethod.amount
+    });
   }
 
   onData(null, {

--- a/imports/plugins/core/discounts/client/components/list.js
+++ b/imports/plugins/core/discounts/client/components/list.js
@@ -81,6 +81,9 @@ function composer(props, onData) {
         code: billing.paymentMethod.code,
         discount: billing.paymentMethod.amount
       });
+      // Found discount payment method. break here for good measure, just in case there's another "code" payment method.
+      // Which I think can happen only if "cart/submitPayment" is executed multiple times, e.g. if DDP connection broke.
+      break;
     }
   }
 

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -1102,14 +1102,14 @@ Meteor.methods({
     // we'll just update the workflow and billing data where
     // method-hooks can process the workflow update.
 
-    const payments = [];
-    let paymentAddress;
-
     // Find the payment address associated that the user input during the
     // checkout process
+    let paymentAddress;
     if (Array.isArray(cart.billing) && cart.billing[0]) {
       paymentAddress = cart.billing[0].address;
     }
+
+    const payments = [];
 
     // Payment plugins which have been updated for marketplace are passing an array as paymentMethods
     if (Array.isArray(paymentMethods)) {
@@ -1149,6 +1149,9 @@ Meteor.methods({
         shopId: Reaction.getPrimaryShopId()
       });
     }
+
+    // e.g. discount records would be already present on the billing array. Add to the end of the array.
+    Array.prototype.push.apply(payments, cart.billing.filter((billingInfo) => billingInfo.paymentMethod));
 
     const selector = {
       _id: cartId

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -1151,7 +1151,8 @@ Meteor.methods({
     }
 
     // e.g. discount records would be already present on the billing array. Add to the end of the array.
-    Array.prototype.push.apply(payments, cart.billing.filter((billingInfo) => billingInfo.paymentMethod));
+    const dicsountRecords = cart.billing.filter((billingInfo) => billingInfo.paymentMethod);
+    payments.push(...dicsountRecords);
 
     const selector = {
       _id: cartId

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -1151,8 +1151,8 @@ Meteor.methods({
     }
 
     // e.g. discount records would be already present on the billing array. Add to the end of the array.
-    const dicsountRecords = cart.billing.filter((billingInfo) => billingInfo.paymentMethod);
-    payments.push(...dicsountRecords);
+    const discountRecords = cart.billing.filter((billingInfo) => billingInfo.paymentMethod);
+    payments.push(...discountRecords);
 
     const selector = {
       _id: cartId

--- a/server/methods/core/payments.js
+++ b/server/methods/core/payments.js
@@ -1,4 +1,5 @@
 import { Meteor } from "meteor/meteor";
+import { Random } from "meteor/random";
 import { check } from "meteor/check";
 import { Reaction, Hooks } from "/server/api";
 
@@ -30,11 +31,16 @@ export const methods = {
     const cart = Collection.findOne(id);
     // The first record holds the selected billing address
     const billing = cart.billing[0];
+    const billingId = Random.id();
     const result = Collection.update({
       _id: id
     }, {
       $addToSet: {
-        billing: { ...billing, paymentMethod }
+        billing: {
+           ...billing,
+          _id: billingId,
+          paymentMethod
+        }
       }
     });
     // calculate discounts

--- a/server/methods/core/payments.js
+++ b/server/methods/core/payments.js
@@ -37,7 +37,7 @@ export const methods = {
     }, {
       $addToSet: {
         billing: {
-           ...billing,
+          ...billing,
           _id: billingId,
           paymentMethod
         }

--- a/server/methods/core/payments.js
+++ b/server/methods/core/payments.js
@@ -27,14 +27,16 @@ export const methods = {
     check(collection, String);
     const Collection = Reaction.Collections[collection];
 
+    const cart = Collection.findOne(id);
+    // The first record holds the selected billing address
+    const billing = cart.billing[0];
     const result = Collection.update({
       _id: id
     }, {
       $addToSet: {
-        billing: { paymentMethod }
+        billing: { ...billing, paymentMethod }
       }
     });
-
     // calculate discounts
     Hooks.Events.run("afterCartUpdateCalculateDiscount", id);
 


### PR DESCRIPTION
Resolves #3783  
Impact: major  
Type: bugfix

## Issue
Discount codes could be applied without limits, i.e. they don't expire.

## Solution
  In method cart/submitPayment any existing billing.paymentmethod (e.g. paymentmethod for discount codes) was overwritten.

I guess this hasn't been working since introducing marketplace (just a wild guess). The solution was to retain any already existing billing.paymentmethods in the array.

NOTICE: Because at various places (copyCartToOrder) the assumption is that all relevant billing data (address, shopId, currency, etc.) is on billing[0] , this does only work if it's appended at the end of the
array. I think it's not good to have this order predefined, but hesitated to dig deeper here without a mandate.

Also I'm not sure if the discout mechanism in general plays well with the marketplace feature.

## Breaking changes
none expected

## Testing
1. As an admin, create a discount code with limit 1
2. As a user, apply the code and checkout
3. As a user, order a second time and checkout again.
4. Try to re-apply the code.
5. A message should appear "Expired code"
