### PR TITLE
Fix for "Browser console warning when beginning checkout"

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
@@ -33,6 +33,14 @@ const wrapComponent = (Comp) => (
       };
     }
 
+    componentDidMount() {
+      this._isMounted = true;
+    }
+
+    componentWillUnmount() {
+      this._isMounted = false;
+    }
+
     handleCartQuantityChange = (event, quantity) => {
       this.setState({
         cartQuantity: Math.max(quantity, 1)
@@ -174,7 +182,9 @@ const wrapComponent = (Comp) => (
               $("#spin").addClass("hidden");
               $(".cart-alert-text").text(`${this.state.productClick * quantity} ${addToCartTitle} ${addToCartText}`);
               $(".cart-alert-text").fadeIn("slow");
-              this.setState({ productClick: 0 });
+              if (this._isMounted) {
+                this.setState({ productClick: 0 });
+              }
             }, 2000);
 
             clearTimeout(this.animationTimeOut);


### PR DESCRIPTION
Resolves #3972   
Impact: **major**  
Type: **bugfix**

## Issue
Receive the following warning in the browser console when clicking on the "checkout" button from the PDP. Also a spinner is shown for a beat or two. Seems to have no effect on actual functionality.

Note that this issue does not occur on every machine. It happen's reliably on Brent's machine, though. I was able to replicate it after playing with setTimeout times.

## Solution / Changes
Don't call setState in a timer without prior check of mount state.


## Breaking changes
none expected


## Testing
1. As an admin navigate to a product page
2. Click on "Add to Cart"
3. Click on the "checkout" button that appears briefly
4. Observe no warnings in the console.