### PR TITLE
fix: cannot search accounts in search modal

### DIFF
--- a/imports/plugins/included/ui-search/lib/components/searchModal.js
+++ b/imports/plugins/included/ui-search/lib/components/searchModal.js
@@ -96,8 +96,8 @@ class SearchModal extends Component {
               data-i18n="search.searchTypeAccounts"
               data-event-action="searchCollection"
               data-event-value="accounts"
-              onClick={this.handleToggleProducts}
-              onKeyUp={this.handleOnKeyUpToggleProducts}
+              onClick={this.handleToggleAccounts}
+              onKeyUp={this.handleOnKeyUpToggleAccounts}
             >
               Accounts
             </button>


### PR DESCRIPTION
Resolves #3828  
Impact: **critical**  
Type: **bugfix**

## Issue

The `Accounts` tab button in the search modal does not switch the view to the accounts tab view; thus, all searches will pull up products and not accounts.

## Solution

Fix `onClick` and `onKeyUp` handlers of the `Accounts` button. They were toggling the display of the products tab and not the accounts tab.

## Breaking changes

none

## Testing

1. Add a few user accounts with addresses
1. Then, sign in as admin
1. Open search modal using the search icon button from the main navigation
1. Click on the Accounts tab
1. Try to search the name on your account, or any registered account
1. Table is not shown, and no results display
1. Try start typing basic (the name of the basic example product) while on the account tab
1. See product search on the wrong tab

