### PR TITLE
(Fix 3813) Handle misconfigured Avalara api

### DIFF
--- a/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
@@ -35,7 +35,7 @@ MethodHooks.after("taxes/calculate", (options) => {
         Meteor.call("taxes/setRate", cartId, taxRate, taxes);
         // for bad auth, timeout, or misconfiguration there's nothing we can do so keep moving
       } else if (_.includes([503, 400, 401], result.error.errorCode)) {
-        Logger.error("Timeout, Authentification or Misconfiguration error: Not tring to estimate");
+        Logger.error("Timeout, Authentification, or Misconfiguration error: Not trying to estimate cart");
       } else {
         Logger.error("Unknown error", result.error.errorCode);
       }

--- a/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { Logger, MethodHooks } from "/server/api";
 import { Cart, Orders } from "/lib/collections";
@@ -32,8 +33,9 @@ MethodHooks.after("taxes/calculate", (options) => {
         const taxAmount = taxes.reduce((totalTaxes, tax) => totalTaxes + tax.tax, 0);
         const taxRate = taxAmount / taxCalc.calcTaxable(cartToCalc);
         Meteor.call("taxes/setRate", cartId, taxRate, taxes);
-      } else if (result.error.errorCode === 503) {
-        Logger.error("timeout error: do nothing here");
+        // for bad auth, timeout, or misconfiguration there's nothing we can do so keep moving
+      } else if (_.includes([503, 400, 401], result.error.errorCode)) {
+        Logger.error("Timeout, Authentification or Misconfiguration error: Not tring to estimate");
       } else {
         Logger.error("Unknown error", result.error.errorCode);
       }

--- a/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { Logger, MethodHooks } from "/server/api";
 import { Cart, Orders } from "/lib/collections";
@@ -34,7 +33,7 @@ MethodHooks.after("taxes/calculate", (options) => {
         const taxRate = taxAmount / taxCalc.calcTaxable(cartToCalc);
         Meteor.call("taxes/setRate", cartId, taxRate, taxes);
         // for bad auth, timeout, or misconfiguration there's nothing we can do so keep moving
-      } else if (_.includes([503, 400, 401], result.error.errorCode)) {
+      } else if ([503, 400, 401].includes(result.error.errorCode)) {
         Logger.error("Timeout, Authentification, or Misconfiguration error: Not trying to estimate cart");
       } else {
         Logger.error("Unknown error", result.error.errorCode);

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -108,6 +108,7 @@ function parseError(error) {
   }
 
   if (error.response && error.response.statusCode === 401) {
+    // authentification error
     errorData = {
       errorCode: 401,
       type: "apiFailure",

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -59,7 +59,6 @@ function checkConfiguration(packageData = taxCalc.getPackageData()) {
     }
   }
   if (!isValid) {
-    // throw new Meteor.Error("bad-configuration", "The Avalara package is not configured correctly. Cannot continue");
     Logger.error("The Avalara package is not configured correctly. Cannot continue");
   }
   return isValid;

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -213,7 +213,7 @@ function avaPost(requestUrl, options) {
     };
   }
   const appVersion = Reaction.getAppVersion();
-  const meteorVersion = _.split(Meteor.release, "@")[1];
+  const meteorVersion = Meteor.release.split("@")[1];
   const machineName = os.hostname();
   const avaClient = `Reaction; ${appVersion}; Meteor HTTP; ${meteorVersion}; ${machineName}`;
   const headers = {
@@ -328,12 +328,12 @@ taxCalc.validateAddress = function (address) {
     if (result.error.type === "apiError") {
       // If we have a problem with the API there's no reason to tell the customer
       // so let's consider this unvalidated but move along
-      Logger.info("API error, ignoring address validation");
+      Logger.error("API error, ignoring address validation");
     }
 
     if (result.error.type === "validationError") {
       // We received a validation error so we need somehow pass this up to the client
-      Logger.info("Address Validation Error");
+      Logger.error("Address Validation Error");
     }
   }
   const content = result.data;

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -620,7 +620,7 @@ export function inviteShopOwner(options) {
   Meteor.users.update(userId, {
     $set: {
       "services.password.reset": { token, email, when: new Date() },
-      name,
+      name
     }
   });
 


### PR DESCRIPTION
Resolves #3813
Impact: **minor**  
Type: **bugfix**

## Issue
In order to make sure that the site operator is made aware of a misconfigured API it used to throw errors and basically stop operation when the API is misconfigured. Now we just log errors and continue.

## Solution
Don't block order processing. Allow orders to be placed and just log errors

## Breaking changes
None


## Testing
1. Enable Avalara and remove the apiLoginId
1. Place an item in cart and checkout
1. Observe that you can place an order even though tax calculation is not working
1. Observe that server errors are thrown to the console which is correct

This does not fix the issue with address validation when the API is configured correctly.
