### PR TITLE
Fix #3975: typo fix

### DIFF
--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.html
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.html
@@ -70,7 +70,7 @@
       <div>
         <form data-event-action="setupShopifyHooks">
           <div>
-            <input type="checkbox" name="orders:orders/create:exportToShopify" {{hookIsActive "orders:order/create:exportToShopify"}}/>
+            <input type="checkbox" name="orders:orders/create:exportToShopify" {{hookIsActive "orders:orders/create:exportToShopify"}}/>
             <label for="optionsPushOrdersOnCreate">
         <span data-i18n="admin.shopifyConnectSettings.optionsPushOrdersOnCreate">
           Push orders to Shopify on create


### PR DESCRIPTION
Resolves #3975  
Impact: **minor**  
Type: **bugfix**

## Issue
typo

## Solution
fixed the typo

## Testing
1. Login as admin
1. Go to Connectors dashboard panel
1. Click on "Push orders to Shopify on create"
1. Click on "Setup Hooks"
1. Close panel
1. Observe that checkbox is selected