### PR TITLE
Fix for "dirty badge in product grid does not work"

### DIFF
--- a/imports/plugins/included/product-variant/containers/productsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainer.js
@@ -178,17 +178,15 @@ function composer(props, onData) {
     shopId: { $in: activeShopsIds }
   });
 
-  const sortedProducts = ReactionProduct.sortProducts(productCursor.fetch(), currentTag);
-  Session.set("productGrid/products", sortedProducts);
-
   const productIds = [];
-  const stateProducts = sortedProducts.map((product) => {
+  const products = productCursor.map((product) => {
     productIds.push(product._id);
 
-    return {
-      ...applyProductRevision(product)
-    };
+    return applyProductRevision(product);
   });
+
+  const sortedProducts = ReactionProduct.sortProducts(products, currentTag);
+  Session.set("productGrid/products", sortedProducts);
 
   reactiveProductIds.set(productIds);
 
@@ -201,7 +199,7 @@ function composer(props, onData) {
 
   onData(null, {
     canLoadMoreProducts,
-    products: stateProducts,
+    products: sortedProducts,
     productsSubscription
   });
 }

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -84,10 +84,24 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
             // If yes, we send a `changed`, otherwise `added`. I'm assuming
             // that this._documents.Products is somewhat equivalent to
             // the merge box Meteor.server.sessions[sessionId].getCollectionView("Products").documents
-            if (this._documents.Products && this._documents.Products[revision.documentId]) {
-              this.changed("Products", revision.documentId, { __revisions: [revision] });
-            } else {
-              this.added("Products", revision.documentId, { __revisions: [revision] });
+            if (this._documents.Products) {
+              if (this._documents.Products[revision.documentId]) {
+                // I find it much clearer without `else if`
+                // eslint-disable-next-line no-lonely-if
+                if (revision.workflow.status !== "revision/published") {
+                  this.changed("Products", revision.documentId, { __revisions: [revision] });
+                } else {
+                  this.changed("Products", revision.documentId, { __revisions: [] });
+                }
+              } else {
+                // I find it much clearer without `else if`
+                // eslint-disable-next-line no-lonely-if
+                if (revision.workflow.status !== "revision/published") {
+                  this.added("Products", revision.documentId, { __revisions: [revision] });
+                } else {
+                  this.added("Products", revision.documentId, { __revisions: [] });
+                }
+              }
             }
           }
         },

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -84,24 +84,10 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
             // If yes, we send a `changed`, otherwise `added`. I'm assuming
             // that this._documents.Products is somewhat equivalent to
             // the merge box Meteor.server.sessions[sessionId].getCollectionView("Products").documents
-            if (this._documents.Products) {
-              if (this._documents.Products[revision.documentId]) {
-                // I find it much clearer without `else if`
-                // eslint-disable-next-line no-lonely-if
-                if (revision.workflow.status !== "revision/published") {
-                  this.changed("Products", revision.documentId, { __revisions: [revision] });
-                } else {
-                  this.changed("Products", revision.documentId, { __revisions: [] });
-                }
-              } else {
-                // I find it much clearer without `else if`
-                // eslint-disable-next-line no-lonely-if
-                if (revision.workflow.status !== "revision/published") {
-                  this.added("Products", revision.documentId, { __revisions: [revision] });
-                } else {
-                  this.added("Products", revision.documentId, { __revisions: [] });
-                }
-              }
+            if (this._documents.Products && this._documents.Products[revision.documentId]) {
+              this.changed("Products", revision.documentId, { __revisions: [revision] });
+            } else {
+              this.added("Products", revision.documentId, { __revisions: [revision] });
             }
           }
         },

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -75,10 +75,10 @@ registerSchema("filters", filters);
  * Broadens an existing selector to include all variants of the given top-level productIds
  * Additionally considers the tags product filter, if given
  * Can operate on the "Revisions" and the "Products" collection
- * @param collectionName {string} - "Revisions" or "Products"
+ * @param collectionName {String} - "Revisions" or "Products"
  * @param selector {object} - the selector that should be extended
  * @param productFilters { object } - the product filter (e.g. orginating from query parameters)
- * @param productIds {[string]} - the top-level productIds we want to get the variants of.
+ * @param productIds {String[]} - the top-level productIds we want to get the variants of.
  */
 function extendSelectorWithVariants(collectionName, selector, productFilters, productIds) {
   let prefix = "";

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -373,29 +373,8 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
             // If yes, we send a `changed`, otherwise `added`. I'm assuming
             // that this._documents.Products is somewhat equivalent to
             // the merge box Meteor.server.sessions[sessionId].getCollectionView("Products").documents
-            if (this._documents.Products) {
-              if (this._documents.Products[revision.documentId]) {
-                // I find it much clearer without `else if`
-                // eslint-disable-next-line no-lonely-if
-                if (revision.workflow.status !== "revision/published") {
-                  this.changed("Products", revision.documentId, { __revisions: [revision] });
-                } else {
-                  // TODO Review: I think this branch will never be executed, because if
-                  // revision.workflow.status === "revision/published" the `added` observe callback
-                  // shouldn't have been called in the first place (because the cursor that's observed
-                  // only fetches documents where revision.workflow.status !== "revision/published")
-                  this.changed("Products", revision.documentId, { __revisions: [] });
-                }
-              } else {
-                // I find it much clearer without `else if`
-                // eslint-disable-next-line no-lonely-if
-                if (revision.workflow.status !== "revision/published") {
-                  this.added("Products", revision.documentId, { __revisions: [revision] });
-                } else {
-                  // TODO: See above.
-                  this.added("Products", revision.documentId, { __revisions: [] });
-                }
-              }
+            if (this._documents.Products && this._documents.Products[revision.documentId]) {
+              this.changed("Products", revision.documentId, { __revisions: [revision] });
             } else {
               this.added("Products", revision.documentId, { __revisions: [revision] });
             }

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -72,6 +72,62 @@ const filters = new SimpleSchema({
 registerSchema("filters", filters);
 
 /**
+ * Broadens an existing selector to include all variants of the given top-level productIds
+ * Additionally considers the tags product filter, if given
+ * Can operate on the "Revisions" and the "Products" collection
+ * @param collectionName {string} - "Revisions" or "Products"
+ * @param selector {object} - the selector that should be extended
+ * @param productFilters { object } - the product filter (e.g. orginating from query parameters)
+ * @param productIds {array of strings} - the top-level productIds we want to get the variants of.
+ */
+function extendSelectorWithVariants(collectionName, selector, productFilters, productIds) {
+  let prefix = "";
+
+  if (collectionName.toLowerCase() === "revisions") {
+    prefix = "documentData.";
+  } else if (collectionName.toLowerCase() !== "products") {
+    throw new Error(`Can't extend selector for collection ${collectionName}.`);
+  }
+
+  // Remove hashtag filter from selector (hashtags are not applied to variants, we need to get variants)
+  const newSelector = _.omit(selector, ["hashtags", "ancestors"]);
+  if (productFilters && productFilters.tags) {
+    // Re-configure selector to pick either Variants of one of the top-level products, or the top-level products in the filter
+    _.extend(newSelector, {
+      $or: [{
+        [`${prefix}ancestors`]: {
+          $in: productIds
+        }
+      }, {
+        $and: [{
+          [`${prefix}hashtags`]: {
+            $in: productFilters.tags
+          }
+        }, {
+          [`${prefix}_id`]: {
+            $in: productIds
+          }
+        }]
+      }]
+    });
+  } else {
+    _.extend(newSelector, {
+      $or: [{
+        [`${prefix}ancestors`]: {
+          $in: productIds
+        }
+      }, {
+        [`${prefix}_id`]: {
+          $in: productIds
+        }
+      }]
+    });
+  }
+  return newSelector;
+}
+
+
+/**
  * products publication
  * @param {Number} [productScrollLimit] - optional, defaults to 24
  * @param {Array} shops - array of shopId to retrieve product from.
@@ -297,53 +353,19 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
       limit: productScrollLimit
     }).map((product) => product._id);
 
-    let newSelector = selector;
 
-    // Remove hashtag filter from selector (hashtags are not applied to variants, we need to get variants)
-    if (productFilters && productFilters.tags) {
-      newSelector = _.omit(selector, ["hashtags", "ancestors"]);
-
-      // Re-configure selector to pick either Variants of one of the top-level products, or the top-level products in the filter
-      _.extend(newSelector, {
-        $or: [{
-          ancestors: {
-            $in: productIds
-          }
-        }, {
-          $and: [{
-            hashtags: {
-              $in: productFilters.tags
-            }
-          }, {
-            _id: {
-              $in: productIds
-            }
-          }]
-        }]
-      });
-    } else {
-      newSelector = _.omit(selector, ["hashtags", "ancestors"]);
-      _.extend(newSelector, {
-        $or: [{
-          ancestors: {
-            $in: productIds
-          }
-        }, {
-          _id: {
-            $in: productIds
-          }
-        }]
-      });
-    }
+    const productSelectorWithVariants = extendSelectorWithVariants("Products", selector, productFilters, productIds);
 
     if (RevisionApi.isRevisionControlEnabled()) {
-      const handle = Revisions.find({
+      const revisionSelector = {
         "workflow.status": {
           $nin: [
             "revision/published"
           ]
         }
-      }).observe({
+      };
+      const revisionSelectorWithVariants = extendSelectorWithVariants("Revisions", revisionSelector, productFilters, productIds);
+      const handle = Revisions.find(revisionSelectorWithVariants).observe({
         added: (revision) => {
           this.added("Revisions", revision._id, revision);
           if (revision.documentType === "product") {
@@ -358,6 +380,10 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
                 if (revision.workflow.status !== "revision/published") {
                   this.changed("Products", revision.documentId, { __revisions: [revision] });
                 } else {
+                  // TODO Review: I think this branch will never be executed, because if
+                  // revision.workflow.status === "revision/published" the `added` observe callback
+                  // shouldn't have been called in the first place (because the cursor that's observed
+                  // only fetches documents where revision.workflow.status !== "revision/published")
                   this.changed("Products", revision.documentId, { __revisions: [] });
                 }
               } else {
@@ -366,9 +392,12 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
                 if (revision.workflow.status !== "revision/published") {
                   this.added("Products", revision.documentId, { __revisions: [revision] });
                 } else {
+                  // TODO: See above
                   this.added("Products", revision.documentId, { __revisions: [] });
                 }
               }
+            } else {
+              this.added("Products", revision.documentId, { __revisions: [revision] });
             }
           }
         },
@@ -381,7 +410,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
           }
         },
         removed: (revision) => {
-          this.removed("Revisions", revision._id, revision);
+          this.removed("Revisions", revision._id);
           if (revision.documentType === "product") {
             if (this._documents.Products && this._documents.Products[revision.documentId]) {
               this.changed("Products", revision.documentId, { __revisions: [] });
@@ -394,11 +423,11 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
         handle.stop();
       });
 
-      return Products.find(newSelector);
+      return Products.find(productSelectorWithVariants);
     }
 
     // Revision control is disabled, but is admin
-    return Products.find(newSelector, {
+    return Products.find(productSelectorWithVariants, {
       sort,
       limit: productScrollLimit
     });

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -78,7 +78,7 @@ registerSchema("filters", filters);
  * @param collectionName {string} - "Revisions" or "Products"
  * @param selector {object} - the selector that should be extended
  * @param productFilters { object } - the product filter (e.g. orginating from query parameters)
- * @param productIds {array of strings} - the top-level productIds we want to get the variants of.
+ * @param productIds {[string]} - the top-level productIds we want to get the variants of.
  */
 function extendSelectorWithVariants(collectionName, selector, productFilters, productIds) {
   let prefix = "";

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -392,7 +392,7 @@ Meteor.publish("Products", function (productScrollLimit = 24, productFilters, so
                 if (revision.workflow.status !== "revision/published") {
                   this.added("Products", revision.documentId, { __revisions: [revision] });
                 } else {
-                  // TODO: See above
+                  // TODO: See above.
                   this.added("Products", revision.documentId, { __revisions: [] });
                 }
               }


### PR DESCRIPTION
Resolves #3982 
Impact: **major**  
Type: **bugfix**

## Issue
The product grid should display unpublished changes via red dot (a badge). This tells the admin that products shown in the grid hold un-commited changes.

## Solution 

This PR fixes the issue described above AND a problem on master where revisions are over-published (see attached gif).

This change is very similar to what have been done in this companion PR: https://github.com/reactioncommerce/reaction/pull/3970 

##  Changes
Product revisions need to be pushed to client, even if the product document (that contain all other fields besides __revisions) is not published yet.

Just adding
  `this.added("Products", revision.documentId, { __revisions: [revision] });`
in line 400 is not sufficient, because then revisions would be over-published. (Which is actually the case in master branch right now.)

To prevent over-publishing, the Revision observer needs to be more specific and select only those revisions, that are not published AND are shown in the product grid. This constraint resulted in the new function "extendSelectorWithVariants".


## Breaking changes
none expected

## Testing
1. As an admin , create at least two products
2. Navigate to the product grid
3. Swap the order of the products via drag'n'drop
4. See the red dot on each product that tells the admin about the un-commited (unpublished) changes
5. Reload the page
6. All dots should still be there until "Publish all" button is pressed (ensure that no product is selected, otherwise the button will have the text "Publish" and does only affect the currently selected product.