### PR TITLE
(fix 3868) Remove cfs:graphicsmagick

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -54,7 +54,6 @@ aldeed:schema-index
 aldeed:template-extension
 bozhao:accounts-instagram
 cfs:filesystem
-cfs:graphicsmagick
 cfs:gridfs
 cfs:standard-packages
 cfs:storage-adapter

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -6,7 +6,6 @@ accounts-password@1.5.0
 accounts-twitter@1.4.1
 alanning:roles@1.2.16
 aldeed:autoform@5.8.1
-aldeed:browser-tests@0.1.1
 aldeed:collection2@2.10.0
 aldeed:collection2-core@1.2.0
 aldeed:schema-deny@1.1.0
@@ -39,7 +38,6 @@ cfs:collection-filters@0.2.4
 cfs:data-man@0.0.6
 cfs:file@0.1.17
 cfs:filesystem@0.1.2
-cfs:graphicsmagick@0.0.18
 cfs:gridfs@0.0.34
 cfs:http-methods@0.0.32
 cfs:http-publish@0.0.13
@@ -62,7 +60,6 @@ ddp-rate-limiter@1.0.7
 ddp-server@2.1.2
 deps@1.0.12
 diff-sequence@1.1.0
-dispatch:mocha@0.4.1
 dispatch:run-as-user@1.1.1
 dynamic-import@0.3.0
 ecmascript@0.10.4


### PR DESCRIPTION
Resolves #3868 
Impact: **major**  
Type: **chore**

## Issue
`cfs:graphicsmagick` is no longer used in the project and can be removed from the project as it throws a warning on startup if you don't have imagemagick/graphicsmagick installed

## Solution
Changes packages file


## Breaking changes
None

## Testing
1. Verify that you can start the app on a system w/o graphicsmagick/imagemagick installed and get no warnings