### PR TITLE
Fix for "ProductsContainerAdmin and ProductsContainerCustomer are not…

### DIFF
--- a/imports/plugins/included/product-variant/containers/productsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainer.js
@@ -1,17 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { compose } from "recompose";
-import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
+import { registerComponent, composeWithTracker, Components } from "@reactioncommerce/reaction-components";
 import { Meteor } from "meteor/meteor";
 import { Reaction } from "/client/api";
-import ProductsContainerAdmin from "./productsContainerAdmin.js";
-import ProductsContainerCustomer from "./productsContainerCustomer.js";
 
 const ProductsContainer = ({ isAdmin }) => {
   if (isAdmin) {
-    return <ProductsContainerAdmin />;
+    return <Components.ProductsAdmin />;
   }
-  return <ProductsContainerCustomer />;
+  return <Components.ProductsCustomer />;
 };
 
 ProductsContainer.propTypes = {


### PR DESCRIPTION
Resolves #4024   
Impact: **major**  
Type: **bughancement**

## Issue
It's not possible to replace ProductsContainerAdmin and ProductsContainerCustomer via replaceComponent function of the Component API.


## Solution
Don't refer directly to React components, but via component registry.

## Breaking changes
none 

## Testing

1. Put this snippet somewhere in code
```
const ProductsComponent = (props) => <div>customized products</div>;
replaceComponent("ProductsCustomer", ProductsComponent);
```
2. As a user, navigate to the product grid
3. Observe, that the custom component is rendered 
