### PR TITLE
Fix for "Summary not shown in Invoice"

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/pdf.js
+++ b/imports/plugins/core/orders/client/templates/list/pdf.js
@@ -28,7 +28,6 @@ Template.completedPDFLayout.onCreated(async function () {
     const order = Orders.findOne({
       _id: currentRoute.params.id
     });
-
     this.state.set({
       order
     });
@@ -42,7 +41,7 @@ Template.completedPDFLayout.helpers({
   },
   billing() {
     const order = Template.instance().state.get("order");
-    if (order && order.length) {
+    if (order && order.billing) {
       return order.billing[0];
     }
 

--- a/imports/plugins/core/orders/client/templates/list/pdf.js
+++ b/imports/plugins/core/orders/client/templates/list/pdf.js
@@ -41,7 +41,7 @@ Template.completedPDFLayout.helpers({
   },
   billing() {
     const order = Template.instance().state.get("order");
-    if (order && order.billing) {
+    if (order && order.billing && order.billing.length) {
       return order.billing[0];
     }
 


### PR DESCRIPTION
Resolves #3971   
Impact: **major**  
Type: **bugfix**

## Issue
Print invoice does not show shipping/taxes etc. The "summary" is just empty

## Solution
Order is not an array. Don't check for length property, but rather for billing.

## Breaking changes
none expected


## Testing
1. Place and complete an order
2. Go to the orders dashboard
3. Click on "Print Invoice"
4. Observe the the Order Summary is NOT empty any longer
