### PR TITLE
(fix 3851) Properly record product revisions

### DIFF
--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -557,7 +557,7 @@ Products.before.update(function (userId, product, fieldNames, modifier, options)
   }
 
   Revisions.update(revisionSelector, revisionModifier);
-  const updatedRevision = Revisions.findOne({ documentId: product._id });
+  const updatedRevision = Revisions.findOne(revisionSelector);
   Hooks.Events.run("afterRevisionsUpdate", userId, updatedRevision);
 
   Logger.debug(`Revison updated for product ${product._id}.`);

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -620,7 +620,7 @@ export function inviteShopOwner(options) {
   Meteor.users.update(userId, {
     $set: {
       "services.password.reset": { token, email, when: new Date() },
-      name,
+      name
     }
   });
 


### PR DESCRIPTION
Resolves #3851 
Impact: **critical**  
Type: **bugfix**

## Issue
Was pulling out the wrong record to send to the function that records the "diff" so no diff was ever being see.

## Solution
Use the same selector for reading and writing


## Breaking changes
None


## Testing
1. Create a product
1. Publish
1. Make a change to the product
1. Observe that the Publish button works and you can publish the changes
