### PR TITLE
Fix migration version after SimpleSchema NPM merge

### DIFF
--- a/imports/plugins/core/versions/server/migrations/21_clean_cart_shipment_method.js
+++ b/imports/plugins/core/versions/server/migrations/21_clean_cart_shipment_method.js
@@ -4,7 +4,7 @@ import { Cart } from "/lib/collections";
 // aldeed:simple-schema behavior would lead to a dangling incomplete shipmentMethod
 // on new carts, but NPM simpl-schema now complains about that when validating.
 Migrations.add({
-  version: 20,
+  version: 21,
   up() {
     Cart.find().forEach((cart) => {
       const unset = {};


### PR DESCRIPTION
Impact: same-version  
Type: bugfix

## Issue
When resolving merge conflicts into 1.9 release branch, the filename of the migration was changed, but the version in the code was not.

## Solution
Corrected the version

## Breaking changes
A same-version fix to an unreleased release

## Testing
1. Start up the app with either a reset DB or current migration version < 21.
2. After startup, verify in MongoDB that the migrations version is 21.
3. Migration was tested previously, but if you want to ensure it ran, you'd have to set at least one cart to have `cart.shipping[0].shipmentMethod` set to an object with only the `_id` key set in it. After migration, that `shipmentMethod` object should be gone in the DB.
