### PR TITLE
Fix #3979 marketplace shipping

### DIFF
--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -242,7 +242,11 @@ export function buildOrderSearchRecord(orderId) {
   orderSearch.variants.title = order.items.map((item) => item.variants && item.variants.title);
   orderSearch.variants.optionTitle = order.items.map((item) => item.variants && item.variants.optionTitle);
 
-  OrderSearch.upsert(orderId, { $set: { ...orderSearch } });
+  try {
+    OrderSearch.upsert(orderId, { $set: { ...orderSearch } });
+  } catch (error) {
+    Logger.error(error, "Failed to add order to OrderSearch collection");
+  }
 }
 
 export function buildOrderSearch(cb) {

--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -242,7 +242,7 @@ export function buildOrderSearchRecord(orderId) {
   orderSearch.variants.title = order.items.map((item) => item.variants && item.variants.title);
   orderSearch.variants.optionTitle = order.items.map((item) => item.variants && item.variants.optionTitle);
 
-  OrderSearch.insert(orderSearch);
+  OrderSearch.upsert(orderId, { $set: { ...orderSearch } });
 }
 
 export function buildOrderSearch(cb) {

--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -245,7 +245,7 @@ export function buildOrderSearchRecord(orderId) {
   try {
     OrderSearch.upsert(orderId, { $set: { ...orderSearch } });
   } catch (error) {
-    Logger.error(error, "Failed to add order to OrderSearch collection");
+    Logger.error(error, "Failed to add order to the OrderSearch collection");
   }
 }
 


### PR DESCRIPTION
Resolves #3979 
Impact: **critical**  
Type: **bugfix**

## Issue
This issue is a timing issue. When a order is updated, a [hook](https://github.com/reactioncommerce/reaction/blob/release-1.9.0/imports/plugins/included/search-mongo/server/hooks/search.js#L51) is run to remove the old `OrderSearch` doc and add the new one. Since the orders is displayed twice, it is updated twice(and the hook runs almost together). 
In general the order of execution is
```
remove doc
insert doc
remove doc
insert doc
```
but in the rare case it becomes
```
remove doc
remove doc
insert doc
insert doc
```
You get the error in the issue. 

One other way to reproduce the issue(and with much more success) is to keep on clicking on the `Approve` or `Shipped` button(they aren't disabled after first click).

## Solution
There is only one place in the code where the record is inserted in the `OrderSearch` collection. At that place I changed the `insert` operation to a `upsert` operation, which will prevent the duplicate id error.

## Testing
1. Configure for marketplace and second shop
1. Create product in second shop
1. In Primary shop place an order with a product from the main shop and from the second shop
1. In the dashboard approve, capture, and attempt to ship the order
1. Observe no error and that the order is marked shipped

OR

1. Place order for a single product.
2. Fo to the dashboard and keep clicking on the `Approve` and then on the `Shipped` button.
1. Observe no error in the console.