### PR TITLE
(Fix 3895) Fix global route hooks

### DIFF
--- a/imports/plugins/core/router/lib/hooks.js
+++ b/imports/plugins/core/router/lib/hooks.js
@@ -50,12 +50,11 @@ function logSomeStuff() {
 Router.Hooks.onEnter("product", logSomeStuff);
    * @param  {String}   routeName Name of route
    * @param  {Function} callback  Callback method
-   * @param  {Object}   args      Object
    * @return {undefined}
    */
-  onEnter(routeName, callback, ...args) {
-    // global onEnter callback
-    if (arguments.length === 1 && typeof args[0] === "function") {
+  onEnter(routeName, callback) {
+    // if first argument is a function it's a global callback
+    if (arguments.length === 1 && typeof routeName === "function") {
       const cb = routeName;
       return this._addHook("onEnter", "GLOBAL", cb);
     }
@@ -70,12 +69,11 @@ Router.Hooks.onEnter("product", logSomeStuff);
    * Can be called as many times as needed to add more than one callback
    * @param  {String}   routeName Name of route
    * @param  {Function} callback  Callback method
-   * @param  {Object}   args      Object
    * @return {undefined}
    */
-  onExit(routeName, callback, ...args) {
-    // global onExit callback
-    if (arguments.length === 1 && typeof args[0] === "function") {
+  onExit(routeName, callback) {
+    // if first argument is a function it's a global callback
+    if (arguments.length === 1 && typeof routeName === "function") {
       const cb = routeName;
       return this._addHook("onExit", "GLOBAL", cb);
     }
@@ -106,10 +104,10 @@ Router.Hooks.onEnter("product", logSomeStuff);
    * @param  {Object} [context] Context object, optional, or `routeName`
    * @return {Array}  Array of hooks
    */
-  run(type, name, constant) {
+  run(type, name, context) {
     const callbacks = this.get(type, name);
     if (typeof callbacks !== "undefined" && !!callbacks.length) {
-      return callbacks.forEach((callback) => callback(constant));
+      return callbacks.forEach((callback) => callback(context));
     }
     return null;
   }


### PR DESCRIPTION
Resolves #3895 
Impact: **minor**  
Type: **bugfix**

## Issue
There was a change to add `...args` and check that parameter is a function but that the was the wrong parameter (i.e. `arguments[0] !== args[0]`)

## Solution
Remove the `...args` parameter and check the if the first parameter is a function.

## Breaking changes
None

## Testing
1. In the browser window add a route global callback as `ReactionRouter.Hooks.onEnter(function () { console.log("bing") })`
1. Observe that your callback is run on every route change
