### PR TITLE
(fix: 3846) Set localstorage even when no Meteor.user exists

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -382,11 +382,11 @@ export default {
           }
         });
       }
-      const packageSettings = store.get(packageName) || {};
-      packageSettings[preference] = value;
-      return store.set(packageName, packageSettings);
     }
-    return false;
+    // set local storage even when we don't have a Meteor.user
+    const packageSettings = store.get(packageName) || {};
+    packageSettings[preference] = value;
+    return store.set(packageName, packageSettings);
   },
 
   updateUserPreferences(packageName, preference, values) {


### PR DESCRIPTION
Resolves #3846 
Impact: **critical**  
Type: **bugfix**

## Issue
When you logout, the `activeShopid` was not being set properly in localstorage.  It was within a `if Meteor.user()` block but localstage does not care about Meteor.user so if you were previously logged in that value was previously set but not properly reset when logging out. If it was previously set to disable/inactive shop then things were broken. So if you logged in as a shop admin for a "new" shop and then logged out, nothing worked.

## Solution
Write to localstorage whether we have a `Meteor.user` or not 

## Breaking changes
None


## Testing
1. Invite a shop owner
1. In an incognito window open the invite URL in the invite email
1. Set your password and visit the index page
1. Logout
1. Observe that you should now see the "main" shop and no errors in the console
1. In your main window login as a shop owner and then login as the primary admin
1. Observe that you see the correct icon for the dashboard (before this fix you would see the shop icons instead of the main ones)
