### PR TITLE
(bugfix): Uploading Product Image

### DIFF
--- a/server/startup/collection-security.js
+++ b/server/startup/collection-security.js
@@ -47,7 +47,7 @@ export default function () {
       if (arg.role) {
         // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
         // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
-        const shopId = Reaction.getUserShopId(this.userId) || Reaction.getShopId();
+        const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
         return Roles.userIsInRole(userId, arg.role, shopId);
       }
@@ -62,7 +62,7 @@ export default function () {
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
       // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
-      const shopId = Reaction.getUserShopId(this.userId) || Reaction.getShopId();
+      const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc.shopId !== shopId;
     }
@@ -74,7 +74,7 @@ export default function () {
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
       // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
-      const shopId = Reaction.getUserShopId(this.userId) || Reaction.getShopId();
+      const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc._id !== shopId;
     }
@@ -85,7 +85,7 @@ export default function () {
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
       // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
-      const shopId = Reaction.getUserShopId(this.userId) || Reaction.getShopId();
+      const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc.metadata.shopId !== shopId;
     }


### PR DESCRIPTION
Resolves #4018   
Impact: **critical**  
Type: **bugfix**

## Issue
Admin users were unable to upload product images to products and an error would be thrown by the server and client.

The issue was coming from `collection-security` startup script, `this.userId` was being passed as a param to `Reaction.getUserShopId()` in several locations and was causing a Match error.
`... Error: Match error: Expected string, got undefined ...`

## Solution
Updated every instance of `Reaction.getUserShopId(this.userId)` to `Reaction.getUserShopId(userId)`

## Breaking changes
None

## Testing
**Uploading Product Images**
1. Sping up a fresh RC shop and log in as an Admin
2. Select a product from the product grid and upload an image to the product.
3. Product image should upload and display without any errors.

**Uploading Brand Asset**
1. As an Admin open the Shop panel from the Admin sidebar.
2. Upload an RC shop logo.
3. The image should upload and display without any errors.

## Notes
* Was able to complete acceptance testing.
* RC test passed & no eslint issues