### PR TITLE
docs(jsdoc): #3840 Namespace Hooks.Events methods and add examples

### DIFF
--- a/server/api/hooks.js
+++ b/server/api/hooks.js
@@ -1,7 +1,10 @@
 import _ from "lodash";
 import { Meteor } from "meteor/meteor";
+
 /**
- * Callback hooks to alter the behavior of common operations or trigger other things.
+ * @file Callback hooks to alter the behavior of common operations or trigger other things.
+ *
+ *
  * @namespace Hooks.Events
  */
 const Hooks = {};
@@ -9,7 +12,10 @@ Hooks.Events = {};
 
 
 /**
- * Add a callback function to a hook
+ * @method add
+ * @summary Add a callback function to a hook
+ * @memberof Hooks.Events
+ * @example Hooks.Events.add("afterAccountsRemove", callback)
  * @param {String} name - The name of the hook
  * @param {Function} callback - The callback function
  * @return {Array} array of the currently defined hooks
@@ -24,7 +30,9 @@ Hooks.Events.add = (name, callback) => {
 
 
 /**
- * Remove a callback from a hook
+ * @method remove
+ * @summary Remove a callback from a hook
+ * @memberof Hooks.Events
  * @param {String} name - The name of the hook
  * @param {String} callbackName - The name of the function to remove
  * @return {Array} array of remaining callbacks
@@ -37,7 +45,10 @@ Hooks.Events.remove = (name, callbackName) => {
 
 
 /**
- * Successively run all of a hook's callbacks on an item
+ * @method run
+ * @summary Successively run all of a hook's callbacks on an item
+ * @memberof Hooks.Events
+ * @example Hooks.Events.run("beforeCoreInit");
  * @param {String} name - The name of the hook
  * @param {Object} item - The object, modifier, etc. on which to run the callbacks
  * @param {Object} [constant] - An optional constant that will be passed along to each callback
@@ -55,7 +66,9 @@ Hooks.Events.run = (name, item, constant) => {
 
 
 /**
- * Successively run all of a hook's callbacks on an item, in async mode (only works on server)
+ * @method runAsync
+ * @summary Successively run all of a hook's callbacks on an item, in async mode (only works on server)
+ * @memberof Hooks.Events
  * @param {String} name - The name of the hook
  * @param {Object} item - The object, modifier, etc. on which to run the callbacks
  * @param {Object} [constant] - An optional constant that will be passed along to each callback


### PR DESCRIPTION
Resolves #3840  
Impact: **minor**  
Type: **docs**

## Issue
- Meteor Event Hooks helpers were not documented, or not displaying on api.docs.reactioncommerce.com

## Solution
- added `@memberof Hooks.Events` to methods
- added examples

## Breaking changes
none

## Testing
1. Pull this PR
2. Run `npm run docs`
3. Open `file:///tmp/reaction-docs/Hooks.Events.html`

## Screenshots

<img width="1266" alt="screen shot 2018-02-26 at 4 59 58 pm" src="https://user-images.githubusercontent.com/3673236/36704763-9d5df030-1b16-11e8-9a4b-b63e231d4e64.png">
