### PR TITLE
fix: added all the missing avalara settings fields to the fieldsProps…

### DIFF
--- a/imports/plugins/included/taxes-avalara/client/containers/avalaraSettingsFormContainer.js
+++ b/imports/plugins/included/taxes-avalara/client/containers/avalaraSettingsFormContainer.js
@@ -50,7 +50,40 @@ const formSettings = {
       inputType: "number"
     },
     "settings.avalara.password": {
+      renderComponent: "string",
       inputType: "password"
+    },
+    "settings.avalara.apiLoginId": {
+      renderComponent: "string",
+      inputType: "text"
+    },
+    "settings.avalara.username": {
+      renderComponent: "string",
+      inputType: "text"
+    },
+    "settings.avalara.companyCode": {
+      renderComponent: "string",
+      inputType: "text"
+    },
+    "settings.avalara.shippingTaxCode": {
+      renderComponent: "string",
+      inputType: "text"
+    },
+    "settings.addressValidation.enabled": {
+      renderComponent: "boolean",
+      inputType: "checkbox"
+    },
+    "settings.avalara.performTaxCalculation": {
+      renderComponent: "boolean",
+      inputType: "checkbox"
+    },
+    "settings.avalara.enableLogging": {
+      renderComponent: "boolean",
+      inputType: "checkbox"
+    },
+    "settings.avalara.commitDocuments": {
+      renderComponent: "boolean",
+      inputType: "checkbox"
     }
   },
   logFieldsProp: {


### PR DESCRIPTION
Resolves #3967   
Impact: **critical**  
Type: **bugfix**

## Issue
The Avalara taxes plugin settings weren't rendering all of the needed input fields. I believe this issue was being caused by the simple schema changes and the Form component not knowing to render most of the fields as it looped through the props.

## Solution
Inside the AvalaraSettingsFormContainer container, I updated the `formSettings` object to include a `renderComponent` & `inputType` for each needed field. Now the Form component can use the `renderComponent` property of each field to determine which field to render.

## Testing
 1. Remove settings.json
 2. Start the app
 3. Login as admin
 4. Open Avalara panel. All needed form fields should render.