### PR TITLE
Reduce Risk of Test False Positives

### DIFF
--- a/imports/plugins/core/catalog/server/methods/catalog.app-test.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.app-test.js
@@ -63,7 +63,7 @@ describe("core product methods", function () {
       expect(insertProductSpy).to.not.have.been.called;
     });
 
-    it("should clone variant by admin", function (done) {
+    it("should clone variant by admin", function () {
       sandbox.stub(Roles, "userIsInRole", () => true);
       const product = addProduct();
       let variants = Products.find({ ancestors: [product._id] }).fetch();
@@ -71,7 +71,6 @@ describe("core product methods", function () {
       Meteor.call("products/cloneVariant", product._id, variants[0]._id);
       variants = Products.find({ ancestors: [product._id] }).count();
       expect(variants).to.equal(2);
-      return done();
     });
 
     it("number of `child variants` between source and cloned `variants` should be equal", function () {
@@ -106,7 +105,7 @@ describe("core product methods", function () {
       expect(updateProductSpy).to.not.have.been.called;
     });
 
-    it("should create top level variant", function (done) {
+    it("should create top level variant", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
       let variants = Products.find({ ancestors: [product._id] }).fetch();
@@ -114,10 +113,9 @@ describe("core product methods", function () {
       Meteor.call("products/createVariant", product._id);
       variants = Products.find({ ancestors: [product._id] }).fetch();
       expect(variants.length).to.equal(2);
-      return done();
     });
 
-    it("should create option variant", function (done) {
+    it("should create option variant", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       let options;
       const product = addProduct();
@@ -132,10 +130,9 @@ describe("core product methods", function () {
         ancestors: { $in: [variant._id] }
       }).fetch();
       expect(options.length).to.equal(3);
-      return done();
     });
 
-    it("should create variant with predefined object", function (done) {
+    it("should create variant with predefined object", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
       const newVariant = {
@@ -150,7 +147,6 @@ describe("core product methods", function () {
       const createdVariant = variants.filter((v) => v._id !== firstVariantId);
       expect(variants.length).to.equal(2);
       expect(createdVariant[0].title).to.equal("newVariant");
-      return done();
     });
   });
 
@@ -166,7 +162,7 @@ describe("core product methods", function () {
       expect(updateProductSpy).to.not.have.been.called;
     });
 
-    it("should not update individual variant by admin passing in full object", function (done) {
+    it("should not update individual variant by admin passing in full object", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
       let variant = Products.findOne({ ancestors: [product._id] });
@@ -176,11 +172,9 @@ describe("core product methods", function () {
       variant = Products.findOne({ ancestors: [product._id] });
       expect(variant.price).to.not.equal(7);
       expect(variant.title).to.not.equal("Updated Title");
-
-      return done();
     });
 
-    it("should update individual variant revision by admin passing in full object", function (done) {
+    it("should update individual variant revision by admin passing in full object", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
       const variant = Products.find({ ancestors: [product._id] }).fetch()[0];
@@ -190,8 +184,6 @@ describe("core product methods", function () {
       const variantRevision = Revisions.find({ documentId: variant._id }).fetch()[0];
       expect(variantRevision.documentData.price).to.equal(7);
       expect(variantRevision.documentData.title).to.equal("Updated Title");
-
-      return done();
     });
 
     it("should not update individual variant by admin passing in partial object", function () {
@@ -299,7 +291,7 @@ describe("core product methods", function () {
       expect(insertProductSpy).to.not.have.been.called;
     });
 
-    it("should clone product", function (done) {
+    it("should clone product", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       sandbox.stub(Meteor.server.method_handlers, "inventory/register", function (...args) {
         check(args, [Match.Any]);
@@ -318,11 +310,9 @@ describe("core product methods", function () {
       expect(productCloned.handle).to.equal(`${product.handle}-copy`);
       expect(productCloned.pageTitle).to.equal(product.pageTitle);
       expect(productCloned.description).to.equal(product.description);
-
-      return done();
     });
 
-    it("product should be cloned with all variants and child variants with equal data, but not the same `_id`s", function (done) {
+    it("product should be cloned with all variants and child variants with equal data, but not the same `_id`s", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       sandbox.stub(Meteor.server.method_handlers, "inventory/register", function (...args) {
         check(args, [Match.Any]);
@@ -344,10 +334,9 @@ describe("core product methods", function () {
       for (let i = 0; i < variants.length; i += 1) {
         expect(cloneVariants.some((clonedVariant) => clonedVariant.title === variants[i].title)).to.be.ok;
       }
-      return done();
     });
 
-    it("product group cloning should create the same number of new products", function (done) {
+    it("product group cloning should create the same number of new products", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       sandbox.stub(Meteor.server.method_handlers, "inventory/register", function (...args) {
         check(args, [Match.Any]);
@@ -362,11 +351,9 @@ describe("core product methods", function () {
         type: "simple"
       }).fetch();
       expect(clones.length).to.equal(2);
-
-      return done();
     });
 
-    it("product group cloning should create the same number of cloned variants", function (done) {
+    it("product group cloning should create the same number of cloned variants", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       sandbox.stub(Meteor.server.method_handlers, "inventory/register", function (...args) {
         check(args, [Match.Any]);
@@ -388,8 +375,6 @@ describe("core product methods", function () {
         ancestors: { $in: [clones[0]._id, clones[1]._id] }
       }).count();
       expect(clonedVariants).to.equal(variants);
-
-      return done();
     });
   });
 
@@ -824,26 +809,33 @@ describe("core product methods", function () {
   });
 
   describe("updateProductPosition", function () {
+    let product;
+    let tag;
+
     beforeEach(function () {
-      return Tags.remove({});
+      Tags.remove({});
+
+      product = addProduct();
+      tag = Factory.create("tag");
     });
 
     it("should throw 403 error by non admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => false);
-      const product = addProduct();
-      const tag = Factory.create("tag");
       const updateProductSpy = sandbox.spy(Products, "update");
+
       expect(() => Meteor.call(
         "products/updateProductPosition",
         product._id, {}, tag._id
       )).to.throw(Meteor.Error, /Access Denied/);
+
       expect(updateProductSpy).to.not.have.been.called;
     });
 
-    it("should not update product position by admin", function (done) {
+    // this test appears to be the inverse of above. where the test above
+    // rejects non-admins, this one does not. I _think_ this check is covered
+    // by the tests below
+    it("should not update product position by admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
-      const product = addProduct();
-      const tag = Factory.create("tag");
       const position = {
         position: 0,
         weight: 0,
@@ -855,14 +847,10 @@ describe("core product methods", function () {
       )).to.not.throw(Meteor.Error, /Access Denied/);
       const updatedProduct = Products.findOne(product._id);
       expect(updatedProduct.positions).to.be.undefined;
-
-      return done();
     });
 
-    it("should update product revision position by admin", function (done) {
+    it("should update product revision position by admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
-      const product = addProduct();
-      const tag = Factory.create("tag");
       const position = {
         position: 0,
         weight: 0,
@@ -874,14 +862,10 @@ describe("core product methods", function () {
       )).to.not.throw(Meteor.Error, /Access Denied/);
       const updatedProductRevision = Revisions.findOne({ documentId: product._id });
       expect(updatedProductRevision.documentData.positions[tag._id].position).to.equal(0);
-
-      return done();
     });
 
-    it("should publish product position by admin", function (done) {
+    it("should publish product position by admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
-      const product = addProduct();
-      const tag = Factory.create("tag");
       const position = {
         position: 0,
         weight: 0,
@@ -894,8 +878,6 @@ describe("core product methods", function () {
       Meteor.call("revisions/publish", product._id);
       const updatedProduct = Products.findOne(product._id);
       expect(updatedProduct.positions[tag._id].position).to.equal(0);
-
-      return done();
     });
   });
 
@@ -989,7 +971,7 @@ describe("core product methods", function () {
       expect(updateProductSpy).to.not.have.been.called;
     });
 
-    it("should not add meta fields by admin", function (done) {
+    it("should not add meta fields by admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       let product = addProduct();
       Meteor.call("products/updateMetaFields", product._id, {
@@ -998,11 +980,9 @@ describe("core product methods", function () {
       });
       product = Products.findOne(product._id);
       expect(product.metafields.length).to.be.equal(0);
-
-      return done();
     });
 
-    it("should add meta fields to product revision by admin", function (done) {
+    it("should add meta fields to product revision by admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       const product = addProduct();
       Meteor.call("products/updateMetaFields", product._id, {
@@ -1012,11 +992,9 @@ describe("core product methods", function () {
       const productRevision = Revisions.findOne({ documentId: product._id });
       expect(productRevision.documentData.metafields[0].key).to.equal("Material");
       expect(productRevision.documentData.metafields[0].value).to.equal("Spandex");
-
-      return done();
     });
 
-    it("should publish add meta fields by admin", function (done) {
+    it("should publish add meta fields by admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       let product = addProduct();
       Meteor.call("products/updateMetaFields", product._id, {
@@ -1027,8 +1005,6 @@ describe("core product methods", function () {
       product = Products.findOne(product._id);
       expect(product.metafields[0].key).to.equal("Material");
       expect(product.metafields[0].value).to.equal("Spandex");
-
-      return done();
     });
   });
 
@@ -1107,7 +1083,10 @@ describe("core product methods", function () {
         selector: { type: "simple" },
         validate: false
       });
-      expect(() => Meteor.call("products/publishProduct", product._id)).to.not.throw(Meteor.Error, /Access Denied/);
+
+      expect(() => Meteor.call("products/publishProduct", product._id))
+        .to.throw(Meteor.Error, /Bad Request/);
+
       product = Products.findOne(product._id);
       expect(product.isVisible).to.equal(isVisible);
     });

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -1467,7 +1467,7 @@ Meteor.methods({
     }).fetch();
     let variantValidator = true;
 
-    if (typeof product === "object" && product.title.length > 1) {
+    if (typeof product === "object" && product.title && product.title.length > 1) {
       if (variants.length > 0) {
         variants.forEach((variant) => {
           // if this is a top variant with children, we avoid it to check price

--- a/imports/plugins/core/job-collection/lib/jobCollection.app-test.js
+++ b/imports/plugins/core/job-collection/lib/jobCollection.app-test.js
@@ -41,6 +41,8 @@ describe("JobCollection", function () {
   let testColl;
 
   before(function () {
+    this.timeout(10000);
+
     clientTestColl = new JobCollection("ClientTest", { idGeneration: "MONGO" });
     serverTestColl = new JobCollection("ServerTest", { idGeneration: "STRING" });
 

--- a/imports/plugins/included/payments-example/server/methods/example-payment-methods.app-test.js
+++ b/imports/plugins/included/payments-example/server/methods/example-payment-methods.app-test.js
@@ -146,7 +146,7 @@ describe("Submit payment", function () {
     // Notice how you need to wrap this call in another function
     expect(function () {
       Meteor.call("exampleSubmit", "authorize", badCardData, paymentData);
-    }).to.throw;
+    }).to.throw();
   });
 });
 
@@ -182,7 +182,7 @@ describe("Capture payment", function () {
     });
     expect(function () {
       Meteor.call("example/payment/capture", "abc123");
-    }).to.throw;
+    }).to.throw();
   });
 });
 

--- a/server/imports/fixtures/accounts.js
+++ b/server/imports/fixtures/accounts.js
@@ -78,6 +78,8 @@ export function getAddress(options = {}) {
  * @property {Date} updatedAt - `new Date()`
  */
 export function createAccountFactory() {
+  // there are many places in code which require that an Account's _id be equal
+  // to the User's _id (and therefore equal to userId)
   Factory.define("account", Accounts, {
     shopId: getShop()._id,
     userId: getUser()._id,

--- a/server/methods/accounts/accounts.app-test.js
+++ b/server/methods/accounts/accounts.app-test.js
@@ -5,23 +5,21 @@ import Random from "@reactioncommerce/random";
 import { Meteor } from "meteor/meteor";
 import { Factory } from "meteor/dburles:factory";
 import { check, Match } from "meteor/check";
-import { Accounts as MeteorAccount } from "meteor/accounts-base";
+import { Accounts as MeteorAccounts } from "meteor/accounts-base";
 import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";
-import { Accounts, Packages, Orders, Products, Shops, Cart } from "/lib/collections";
-import { Reaction } from "/server/api";
+import { SSR } from "meteor/meteorhacks:ssr";
+import { Accounts, Groups, Packages, Orders, Products, Shops, Cart } from "/lib/collections";
+import { Logger, Reaction } from "/server/api";
 import { getShop, getAddress } from "/server/imports/fixtures/shops";
 import Fixtures from "/server/imports/fixtures";
 
 Fixtures();
 
-before(function () {
-  this.timeout(10000);
-});
-
 describe("Account Meteor method ", function () {
   let shopId;
-  const fakeUser = Factory.create("account");
+  let fakeUser;
+  let fakeAccount;
   const originals = {};
   let sandbox;
 
@@ -46,6 +44,16 @@ describe("Account Meteor method ", function () {
   beforeEach(function () {
     shopId = getShop()._id;
     sandbox = sinon.sandbox.create();
+
+    fakeUser = Factory.create("user");
+    const userId = fakeUser._id;
+    // set the _id... some code requires that Account#_id === Account#userId
+    fakeAccount = Factory.create("account", { _id: userId, userId, shopId });
+    sandbox.stub(Meteor, "userId", () => userId);
+    sandbox.stub(Meteor, "user", () => fakeUser);
+    sandbox.stub(Reaction, "getShopId", () => shopId);
+
+    Object.keys(originals).forEach((method) => spyOnMethod(method, userId));
   });
 
   afterEach(function () {
@@ -55,82 +63,77 @@ describe("Account Meteor method ", function () {
   function spyOnMethod(method, id) {
     return sandbox.stub(Meteor.server.method_handlers, `cart/${method}`, function (...args) {
       check(args, [Match.Any]); // to prevent audit_arguments from complaining
-      this.userId = id;
+      this.userId = id; // having to do this makes me think that we should be using Meteor.userId() instead of this.userId in our Meteor methods
       return originals[method].apply(this, args);
     });
   }
 
   describe("addressBookAdd", function () {
     beforeEach(function () {
-      Cart.remove({});
-      Accounts.remove({});
+      const sessionId = Random.id(); // Required for creating a cart
+      // editing your address book also udpates your cart, so be sure there
+      // is a cart present
+      Meteor.call("cart/createCart", fakeAccount.userId, sessionId);
     });
 
-    it("should allow user to add new addresses", function (done) {
-      let account = Factory.create("account");
-      sandbox.stub(Meteor, "userId", function () {
-        return account.userId;
-      });
+    it("should allow user to add new addresses", function () {
       const address = getAddress();
       // we already have one address by default
-      expect(account.profile.addressBook.length).to.equal(1);
+      expect(fakeAccount.profile.addressBook.length).to.equal(1);
+
       Meteor.call("accounts/addressBookAdd", address);
-      account = Accounts.findOne(account._id);
+
+      const account = Accounts.findOne({ _id: fakeAccount._id });
       expect(account.profile.addressBook.length).to.equal(2);
-      return done();
     });
 
-    it("should allow Admin to add new addresses to other users", function (done) {
+    it("should allow Admin to add new addresses to other users", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
-      let account = Factory.create("account");
       const address = getAddress();
-      expect(account.profile.addressBook.length).to.equal(1);
-      Meteor.call("accounts/addressBookAdd", address, account.userId);
+      expect(fakeAccount.profile.addressBook.length).to.equal(1);
 
-      account = Accounts.findOne(account._id);
+      Meteor.call("accounts/addressBookAdd", address, fakeAccount.userId);
+
+      const account = Accounts.findOne({ _id: fakeAccount._id });
       expect(account.profile.addressBook.length).to.equal(2);
-      return done();
     });
 
-    it("should insert exactly the same address as expected", function (done) {
-      let account = Factory.create("account");
-      sandbox.stub(Meteor, "userId", function () {
-        return account.userId;
-      });
+    it("should insert exactly the same address as expected", function () {
       const address = getAddress();
+
       Meteor.call("accounts/addressBookAdd", address);
-      account = Accounts.findOne(account._id);
+
+      const account = Accounts.findOne({ _id: fakeAccount._id });
       expect(account.profile.addressBook.length).to.equal(2);
       const newAddress = account.profile.addressBook[
         account.profile.addressBook.length - 1];
       delete newAddress._id;
       delete newAddress.failedValidation;
       expect(_.isEqual(address, newAddress)).to.be.true;
-      return done();
     });
 
-    it("should throw error if wrong arguments were passed", function (done) {
+    it("should throw error if wrong arguments were passed", function () {
       const accountSpy = sandbox.spy(Accounts, "update");
 
       expect(function () {
         return Meteor.call("accounts/addressBookAdd", 123456);
-      }).to.throw;
-
-      expect(function () {
-        return Meteor.call("accounts/addressBookAdd", {});
-      }).to.throw;
+      }).to.throw(Error, /must be an object/);
 
       expect(function () {
         return Meteor.call("accounts/addressBookAdd", null);
-      }).to.throw;
+      }).to.throw(Error, /must be an object/);
 
       expect(function () {
         return Meteor.call("accounts/addressBookAdd");
-      }).to.throw;
+      }).to.throw(Error, /must be an object/);
 
       expect(function () {
         return Meteor.call("accounts/addressBookAdd", "asdad", 123);
-      }).to.throw;
+      }).to.throw(Error, /must be an object/);
+
+      expect(function () {
+        return Meteor.call("accounts/addressBookAdd", {});
+      }).to.throw(Error, /Full name is required/);
 
       // https://github.com/aldeed/meteor-simple-schema/issues/522
       expect(function () {
@@ -138,17 +141,12 @@ describe("Account Meteor method ", function () {
           "accounts/addressBookAdd",
           () => { expect(true).to.be.true; }
         );
-      }).to.not.throw;
+      }).to.not.throw();
 
       expect(accountSpy).to.not.have.been.called;
-
-      return done();
     });
 
-    it("should not let non-Admin add address to another user", function (done) {
-      sandbox.stub(Meteor, "userId", function () {
-        return fakeUser._id;
-      });
+    it("should not let non-Admin add address to another user", function () {
       const account2 = Factory.create("account");
       const updateAccountSpy = sandbox.spy(Accounts, "update");
       const upsertAccountSpy = sandbox.spy(Accounts, "upsert");
@@ -157,29 +155,15 @@ describe("Account Meteor method ", function () {
           "accounts/addressBookAdd", getAddress(),
           account2._id
         );
-      }).to.throw();
+      }).to.throw(Meteor.Error, /Access denied/);
       expect(updateAccountSpy).to.not.have.been.called;
       expect(upsertAccountSpy).to.not.have.been.called;
-
-      return done();
     });
 
     it(
       "should disable isShipping/BillingDefault properties inside sibling" +
       " address if we enable them while adding",
-      function (done) {
-        const account = Factory.create("account");
-        sandbox.stub(Meteor, "userId", function () {
-          return account.userId;
-        });
-        sandbox.stub(Reaction, "getShopId", function () {
-          return shopId;
-        });
-        const sessionId = Random.id(); // Required for creating a cart
-        spyOnMethod("setShipmentAddress", account.userId);
-        spyOnMethod("setPaymentAddress", account.userId);
-
-        Meteor.call("cart/createCart", account.userId, sessionId);
+      function () {
         // cart was created without any default addresses, we need to add one
         const address = Object.assign({}, getAddress(), {
           isShippingDefault: true,
@@ -196,18 +180,14 @@ describe("Account Meteor method ", function () {
         Meteor.call("accounts/addressBookAdd", newAddress);
 
         // now we need to get address ids from cart and compare their
-        const cart = Cart.findOne({ userId: account.userId });
+        const cart = Cart.findOne({ userId: fakeAccount.userId });
         expect(cart.shipping[0].address._id).to.equal(newAddress._id);
         expect(cart.billing[0].address._id).to.equal(newAddress._id);
-
-        return done();
       }
     );
   });
 
   describe("addressBookUpdate", function () {
-    // Required for creating a cart
-    const sessionId = Random.id();
     let removeInventoryStub;
 
     before(function () {
@@ -221,86 +201,68 @@ describe("Account Meteor method ", function () {
       removeInventoryStub.restore();
     });
 
-    beforeEach(() => {
-      Cart.remove({});
-      Accounts.remove({});
+    beforeEach(function () {
+      const sessionId = Random.id(); // Required for creating a cart
+      // editing your address book also udpates your cart, so be sure there
+      // is a cart present
+      Meteor.call("cart/createCart", fakeAccount.userId, sessionId);
     });
 
-    it("should allow user to edit addresses", function (done) {
-      const account = Factory.create("account");
-      sandbox.stub(Meteor, "userId", function () {
-        return account.userId;
-      });
-      sandbox.stub(Reaction, "getShopId", function () {
-        return shopId;
-      });
-      sandbox.stub(Reaction, "hasAdminAccess", function () {
-        return true;
-      });
-      spyOnMethod("setShipmentAddress", account.userId);
-      spyOnMethod("setPaymentAddress", account.userId);
+    it("should allow user to edit addresses", function () {
+      sandbox.stub(Reaction, "hasAdminAccess", () => true);
       const updateAccountSpy = sandbox.spy(Accounts, "update");
 
-      Meteor.call("cart/createCart", account.userId, sessionId);
-
       // we put new faker address over current address to test all fields
       // at once, but keep current address._id
-      const address = Object.assign({}, account.profile.addressBook[0], getAddress());
+      const address = Object.assign({}, fakeAccount.profile.addressBook[0], getAddress());
       Meteor.call("accounts/addressBookUpdate", address);
       expect(updateAccountSpy).to.have.been.called;
-
-      return done();
     });
 
-    it("should allow Admin to edit other user address", function (done) {
+    it("should allow Admin to edit other user address", function () {
       sandbox.stub(Reaction, "hasPermission", () => true);
       sandbox.stub(Reaction, "hasAdminAccess", () => true);
-      let account = Factory.create("account");
-      spyOnMethod("setShipmentAddress", account.userId);
-      spyOnMethod("setPaymentAddress", account.userId);
-
-      sandbox.stub(Reaction, "getShopId", () => shopId);
-      Meteor.call("cart/createCart", account.userId, sessionId);
 
       // we put new faker address over current address to test all fields
       // at once, but keep current address._id
-      const address = Object.assign({}, account.profile.addressBook[0], getAddress());
-      Meteor.call("accounts/addressBookUpdate", address, account.userId);
+      const address = Object.assign({}, fakeAccount.profile.addressBook[0], getAddress());
+      Meteor.call("accounts/addressBookUpdate", address, fakeAccount.userId);
 
       // comparing two addresses to equality
-      account = Accounts.findOne(account._id);
+      const account = Accounts.findOne({ _id: fakeAccount._id });
       const newAddress = account.profile.addressBook[0];
       expect(_.isEqual(address, newAddress)).to.be.true;
-
-      return done();
     });
 
     it("should update fields to exactly the same what we need", function () {
-      let account = Factory.create("account");
-      sandbox.stub(Meteor, "userId", () => account.userId);
-      sandbox.stub(Reaction, "getShopId", () => shopId);
-      spyOnMethod("setShipmentAddress", account.userId);
-      spyOnMethod("setPaymentAddress", account.userId);
-      Meteor.call("cart/createCart", account.userId, sessionId);
-
       // we put new faker address over current address to test all fields
       // at once, but keep current address._id
-      const address = Object.assign({}, account.profile.addressBook[0], getAddress());
+      const address = Object.assign({}, fakeAccount.profile.addressBook[0], getAddress());
       Meteor.call("accounts/addressBookUpdate", address);
 
       // comparing two addresses to equality
-      account = Accounts.findOne(account._id);
+      const account = Accounts.findOne({ _id: fakeAccount._id });
       const newAddress = account.profile.addressBook[0];
       expect(_.isEqual(address, newAddress)).to.be.true;
     });
 
     it("should throw error if wrong arguments were passed", function () {
       const updateAccountSpy = sandbox.spy(Accounts, "update");
-      expect(() => Meteor.call("accounts/addressBookUpdate", 123456)).to.throw;
-      expect(() => Meteor.call("accounts/addressBookUpdate", {})).to.throw;
-      expect(() => Meteor.call("accounts/addressBookUpdate", null)).to.throw;
-      expect(() => Meteor.call("accounts/addressBookUpdate")).to.throw;
-      expect(() => Meteor.call("accounts/addressBookUpdate", "asdad", 123)).to.throw;
+
+      expect(() => Meteor.call("accounts/addressBookUpdate", 123456))
+        .to.throw(Error, /must be an object/);
+
+      expect(() => Meteor.call("accounts/addressBookUpdate", null))
+        .to.throw(Error, /must be an object/);
+
+      expect(() => Meteor.call("accounts/addressBookUpdate"))
+        .to.throw(Error, /must be an object/);
+
+      expect(() => Meteor.call("accounts/addressBookUpdate", "asdad", 123))
+        .to.throw(Error, /must be an object/);
+
+      expect(() => Meteor.call("accounts/addressBookUpdate", {}))
+        .to.throw(Error, /Full name is required/);
 
       // https://github.com/aldeed/meteor-simple-schema/issues/522
       expect(function () {
@@ -308,46 +270,43 @@ describe("Account Meteor method ", function () {
           "accounts/addressBookUpdate",
           () => { expect(true).to.be.true; }
         );
-      }).to.not.throw;
+      }).to.not.throw();
       expect(updateAccountSpy).to.not.have.been.called;
     });
 
     it("should not let non-Admin to edit address of another user", function () {
-      const account = Factory.create("account");
       const account2 = Factory.create("account");
-      sandbox.stub(Meteor, "userId", () => account.userId);
       const accountUpdateSpy = sandbox.spy(Accounts, "update");
-      expect(() => Meteor.call("accounts/addressBookUpdate", getAddress(), account2._id)).to.throw;
+
+      expect(() => Meteor.call("accounts/addressBookUpdate", getAddress(), account2._id))
+        .to.throw(Meteor.Error, /Access denied/);
+
       expect(accountUpdateSpy).to.not.have.been.called;
     });
 
     it("enabling isShipping/BillingDefault properties should add this address to cart", function () {
-      const account = Factory.create("account");
-      spyOnMethod("setShipmentAddress", account.userId);
-      spyOnMethod("setPaymentAddress", account.userId);
-      sandbox.stub(Meteor, "userId", function () {
-        return account.userId;
-      });
-      sandbox.stub(Reaction, "getShopId", () => shopId);
-      Meteor.call("cart/createCart", account.userId, sessionId);
       // first we need to disable defaults, because we already have some
       // random defaults in account, but cart is clean. This is test only
       // situation.
-      let address = Object.assign({}, account.profile.addressBook[0], {
+      let address = Object.assign({}, fakeAccount.profile.addressBook[0], {
         isShippingDefault: false,
         isBillingDefault: false
       });
       Meteor.call("accounts/addressBookUpdate", address);
-      let cart = Cart.findOne({ userId: account.userId });
-      expect(cart.billing).to.be.defined;
-      expect(cart.shipping).to.be.undefined;
 
-      address = Object.assign({}, account.profile.addressBook[0], {
+      let cart = Cart.findOne({ userId: fakeAccount.userId });
+      // "cart/unsetAddresses" unsets cart.type.address, not cart.type,
+      // so we ensure that either cart.type (if the address was never
+      // created) or cart.type.address (if it had been unset) are now undefined
+      expect(cart.billing && cart.billing.address).to.be.undefined;
+      expect(cart.shipping && cart.shipping.address).to.be.undefined;
+
+      address = Object.assign({}, fakeAccount.profile.addressBook[0], {
         isShippingDefault: true,
         isBillingDefault: true
       });
       Meteor.call("accounts/addressBookUpdate", address);
-      cart = Cart.findOne({ userId: account.userId });
+      cart = Cart.findOne({ userId: fakeAccount.userId });
       expect(cart).to.not.be.undefined;
 
       expect(cart.billing[0].address._id).to.equal(address._id);
@@ -357,17 +316,9 @@ describe("Account Meteor method ", function () {
     it(
       "should disable isShipping/BillingDefault properties inside sibling" +
       " address if we enable them while editing",
-      function (done) {
-        let account = Factory.create("account");
-        spyOnMethod("setShipmentAddress", account.userId);
-        spyOnMethod("setPaymentAddress", account.userId);
-        sandbox.stub(Meteor, "userId", function () {
-          return account.userId;
-        });
-        sandbox.stub(Reaction, "getShopId", () => shopId);
-        Meteor.call("cart/createCart", account.userId, sessionId);
+      function () {
         // cart was created without any default addresses, we need to add one
-        let address = Object.assign({}, account.profile.addressBook[0], {
+        let address = Object.assign({}, fakeAccount.profile.addressBook[0], {
           isShippingDefault: true,
           isBillingDefault: true
         });
@@ -388,26 +339,19 @@ describe("Account Meteor method ", function () {
 
         Meteor.call("accounts/addressBookUpdate", address, null, "isBillingDefault");
         Meteor.call("accounts/addressBookUpdate", address, null, "isShippingDefault");
-        account = Accounts.findOne(account._id);
+        const account = Accounts.findOne({ _id: fakeAccount._id });
 
         expect(account.profile.addressBook[0].isBillingDefault).to.be.false;
         expect(account.profile.addressBook[0].isShippingDefault).to.be.false;
-        return done();
       }
     );
 
     it("should update cart default addresses via `type` argument", function () {
-      const account = Factory.create("account");
-      const { userId } = account;
-      spyOnMethod("setShipmentAddress", account.userId);
-      spyOnMethod("setPaymentAddress", account.userId);
-      sandbox.stub(Reaction, "getShopId", () => shopId);
-      sandbox.stub(Meteor, "userId", () => userId);
-      Meteor.call("cart/createCart", userId, sessionId);
+      const { userId } = fakeAccount;
       // clean account
       Meteor.call(
         "accounts/addressBookRemove",
-        account.profile.addressBook[0]._id
+        fakeAccount.profile.addressBook[0]._id
       );
       // preparation
       let address = Object.assign({}, getAddress(), {
@@ -430,33 +374,53 @@ describe("Account Meteor method ", function () {
   });
 
   describe("addressBookRemove", function () {
+    beforeEach(function () {
+      const sessionId = Random.id(); // Required for creating a cart
+      // editing your address book also udpates your cart, so be sure there
+      // is a cart present
+      Meteor.call("cart/createCart", fakeAccount.userId, sessionId);
+    });
+
     it("should allow user to remove address", function () {
-      let account = Factory.create("account");
-      const address = account.profile.addressBook[0];
-      sandbox.stub(Meteor, "userId", () => account.userId);
-      expect(account.profile.addressBook.length).to.equal(1);
+      const address = fakeAccount.profile.addressBook[0];
+      expect(fakeAccount.profile.addressBook.length).to.equal(1);
+
       Meteor.call("accounts/addressBookRemove", address._id);
-      account = Accounts.findOne(account._id);
+
+      const account = Accounts.findOne({ _id: fakeAccount._id });
       expect(account.profile.addressBook.length).to.equal(0);
     });
 
+    // TODO: I don't believe this test does what it says it does
+    // I am pretty sure the user acting is the same user who is being acted upon
     it("should allow Admin to remove other user address", function () {
-      let account = Factory.create("account");
-      const address = account.profile.addressBook[0];
+      const address = fakeAccount.profile.addressBook[0];
       sandbox.stub(Reaction, "hasPermission", () => true);
-      expect(account.profile.addressBook.length).to.equal(1);
-      Meteor.call("accounts/addressBookRemove", address._id, account.userId);
-      account = Accounts.findOne(account._id);
+      expect(fakeAccount.profile.addressBook.length).to.equal(1);
+
+      Meteor.call("accounts/addressBookRemove", address._id, fakeAccount.userId);
+
+      const account = Accounts.findOne({ _id: fakeAccount._id });
       expect(account.profile.addressBook.length).to.equal(0);
     });
 
     it("should throw error if wrong arguments were passed", function () {
       const updateAccountSpy = sandbox.spy(Accounts, "update");
-      expect(() => Meteor.call("accounts/addressBookRemove", 123456)).to.throw;
-      expect(() => Meteor.call("accounts/addressBookRemove", {})).to.throw;
-      expect(() => Meteor.call("accounts/addressBookRemove", null)).to.throw;
-      expect(() => Meteor.call("accounts/addressBookRemove")).to.throw;
-      expect(() => Meteor.call("accounts/addressBookRemove", "asdad", 123)).to.throw;
+
+      expect(() => Meteor.call("accounts/addressBookRemove", 123456))
+        .to.throw(Match.Error, /Expected string, got number/);
+
+      expect(() => Meteor.call("accounts/addressBookRemove", {}))
+        .to.throw(Match.Error, /Expected string, got object/);
+
+      expect(() => Meteor.call("accounts/addressBookRemove", null))
+        .to.throw(Match.Error, /Expected string, got null/);
+
+      expect(() => Meteor.call("accounts/addressBookRemove"))
+        .to.throw(Match.Error, /Expected string, got undefined/);
+
+      expect(() => Meteor.call("accounts/addressBookRemove", "asdad", 123))
+        .to.throw(Match.Error, /Match.Optional/);
 
       // https://github.com/aldeed/meteor-simple-schema/issues/522
       expect(function () {
@@ -464,136 +428,220 @@ describe("Account Meteor method ", function () {
           "accounts/addressBookRemove",
           () => { expect(true).to.be.true; }
         );
-      }).to.not.throw;
+      }).to.not.throw();
       expect(updateAccountSpy).to.not.have.been.called;
     });
 
     it("should not let non-Admin to remove address of another user", function () {
-      const account = Factory.create("account");
       const account2 = Factory.create("account");
       const address2 = account2.profile.addressBook[0];
-      sandbox.stub(Meteor, "userId", function () {
-        return account.userId;
-      });
       const accountUpdateSpy = sandbox.spy(Accounts, "update");
       expect(() => Meteor.call(
         "accounts/addressBookRemove",
         address2._id, account2.userId
-      )).to.throw;
+      )).to.throw(Meteor.Error, /Access denied/);
       expect(accountUpdateSpy).to.not.have.been.called;
     });
 
     it("should call `cart/unsetAddresses` Method", function () {
-      const account = Factory.create("account");
-      const address = account.profile.addressBook[0];
-      sandbox.stub(Meteor, "userId", () => account.userId);
+      const address = fakeAccount.profile.addressBook[0];
       const cartUnsetSpy = sandbox.spy(Meteor.server.method_handlers, "cart/unsetAddresses");
 
       Meteor.call("accounts/addressBookRemove", address._id);
       expect(cartUnsetSpy).to.have.been.called;
       expect(cartUnsetSpy.args[0][0]).to.equal(address._id);
-      expect(cartUnsetSpy.args[0][1]).to.equal(account.userId);
+      expect(cartUnsetSpy.args[0][1]).to.equal(fakeAccount.userId);
     });
 
     it("should throw an error if address does not exist to remove", function () {
-      sandbox.stub(Meteor, "userId", () => fakeUser.userId);
-      expect(() => Meteor.call("accounts/addressBookRemove", "asdasdasd")).to.throw(Meteor.Error, /Unable to remove address from account/);
+      expect(() => Meteor.call("accounts/addressBookRemove", "asdasdasd"))
+        .to.throw(Meteor.Error, /Unable to remove address from account/);
     });
   });
 
   describe("accounts/inviteShopMember", function () {
-    it("should not let non-Owners invite a user to the shop", function () {
-      sandbox.stub(Reaction, "hasPermission", () => false);
-      const createUserSpy = sandbox.spy(MeteorAccount, "createUser");
-      // create user
-      expect(() =>
-        Meteor.call("accounts/inviteShopMember", {
-          shopId,
-          groupId: Random.id(),
-          email: fakeUser.emails[0].address,
-          name: fakeUser.profile.addressBook[0].fullName
-        })).to.throw(Meteor.Error, /Access denied/);
-      // expect that createUser shouldnt have run
+    let createUserSpy;
+    let sendEmailSpy;
+    let groupId;
+    let group;
+
+    function callDescribed(accountAttributes = {}) {
+      const options = Object.assign({
+        shopId,
+        groupId,
+        email: fakeUser.emails[0].address,
+        name: fakeAccount.profile.addressBook[0].fullName
+      }, accountAttributes);
+
+      return Meteor.call("accounts/inviteShopMember", options);
+    }
+
+    function stubPermissioning(settings) {
+      const { hasPermission, canInviteToGroup } = settings;
+
+      sandbox.stub(Reaction, "hasPermission", () => hasPermission);
+      sandbox
+        .stub(Reaction, "canInviteToGroup", () => canInviteToGroup)
+        .withArgs({ group, user: fakeUser });
+    }
+
+    beforeEach(function () {
+      createUserSpy = sandbox.spy(MeteorAccounts, "createUser");
+      sendEmailSpy = sandbox.stub(Reaction.Email, "send"); // stub instead of spy so we don't actually try to send
+
+      groupId = Random.id();
+      group = Factory.create("group");
+      sandbox.stub(Groups, "findOne", () => group).withArgs({ _id: groupId });
+    });
+
+    it("requires reaction-accounts permission", function () {
+      stubPermissioning({ hasPermission: false });
+      sandbox.stub(Logger, "error") // since we expect this, let's keep the output clean
+        .withArgs(sinon.match(/reaction-accounts permissions/));
+
+      expect(callDescribed).to.throw(Meteor.Error, /Access denied/);
       expect(createUserSpy).to.not.have.been.called;
     });
 
-    it("should let a Owner invite a user to the shop", function (done) {
-      this.timeout(20000);
-      this.retries(3);
-      sandbox.stub(Reaction, "hasPermission", () => true);
-      // TODO: Need to udpate this test to properly check the account created
-      // there's currently an error with Media branding asset when trying to do that
-      expect(() =>
-        Meteor.call("accounts/inviteShopMember", {
-          shopId,
-          groupId: Random.id(),
-          email: fakeUser.emails[0].address,
-          name: fakeUser.profile.addressBook[0].fullName
-        })).to.not.throw(Meteor.Error, /Access denied/);
-      return done();
+    it("ensures the user has invite permission for this group/shop", function () {
+      stubPermissioning({ hasPermission: true, canInviteToGroup: false });
+
+      expect(callDescribed).to.throw(Meteor.Error, /Cannot invite/);
+      expect(createUserSpy).to.not.have.been.called;
+    });
+
+    it("prevents inviting the owner of a shop (only a member)", function () {
+      group.slug = "owner";
+      stubPermissioning({ hasPermission: true, canInviteToGroup: true });
+
+      expect(callDescribed).to.throw(Meteor.Error, /invite owner/);
+      expect(createUserSpy).to.not.have.been.called;
+    });
+
+    it("invites existing users", function () {
+      const subjectSpy = sandbox.spy(SSR, "render");
+
+      stubPermissioning({ hasPermission: true, canInviteToGroup: true });
+      sandbox
+        .stub(Meteor.users, "findOne", () => fakeUser)
+        .withArgs({ "emails.address": fakeUser.emails[0].address });
+
+      callDescribed();
+
+      expect(sendEmailSpy).to.have.been.called;
+      expect(createUserSpy).to.not.have.been.called;
+      expect(subjectSpy)
+        .to.have.been.calledWith(sinon.match(/inviteShopMember/));
+    });
+
+    it("creates and invites new users", function () {
+      const email = `${Random.id()}@example.com`;
+      const subjectSpy = sandbox.spy(SSR, "render");
+
+      stubPermissioning({ hasPermission: true, canInviteToGroup: true });
+
+      callDescribed({ email });
+
+      expect(sendEmailSpy).to.have.been.called;
+      expect(createUserSpy).to.have.been.called;
+      expect(subjectSpy)
+        .to.have.been.calledWith(sinon.match(/inviteNewShopMember/));
     });
   });
 
   describe("accounts/inviteShopOwner", function () {
+    let createUserSpy;
+    let sendEmailSpy;
+    let groupId;
+    let group;
+
+    function callDescribed(accountAttributes = {}, shopData) {
+      const options = Object.assign({
+        email: fakeUser.emails[0].address,
+        name: fakeAccount.profile.addressBook[0].fullName
+      }, accountAttributes);
+
+      return Meteor.call("accounts/inviteShopOwner", options, shopData);
+    }
+
+    function stubPermissioning(settings) {
+      const { hasPermission } = settings;
+
+      sandbox
+        .stub(Reaction, "hasPermission", () => hasPermission)
+        .withArgs("admin", fakeAccount.userId, sinon.match.string);
+
+      // the following stub is just to speed things up. the tests were timing
+      // out in the shop creation step. this seems to resolve that.
+      sandbox.stub(Reaction, "insertPackagesForShop");
+    }
+
     beforeEach(function () {
-      sandbox.stub(Meteor, "user", function () {
-        return fakeUser;
-      });
+      // fakeAccount = Factory.create("account");
+      createUserSpy = sandbox.spy(MeteorAccounts, "createUser");
+      sendEmailSpy = sandbox.stub(Reaction.Email, "send");
+
+      // resolves issues with the onCreateUser event handler
+      groupId = Random.id();
+      group = Factory.create("group");
+      sandbox
+        .stub(Groups, "findOne", () => group)
+        .withArgs({ _id: groupId, shopId: sinon.match.string });
+
+      // since we expect a note to be written, let's ignore it to keep the output clean
+      sandbox.stub(Logger, "info").withArgs(sinon.match(/Created shop/));
     });
 
-    it("should ensure only admin can invite as shop owner", function () {
-      sandbox.stub(Reaction, "hasPermission", () => false);
-      const createUserSpy = sandbox.spy(MeteorAccount, "createUser");
-      expect(() =>
-        Meteor.call("accounts/inviteShopOwner", {
-          email: fakeUser.emails[0].address,
-          name: fakeUser.profile.addressBook[0].fullName
-        })).to.throw(Meteor.Error, /Access denied/);
+    it("requires admin permission", function () {
+      stubPermissioning({ hasPermission: false });
+
+      expect(callDescribed).to.throw(Meteor.Error, /Access denied/);
       expect(createUserSpy).to.not.have.been.called;
     });
 
-    it("should confirm if email already exists before creating", function (done) {
-      sandbox.stub(Reaction, "hasPermission", () => true);
-      expect(() =>
-        Meteor.call("accounts/inviteShopOwner", {
-          email: fakeUser.emails[0].address,
-          name: fakeUser.profile.addressBook[0].fullName
-        })).to.not.throw(Meteor.Error, /Access denied/);
+    it("invites existing users", function () {
+      const subjectSpy = sandbox.spy(SSR, "render");
 
-      return done();
+      stubPermissioning({ hasPermission: true });
+      sandbox
+        .stub(Meteor.users, "findOne", () => fakeUser)
+        .withArgs({ "emails.address": fakeUser.emails[0].address });
+
+      callDescribed();
+
+      expect(sendEmailSpy).to.have.been.called;
+      expect(createUserSpy).to.not.have.been.called;
+      expect(subjectSpy)
+        .to.have.been.calledWith(sinon.match(/inviteShopOwner/));
     });
 
-    it("should let admin invite a user to manage a shop", function (done) {
-      sandbox.stub(Reaction, "hasPermission", () => true);
-      expect(() =>
-        Meteor.call("accounts/inviteShopOwner", {
-          email: "custom@email.co",
-          name: "custom name"
-        })).to.not.throw(Meteor.Error, /Access denied/);
+    it("creates and invites new users", function () {
+      const email = `${Random.id()}@example.com`;
+      const subjectSpy = sandbox.spy(SSR, "render");
 
-      return done();
+      stubPermissioning({ hasPermission: true });
+
+      callDescribed({ email });
+
+      expect(sendEmailSpy).to.have.been.called;
+      expect(createUserSpy).to.have.been.called;
+      expect(subjectSpy)
+        .to.have.been.calledWith(sinon.match(/inviteShopOwner/));
     });
 
     it("creates a shop with the data provided", function () {
       const primaryShop = getShop();
       const name = Random.id();
       const shopData = { name };
+      const email = `${Random.id()}@example.com`;
 
-      sandbox.stub(Reaction, "hasPermission", () => true);
+      stubPermissioning({ hasPermission: true });
       sandbox.stub(Reaction, "getPrimaryShop", () => primaryShop);
 
-      const newUser = Factory.create("user");
-      // create Account to go with new user
-      const newAccount = Factory.create("account", { _id: newUser.id, shopId: primaryShop.id });
-      // to resolve an issue in the onCreateUser hook, stub user creation
-      sandbox.stub(MeteorAccount, "createUser", () => newUser._id);
-      sandbox.stub(Accounts, "findOne", () => newAccount)
-        .withArgs({ id: newUser._id });
+      sandbox.stub(Accounts, "findOne", () => fakeAccount)
+        .withArgs({ id: fakeUser._id });
 
-      Meteor.call("accounts/inviteShopOwner", {
-        email: "custom1@email.co",
-        name: "custom name"
-      }, shopData);
+      callDescribed({ email }, shopData);
 
       const newShopCount = Shops.find({ name }).count();
       expect(newShopCount).to.equal(1);

--- a/server/methods/core/cart-create.app-test.js
+++ b/server/methods/core/cart-create.app-test.js
@@ -281,30 +281,30 @@ describe("Add/Create cart methods", function () {
 
       expect(function () {
         return Meteor.call("cart/unsetAddresses", 123456);
-      }).to.throw;
+      }).to.throw();
 
       expect(function () {
         return Meteor.call("cart/unsetAddresses", {});
-      }).to.throw;
+      }).to.throw();
 
       expect(function () {
         return Meteor.call("cart/unsetAddresses", null);
-      }).to.throw;
+      }).to.throw();
 
       expect(function () {
         return Meteor.call("cart/unsetAddresses");
-      }).to.throw;
+      }).to.throw();
 
       expect(function () {
         return Meteor.call("cart/unsetAddresses", "asdad", 123);
-      }).to.throw;
+      }).to.throw();
 
       // https://github.com/aldeed/meteor-simple-schema/issues/522
       expect(function () {
         return Meteor.call("accounts/addressBookRemove", () => {
           expect(true).to.be.true;
         });
-      }).to.not.throw;
+      }).to.not.throw();
 
       expect(accountUpdateStub).to.not.have.been.called;
       accountUpdateStub.restore();

--- a/server/methods/core/orders.app-test.js
+++ b/server/methods/core/orders.app-test.js
@@ -6,7 +6,7 @@ import { Factory } from "meteor/dburles:factory";
 import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";
 import Fixtures from "/server/imports/fixtures";
-import { Reaction } from "/server/api";
+import { Reaction, Logger } from "/server/api";
 import { getShop } from "/server/imports/fixtures/shops";
 import { Orders, Notifications, Products, Shops } from "/lib/collections";
 import { Media } from "/imports/plugins/core/files/server";
@@ -551,6 +551,8 @@ describe("orders test", function () {
           saved: false
         };
       });
+
+      sandbox.stub(Logger, "fatal"); // since we expect this, let's keep the output clean
       Meteor.call("orders/capturePayments", order._id, () => {
         const orderPaymentMethod = billingObjectMethod(Orders.findOne({ _id: order._id })).paymentMethod;
         expect(orderPaymentMethod.mode).to.equal("capture");


### PR DESCRIPTION
_(Resolves n/a)_
Impact: **minor**  
Type: **test**

## Issue
I noticed a few things in the test suite that could easily result in false positives.
1) ensure that the `.to.not.throw` expectation runs by adding the `()` (I imagine that `throw` being a reserved word is a problem here... but not sure).
2) remove the parameters from `.to.not.throw`, which is even highlighted in the chai documentation:
> However, it’s dangerous to negate .throw when providing any arguments. The problem is that it creates uncertain expectations by asserting that the target either doesn’t throw an error, or that it throws an error but of a different type than the given type, or that it throws an error of the given type but with a message that doesn’t include the given string. It’s often best to identify the exact output that’s expected, and then write an assertion that only accepts that exact output.

this broke a few tests, so the second commit resolves those failures

## Testing
1. I think it is a bug in the testing framework, but the following test does not fail:
``` JavaScript
it("handles .to.not.throw", function () {
  expect(() => { throw "error"; }).to.not.throw;
});
```
whereas this does fail.
``` JavaScript
it("handles .to.not.throw()", function () {
  expect(() => { throw "error"; }).to.not.throw();
});
```

I wound up re-writing the test groups for `inviteShopMember` and `inviteShopOwner` which were failing after these changes.