### PR TITLE
Fix #4009: inventory badge component added

### DIFF
--- a/imports/plugins/core/ui/client/components/badge/index.js
+++ b/imports/plugins/core/ui/client/components/badge/index.js
@@ -1,1 +1,2 @@
 export { default as Badge } from "./badge";
+export { default as InventoryBadge } from "./inventoryBadge";

--- a/imports/plugins/core/ui/client/components/badge/inventoryBadge.js
+++ b/imports/plugins/core/ui/client/components/badge/inventoryBadge.js
@@ -14,16 +14,7 @@ class InventoryBadge extends Component {
 }
 
 InventoryBadge.propTypes = {
-  badgeSize: PropTypes.string,
-  className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  i18nKeyLabel: PropTypes.string,
-  i18nKeyTooltip: PropTypes.string,
-  indicator: PropTypes.bool,
-  label: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  status: PropTypes.string,
-  tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.node]),
-  tooltipAttachment: PropTypes.string,
-  variant: PropTypes.object
+  label: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 
 registerComponent("InventoryBadge", InventoryBadge);

--- a/imports/plugins/core/ui/client/components/badge/inventoryBadge.js
+++ b/imports/plugins/core/ui/client/components/badge/inventoryBadge.js
@@ -1,0 +1,31 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Components, registerComponent } from "@reactioncommerce/reaction-components";
+
+class InventoryBadge extends Component {
+  render() {
+    if (this.props.label) {
+      return (
+        <Components.Badge {...this.props} />
+      );
+    }
+    return null;
+  }
+}
+
+InventoryBadge.propTypes = {
+  badgeSize: PropTypes.string,
+  className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  i18nKeyLabel: PropTypes.string,
+  i18nKeyTooltip: PropTypes.string,
+  indicator: PropTypes.bool,
+  label: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  status: PropTypes.string,
+  tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.node]),
+  tooltipAttachment: PropTypes.string,
+  variant: PropTypes.object
+};
+
+registerComponent("InventoryBadge", InventoryBadge);
+
+export default InventoryBadge;

--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -72,6 +72,17 @@ class TextField extends Component {
     return undefined;
   }
 
+  getEventValue(event) {
+    if (this.props.type === "number") {
+      try {
+        return Number(event.target.value);
+      } catch (err) {
+        return event.target.value;
+      }
+    }
+    return event.target.value;
+  }
+
   /**
    * onValueChange
    * @summary set the state when the value of the input is changed
@@ -80,7 +91,7 @@ class TextField extends Component {
    */
   onChange = (event) => {
     if (this.props.onChange) {
-      this.props.onChange(event, event.target.value, this.props.name);
+      this.props.onChange(event, this.getEventValue(event), this.props.name);
     }
   }
 
@@ -98,7 +109,7 @@ class TextField extends Component {
       });
     }
     if (this.props.onBlur) {
-      this.props.onBlur(event, event.target.value, this.props.name);
+      this.props.onBlur(event, this.getEventValue(event), this.props.name);
     }
   }
 
@@ -117,7 +128,7 @@ class TextField extends Component {
       });
     }
     if (this.props.onFocus) {
-      this.props.onFocus(event, event.target.value, this.props.name);
+      this.props.onFocus(event, this.getEventValue(event), this.props.name);
     }
   }
 

--- a/imports/plugins/core/ui/client/containers/index.js
+++ b/imports/plugins/core/ui/client/containers/index.js
@@ -2,6 +2,7 @@ export { default as EditContainer } from "./edit";
 export { default as AlertContainer } from "./alerts";
 export { default as AppContainer } from "./appContainer";
 export { default as ReactionAvatarContainer } from "./avatar";
+export { default as InventoryBadgeContainer } from "./inventoryBadge";
 export { default as SortableItem } from "./sortableItem";
 export { default as MediaGalleryContainer } from "./mediaGallery";
 export { default as TagListContainer } from "./tagListContainer";

--- a/imports/plugins/core/ui/client/containers/inventoryBadge.js
+++ b/imports/plugins/core/ui/client/containers/inventoryBadge.js
@@ -1,0 +1,32 @@
+import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
+import { InventoryBadge } from "../components/badge";
+
+const composer = (props, onData) => {
+  const { variant, soldOut } = props;
+  const { inventoryManagement, inventoryPolicy, lowInventoryWarningThreshold, inventoryQuantity } = variant;
+  let label = null;
+  let i18nKeyLabel = null;
+  let status = null;
+  // TODO: update this to use Catalog API.
+  if (inventoryManagement && !inventoryPolicy && Number(inventoryQuantity) === 0) {
+    status = "info";
+    label = "Backorder";
+    i18nKeyLabel = "productDetail.backOrder";
+  } else if (soldOut) {
+    status = "danger";
+    label = "Sold Out!";
+    i18nKeyLabel = "productDetail.soldOut";
+  } else if (inventoryManagement && inventoryPolicy) {
+    if (Number(lowInventoryWarningThreshold) >= Number(inventoryQuantity)) {
+      status = "warning";
+      label = "Limited Supply";
+      i18nKeyLabel = "productDetail.limitedSupply";
+    }
+  }
+
+  onData(null, { ...props, label, i18nKeyLabel, status });
+};
+
+registerComponent("InventoryBadge", InventoryBadge, composeWithTracker(composer));
+
+export default composeWithTracker(composer)(InventoryBadge);

--- a/imports/plugins/core/ui/client/containers/inventoryBadge.js
+++ b/imports/plugins/core/ui/client/containers/inventoryBadge.js
@@ -8,7 +8,7 @@ const composer = (props, onData) => {
   let i18nKeyLabel = null;
   let status = null;
   // TODO: update this to use Catalog API.
-  if (inventoryManagement && !inventoryPolicy && Number(inventoryQuantity) === 0) {
+  if (inventoryManagement && !inventoryPolicy && inventoryQuantity === 0) {
     status = "info";
     label = "Backorder";
     i18nKeyLabel = "productDetail.backOrder";
@@ -16,8 +16,8 @@ const composer = (props, onData) => {
     status = "danger";
     label = "Sold Out!";
     i18nKeyLabel = "productDetail.soldOut";
-  } else if (inventoryManagement && inventoryPolicy) {
-    if (Number(lowInventoryWarningThreshold) >= Number(inventoryQuantity)) {
+  } else if (inventoryManagement && !inventoryPolicy) {
+    if (lowInventoryWarningThreshold >= inventoryQuantity) {
       status = "warning";
       label = "Limited Supply";
       i18nKeyLabel = "productDetail.limitedSupply";

--- a/imports/plugins/core/ui/client/containers/inventoryBadge.js
+++ b/imports/plugins/core/ui/client/containers/inventoryBadge.js
@@ -1,9 +1,11 @@
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { InventoryBadge } from "../components/badge";
+import { ReactionProduct } from "/lib/api";
 
 const composer = (props, onData) => {
   const { variant, soldOut } = props;
-  const { inventoryManagement, inventoryPolicy, lowInventoryWarningThreshold, inventoryQuantity } = variant;
+  const { inventoryManagement, inventoryPolicy, lowInventoryWarningThreshold } = variant;
+  const inventoryQuantity = ReactionProduct.getVariantQuantity(variant);
   let label = null;
   let i18nKeyLabel = null;
   let status = null;
@@ -16,7 +18,7 @@ const composer = (props, onData) => {
     status = "danger";
     label = "Sold Out!";
     i18nKeyLabel = "productDetail.soldOut";
-  } else if (inventoryManagement && !inventoryPolicy) {
+  } else if (inventoryManagement) {
     if (lowInventoryWarningThreshold >= inventoryQuantity) {
       status = "warning";
       label = "Limited Supply";

--- a/imports/plugins/included/product-detail-simple/client/components/variant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variant.js
@@ -43,49 +43,6 @@ class Variant extends Component {
     return this.props.displayPrice || this.props.variant.price;
   }
 
-  renderInventoryStatus() {
-    const {
-      inventoryManagement,
-      inventoryPolicy
-    } = this.props.variant;
-
-    // If variant is sold out, show Sold Out badge
-    if (inventoryManagement && this.props.soldOut) {
-      if (inventoryPolicy) {
-        return (
-          <span className="variant-qty-sold-out badge badge-danger variant-badge-label">
-            <Components.Translation defaultValue="Sold Out!" i18nKey="productDetail.soldOut" />
-          </span>
-        );
-      }
-
-      return (
-        <span className="variant-qty-sold-out badge badge-info variant-badge-label">
-          <Components.Translation defaultValue="Backorder" i18nKey="productDetail.backOrder" />
-        </span>
-      );
-    }
-
-    // If Warning Threshold is met, show Limited Supply Badge
-    if (inventoryManagement && this.props.variant.lowInventoryWarningThreshold >= this.props.variant.inventoryTotal) {
-      if (inventoryPolicy) {
-        return (
-          <span className="variant-qty-sold-out badge badge-warning variant-badge-label">
-            <Components.Translation defaultValue="Limited Supply" i18nKey="productDetail.limitedSupply" />
-          </span>
-        );
-      }
-
-      return (
-        <span className="variant-qty-sold-out badge badge-info variant-badge-label">
-          <Components.Translation defaultValue="Backorder" i18nKey="productDetail.backOrder" />
-        </span>
-      );
-    }
-
-    return null;
-  }
-
   renderDeletionStatus() {
     if (this.props.variant.isDeleted) {
       return (
@@ -188,7 +145,7 @@ class Variant extends Component {
 
           <div className="alerts">
             {this.renderDeletionStatus()}
-            {this.renderInventoryStatus()}
+            <Components.InventoryBadge className="variant-qty-sold-out variant-badge-label" {...this.props} />
             {this.renderValidationButton()}
             {this.props.editButton}
           </div>

--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -305,6 +305,7 @@ class VariantForm extends Component {
             i18nKeyPlaceholder="0"
             placeholder="0"
             label="Quantity"
+            type="number"
             name="inventoryQuantity"
             ref="inventoryQuantityInput"
             value={this.props.onUpdateQuantityField(this.variant)}
@@ -324,6 +325,7 @@ class VariantForm extends Component {
           i18nKeyPlaceholder="0"
           placeholder="0"
           label="Quantity"
+          type="number"
           name="inventoryQuantity"
           ref="inventoryQuantityInput"
           value={this.variant.inventoryQuantity}
@@ -551,6 +553,7 @@ class VariantForm extends Component {
                 i18nKeyLabel="productVariant.lowInventoryWarningThreshold"
                 i18nKeyPlaceholder="0"
                 placeholder="0"
+                type="number"
                 label="Warn At"
                 name="lowInventoryWarningThreshold"
                 ref="lowInventoryWarningThresholdInput"


### PR DESCRIPTION
Resolves #4009  
Impact: **major**  
Type: **bugfix**

## Issue
The logic to decide which badge to display was not correct.

## Solution
A new badge component is made that uses the `Product` to decide the badge to idspa

## Testing
1. Create a product
1. Set the Quantity to 5
1. Set the warn at number to 5
1. Ensure that Allow backorder is enabled
1. `Limited Supply` label is shown.
1. Change Quantity to 0
1. `Backorder` label is displayed.
1. Disable Allow backorder.
1. `Sold out` label should be displayed.
1. Set quantity to 10.
1. No label is displayed.
