### PR TITLE
docs(jsdoc) #3840 - document and namespace Router.Hooks methods

### DIFF
--- a/imports/plugins/core/router/lib/hooks.js
+++ b/imports/plugins/core/router/lib/hooks.js
@@ -1,7 +1,9 @@
-
 /**
- * Route Hook Methods
+ * @file Route Hook Methods - The Router.Hooks namespace provides a router-agnostic API for registering functions to be called either on specific routes or on every route. Read more about [Routing in Reaction](https://docs.reactioncommerce.com/reaction-docs/master/routing).
+ *
+ * @namespace Router.Hooks
  */
+
 const Hooks = {
   _hooks: {
     onEnter: {},
@@ -35,6 +37,22 @@ const Hooks = {
     }
   },
 
+  /**
+   * @method onEnter
+   * @memberof Router.Hooks
+   * @summary Register a hook on a specific route
+   * Can be called as many times as needed to add more than one callback
+   * @example // create a function to do something on the product detail page
+function logSomeStuff() {
+  console.log("We're arriving at the product page!");
+}
+// add that to the product detail page onEnter hook
+Router.Hooks.onEnter("product", logSomeStuff);
+   * @param  {String}   routeName Name of route
+   * @param  {Function} callback  Callback method
+   * @param  {Object}   args      Object
+   * @return {undefined}
+   */
   onEnter(routeName, callback, ...args) {
     // global onEnter callback
     if (arguments.length === 1 && typeof args[0] === "function") {
@@ -45,6 +63,16 @@ const Hooks = {
     return this._addHook("onEnter", routeName, callback);
   },
 
+  /**
+   * @method onExit
+   * @memberof Router.Hooks
+   * @summary Register a hook on a specific route
+   * Can be called as many times as needed to add more than one callback
+   * @param  {String}   routeName Name of route
+   * @param  {Function} callback  Callback method
+   * @param  {Object}   args      Object
+   * @return {undefined}
+   */
   onExit(routeName, callback, ...args) {
     // global onExit callback
     if (arguments.length === 1 && typeof args[0] === "function") {
@@ -55,12 +83,29 @@ const Hooks = {
     return this._addHook("onExit", routeName, callback);
   },
 
+  /**
+   * @method get
+   * @memberof Router.Hooks
+   * @summary Get all registered hooks for a specific route
+   * @param  {String} type Type of hook - `"onEnter"` or `"onExit"`
+   * @param  {String} name Name of Route
+   * @return {Array}  Array of hooks
+   */
   get(type, name) {
     const group = this._hooks[type] || {};
     const callbacks = group[name];
     return (typeof callbacks !== "undefined" && !!callbacks.length) ? callbacks : [];
   },
 
+  /**
+   * @method run
+   * @memberof Router.Hooks
+   * @summary Run all registered hooks
+   * @param  {String} type Type of hook - `"onEnter"` or `"onExit"`
+   * @param  {String} name "GLOBAL" for all registered global hooks
+   * @param  {Object} [context] Context object, optional, or `routeName`
+   * @return {Array}  Array of hooks
+   */
   run(type, name, constant) {
     const callbacks = this.get(type, name);
     if (typeof callbacks !== "undefined" && !!callbacks.length) {


### PR DESCRIPTION
Resolves #3840  
Impact: **minor**  
Type: **docs**

## Issue
- Router Hook methods were not documented

## Solution
- added `@memberof Router.Hooks` to methods
- added `@namespace Router.Hooks`
- added `@file` link to appropriate docs

## Breaking changes
none

## Testing
1. Pull this PR
2. Run `npm run docs`
3. Open `file:///tmp/reaction-docs/Router.Hooks.html`

## Screenshots
<img width="1436" alt="screen shot 2018-03-01 at 12 00 58 am" src="https://user-images.githubusercontent.com/3673236/36833356-f46655ba-1ce3-11e8-9a78-9c4e96acf96b.png">
<img width="1417" alt="screen shot 2018-03-01 at 12 01 07 am" src="https://user-images.githubusercontent.com/3673236/36833357-f49754a8-1ce3-11e8-8ba9-405018cd09b0.png">
