### PR TITLE
Console error during checkout

### DIFF
--- a/imports/plugins/core/checkout/client/containers/cartSubTotalContainer.js
+++ b/imports/plugins/core/checkout/client/containers/cartSubTotalContainer.js
@@ -1,5 +1,6 @@
 import { setTimeout } from "timers";
-import { Components, registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
+import { compose } from "recompose";
+import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Cart } from "/lib/collections";
 import CartSubTotal from "../components/cartSubTotal";
 
@@ -7,7 +8,10 @@ function composer(props, onData) {
   onData(null, {
     isLoading: true
   });
+
+  let stopped = false;
   setTimeout(() => {
+    if (stopped) return;
     const cart = Cart.findOne();
     if (cart) {
       onData(null, {
@@ -21,8 +25,16 @@ function composer(props, onData) {
       });
     }
   }, 200);
+
+  return () => {
+    stopped = true;
+  };
 }
 
-registerComponent("CartSubTotal", CartSubTotal, composeWithTracker(composer));
+const hocs = [
+  composeWithTracker(composer)
+];
 
-export default composeWithTracker(composer, Components.Loading)(CartSubTotal);
+registerComponent("CartSubTotal", CartSubTotal, hocs);
+
+export default compose(...hocs)(CartSubTotal);


### PR DESCRIPTION
Resolves #3944   
Impact: **major**  
Type: **bugfix**

## Issue
Receive this console error after selecting shipping method on `release-1.9.0`
```
compose.js:76 Uncaught Error: Trying to set data after component(Tracker(CartSubTotal)) has unmounted.
    at onData (compose.js:76)
    at cartSubTotalContainer.js:13
```

also see this error on completed order page:
```
cartOrder.js:169 Uncaught TypeError: Cannot read property 'reduce' of undefined
    at Object.getDiscounts (cartOrder.js:169)
    at cartSubTotalContainer.js:17
```

## Solution / Changes
The compose HOC executes a callback when the component is about to unmount. Listen to it and prevent the timeout callback to call onData if the HOC is doomed.


## Breaking changes
none expected.


## Testing
Please provide starting context, i.e. logged in as a user, configure a particular payment method.
1. As admin set up shipping and payment (I used Stripe and Flat Rate)
2. Add something to cart and checkout
3. After selecting shipping method no error should be displayed in the browser console
