### PR TITLE
Fix for "Changing user currency does not update prices"

### DIFF
--- a/imports/plugins/included/jobcontrol/server/jobs/cart.js
+++ b/imports/plugins/included/jobcontrol/server/jobs/cart.js
@@ -1,4 +1,3 @@
-import later from "later";
 import { Job } from "/imports/plugins/core/job-collection/lib";
 import { Meteor } from "meteor/meteor";
 import { Accounts, Cart, Jobs } from "/lib/collections";
@@ -33,7 +32,7 @@ export function setupStaleCartHook() {
           backoff: "exponential" // delay by twice as long for each subsequent retry
         })
         .repeat({
-          schedule: later.parse.text("every day")
+          schedule: Jobs.later.parse.text("every day")
         })
         .save({
           cancelRepeats: true

--- a/imports/plugins/included/jobcontrol/server/jobs/cleanup.js
+++ b/imports/plugins/included/jobcontrol/server/jobs/cleanup.js
@@ -1,4 +1,3 @@
-import later from "later";
 import { Job } from "/imports/plugins/core/job-collection/lib";
 import { Jobs } from "/lib/collections";
 import { Hooks, Logger } from "/server/api";
@@ -20,7 +19,7 @@ export function addCleanupJobControlHook() {
         backoff: "exponential"
       })
       .repeat({
-        schedule: later.parse.text("every day")
+        schedule: Jobs.later.parse.text("every day")
       })
       .save({
         cancelRepeats: true

--- a/imports/plugins/included/jobcontrol/server/jobs/exchangerates.js
+++ b/imports/plugins/included/jobcontrol/server/jobs/exchangerates.js
@@ -15,7 +15,6 @@ export function setupFetchFlushCurrencyHooks() {
       const refreshPeriod = exchangeConfig.refreshPeriod || "every 4 hours";
       Logger.debug(`Adding shop/fetchCurrencyRates to JobControl. Refresh ${refreshPeriod}`);
       new Job(Jobs, "shop/fetchCurrencyRates", {})
-        .priority("normal")
         .retry({
           retries: 5,
           wait: 60000,
@@ -33,7 +32,6 @@ export function setupFetchFlushCurrencyHooks() {
       // Run the first time immediately after server start. The repeat({schedule}) option via
       // later.js scheduling won't run before the first scheduled time, even with delay() or after()
       new Job(Jobs, "shop/fetchCurrencyRates", {})
-        .priority("normal")
         .retry({
           retries: 5,
           wait: 10000
@@ -53,7 +51,6 @@ export function setupFetchFlushCurrencyHooks() {
       // TODO: Add this as a configurable option
       const refreshPeriod = "Every 24 hours";
       new Job(Jobs, "shop/flushCurrencyRates", {})
-        .priority("normal")
         .retry({
           retries: 5,
           wait: 60000,


### PR DESCRIPTION
Resolves #3833  
Impact: **critical**  
Type: **bugfix**

## Issue
Description of the issue this PR is solving, why it's happening, and how to reproduce it. This may differ from the original ticket as you now have more information at your disposal.

## Solution
Changes:
Seems not possible to have a job that's scheduled via later.js to have
started immediately. Tried with delay() and after(), but no avail.

The solution was to just schedule a one-off task whenever the server
starts.

Also I did refactor the import of later.js , because it was not
consistently. Sometimes it was required directly, sometimes via
`Jobs.later`

## Breaking changes
none expected

## Testing
1. Reset the database
2. Start server
3. The currency exchange rates should be fetched immediately (or very short after spinning up the server)
4. Try to change the currency in the nav bar
5. Prices should change
