### PR TITLE
Clean paymentMethod objects before validating

### DIFF
--- a/imports/plugins/included/payments-authnet/server/methods/authnet.js
+++ b/imports/plugins/included/payments-authnet/server/methods/authnet.js
@@ -107,7 +107,7 @@ Meteor.methods({
     // Call both check and validate because by calling `clean`, the audit pkg
     // thinks that we haven't checked paymentMethod arg
     check(paymentMethod, Object);
-    PaymentMethodArgument.validate(paymentMethod);
+    PaymentMethodArgument.validate(PaymentMethodArgument.clean(paymentMethod));
 
     const {
       transactionId,
@@ -177,7 +177,7 @@ Meteor.methods({
     // Call both check and validate because by calling `clean`, the audit pkg
     // thinks that we haven't checked paymentMethod arg
     check(paymentMethod, Object);
-    PaymentMethodArgument.validate(paymentMethod);
+    PaymentMethodArgument.validate(PaymentMethodArgument.clean(paymentMethod));
 
     const result = {
       saved: false,

--- a/imports/plugins/included/payments-braintree/server/methods/braintreeMethods.js
+++ b/imports/plugins/included/payments-braintree/server/methods/braintreeMethods.js
@@ -103,7 +103,7 @@ export function createRefund(paymentMethod, amount) {
   // Call both check and validate because by calling `clean`, the audit pkg
   // thinks that we haven't checked paymentMethod arg
   check(paymentMethod, Object);
-  PaymentMethodArgument.validate(paymentMethod);
+  PaymentMethodArgument.validate(PaymentMethodArgument.clean(paymentMethod));
 
   const refundDetails = {
     transactionId: paymentMethod.transactionId,


### PR DESCRIPTION
Resolves #3960  
Impact: **critical**  
Type: **bugfix**

## Issue
Authnet payments fail to capture transaction and returns a simple schema validation error.

To reproduce:
1. Configure Shippo, Authorize.net, Avalara
2. Checkout with an authorize.net payment
3. Monitor Console Log

## Solution
The solution was to `clean` the PaymentMethod object before running them through the validator. This is how @aldeed had the other payment packages working and it appears that braintree and authnet were simply not cleaned, though the code comments indicate that was the intent.

## Breaking changes
n/a

## Testing
1. Configure Shippo, Authorize.net, Avalara
2. Checkout with an authorize.net payment
3. Monitor Console Log
