### PR TITLE
Fix for "PDP Image gallery does not handle portrait sized images well"

### DIFF
--- a/imports/plugins/core/ui/client/components/media/mediaGallery.js
+++ b/imports/plugins/core/ui/client/components/media/mediaGallery.js
@@ -168,7 +168,10 @@ class MediaGallery extends Component {
 
   renderMediaGalleryUploader() {
     const { mediaGalleryWidth: containerWidth, uploadProgress } = this.props;
-    const classes = { "admin-featuredImage": Reaction.hasAdminAccess() };
+    const classes = {
+      "admin-featuredImage": Reaction.hasAdminAccess(),
+      "featuredImage": true
+    };
 
     return (
       <div className="rui media-gallery">
@@ -198,7 +201,10 @@ class MediaGallery extends Component {
 
   renderMediaGallery() {
     const containerWidth = this.props.mediaGalleryWidth;
-    const classes = { "admin-featuredImage": Reaction.hasAdminAccess() };
+    const classes = {
+      "admin-featuredImage": Reaction.hasAdminAccess(),
+      "featuredImage": true
+    };
 
     return (
       <div className="rui media-gallery">

--- a/imports/plugins/included/default-theme/client/styles/media.less
+++ b/imports/plugins/included/default-theme/client/styles/media.less
@@ -29,32 +29,6 @@
   width: 100%;
 }
 
-// .rui.media img {
-//   width: auto;
-//   height: auto;
-//   max-width: 100%;
-//   max-height: 100%;
-// }
-
-
-// Gallery Featured Image
-.rui.media-gallery .featuredImage {
-  width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-    // background: @white;
-    // Height is set via React.Measure to match width
-    // Width is 100%
-}
-
-.rui.media-gallery .featuredImage .gallery-image {
-  flex-basis: 100%;
-  padding: 3px;
-}
-
-
 // Gallery Thumbnails
 .rui.gallery-thumbnails {
   display: flex;
@@ -68,7 +42,6 @@
   flex-basis: 25%;
   padding: 3px;
 }
-
 
 // Media Gallery Admin
 .rui.media-gallery .rui.gallery-drop-pane {
@@ -140,6 +113,21 @@
   color: @gray-dark;
 }
 
+.rui.media-gallery .featuredImage {
+  & > div {
+    height: 100%;
+    .gallery-image {
+      height: 100%;
+    }
+  }
+}
+
+.rui.media-gallery .gallery-image .img-responsive {
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
+}
+
 .admin-gallery-image {
   cursor: pointer;
 
@@ -149,39 +137,20 @@
   }
 }
 
+.gallery-image.no-fade-on-hover,
 .admin-gallery-image.no-fade-on-hover {
   &:hover {
     opacity: 1;
   }
-
-  & > div {
-    height: auto !important;
-
-    & > img {
-      height: auto !important;
-    }
-  }
-
-}
-
-.gallery-image.no-fade-on-hover {
-  &:hover {
-    opacity: 1;
-  }
-
-  & > div {
-    height: auto !important;
-
-    & > img {
-      height: auto !important;
-    }
-  }
-
 }
 
 .zoomed-image-container {
   z-index: 1;
   direction: ltr;
+  background-color: @body-bg;
+  img {
+     object-fit: contain;
+  }
 }
 
 @media(min-width: 480px) {


### PR DESCRIPTION
Resolves #3883   
Impact: **major**  
Type: **bugfix**

## Issue
The PDP image gallery does not handle images that are taller than they are wide appropriately. As a non-admin, the images can block off other elements of the page.

## Solution/Changes
- Don't allow to get the image container bigger than it's outer
container.
- Set the images width and height to 100%, but prevent distortion via
object-fit rule.
- the value is set to `contain` which reflects the spec from Ryan.
Alternatively the value `cover` would also be an option, which ensures
that the whole available image area is covered.

## Breaking changes
none


## Testing
1) As an admin, visit the PDP for the default product
2) Upload an image that is taller than it is wide by a significant margin (4:3 or greater)
3) The image should not overflow its parent container. It should not cover other content.
 