### PR TITLE
This fix undos a mistakenly merged "revert commit".

### DIFF
--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -572,7 +572,7 @@ Products.before.update(function (userId, product, fieldNames, modifier, options)
   }
 
   Revisions.update(revisionSelector, revisionModifier);
-  const updatedRevision = Revisions.findOne({ documentId: product._id });
+  const updatedRevision = Revisions.findOne(revisionSelector);
   Hooks.Events.run("afterRevisionsUpdate", userId, updatedRevision);
 
   Logger.debug(`Revison updated for product ${product._id}.`);


### PR DESCRIPTION
This fix undos a mistakenly merged "revert commit".
    https://github.com/reactioncommerce/reaction/commit/040ab004bac1e68f38aa3e820aa523e8372f99b6

It originally targeted this issue: https://github.com/reactioncommerce/reaction/issues/3851, which was fixed by that PR https://github.com/reactioncommerce/reaction/pull/3857/files.

@zenweasel  I'm not sure if I'm hunting a phantom here. Maybe it's just plain obvious that your changes are not in release-1.9.0 because they have never been merged officially. Or it's a PEBKAC problem of me.
