### PR TITLE
Fix #3718: Inventory updated on shopify sync

### DIFF
--- a/imports/plugins/included/connectors-shopify/server/endpoints/webhooks.js
+++ b/imports/plugins/included/connectors-shopify/server/endpoints/webhooks.js
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import { Meteor } from "meteor/meteor";
 import { Reaction } from "/server/api";
+import { methods } from "../methods/sync/orders";
 
 /**
  * verifies that the request coming from a webhook is from the connected Shopify shop
@@ -48,6 +49,6 @@ Reaction.Endpoints.add("post", "/webhooks/shopify/orders-create", (req, res) => 
 
   // If we can verify that this request is legitimate, call our shopify/sync/orders/created
   if (verifyWebhook(req)) {
-    Meteor.call("connectors/shopify/sync/orders/created", req.body.line_items);
+    methods.adjustInventory(req.body.line_items);
   }
 });

--- a/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
@@ -39,12 +39,8 @@ export const methods = {
    * @param {object} lineItems array of line items from a Shopify order
    * @returns {undefined}
    */
-  "connectors/shopify/sync/orders/created": (lineItems) => {
+  adjustInventory: (lineItems) => {
     check(lineItems, [Object]);
-
-    if (!Reaction.hasPermission(connectorsRoles)) {
-      throw new Meteor.Error("access-denied", "Access Denied");
-    }
 
     lineItems.forEach((lineItem) => {
       const variantsWithShopifyId = Products.find({ shopifyId: lineItem.variant_id }).fetch();
@@ -62,12 +58,11 @@ export const methods = {
           eventLog: {
             title: "Product inventory updated by Shopify webhook",
             type: "update-webhook",
-            description: `Shopify order created which caused inventory to be reduced by ${lineItem.quantity}`
+            description: `Shopify order created which caused inventory to be reduced by ${lineItem.quantity}`,
+            createdAt: new Date()
           }
         }
       }, { selector: { type: "variant" } });
     });
   }
 };
-
-Meteor.methods(methods);

--- a/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
@@ -62,7 +62,7 @@ export const methods = {
             createdAt: new Date()
           }
         }
-      }, { selector: { type: "variant" } });
+      }, { selector: { type: "variant" }, publish: true });
     });
   }
 };


### PR DESCRIPTION
Resolves #3718  
Impact: **major**  
Type: **bugfix**

## Issue
[This](https://github.com/reactioncommerce/reaction/blob/master/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js#L45) line which checks if the user has appropriate permissions.
But since it is a request coming from shopify, there would be no user.


## Solution
The permission check for user was redundant because we were already verifying the HMAC of the request. 
So removed the check for permission and refactored the method so that it's not added to Meteor's methods.


## Testing
1. Login as shop admin
1. Specify Shopify credentials in dashboard settings
1. Import products
1. Setup sync.
1. Go to Shopify console and place order for a product
1. The inventoryQuantity of the product should get updated in the database. 
