### PR TITLE
Fix: `Reaction.getShopId` missing `()`

### DIFF
--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -300,7 +300,7 @@ export const methods = {
 
     return Orders.update({
       "_id": order._id,
-      "billing.shopId": Reaction.getShopId,
+      "billing.shopId": Reaction.getShopId(),
       "billing.paymentMethod.method": "credit"
     }, {
       $set: {
@@ -432,7 +432,7 @@ export const methods = {
 
     return Orders.update({
       "_id": order._id,
-      "billing.shopId": Reaction.getShopId,
+      "billing.shopId": Reaction.getShopId(),
       "billing.paymentMethod.method": "credit"
     }, {
       $set: {


### PR DESCRIPTION
Impact: major?
Type: bugfix

## Issue
While working on another PR, I noticed that in two places, we query for an order using `"billing.shopId": Reaction.getShopId` (that is, passing the function as a parameter instead of the function's return value). It is entirely possible that the mongo library knows to execute functions, so at worst, this PR will maintain consistency with the rest of the file which uses `"billing.shopId": Reaction.getShopId()`.

## Solution
execute the function instead of passing a function pointer

## Testing
I have not written tests for this, but hope to do so shortly.
