### PR TITLE
 Fix for "Reactivity error when products are not published yet"

### DIFF
--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -89,8 +89,8 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
           if (revision.documentType === "product") {
             // Check merge box (session collection view), if product is already in cache.
             // If yes, we send a `changed`, otherwise `added`. I'm assuming
-            // that this._documents.Products is somewhat equivalent to
-            // the merge box Meteor.server.sessions[sessionId].getCollectionView("Products").documents
+            // that this._documents.Products is somewhat equivalent to the
+            // merge box Meteor.server.sessions[sessionId].getCollectionView("Products").documents
             if (this._documents.Products && this._documents.Products[revision.documentId]) {
               this.changed("Products", revision.documentId, { __revisions: [revision] });
             } else {

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -76,12 +76,9 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
             "revision/published"
           ]
         },
-        "documentData.isDeleted": { $in: [null, false] },
-        "documentData.isVisible": { $in: [true, false, undefined] },
         "$or": [
           { "documentData._id": _id },
-          { "documentData.ancestors": _id },
-          { "documentData.handle": productIdOrHandle }
+          { "documentData.ancestors": _id }
         ]
       }).observe({
         added: (revision) => {

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -91,29 +91,8 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
             // If yes, we send a `changed`, otherwise `added`. I'm assuming
             // that this._documents.Products is somewhat equivalent to
             // the merge box Meteor.server.sessions[sessionId].getCollectionView("Products").documents
-            if (this._documents.Products) {
-              if (this._documents.Products[revision.documentId]) {
-                // I find it much clearer without `else if`
-                // eslint-disable-next-line no-lonely-if
-                if (revision.workflow.status !== "revision/published") {
-                  this.changed("Products", revision.documentId, { __revisions: [revision] });
-                } else {
-                  // TODO Review: I think this branch will never be executed, because if
-                  // revision.workflow.status === "revision/published" the `added` observe callback
-                  // shouldn't have been called in the first place (because the cursor that's observed
-                  // only fetches documents where revision.workflow.status !== "revision/published")
-                  this.changed("Products", revision.documentId, { __revisions: [] });
-                }
-              } else {
-                // I find it much clearer without `else if`
-                // eslint-disable-next-line no-lonely-if
-                if (revision.workflow.status !== "revision/published") {
-                  this.added("Products", revision.documentId, { __revisions: [revision] });
-                } else {
-                  // TODO: See above
-                  this.added("Products", revision.documentId, { __revisions: [] });
-                }
-              }
+            if (this._documents.Products && this._documents.Products[revision.documentId]) {
+              this.changed("Products", revision.documentId, { __revisions: [revision] });
             } else {
               this.added("Products", revision.documentId, { __revisions: [revision] });
             }

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -381,7 +381,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
           }
         },
         removed: (revision) => {
-          this.removed("Revisions", revision._id, revision);
+          this.removed("Revisions", revision._id);
           if (revision.documentType === "product") {
             if (this._documents.Products && this._documents.Products[revision.documentId]) {
               this.changed("Products", revision.documentId, { __revisions: [] });


### PR DESCRIPTION
Resolves #3958   
Impact: **major**  
Type: **bugfix**

## Issue
Field changes (revisions) are not always applied for unpublished changes.

## Solution / Changes
The revision observer should push revisions to client even if product
document does not exist in session collection view (merge box) yet.
Otherwise the revision field would never be pushed to the client on
initial load of PDP, which causes the reactivity error observed in

The crux is to not "over-publish" revisions. Just adding `this.added("Products", id, fields)` in line 118 would result in revisions being pushed to the client that are completely unrelated.

This is because the current observer is not specific enough. It justs
observes all revisions that are not published yet. This is too broad.
The selector needs to be more specific and just observe revision
documents that belong to the currently published product. This fact
resulted in the changes of line 78 - 85.

Another thing where I've been wrong has to do with the comment in line
101. I think that branch is actually dead code which can be removed. I
haven't done that in this PR to keep the changes manageable. I think it
does not hurt either, but I will create a new ticket to follow up on
this.

And lastly there was a unnecessary 2nd parameter passed to `this.removed`,
which has been removed in this PR.


## Breaking changes
none expected

## Testing
1. As an admin, create AND publish a product
2. Change the subtitle of the published product (any other field should work as well)
3. Don't publish your changes
4. Navigate to the product grid
5. Navigate back to the PDP of the changed (but unpublished) product
6. See that the subtitle field does have the previously applied changes
