### PR TITLE
docs(jsdoc): #3840 DOM module - add @memberof, @method

### DIFF
--- a/imports/plugins/core/dom/client/dom.js
+++ b/imports/plugins/core/dom/client/dom.js
@@ -1,17 +1,18 @@
 /**
  * @file Exposes the DOM object used to manipulate the document.
- *  NOTE: this functions are only meant to be used on the client.
- * @author Will Lopez
+ * The functions are only meant to be used on the client.
  * @namespace DOM
  */
 
 const DOM = {};
 
-/*
- * Sets/adds a meta tag to the document head
+/**
+ * @method setMetaTag
+ * @memberof DOM
+ * @summary Sets/adds a meta tag to the document head
  * @param {Object} attributes - key/value pairs for tag attributes
  * @return {undefined} no return value
-  */
+ */
 DOM.setMetaTag = (attributes) => {
   const currentMetaTag = document.querySelector(`meta[name="${attributes.name}"]`);
 
@@ -34,11 +35,13 @@ DOM.setMetaTag = (attributes) => {
   document.head.appendChild(newMetaTag);
 };
 
-/*
- * Adds a link tags to the document head
+/**
+ * @method addLinkTag
+ * @memberof DOM
+ * @summary Adds a link tags to the document head
  * @param {Object} attributes - key/value pairs for tag attributes
  * @return {undefined} no return value
-  */
+ */
 DOM.addLinkTag = (attributes) => {
   const newLinkTag = document.createElement("link");
 
@@ -52,8 +55,9 @@ DOM.addLinkTag = (attributes) => {
 };
 
 /**
- * Removes document head tags
- *
+ * @method removeDocHeadAddedTags
+ * @memberof DOM
+ * @summary Removes document head tags
  * @returns {undefined} no return value
  */
 DOM.removeDocHeadAddedTags = () => {


### PR DESCRIPTION
Resolves #3840  
Impact: **minor**  
Type: **docs**

## Issue
- Meteor DOM helpers were documented, but not displaying on api.docs.reactioncommerce.com b/c of a JSDoc syntax error

## Solution
- use two **, not one
- added `@memberof DOM` to methods
- added `@method` in front of the method name
- added `@summary` in front of the summary/description

## Breaking changes
none

## Testing
1. Pull this PR
2. Run `npm run docs`
3. Open `file:///tmp/reaction-docs/DOM.html`

## Screenshots

New with PR vs. Current: http://api.docs.reactioncommerce.com/DOM.html

<img width="1297" alt="screen shot 2018-02-26 at 4 48 07 pm" src="https://user-images.githubusercontent.com/3673236/36704450-3ff28f7e-1b15-11e8-9987-514391649ef4.png">
