### PR TITLE
Fix #3942: publishing group related to current shop

### DIFF
--- a/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
+++ b/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
@@ -91,7 +91,7 @@ const handlers = {
 const composer = (props, onData) => {
   const shopId = Reaction.getShopId();
   const adminUserSub = Meteor.subscribe("Accounts", null);
-  const grpSub = Meteor.subscribe("Groups");
+  const grpSub = Meteor.subscribe("Groups", { shopId });
 
   if (adminUserSub.ready() && grpSub.ready()) {
     const groups = Groups.find({


### PR DESCRIPTION
Resolves #3942   
Impact: **major**  
Type: **bugfix**

## Issue
The groups published to the client weren't being refreshed when the `activeShopId` changes because the code inside the publication on the server side is not reactive.

## Solution
Sending the current shopId from the client-side. This causes the publication code to run again and the correct groups are published to client-side.

## Testing
1. As the marketplace owner
1. Invite a marketplace shop
1. Mark the shop active.
1. Use the shop switcher to switch to that shop
1. Open accounts panel
1. Observe the groups and permission are displayed correctly.