### PR TITLE
Fix 3702 order refunding number input

### DIFF
--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -182,7 +182,7 @@ class InvoiceContainer extends Component {
       if (refundedQuantity !== 0) {
         editedItems.push(isEdited);
       }
-    } else {
+    } else if (refundedQuantity !== 0) {
       editedItems.push({
         id: lineItem._id,
         title: lineItem.title,

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -40,28 +40,30 @@ class NumberTypeInput extends Component {
   }
 
   handleChange = (event, value) => {
-    const { maxValue, minValue } = this.state;
-    console.log("handle change", event, value)
-
     let newValue = parseInt(value, 10);
-    console.log("new val", newValue)
+    const { maxValue, minValue } = this.state;
+    // prevent the new value from being
+    // greater or less than the min and max values
     if (newValue > maxValue) newValue = maxValue;
     if (newValue < minValue) newValue = minValue;
 
 
-    // TODO: comment on this handler
+    // setting the value state
+    // if a new value set edited css class
     this.setState({
       value: newValue,
       className: { edited: (newValue !== maxValue) }
     });
 
+    // if props.onChange and the new value is a number
     if (this.props.onChange && !isNaN(newValue)) {
-      console.log("passing back value", newValue)
       this.props.onChange(event, newValue);
     }
   }
 
   handleBlur = () => {
+    // if input is left empty reset
+    // it's value to be the max value
     if (isNaN(this.state.value)) {
       this.setState({
         value: this.state.maxValue
@@ -70,7 +72,6 @@ class NumberTypeInput extends Component {
   }
 
   render() {
-    console.log("state value", this.state.value)
     const fieldClassName = classnames({
       "number-input-field": true,
       ...(this.state.className)

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -48,10 +48,10 @@ class NumberTypeInput extends Component {
   }
 
   handleChange = (event, value) => {
-    // if not value is passed to handler
+    // if no value is passed to handler
     // grab the value from the input's event.target
     // this will account for any number entry via the keyboard
-    if (!value) {
+    if (value === undefined) {
       // grabbing value from the event target
       // & coverting it from a string to number
       value = parseInt(event.target.value);

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -93,6 +93,7 @@ class NumberTypeInput extends Component {
           <Components.Button
             className="button"
             icon="fa fa-chevron-down"
+            disabled={this.state.minValue === this.state.value}
             onClick={this.handleDecrementButton}
           />
         </div>

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -21,10 +21,6 @@ class NumberTypeInput extends Component {
       maxValue: props.maxValue || undefined,
       className: {}
     };
-
-    this.handleIncrementButton = this.handleIncrementButton.bind(this);
-    this.handleDecrementButton = this.handleDecrementButton.bind(this);
-    this.handleChange = this.handleChange.bind(this);
   }
 
   handleIncrementButton = (event) => {

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -42,11 +42,15 @@ class NumberTypeInput extends Component {
   handleChange = (event, value) => {
     let newValue = parseInt(value, 10);
     const { maxValue, minValue } = this.state;
+
     // prevent the new value from being
     // greater or less than the min and max values
-    if (newValue > maxValue) newValue = maxValue;
-    if (newValue < minValue) newValue = minValue;
-
+    if (newValue > maxValue) {
+      newValue = maxValue;
+    }
+    if (newValue < minValue) {
+      newValue = minValue;
+    }
 
     // setting the value state
     // if a new value set edited css class

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -40,16 +40,32 @@ class NumberTypeInput extends Component {
   }
 
   handleChange = (event, value) => {
+    const { maxValue, minValue } = this.state;
     console.log("handle change", event, value)
-    console.log("typeof value", typeof value)
+
+    let newValue = parseInt(value, 10);
+    console.log("new val", newValue)
+    if (newValue > maxValue) newValue = maxValue;
+    if (newValue < minValue) newValue = minValue;
+
+
     // TODO: comment on this handler
     this.setState({
-      value: parseInt(value, 10),
-      className: { edited: true }
+      value: newValue,
+      className: { edited: (newValue !== maxValue) }
     });
 
-    if (this.props.onChange && !isNaN(value)) {
-      this.props.onChange(event, value);
+    if (this.props.onChange && !isNaN(newValue)) {
+      console.log("passing back value", newValue)
+      this.props.onChange(event, newValue);
+    }
+  }
+
+  handleBlur = () => {
+    if (isNaN(this.state.value)) {
+      this.setState({
+        value: this.state.maxValue
+      });
     }
   }
 
@@ -65,7 +81,10 @@ class NumberTypeInput extends Component {
         <Components.TextField
           className={fieldClassName}
           type="number"
+          onBlur={this.handleBlur}
           onChange={this.handleChange}
+          maxValue={this.state.maxValue}
+          minValue={this.state.minValue}
           value={this.state.value}
         />
         <div className="stacked-buttons">
@@ -91,12 +110,3 @@ class NumberTypeInput extends Component {
 registerComponent("NumberTypeInput", NumberTypeInput);
 
 export default NumberTypeInput;
-
-//   <input
-// className={fieldClassName}
-// min={this.state.minValue}
-// max={this.state.maxValue}
-// value={this.state.value}
-// onChange={this.handleChange}
-// type="number"
-//   />

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -61,13 +61,15 @@ class NumberTypeInput extends Component {
     }
   }
 
-  handleBlur = () => {
+  handleBlur = (event) => {
+    const { maxValue } = this.state;
     // if input is left empty reset
     // it's value to be the max value
     if (isNaN(this.state.value)) {
       this.setState({
-        value: this.state.maxValue
+        value: maxValue
       });
+      this.props.onChange(event, maxValue);
     }
   }
 

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -27,10 +27,6 @@ class NumberTypeInput extends Component {
     const value = this.state.value + 1;
 
     if (this.state.maxValue && value <= this.state.maxValue) {
-      this.setState({
-        value,
-        className: { edited: true }
-      });
       this.handleChange(event, value);
     }
   }
@@ -39,34 +35,26 @@ class NumberTypeInput extends Component {
     const value = this.state.value - 1;
 
     if (value >= this.state.minValue) {
-      this.setState({
-        value,
-        className: { edited: true }
-      });
       this.handleChange(event, value);
     }
   }
 
   handleChange = (event, value) => {
-    // if no value is passed to handler
-    // grab the value from the input's event.target
-    // this will account for any number entry via the keyboard
-    if (value === undefined) {
-      // grabbing value from the event target
-      // & coverting it from a string to number
-      value = parseInt(event.target.value);
-      this.setState({
-        value,
-        className: { edited: true }
-      });
-    }
+    console.log("handle change", event, value)
+    console.log("typeof value", typeof value)
+    // TODO: comment on this handler
+    this.setState({
+      value: parseInt(value, 10),
+      className: { edited: true }
+    });
 
-    if (this.props.onChange) {
+    if (this.props.onChange && !isNaN(value)) {
       this.props.onChange(event, value);
     }
   }
 
   render() {
+    console.log("state value", this.state.value)
     const fieldClassName = classnames({
       "number-input-field": true,
       ...(this.state.className)
@@ -74,13 +62,11 @@ class NumberTypeInput extends Component {
 
     return (
       <div className="rui number-input">
-        <input
+        <Components.TextField
           className={fieldClassName}
-          min={this.state.minValue}
-          max={this.state.maxValue}
-          value={this.state.value}
-          onChange={this.handleChange}
           type="number"
+          onChange={this.handleChange}
+          value={this.state.value}
         />
         <div className="stacked-buttons">
           <Components.Button
@@ -105,3 +91,12 @@ class NumberTypeInput extends Component {
 registerComponent("NumberTypeInput", NumberTypeInput);
 
 export default NumberTypeInput;
+
+//   <input
+// className={fieldClassName}
+// min={this.state.minValue}
+// max={this.state.maxValue}
+// value={this.state.value}
+// onChange={this.handleChange}
+// type="number"
+//   />

--- a/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numberTypeInput.js
@@ -52,6 +52,19 @@ class NumberTypeInput extends Component {
   }
 
   handleChange = (event, value) => {
+    // if not value is passed to handler
+    // grab the value from the input's event.target
+    // this will account for any number entry via the keyboard
+    if (!value) {
+      // grabbing value from the event target
+      // & coverting it from a string to number
+      value = parseInt(event.target.value);
+      this.setState({
+        value,
+        className: { edited: true }
+      });
+    }
+
     if (this.props.onChange) {
       this.props.onChange(event, value);
     }

--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -28,7 +28,12 @@ class TextField extends Component {
     if (this.props.isCurrency && !this.state.isEditing) {
       return (this.state && this.state.value) || this.props.value || "";
     }
-    return this.props.value || "";
+    // if the props.value is not a number
+    // return ether the value or and empty string
+    if (isNaN(this.props.value)) {
+      return this.props.value || "";
+    }
+    return this.props.value;
   }
 
   /**

--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -187,6 +187,8 @@ class TextField extends Component {
         placeholder={placeholder}
         ref="input"
         type={this.props.type || "text"}
+        min={this.props.minValue}
+        max={this.props.maxValue}
         value={this.value}
         style={this.props.style}
         disabled={this.props.disabled}
@@ -302,6 +304,8 @@ TextField.propTypes = {
   isValid: PropTypes.bool,
   label: PropTypes.string,
   maxRows: PropTypes.number,
+  maxValue: PropTypes.any,
+  minValue: PropTypes.number,
   multiline: PropTypes.bool,
   name: PropTypes.string,
   onBlur: PropTypes.func,

--- a/imports/plugins/included/default-theme/client/styles/forms.less
+++ b/imports/plugins/included/default-theme/client/styles/forms.less
@@ -186,7 +186,7 @@
     text-align: center;
     background-color: #f7f7f7;
     border: solid 1px #cccccc;
-    flex: 1;
+    flex: 0 0 auto;
   }
 
   .edited {

--- a/imports/plugins/included/default-theme/client/styles/forms.less
+++ b/imports/plugins/included/default-theme/client/styles/forms.less
@@ -187,6 +187,7 @@
     background-color: #f7f7f7;
     border: solid 1px #cccccc;
     flex: 0 0 auto;
+    padding: 0;
   }
 
   .edited {


### PR DESCRIPTION
Resolves #3702  
Impact: **major**  
Type: **bugfix**

## Issue
The NumberTypeInput wasn't aware of input value changes that didn't come from the up/down arrow buttons.

The inputs were also not displaying properly in Firefox
![screen shot 2018-02-21 at 5 14 50 pm](https://user-images.githubusercontent.com/1135948/36567867-828a5cf2-17ed-11e8-9754-88bb89668623.png)

## Solution
* I fixed the Firefox issue by updating it's `flex` property to be `0 0 auto` so the input won't try to fill the available space.
* Updated the `handleChange` method to check if the param value is undefined. If it is set the value to be `event.target.value` and then update the components state. Now the component will be aware of any value changes from the keyboard.
* Removed the handler binding in the `constructor` since all the handler methods are using arrow function I figured the binding wasn't needed.
* Added a disabled property to the down arrow button that disables the button if the input's `value` and `minValue` are equal.

## Testing
* Create an order with multiple quantities of the same variant / option
* As an Admin begin to process the order
* Open the individual item processing flow by clicking the product image inside the processing dashboard
* Attempt to change the quantity by typing a number in the input box

**Notes**
RC test passed
Was able to complete acceptance test