### PR TITLE
Bug Fix: Restore Global Hooks

### DIFF
--- a/imports/plugins/core/router/lib/__tests__/hooks.spec.js
+++ b/imports/plugins/core/router/lib/__tests__/hooks.spec.js
@@ -1,0 +1,38 @@
+import Hooks from "../hooks.js";
+
+describe("Hooks", () => {
+  let callback;
+
+  beforeEach(() => {
+    callback = jest.fn();
+  });
+
+  afterEach(() => {
+    // super gross reset
+    Hooks._hooks = {
+      onEnter: {},
+      onExit: {}
+    };
+  });
+
+  ["onEnter", "onExit"].forEach((hook) => {
+    describe(hook, () => {
+      test("callback is added to the Global set of hooks", () => {
+        Hooks[hook](callback);
+
+        Hooks.run(hook, "GLOBAL");
+
+        expect(callback).toHaveBeenCalled();
+      });
+
+      test("callback is added to the route-specific set of hooks", () => {
+        const route = "/reaction";
+
+        Hooks[hook](route, callback);
+        Hooks.run(hook, route);
+
+        expect(callback).toHaveBeenCalled();
+      })
+    });
+  });
+});

--- a/imports/plugins/core/router/lib/hooks.js
+++ b/imports/plugins/core/router/lib/hooks.js
@@ -35,24 +35,24 @@ const Hooks = {
     }
   },
 
-  onEnter(routeName, callback, ...args) {
+  onEnter(routeNameOrGlobalCallback, callback) {
     // global onEnter callback
-    if (arguments.length === 1 && typeof args[0] === "function") {
-      const cb = routeName;
+    if (arguments.length === 1 && typeof routeNameOrGlobalCallback === "function") {
+      const cb = routeNameOrGlobalCallback;
       return this._addHook("onEnter", "GLOBAL", cb);
     }
     // route-specific onEnter callback
-    return this._addHook("onEnter", routeName, callback);
+    return this._addHook("onEnter", routeNameOrGlobalCallback, callback);
   },
 
-  onExit(routeName, callback, ...args) {
+  onExit(routeNameOrGlobalCallback, callback) {
     // global onExit callback
-    if (arguments.length === 1 && typeof args[0] === "function") {
-      const cb = routeName;
+    if (arguments.length === 1 && typeof routeNameOrGlobalCallback === "function") {
+      const cb = routeNameOrGlobalCallback;
       return this._addHook("onExit", "GLOBAL", cb);
     }
     // route-specific onExit callback
-    return this._addHook("onExit", routeName, callback);
+    return this._addHook("onExit", routeNameOrGlobalCallback, callback);
   },
 
   get(type, name) {


### PR DESCRIPTION
_(Resolves n/a)_ 
Impact: minor
Type: bugfix

## Issue
A bug was introduced in v1.8.0 which prevents "GLOBAL" hooks from running

## Solution
Simple bug fix to resolve it.

## Testing
1. I noticed this when the body classname corresponding the the current route went missing. If you put a breakpoint in `/plugins/core/router/lib/hooks#onEnter` you will see that the callback, when Global, is set as the key in _hooks dictionary, with an undefined value (as opposed to key = "GLOBAL", value = the callback).

I wrote tests to ensure the behavior is correct (running them was a challenge!)

for reference:
https://github.com/reactioncommerce/reaction/commit/b1e7c262da0180fb766e489d506b049255a0cd7b#diff-7a0053142e3429cdf8d5779fd11692c9