### PR TITLE
(performance): delayed response in localization settings

### DIFF
--- a/imports/plugins/core/i18n/client/components/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/components/localizationSettings.js
@@ -27,27 +27,32 @@ class LocalizationSettings extends Component {
     super(props);
 
     this.state = {
+      currencies: props.currencies,
       languages: props.languages
     };
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({
+      currencies: nextProps.currencies,
       languages: nextProps.languages
     });
   }
 
-  renderCurrencies() {
-    return this.props.currencies.map((currency, key) => (
-      <Components.ListItem
-        actionType={"switch"}
-        key={key}
-        label={currency.label}
-        switchOn={currency.enabled}
-        switchName={currency.name}
-        onSwitchChange={this.props.onUpdateCurrencyConfiguration}
-      />
-    ));
+  handleUpdateCurrencyConfiguration = (event, isChecked, name) => {
+    const currencyIndex = this.state.currencies.findIndex((currency) => currency.name === name);
+
+    this.setState((state) => {
+      const newStateCurrencies = state.currencies;
+      newStateCurrencies[currencyIndex].enabled = isChecked;
+      return { currencies: newStateCurrencies };
+    }, () => {
+      // Delaying to allow animation before sending data to server
+      // If animation is not delayed, it twitches when actual update happens
+      setTimeout(() => {
+        this.props.onUpdateCurrencyConfiguration(event, isChecked, name);
+      }, 200);
+    });
   }
 
   handleUpdateLangaugeConfiguration = (event, isChecked, name) => {
@@ -64,6 +69,19 @@ class LocalizationSettings extends Component {
         this.props.onUpdateLanguageConfiguration(event, isChecked, name);
       }, 200);
     });
+  }
+
+  renderCurrencies() {
+    return this.props.currencies.map((currency, key) => (
+      <Components.ListItem
+        actionType={"switch"}
+        key={key}
+        label={currency.label}
+        switchOn={currency.enabled}
+        switchName={currency.name}
+        onSwitchChange={this.handleUpdateCurrencyConfiguration}
+      />
+    ));
   }
 
   renderLanguages() {

--- a/imports/plugins/core/i18n/client/components/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/components/localizationSettings.js
@@ -23,6 +23,20 @@ class LocalizationSettings extends Component {
     uomOptions: PropTypes.array
   }
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      languages: props.languages
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      languages: nextProps.languages
+    });
+  }
+
   renderCurrencies() {
     return this.props.currencies.map((currency, key) => (
       <Components.ListItem
@@ -36,15 +50,31 @@ class LocalizationSettings extends Component {
     ));
   }
 
+  handleUpdateLangaugeConfiguration = (event, isChecked, name) => {
+    const languageIndex = this.state.languages.findIndex((language) => language.value === name);
+
+    this.setState((state) => {
+      const newStateLanguages = state.languages;
+      newStateLanguages[languageIndex].enabled = isChecked;
+      return { languages: newStateLanguages };
+    }, () => {
+      // Delaying to allow animation before sending data to server
+      // If animation is not delayed, it twitches when actual update happens
+      setTimeout(() => {
+        this.props.onUpdateLanguageConfiguration(event, isChecked, name);
+      }, 200);
+    });
+  }
+
   renderLanguages() {
-    return this.props.languages.map((language, key) => (
+    return this.state.languages.map((language, key) => (
       <Components.ListItem
         actionType={"switch"}
         key={key}
         label={language.label}
         switchOn={language.enabled}
         switchName={language.value}
-        onSwitchChange={this.props.onUpdateLanguageConfiguration}
+        onSwitchChange={this.handleUpdateLangaugeConfiguration}
       />
     ));
   }

--- a/imports/plugins/core/router/client/browserRouter.js
+++ b/imports/plugins/core/router/client/browserRouter.js
@@ -151,7 +151,7 @@ export function initBrowserRouter() {
 
   Router.Hooks.onEnter(MetaData.init);
 
-  Tracker.autorun(() => {
+  Tracker.autorun((computation) => {
     if (Router.ready()) {
       ReactDOM.render((
         <BrowserRouter history={history}>
@@ -159,6 +159,8 @@ export function initBrowserRouter() {
             <Components.App children={Router.reactComponents} />
           </TranslationProvider>
         </BrowserRouter>), getRootNode());
+
+      computation.stop();
     }
   });
 }

--- a/imports/plugins/core/router/client/startup.js
+++ b/imports/plugins/core/router/client/startup.js
@@ -19,6 +19,8 @@ Meteor.startup(() => {
   const merchantShopSub = Meteor.subscribe("MerchantShops");
   const packageSub = Meteor.subscribe("Packages");
 
+  let isLoaded = false;
+
   Tracker.autorun(() => {
     // initialize client routing
     if (
@@ -38,7 +40,10 @@ Meteor.startup(() => {
       Tracker.nonreactive(() => {
         // Make sure we have shops before we try to make routes for them
         if (Array.isArray(shops) && shops.length) {
-          initBrowserRouter();
+          if (!isLoaded) {
+            isLoaded = true;
+            initBrowserRouter();
+          }
         }
       });
     }

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -620,7 +620,7 @@ export function inviteShopOwner(options) {
   Meteor.users.update(userId, {
     $set: {
       "services.password.reset": { token, email, when: new Date() },
-      name,
+      name
     }
   });
 


### PR DESCRIPTION
Resolves #3497 
Impact: **minor**  
Type: **performance**

## Issue
1) When turning on / off languages and currencies in your Shop settings, there is a slight delay in response after the toggle is clicked.
2) The app was re-rendering `x+1` times, with `x` being the number of times you've toggled a switch.

## Solution
There are various issues addressed in this PR, stemming from the original ticket:
1) The "issue" here seems to be that since we are changing settings on the `Shops` collection, everything that depends on the `shop` settings, and has `Trackers` on the `shop`, needs to update - which means the whole app updates. Add this in with the slight RT delay when making a `Meteor.call` to the server, and we are seeing this delay of about `1500ms`. The solution here is to add an optimistic UI update with `state`, and then do the `Meteor.call`. Because the timing of the `Meteor.call` is just delayed enough to return a result about `50%` of the way through the `state` animation, we add a `200ms` timeout to make sure the call doesn't happen in the middle of the animation, and make the animation look broken.
2. Add a tracker `.stop()` to the top level app tracker

## Breaking changes
None

## Testing
1. Login as an admin
2. Navigate to the i18n settings in the dashboard
3. Toggle on / off various languages and currencies
4. See no delay in toggle UI updates, and see that the currencies and languages are enabled / disabled as they should be