### PR TITLE
Fix for ui glitches using dynamic merchandising

### DIFF
--- a/imports/plugins/core/ui/client/containers/sortableItem.js
+++ b/imports/plugins/core/ui/client/containers/sortableItem.js
@@ -2,14 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { DragSource, DropTarget } from "react-dnd";
 
-const cardSource = {
-  beginDrag(props) {
-    return {
-      index: props.index
-    };
-  }
-};
-
 /**
  * Specifies the props to inject into your component.
  * @param {DragSourceConnector} connect An onject containing functions to assign roles to a component's DOM nodes
@@ -19,7 +11,6 @@ const cardSource = {
 function collectDropSource(connect, monitor) {
   return {
     connectDragSource: connect.dragSource(),
-    connectDragPreview: connect.dragPreview(),
     isDragging: monitor.isDragging()
   };
 }
@@ -29,6 +20,15 @@ function collectDropTarget(connect) {
     connectDropTarget: connect.dropTarget()
   };
 }
+
+const cardSource = {
+  beginDrag(props) {
+    const { index } = props;
+    return {
+      index
+    };
+  }
+};
 
 const cardTarget = {
   hover(props, monitor) {
@@ -48,6 +48,9 @@ const cardTarget = {
     // but it's good here for the sake of performance
     // to avoid expensive index searches.
     monitor.getItem().index = hoverIndex;
+  },
+  drop(props) {
+    props.onDrop();
   }
 };
 
@@ -61,7 +64,6 @@ export default function ComposeSortableItem(itemType) {
 
     SortableItem.propTypes = {
       // Injected by React DnD:
-      connectDragPreview: PropTypes.func.isRequired,
       connectDragSource: PropTypes.func.isRequired,
       connectDropTarget: PropTypes.func.isRequired,
       isDragging: PropTypes.bool.isRequired

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -99,24 +99,24 @@ const wrapComponent = (Comp) => (
       const tag = ReactionProduct.getTag();
       const dragProductId = this.state.productIds[dragIndex];
       const hoverProductId = this.state.productIds[hoverIndex];
-      const dragProductWeight = this.state.productsByKey[dragProductId].positions[tag].weight || 0;
-      const dropProductWeight = this.state.productsByKey[hoverProductId].positions[tag].weight || 0;
+      const dragProductWeight = _.get(this, `state.productsByKey[${dragProductId}].positions[${tag}].weight`, 0);
+      const dropProductWeight = _.get(this ,`state.productsByKey[${hoverProductId}].positions[${tag}].weight`, 0);
 
       const newState = update(this.state, {
         productsByKey: {
           [dragProductId]: {
-            positions: {
-              [tag]: {
-                $merge: {
+            $merge: {
+              positions: {
+                [tag]: {
                   weight: dropProductWeight
                 }
               }
             }
           },
           [hoverProductId]: {
-            positions: {
-              [tag]: {
-                $merge: {
+            $merge: {
+              positions: {
+                [tag]: {
                   weight: dragProductWeight
                 }
               }

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -96,26 +96,46 @@ const wrapComponent = (Comp) => (
     }
 
     handleProductDrag = (dragIndex, hoverIndex) => {
-      const newState = this.changeProductOrderOnState(dragIndex, hoverIndex);
-      this.setState(newState, this.callUpdateMethod);
-    }
+      const tag = ReactionProduct.getTag();
+      const dragProductId = this.state.productIds[dragIndex];
+      const hoverProductId = this.state.productIds[hoverIndex];
+      const dragProductWeight = this.state.productsByKey[dragProductId].positions[tag].weight || 0;
+      const dropProductWeight = this.state.productsByKey[hoverProductId].positions[tag].weight || 0;
 
-    changeProductOrderOnState(dragIndex, hoverIndex) {
-      const product = this.state.productIds[dragIndex];
-
-      return update(this.state, {
+      const newState = update(this.state, {
+        productsByKey: {
+          [dragProductId]: {
+            positions: {
+              [tag]: {
+                $merge: {
+                  weight: dropProductWeight
+                }
+              }
+            }
+          },
+          [hoverProductId]: {
+            positions: {
+              [tag]: {
+                $merge: {
+                  weight: dragProductWeight
+                }
+              }
+            }
+          }
+        },
         productIds: {
           $splice: [
             [dragIndex, 1],
-            [hoverIndex, 0, product]
+            [hoverIndex, 0, dragProductId]
           ]
         }
       });
+
+      this.setState(newState);
     }
 
-    callUpdateMethod() {
+    handleProductDrop = () => {
       const tag = ReactionProduct.getTag();
-
       this.state.productIds.map((productId, index) => {
         const position = { position: index, updatedAt: new Date() };
 
@@ -142,6 +162,7 @@ const wrapComponent = (Comp) => (
             {...this.props}
             products={this.products}
             onMove={this.handleProductDrag}
+            onDrop={this.handleProductDrop}
             itemSelectHandler={this.handleSelectProductItem}
           />
         </Components.DragDropProvider>


### PR DESCRIPTION
Resolves #3880   
Impact: **major**  
Type: **bugfix**

## Issue
Dynamically merchandising by drag and drop has UI glitches and doesn't order products consistently, making it difficult to order products.

## Solution
This bug happened whenever products with different sized were juggled
around. The moment the drag source hovered the drop target they got
swapped, which would potentially result in a different arrangement of
the items. This could lead to the unfortunate situation, that the very
same item gets swapped over and over endlessly.

## Changes
 -  Don't apply layout (box size) changes on swaps until the drag source is
 actually dropped.
 - Update of the collection that persists the new order gets delayed
 until drag source is dropped. Before this change a mere hovering resulted in
 swapping AND persisting the new product order.


## Breaking changes
none expected



## Testing
1) Logged in as Admin
2) Add images to the default product from the PDP with different sizes
3) From the product Grid, clone the default product several times
4) Drag and drop products to arrange them in a different order.
5) There should no longer be a limbo state where products are swapping wild or endlessly.

