### PR TITLE
CI: Run Jest and Meteor tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
           command: |
             npm run lint
 
-  test-integration:
+  test-app:
     <<: *defaults
     steps:
       - checkout
@@ -210,7 +210,7 @@ workflows:
     jobs:
       - build
       - dockerfile-lint
-      - test-integration:
+      - test-app:
           requires:
             - build
       - test-unit:
@@ -228,7 +228,7 @@ workflows:
       - deploy-docs:
           requires:
             - test-unit
-            - test-integration
+            - test-app
             - docker-build
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,19 @@ jobs:
           name: Run Integration Tests
           command: .circleci/tests.sh
 
+  test-unit:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-node-modules-{{ checksum "package.json" }}
+            - v1-node-modules-{{ .Branch }}
+            - v1-node-modules-master
+      - run:
+          name: Run Unit Tests
+          command: npm run test:unit
+
   dockerfile-lint:
     <<: *defaults
     docker:
@@ -200,6 +213,9 @@ workflows:
       - test-integration:
           requires:
             - build
+      - test-unit:
+          requires:
+            - build
       - eslint:
           requires:
             - build
@@ -211,6 +227,7 @@ workflows:
             - docker-build
       - deploy-docs:
           requires:
+            - test-unit
             - test-integration
             - docker-build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
           command: |
             npm run lint
 
-  test:
+  test-integration:
     <<: *defaults
     steps:
       - checkout
@@ -174,7 +174,10 @@ jobs:
           name: Install Reaction CLI
           command: sudo npm install -g reaction-cli
       - run:
-          name: Reaction Test
+          name: Load App Plugins
+          command: reaction plugins load
+      - run:
+          name: Run Integration Tests
           command: .circleci/tests.sh
 
   dockerfile-lint:
@@ -194,7 +197,7 @@ workflows:
     jobs:
       - build
       - dockerfile-lint
-      - test:
+      - test-integration:
           requires:
             - build
       - eslint:
@@ -208,7 +211,7 @@ workflows:
             - docker-build
       - deploy-docs:
           requires:
-            - test
+            - test-integration
             - docker-build
           filters:
             branches:

--- a/.circleci/tests.sh
+++ b/.circleci/tests.sh
@@ -9,12 +9,12 @@
 
 set +e
 
-reaction test
+npm run test:app
 
 if [ $? -eq 0 ]; then
   echo "Reaction tests have passed!"
 else
   echo "Reaction tests failed. Trying one more time..."
   set -e
-  reaction test
+  npm run test:app
 fi


### PR DESCRIPTION
Resolves #4028  
Type: **feature|test|chore**

## Changes
1. Add a jest test step that runs `npm run test:unit`.  (`test-unit` job)
2. Change the existing test step to run `reaction plugins load` followed by `npm run test:app`. (now called `test-app` job)

The two run in parallel as seen on this branch's build:

![screenshot 2018-03-19 18 51 57](https://user-images.githubusercontent.com/5229321/37612876-b9359bbe-2ba6-11e8-8447-48041b657388.jpg)

## When this PR is merged:
- [ ] Update the Pull Request [CI] requirements to reflect the separation of tests. Both `test-unit` and `test-app` should be required.
