### PR TITLE
Remove collection hooks package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -54,7 +54,6 @@ aldeed:schema-index@3.0.0
 aldeed:template-extension
 bozhao:accounts-instagram
 dispatch:run-as-user
-matb33:collection-hooks
 meteorhacks:ssr
 meteorhacks:subs-manager
 ongoworks:security

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -66,7 +66,6 @@ less@2.7.12
 livedata@1.0.18
 localstorage@1.2.0
 logging@1.1.19
-matb33:collection-hooks@0.8.4
 mdg:validated-method@1.1.0
 meteor@1.8.2
 meteor-base@1.3.0

--- a/imports/plugins/core/catalog/server/methods/catalog.app-test.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.app-test.js
@@ -42,7 +42,7 @@ describe("Catalog", function () {
     };
 
     beforeEach(function (done) {
-      Collections.Products.direct.remove({});
+      Collections.Products.remove({});
       Collections.Catalog.remove({});
 
       // a product with price range A, and not visible

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -25,7 +25,7 @@ export const methods = {
       throw new Meteor.Error("access-denied", "Access Denied");
     }
 
-    return Discounts.direct.remove({ _id: discountId });
+    return Discounts.remove({ _id: discountId });
   },
 
   /**
@@ -43,7 +43,7 @@ export const methods = {
     check(discountRate, Number);
     check(discounts, Match.Optional(Array));
 
-    return Cart.direct.update(cartId, {
+    return Cart.update(cartId, {
       $set: {
         discounts,
         discount: discountRate

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -6,8 +6,7 @@ import { Hooks, Logger } from "/server/api";
 function handleImageRevision(revision) {
   let result = 0;
   if (revision.changeType === "insert") {
-    // TODO: after we've removed the hook, we shouldn't need updates
-    result = MediaRecords.direct.update({
+    result = MediaRecords.update({
       _id: revision.documentId
     }, {
       $set: {
@@ -15,8 +14,7 @@ function handleImageRevision(revision) {
       }
     });
   } else if (revision.changeType === "remove") {
-    // TODO: after we've removed the hook, we shouldn't need updates
-    result = MediaRecords.direct.update({
+    result = MediaRecords.update({
       _id: revision.documentId
     }, {
       $set: {
@@ -24,8 +22,7 @@ function handleImageRevision(revision) {
       }
     });
   } else if (revision.changeType === "update") {
-    // TODO: after we've removed the hook, we shouldn't need updates
-    result = MediaRecords.direct.update({
+    result = MediaRecords.update({
       _id: revision.documentId
     }, {
       $set: {

--- a/imports/plugins/core/taxes/server/methods/methods.js
+++ b/imports/plugins/core/taxes/server/methods/methods.js
@@ -82,7 +82,7 @@ export const methods = {
     check(taxRate, Number);
     check(taxes, Match.Optional(Array));
 
-    return Cart.direct.update(cartId, {
+    return Cart.update(cartId, {
       $set: {
         taxes,
         tax: taxRate
@@ -114,7 +114,7 @@ export const methods = {
 
     const { cartTaxData, cartTaxRate, itemsWithTax, taxRatesByShop } = options;
 
-    return Cart.direct.update(cartId, {
+    return Cart.update(cartId, {
       $set: {
         taxes: cartTaxData,
         tax: cartTaxRate,

--- a/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
+++ b/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
@@ -36,7 +36,7 @@ describe("Inventory Hooks", function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    Products.direct.remove({});
+    Products.remove({});
     const { product, variant } = addProductSingleVariant();
     cart = createCart(product._id, variant._id);
     resetInventory();

--- a/server/api/core/templates.app-test.js
+++ b/server/api/core/templates.app-test.js
@@ -22,7 +22,7 @@ function sampleReactComponent() {
 
 describe("Templates:", function () {
   beforeEach(function () {
-    Templates.direct.remove();
+    Templates.remove();
     resetRegisteredTemplates();
   });
 

--- a/server/imports/fixtures/fixtures.app-test.js
+++ b/server/imports/fixtures/fixtures.app-test.js
@@ -18,12 +18,12 @@ describe("Fixtures:", function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    Collections.Orders.direct.remove();
+    Collections.Orders.remove();
   });
 
   afterEach(function () {
     sandbox.restore();
-    Collections.Orders.direct.remove();
+    Collections.Orders.remove();
   });
 
   it("Account fixture should create an account", function () {

--- a/server/methods/accounts/accounts.app-test.js
+++ b/server/methods/accounts/accounts.app-test.js
@@ -33,12 +33,12 @@ describe("Account Meteor method ", function () {
   });
 
   after(() => {
-    Packages.direct.remove({});
-    Cart.direct.remove({});
+    Packages.remove({});
+    Cart.remove({});
     Accounts.remove({});
-    Orders.direct.remove({});
-    Products.direct.remove({});
-    Shops.direct.remove({});
+    Orders.remove({});
+    Products.remove({});
+    Shops.remove({});
     if (sandbox) {
       sandbox.restore();
     }

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -30,15 +30,6 @@ describe("core product methods", function () {
   let insertStub;
 
   before(function () {
-    // We are mocking inventory hooks, because we don't need them here, but
-    // if you want to do a real stress test, you could try to comment out
-    // this three lines. This is needed only for ./reaction test. In one
-    // package test this is ignoring.
-    if (Array.isArray(Products._hookAspects.remove.after) && Products._hookAspects.remove.after.length) {
-      updateStub = sinon.stub(Products._hookAspects.update.after[0], "aspect");
-      removeStub = sinon.stub(Products._hookAspects.remove.after[0], "aspect");
-      insertStub = sinon.stub(Products._hookAspects.insert.after[0], "aspect");
-    }
     Products.remove({});
   });
 

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -39,7 +39,7 @@ describe("core product methods", function () {
       removeStub = sinon.stub(Products._hookAspects.remove.after[0], "aspect");
       insertStub = sinon.stub(Products._hookAspects.insert.after[0], "aspect");
     }
-    Products.direct.remove({});
+    Products.remove({});
   });
 
   after(function () {
@@ -298,7 +298,7 @@ describe("core product methods", function () {
     // cloning hierarchy, so the only way to track that will be cleaning
     // collection on before each test.
     beforeEach(function () {
-      return Products.direct.remove({});
+      return Products.remove({});
     });
 
     it("should throw 403 error by non admin", function () {

--- a/server/methods/core/cart-remove.app-test.js
+++ b/server/methods/core/cart-remove.app-test.js
@@ -52,9 +52,9 @@ describe("cart methods", function () {
       const cartItemId = cartFromCollection.items[0]._id;
       assert.equal(cartFromCollection.items.length, 2);
       Meteor.call("cart/removeFromCart", cartItemId);
-      // Expect Cart.update to be called twice, because cart/removeFromCart
-      // triggers a Hooks.Events which calls Cart.update.
-      assert.equal(updateSpy.callCount, 2, "update should be called one time");
+      // The cart/removeFromCart method will trigger the hook
+      // afterCartUpdateCalculateDiscount 4 times.
+      assert.equal(updateSpy.callCount, 4, "update should be called four times");
       Meteor._sleepForMs(1000);
       const updatedCart = Collections.Cart.findOne(cart._id);
       assert.equal(updatedCart.items.length, 1, "there should be one item left in cart");

--- a/server/publications/collections/cart-publications.app-test.js
+++ b/server/publications/collections/cart-publications.app-test.js
@@ -36,11 +36,11 @@ describe("Cart Publication", function () {
     };
 
     beforeEach(() => {
-      Collections.Cart.direct.remove({});
+      Collections.Cart.remove({});
     });
 
     afterEach(() => {
-      Collections.Cart.direct.remove({});
+      Collections.Cart.remove({});
     });
 
     it("should return a cart cursor", function () {

--- a/server/publications/collections/orders-publications.app-test.js
+++ b/server/publications/collections/orders-publications.app-test.js
@@ -22,12 +22,12 @@ describe("Order Publication", function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    Collections.Orders.direct.remove();
+    Collections.Orders.remove();
   });
 
   afterEach(function () {
     sandbox.restore();
-    Collections.Orders.direct.remove();
+    Collections.Orders.remove();
   });
 
   describe("Orders", () => {

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -42,7 +42,7 @@ describe("Publication", function () {
     };
 
     beforeEach(function () {
-      Collections.Products.direct.remove({});
+      Collections.Products.remove({});
 
       // a product with price range A, and not visible
       Collections.Products.insert({


### PR DESCRIPTION
Resolves #3547 
Impact: Major
Type: Refactor

## Issue
Remove `matb33:collection-hooks` package

## Solution
Remove meteor package and refactor all `.direct` calls and all hook mocks in server tests.

## Breaking changes
All `before.*` and `after.*` collection hooks have been removed from reaction.

## Testing

1. Create a new product
2. Upload product images
3. on client (not logged in) place order for the newly created product
4. Fulfill order
5. Verify no console errors occurred. 