### PR TITLE
chore: upgrade react-dates to 16.3.6

### DIFF
--- a/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
+++ b/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
@@ -80,7 +80,7 @@ CalendarPicker.defaultProps = {
   initialEndDate: null,
 
   // day presentation and interaction related props
-  renderDay: null,
+  renderDayContents: null,
   minimumNights: 1,
   isDayBlocked: () => false,
   isDayHighlighted: () => false,
@@ -126,7 +126,7 @@ CalendarPicker.propTypes = {
   onOutsideClick: PropTypes.func,
   onPrevMonthClick: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
-  renderDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   withPortal: PropTypes.bool
 };
 

--- a/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
+++ b/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
@@ -52,14 +52,21 @@ class CalendarPicker extends Component {
     });
   }
 
+  renderDayContents(day) {
+    return (
+      <span className="CalendarDay__contents">{day.format("D")}</span>
+    );
+  }
+
   render() {
-    const { focusedInput, startDate, endDate } = this.state;
+    const { focusedInput, startDate, endDate, renderDayContents } = this.state;
 
     const props = omit(this.props, ["autoFocus", "autoFocusEndDate", "initialStartDate", "initialEndDate"]);
 
     return (
       <DayPickerRangeController
         {...props}
+        renderDayContents={renderDayContents || this.renderDayContents}
         onDatesChange={this.onDatesChange}
         onFocusChange={this.onFocusChange}
         focusedInput={focusedInput}

--- a/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/sync/orders.js
@@ -1,8 +1,5 @@
-import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
-import { Reaction } from "/server/api";
 import { Products } from "/lib/collections";
-import { connectorsRoles } from "../../lib/roles";
 
 /**
  * @file Methods for syncing Shopify orders

--- a/imports/plugins/included/default-theme/client/styles/calendarPicker.less
+++ b/imports/plugins/included/default-theme/client/styles/calendarPicker.less
@@ -96,7 +96,12 @@
   color: @rui-default-text;
   background: #f7f7f7;
 
-  button {
+  .CalendarDay__contents {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
     background: @rui-info;
     border-radius: 50%;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -882,11 +882,6 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
-    "array-flatten": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
-    },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
@@ -925,6 +920,30 @@
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.9.0"
+      }
+    },
+    "array.prototype.flatten": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatten/-/array.prototype.flatten-1.2.1.tgz",
+      "integrity": "sha512-3GhsA78XgK//wQKbhUe6L93kknekGlTRY0kvYcpuSi0aa9rVrMr/okeIIv/XSpN8fZ5iUM+bWifhf2/7CYKtIg==",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+          "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+          "requires": {
+            "es-to-primitive": "1.1.1",
+            "function-bind": "1.1.1",
+            "has": "1.0.1",
+            "is-callable": "1.1.3",
+            "is-regex": "1.0.4"
+          }
+        }
       }
     },
     "arrify": {
@@ -1994,6 +2013,11 @@
         }
       }
     },
+    "brcast": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+      "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
+    },
     "browser-process-hrtime": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
@@ -2978,6 +3002,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
       "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
+    },
+    "direction": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.1.tgz",
+      "integrity": "sha1-BIHMbrRLS7DADaDdsQqRRpu//l0="
     },
     "discontinuous-range": {
       "version": "1.0.0",
@@ -9842,9 +9871,9 @@
       }
     },
     "react-dates": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-15.5.3.tgz",
-      "integrity": "sha512-tH/2fTMkiak/3EgfTeNMXyqVGLYZyO9vdGh3EtVBCjvzh0e5xS8NVhREM408aetkJfWpSSqA23TrEOdMf+ZQtA==",
+      "version": "16.3.6",
+      "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-16.3.6.tgz",
+      "integrity": "sha512-wVvyRFKyLk/txS19AK/dqU40fwhTNc/+kwikzTTcrsdM7fa8AJAwmB2MrKeu3h+Fk4aILm9JSDXtmp1JQrrVpA==",
       "requires": {
         "airbnb-prop-types": "2.8.1",
         "consolidated-events": "1.1.1",
@@ -9855,9 +9884,9 @@
         "prop-types": "15.6.0",
         "react-addons-shallow-compare": "15.6.2",
         "react-moment-proptypes": "1.5.0",
-        "react-portal": "4.1.2",
-        "react-with-styles": "2.2.0",
-        "react-with-styles-interface-css": "3.0.0"
+        "react-portal": "4.1.3",
+        "react-with-styles": "3.1.0",
+        "react-with-styles-interface-css": "4.0.1"
       }
     },
     "react-dnd": {
@@ -10041,9 +10070,9 @@
       "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg=="
     },
     "react-portal": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.1.2.tgz",
-      "integrity": "sha512-SJXarj4bMfV2lf3SGEDoBQHyht3qGW+bMj7fWDPVLHt4FmIJI98+7JaYtV4OOi6SZMEcVk9iKBc/IO3MEAnLKw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.1.3.tgz",
+      "integrity": "sha512-0JHna4qv6LhkQfBg2/Ket0NsVAOHezBtInNlr1XHDEPR4LplUWuY5oJ4ysHCMxHpP2Rtd3B44SRUAnHmOzOCaA==",
       "requires": {
         "prop-types": "15.6.0"
       }
@@ -10302,24 +10331,40 @@
         }
       }
     },
+    "react-with-direction": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.0.tgz",
+      "integrity": "sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==",
+      "requires": {
+        "airbnb-prop-types": "2.8.1",
+        "brcast": "2.0.2",
+        "deepmerge": "1.5.2",
+        "direction": "1.0.1",
+        "hoist-non-react-statics": "2.3.1",
+        "object.assign": "4.1.0",
+        "object.values": "1.0.4",
+        "prop-types": "15.6.0"
+      }
+    },
     "react-with-styles": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-2.2.0.tgz",
-      "integrity": "sha1-yFNS2eWVGCSyWb+frRHbz3ShVXE=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.1.0.tgz",
+      "integrity": "sha512-neH8a79MoPGTMhwRstNVRydJaZA2yjwNSBYo1zFjkQZ44EGRUgs/RR2dMdSt2ARa8yGew2rOpeKQOWqaEoqnpw==",
       "requires": {
         "deepmerge": "1.5.2",
         "global-cache": "1.2.1",
         "hoist-non-react-statics": "2.3.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.0",
+        "react-with-direction": "1.3.0"
       }
     },
     "react-with-styles-interface-css": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-3.0.0.tgz",
-      "integrity": "sha512-SsjJrabqVa7PedwCC/P7lseXnHHxD1H5GHBNt4lDxVHhQhAhlb6PVYR/dcH7JWOzv1nH5LRKOdqI9A5OIZ27bQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.1.tgz",
+      "integrity": "sha512-kLS+Ytv0/XBph7ovFP/7IazwBD/W/Xo9Zr/90d6QSGCRjhvHZXusFDOzXUwBE1GAkGRjZy+RrgbPad5wKyXclA==",
       "requires": {
         "aphrodite": "1.2.5",
-        "array-flatten": "2.1.1",
+        "array.prototype.flatten": "1.2.1",
         "global-cache": "1.2.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "url": "https://github.com/reactioncommerce/reaction/issues"
   },
   "dependencies": {
-    "@reactioncommerce/job-queue": "^1.0.4",
     "@babel/runtime": "7.0.0-beta.38",
+    "@reactioncommerce/job-queue": "^1.0.4",
     "@reactioncommerce/nodemailer": "^5.0.5",
     "accounting-js": "^1.1.1",
     "authorize-net": "^1.1.1",
@@ -85,7 +85,7 @@
     "react-avatar": "^2.5.1",
     "react-color": "^2.13.8",
     "react-copy-to-clipboard": "^5.0.1",
-    "react-dates": "^15.5.3",
+    "react-dates": "^16.3.6",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
     "react-dom": "16.2.0",


### PR DESCRIPTION
Resolves #3443   
Impact: **breaking**  
Type: **chore**

## Issue
Update [react-dates](https://github.com/airbnb/react-dates) package to version `16.3.6`

## Solution

1. `meteor npm install react-dates@16.3.6`
2. Change prop `renderDay` to `renderDayContents`
3. Fix styling issues with start and end dates in date ranges

## Breaking changes

- change prop `renderDay` to `renderDayContents`

## Testing

1. Install the reaction devtools package https://github.com/reactioncommerce/reaction-devtools
2. As an admin, load the orders from the small dataset from devtools panel
3. Open Orders panel and filter dates
