### PR TITLE
(Fix) Add back missing browser policy

### DIFF
--- a/imports/plugins/core/ui/server/index.js
+++ b/imports/plugins/core/ui/server/index.js
@@ -1,1 +1,2 @@
 import "./i18n";
+import "./policy";

--- a/imports/plugins/core/ui/server/policy.js
+++ b/imports/plugins/core/ui/server/policy.js
@@ -1,0 +1,6 @@
+import { BrowserPolicy } from "meteor/browser-policy-common";
+
+BrowserPolicy.content.allowOriginForAll("*.facebook.com");
+BrowserPolicy.content.allowOriginForAll("connect.facebook.net");
+BrowserPolicy.content.allowOriginForAll("fonts.googleapis.com");
+BrowserPolicy.content.allowOriginForAll("fonts.gstatic.com");


### PR DESCRIPTION
Resolves N/A  
Impact: **major**  
Type: **bugfix**

## Issue
The policy file that allows us to use remove web fonts and facebook login were removed in this PR: https://github.com/reactioncommerce/reaction/pull/3814 but we need to keep the policy files to allow us to use webfonts. 

## Solution
Restore the policy files minus the remote tracking scripts. I guessed at the best directory for this but I could be convinced to use any other

## Breaking changes
None


## Testing
1. View the site in a deployed environment (I guess. I don't think you will see them in a dev environment).
1. Observe that you don't receive content warnings

(To see what the warnings look like you can view https://swag.getreaction.io)

