### PR TITLE
Call CompletedOrder via Components API

### DIFF
--- a/imports/plugins/core/accounts/client/components/ordersList.js
+++ b/imports/plugins/core/accounts/client/components/ordersList.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import CompletedOrder from "../../../checkout/client/components/completedOrder";
+import { Components } from "@reactioncommerce/reaction-components";
+
 
 /**
  * @summary React component to display an array of completed orders
@@ -26,7 +27,7 @@ class OrdersList extends Component {
           {allOrdersInfo.map((order) => {
             const orderKey = order.orderId;
             return (
-              <CompletedOrder
+              <Components.CompletedOrder
                 key={orderKey}
                 shops={order.shops}
                 order={order.order}


### PR DESCRIPTION
Call CompletedOrder via Components API rather than as a direct import. This means that there is no need to replace OrdersList if in turn you wish to make changes to the "CompletedOrder" component.

Resolves #N/A
Impact: **minor**  
Type: **bugfix**

## Issue
CompletedOrder is currently called by direct import. This means, that if you wish to replace or edit CompletedOrder in your plugin, you must also replace OrdersList (which cannot currently be done - see https://github.com/reactioncommerce/reaction/pull/3848)

## Solution
Replace direct import with Components.CompletedOrder

## Breaking changes
N/A

## Testing
1. Make change
2. Test Completed Order Component on Profile page

*Only my 2nd PR. Please give me a head-up if I could make this clearer or more concise.
