### PR TITLE
Fix 3945: update shopId the right way.

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -385,11 +385,10 @@ export default {
           }
         });
       }
-      const packageSettings = store.get(packageName) || {};
-      packageSettings[preference] = value;
-      return store.set(packageName, packageSettings);
     }
-    return false;
+    const packageSettings = store.get(packageName) || {};
+    packageSettings[preference] = value;
+    return store.set(packageName, packageSettings);
   },
 
   updateUserPreferences(packageName, preference, values) {

--- a/client/modules/core/startup.js
+++ b/client/modules/core/startup.js
@@ -30,7 +30,12 @@ Meteor.startup(() => {
           Object.keys(user.profile.preferences).forEach((packageName) => {
             const packageSettings = user.profile.preferences[packageName];
             Object.keys(packageSettings).forEach((preference) => {
-              Reaction.setUserPreferences(packageName, preference, packageSettings[preference]);
+              if (packageName === "reaction" && preference === "activeShopId") {
+                // Because activeShopId is cached on client side.
+                Reaction.setShopId(packageSettings[preference]);
+              } else {
+                Reaction.setUserPreferences(packageName, preference, packageSettings[preference]);
+              }
             });
           });
         }


### PR DESCRIPTION
Resolves #3945 
Impact: **critical**  
Type: **bugfix**

## Issue
The `activeShopId` is cached on the client side [here](https://github.com/reactioncommerce/reaction/blob/master/client/modules/core/main.js#L27). So when `Rection.setUserPreferences("reaction", "activeShopId", newShopId)` is used directly the value is not cached.

## Solution
Replaced that call with `Reaction.setShopId(newShopId)` which takes care of the caching.

## Testing
1. Invite a user to marketplace.
1. Sign in as that user.
1. Observe you get `Reaction1` in the NavBar
1. Log out
1. Check localStorage to see that the `reaction = { activeShopId: "<primaryshopid>" }` is set to the primary shop.
1. Login again.
1. Observe you get `Reaction1` in the NavBar and the value is updated in the localStorage.
