### PR TITLE
Fix: delete shipping rates one at a time

### DIFF
--- a/imports/plugins/included/shipping-rates/server/methods/rates.js
+++ b/imports/plugins/included/shipping-rates/server/methods/rates.js
@@ -92,13 +92,22 @@ export const methods = {
       throw new Meteor.Error("access-denied", "Access Denied");
     }
 
-    return Shipping.update({
+    const rates = Shipping.findOne({ "methods._id": rateId });
+    const { methods: shippingMethods } = rates;
+    const updatedMethods = shippingMethods.filter((method) => method._id !== rateId);
+
+    // HACK: not sure why we need to do this.. but it works.
+    // Replaced a $pull which in theory is better, but was broken.
+    // Issue w/ pull was introduced during the simpl-schema update
+    const deleted = Shipping.update({
       "methods._id": rateId
     }, {
-      $pull: {
-        methods: { _id: rateId }
+      $set: {
+        methods: updatedMethods
       }
     });
+
+    return deleted;
   }
 };
 


### PR DESCRIPTION
Resolves #3956
Impact: **minor**  
Type: **bugfix**

## Issue
When deleting a single shipping rate from the shipping dashboard, sometimes all shipping rates would get deleted. Occasionally you would not be able to delete rates as well. Not sure if this got introduced via the simpl-schema updates or something else.

## Solution
This solution replaces the method that used `$pull` to remove a single shipping rate from the array on Mongo with a slower, clunkier solution which gets the shipping methods from the db and filters them on the server and then uses `$set` to update the entire array of methods. 

This shouldn't have any serious performance implications as this only runs when the admin removes an existing shipping method.

## Breaking changes
n/a

## Testing
1. Reset the app
1. Delete a shipping method
1. Observe that methods delete one-by-one
