### PR TITLE
Fix:3703 Fix can't input refund properly

### DIFF
--- a/imports/plugins/core/ui/client/components/numericInput/numericInput.html
+++ b/imports/plugins/core/ui/client/components/numericInput/numericInput.html
@@ -1,3 +1,0 @@
-<template name="numericInput">
-  <input type="text" name="{{name}}" value="{{value}}" class="{{class}}">
-</template>

--- a/imports/plugins/core/ui/client/index.js
+++ b/imports/plugins/core/ui/client/index.js
@@ -13,7 +13,6 @@ import "./components/cards/cardGroup.html";
 import "./components/cards/cards.html";
 import "./components/cards/cards.js";
 
-import "./components/numericInput/numericInput.html";
 import "./components/numericInput/numericInput.js";
 
 import "./components/select/select.html";

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -620,7 +620,7 @@ export function inviteShopOwner(options) {
   Meteor.users.update(userId, {
     $set: {
       "services.password.reset": { token, email, when: new Date() },
-      name,
+      name
     }
   });
 


### PR DESCRIPTION
Resolves #3703   
Impact: **major**  
Type: **bugfix**

## Issue
When typing a refund, there are two main issues.

1. Due to what seems like our currency.js internationalization of prices, it is hard to type the correct number in the input box, without clicking at the beginning of the number and inputting from there.
2. If I click at the end of the input box (after both cent decimals, i.e. after .00, no matter what number I type, the number will increment by 1 cent, making it nearly impossible to get the correct number without clicking again:


## Solution
Don't enforce proper formatting during edit mode. Don't display the currency sign during edit mode. This way the user is completely free to enter whatever he wants.

When the focus blurs, the formatting routine kicks in and displays the value in the correct locale.

## Changes
      -  Introduce edit mode
      -  Don't format via account-js when edit mode is active
      -  Handle maxValue propperty
      -  Don't show currency sign in active mode
      -  Replace unused setCaretPosition with selectAll

## Breaking changes
None expected

## Testing
1. As a user, create a order and checkout with a credit card payment method.
2. As an admin, log in and approve the order. Capture the payment.
3. Then try to refund parts of the order. It should be possible to enter any amount up to the maximum value in the current locale (the currency from shop base settings)
4. Blurring the field should result in a properly formatted currency value
5. After Applying the Refund, the value of the Refund field should be reseted to 0.00


More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
