### PR TITLE
Fix #3965: Check for number if sms is enabled.

### DIFF
--- a/imports/plugins/included/sms/server/methods/sms.js
+++ b/imports/plugins/included/sms/server/methods/sms.js
@@ -76,12 +76,12 @@ Meteor.methods({
       return;
     }
 
-    const formattedPhone = formatPhoneNumber(phone, country);
-
     const smsSettings = Sms.findOne({ shopId });
     if (!smsSettings) {
       return;
     }
+
+    const formattedPhone = formatPhoneNumber(phone, country);
 
     const { apiKey, apiToken, smsPhone, smsProvider } = smsSettings;
     if (smsProvider === "twilio") {

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -229,7 +229,7 @@ export function formatPhoneNumber(phone, countryCode) {
       // try attaching the country code to phone number
       return `${countryExtension}${phoneNumber}`;
     }
-    throw new Meteor.Error("invalid-parameter", "Incorrect format for phone number.");
+    throw new Meteor.Error("invalid-parameter", `Incorrect format for phone number ${phone} with country ${countryCode}`);
   } catch (error) {
     throw new Meteor.Error("invalid-parameter", error);
   }


### PR DESCRIPTION
Resolves #3965   
Impact: **major**  
Type: **bugfix**

## Issue
The check for validating the phone number was before checking if any SMS service was enabled.

## Solution
Moved the check for validation after SMS service is checked.
Also improved the error message.

## Breaking changes
None

## Testing
1. Spin up a new RC shop, log in as an admin and set up a payment provider and shipping.
1. As an admin open the dev-tools panel, click "reset data" then load in the small product set as well as the small order set.
1. In another browser as an anonymous customer select an item from the product grid, add a few to the cart and click the "checkout" button.
1. Enter a invalid phone number in the address screen.
1. Complete the checkout process and wait for the Order confirmation screen.
1. Observe no error.