### PR TITLE
(Fix 3836) Fix invite shop owner

### DIFF
--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -371,7 +371,7 @@ export default {
    * @summary Get shop ID
    * @todo This should intelligently find the correct default shop Probably whatever the main shop is or marketplace
    * @param  {String} userId User ID String
-   * @return {StringId}        active shop ID
+   * @return {String} active shop ID
    */
   getShopId(userId) {
     check(userId, Match.Maybe(String));
@@ -595,6 +595,24 @@ export default {
     return defaultValue || undefined;
   },
 
+  /**
+   * @name setUserPreferences
+   * @method
+   * @summary save user preferences in the Accounts collection
+   * @param {String} packageName
+   * @param {String} preference
+   * @param {String} value
+   * @param {String} userId
+   * @return {Number} setPreferenceResult
+   */
+  setUserPreferences(packageName, preference, value, userId) {
+    const setPreferenceResult = AccountsCollection.update(userId, {
+      $set: {
+        [`profile.preferences.${packageName}.${preference}`]: value
+      }
+    });
+    return setPreferenceResult;
+  },
   /**
    *  @name insertPackagesForShop
    *  @method

--- a/server/api/core/groups.js
+++ b/server/api/core/groups.js
@@ -76,6 +76,7 @@ function getDefaultGroupRoles() {
 
   // we're making a Shop Manager default group that have all roles except the owner role
   const shopManagerRoles = ownerRoles.filter((role) => role !== "owner" && role !== "admin");
+  shopManagerRoles.push("shopSettings");
 
   const roles = {
     "shop manager": shopManagerRoles,

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -617,6 +617,13 @@ export function inviteShopOwner(options) {
   // uses primaryShop's data (name, address etc) in email copy sent to new merchant
   const dataForEmail = getDataForEmail({ shop: primaryShop, currentUserName, name, token, emailLogo });
 
+  Meteor.users.update(userId, {
+    $set: {
+      "services.password.reset": { token, email, when: new Date() },
+      name,
+    }
+  });
+
   Reaction.Email.send({
     to: email,
     from: `${_.get(dataForEmail, "primaryShop.name")} <${_.get(dataForEmail, "primaryShop.emails[0].address")}>`,

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -600,7 +600,7 @@ export function inviteShopOwner(options) {
     });
   }
 
-  const { shopId } = Meteor.call("shop/createShop", userId) || {};
+  Meteor.call("shop/createShop", userId);
   const primaryShop = Reaction.getPrimaryShop();
 
   // Compile Email with SSR
@@ -616,14 +616,6 @@ export function inviteShopOwner(options) {
   const currentUserName = getCurrentUserName(currentUser);
   // uses primaryShop's data (name, address etc) in email copy sent to new merchant
   const dataForEmail = getDataForEmail({ shop: primaryShop, currentUserName, name, token, emailLogo });
-
-  Meteor.users.update(userId, {
-    $set: {
-      "services.password.reset": { token, email, when: new Date() },
-      name,
-      "profile.preferences.reaction.activeShopId": shopId
-    }
-  });
 
   Reaction.Email.send({
     to: email,

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -137,7 +137,7 @@ Meteor.methods({
     Reaction.setUserPreferences("reaction", "activeShopId", shopUser._id, shopUser._id);
     Collections.Accounts.update({ _id: shopUser._id }, {
       $set: {
-        shopId: shop._id,
+        shopId: shop._id
       },
       $addToSet: {
         groups: ownerGroup._id

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -133,9 +133,11 @@ Meteor.methods({
     Reaction.createGroups({ shopId: shop._id });
     const ownerGroup = Collections.Groups.findOne({ slug: "owner", shopId: shop._id });
     Roles.addUsersToRoles([currentUser, shopUser._id], ownerGroup.permissions, shop._id);
+    // Set the active shopId for this user
+    Reaction.setUserPreferences("reaction", "activeShopId", shopUser._id, shopUser._id);
     Collections.Accounts.update({ _id: shopUser._id }, {
       $set: {
-        shopId: shop._id
+        shopId: shop._id,
       },
       $addToSet: {
         groups: ownerGroup._id

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -134,7 +134,7 @@ Meteor.methods({
     const ownerGroup = Collections.Groups.findOne({ slug: "owner", shopId: shop._id });
     Roles.addUsersToRoles([currentUser, shopUser._id], ownerGroup.permissions, shop._id);
     // Set the active shopId for this user
-    Reaction.setUserPreferences("reaction", "activeShopId", shopUser._id, shopUser._id);
+    Reaction.setUserPreferences("reaction", "activeShopId", shop._id, shopUser._id);
     Collections.Accounts.update({ _id: shopUser._id }, {
       $set: {
         shopId: shop._id


### PR DESCRIPTION
Resolves #3836 
Impact: **critical**  
Type: **bugfix**

## Issue
Two issues:
1. the "shopSettings" permissions was not being assigned to shop owners when invited
1. `getShopId` was not looking in the right place for the `activeShopId` so it was never finding the role even when it exists

## Solution
1. Add the role when creating a shop
1. create a new method called `setUserPreferences` that sets preferences for a user, and then call that when creating a shop

## Breaking changes
If other things are expecting `acitveShopId` to exist elsewhere it might break something


## Testing
1. Invite a shop owner
1. Login in incognito as that user and set password
1. Try to change the address
1. Observe that you receive no error


