### PR TITLE
(Fix) Add catalog migrations

### DIFF
--- a/imports/plugins/core/versions/server/migrations/24_publish_all_existing_visible_products.js
+++ b/imports/plugins/core/versions/server/migrations/24_publish_all_existing_visible_products.js
@@ -5,7 +5,10 @@ import { publishProductsToCatalog } from "/imports/plugins/core/catalog/server/m
 Migrations.add({
   version: 24,
   up() {
-    const visiblePublishedProducts = Products.find({ isVisible: true, isDeleted: false, type: "simple" }, { _id: 1 }).map((product) => product._id);
+    const visiblePublishedProducts = Products.find(
+      { isVisible: true, isDeleted: false, type: "simple" },
+      { _id: 1 }
+    ).map((product) => product._id);
     publishProductsToCatalog(visiblePublishedProducts);
   }
 });

--- a/imports/plugins/core/versions/server/migrations/24_publish_all_existing_visible_products.js
+++ b/imports/plugins/core/versions/server/migrations/24_publish_all_existing_visible_products.js
@@ -1,0 +1,11 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Products } from "/lib/collections";
+import { publishProductsToCatalog } from "/imports/plugins/core/catalog/server/methods/catalog";
+
+Migrations.add({
+  version: 24,
+  up() {
+    const visiblePublishedProducts = Products.find({ isVisible: true, isDeleted: false, type: "simple" }, { _id: 1 }).map((product) => product._id);
+    publishProductsToCatalog(visiblePublishedProducts);
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -21,3 +21,4 @@ import "./20_add_shop_to_marketplace";
 import "./21_clean_cart_shipment_method";
 import "./22_register_verify_account";
 import "./23_drop_tempstore_collections";
+import "./24_publish_all_existing_visible_products";


### PR DESCRIPTION
Resolves NA  
Impact: **minor**  
Type: **chore**

## Issue
Users who migrate from `1.8.2` to `1.9.0` would end up with an empty catalog

## Solution
Publish all existing visible products to the catalog


## Testing
1. Start the app on `master` (1.8.2)
1. Stop the app
1. checkout this branch
1. `rm -rf node_modules`
1. `meteor npm install`
1. Start the app
1. Observe that the migration runs and the default product is visible to anonymous users
