### PR TITLE
Fix settings startup error

### DIFF
--- a/imports/plugins/core/ui/register.js
+++ b/imports/plugins/core/ui/register.js
@@ -5,7 +5,6 @@ Reaction.registerPackage({
   name: "reaction-ui",
   icon: "fa fa-html5",
   autoEnable: true,
-  settings: "",
   registry: [],
   layout: []
 });


### PR DESCRIPTION
Resolves issue reported by @aaronjudd  
Impact: **same-version**  
Type: **bugfix**

## Issue
After merging of SimpleSchema PR, if your database is empty, you see this error on startup:

```
WARN Reaction: Error while importing to Packages: Cannot update 'settings' and 'settings' at the same time
```

This was always being done incorrectly, but old SimpleSchema didn't seem to mind.

## Solution
Now there's no error.

## Breaking changes
NONE

## Testing
1. `meteor reset`
2. Start the app and make sure you don't see the above error.
