### PR TITLE
Fix #4016: userId instead of this.userId

### DIFF
--- a/server/startup/collection-security.js
+++ b/server/startup/collection-security.js
@@ -47,7 +47,7 @@ export default function () {
       if (arg.role) {
         // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
         // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
-        const shopId = Reaction.getUserShopId(this.userId) || Reaction.getShopId();
+        const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
         return Roles.userIsInRole(userId, arg.role, shopId);
       }
@@ -62,7 +62,7 @@ export default function () {
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
       // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
-      const shopId = Reaction.getUserShopId(this.userId) || Reaction.getShopId();
+      const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc.shopId !== shopId;
     }
@@ -74,7 +74,7 @@ export default function () {
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
       // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
-      const shopId = Reaction.getUserShopId(this.userId) || Reaction.getShopId();
+      const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc._id !== shopId;
     }
@@ -85,7 +85,7 @@ export default function () {
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
       // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
-      const shopId = Reaction.getUserShopId(this.userId) || Reaction.getShopId();
+      const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc.metadata.shopId !== shopId;
     }


### PR DESCRIPTION
Resolves #4016  
Impact: **critical**  
Type: **bugfix**

## Issue
Typo, was using `this.userId`

## Solution
Used the `userId` from the function parameters.

## Breaking changes
None

## Testing
1. Load app
1. Go to Payment settings
1. Enable Stripe
1. Click on "Save Settings"
1. Observe **no** errors