### PR TITLE
Call OrdersList as a Component

### DIFF
--- a/imports/plugins/core/accounts/client/templates/profile/userOrdersList.js
+++ b/imports/plugins/core/accounts/client/templates/profile/userOrdersList.js
@@ -1,5 +1,5 @@
 import { Template } from "meteor/templating";
-import UserOrdersList from "/imports/plugins/core/accounts/client/containers/userOrdersListContainer";
+import { Components } from "@reactioncommerce/reaction-components";
 
 /**
  * userOrdersList helpers
@@ -17,7 +17,7 @@ Template.userOrdersList.helpers({
     }
 
     return {
-      component: UserOrdersList,
+      component: Components.OrdersList,
       orders
     };
   }


### PR DESCRIPTION
Resolves 3849
Impact: **minor**  
Type: **bugfix**

## Issue
OrdersList is currently called via direct import. It is therefore not possible to replace this component. 

## Solution
Change from Direct Import to "Components.OrdersList"

## Breaking changes
N/A


## Testing
1. Make amendment
2. Testing - go to profile and check for no errors.

1. Anywhere in code, paste this snippet:
```
const MyOrdersList = () => {
  return <div>custom orders</div>
};

replaceComponent("OrdersList", MyOrdersList);
```
2. As an user or admin navigate to the "Your orders" section on the profile page: http://localhost:3000/account/profile

3. The custom component should be rendered



