### PR TITLE
chore: add imports/plugins/custom to eslint ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,8 @@
 # things to ignore in lint
 
 *.min.*
-server/plugins.js
-client/plugins.js
-packages/*
 .reaction/jsdoc/templates/*
+client/plugins.js
 imports/plugins/custom/*
+packages/*
+server/plugins.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ server/plugins.js
 client/plugins.js
 packages/*
 .reaction/jsdoc/templates/*
+imports/plugins/custom/*


### PR DESCRIPTION
Resolves #3900
Impact: **minor**  
Type: **chore**

## Issue
When running `npx eslint .`, with plugins inside the `imports/plugins/custom` folder, various npm dependency errors are continuously returned.

## Solution
Add `imports/plugins/custom` to the `.eslintignore` file. 

## Breaking changes
none

## Testing
1. Install a plugin into the custom plugins folder (i.e. our Reaction Devtools https://github.com/reactioncommerce/reaction-devtools)
2. Run `npx eslint .`
3. See no dependency errors / see the eslint runs as it should
