### PR TITLE
Handle integer schema type when getting form field type

### DIFF
--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -260,11 +260,21 @@ class Form extends Component {
 
     if (this.isFieldHidden(fieldName) === false) {
       const fieldSchema = schema.getDefinition(fieldName);
+
+      // Get the type from the schema, as a typeof string
+      const fieldType = fieldSchema.type[0].type;
+      let fieldTypeString;
+      if (fieldType === "SimpleSchema.Integer") {
+        fieldTypeString = "number";
+      } else {
+        // This assumes that oneOf is not used for any schema types
+        fieldTypeString = typeof fieldType();
+      }
+
       const fieldProps = {
         ...fieldSchema,
         name: fieldName,
-        // This assumes that oneOf is not used for any schema types
-        type: typeof fieldSchema.type[0].type(),
+        type: fieldTypeString,
         ...additionalFieldProps
       };
 


### PR DESCRIPTION
Issue: Reported by @aaronjudd in https://github.com/reactioncommerce/reaction/pull/3331#issuecomment-371020531
Impact: **same-version**  
Type: **bugfix**

## Issue
When clicking to open Tax panel in admin dashboard, error in console:

```Exception from Tracker recompute function:
meteor.js?hash=b0f12795c8cc1423b5850502871996903f947ed5:992 TypeError: fieldSchema.type[0].type is not a function
    at Form.renderField (form.js:267)
    at form.js:316
    at Array.map (<anonymous>)
    at Form.renderWithSchema (form.js:304)
    at Form.render (form.js:344)
    at finishClassComponent (modules.js?hash=4f2eb55914217a0342d190203eac0918f9672a78:186673)
    at updateClassComponent (modules.js?hash=4f2eb55914217a0342d190203eac0918f9672a78:186650)
    at beginWork (modules.js?hash=4f2eb55914217a0342d190203eac0918f9672a78:187025)
    at performUnitOfWork (modules.js?hash=4f2eb55914217a0342d190203eac0918f9672a78:189024)
    at workLoop (modules.js?hash=4f2eb55914217a0342d190203eac0918f9672a78:189088)```

## Solution
This was due to some schema type logic in the `Form` component that did not account for the `SimpleSchema.Integer` pseudo-type. I improved the logic to treat that type as "number".

## Breaking changes
None. Same version fix.

## Testing
1. Log in as admin.
2. Click on "Tax" in admin menu. Verify no errors in console.
3. Verify that all the forms in that panel work as expected. In particular, `Avalara` form was throwing the error on render.

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
