### PR TITLE
Fix for "Browser console shows error when replacing Tag schema"

### DIFF
--- a/lib/api/prop-types.js
+++ b/lib/api/prop-types.js
@@ -1,15 +1,14 @@
 import _ from "lodash";
 import { check } from "meteor/check";
-import * as Schemas from "/lib/collections/schemas";
+import { getSchemas } from "@reactioncommerce/reaction-collections";
+
+const Schemas = getSchemas();
 
 /**
  * @file **PropTypes** - React Component PropTypes methods for validating Tags
  *
  * @namespace PropTypes
  */
-
-const TagSchema = Schemas.Tag.newContext();
-
 export const PropTypes = {};
 
 /**
@@ -24,7 +23,7 @@ export const PropTypes = {};
 PropTypes.Tag = (props, propName) => {
   check(props, Object);
   check(propName, String);
-
+  const TagSchema = Schemas.Tag.newContext();
   if (_.isEmpty(props[propName]) === false) {
     if (TagSchema.validate(props[propName]) === false) {
       return new Error("Tag must be of type: Schemas.Tag");
@@ -44,7 +43,7 @@ PropTypes.Tag = (props, propName) => {
 PropTypes.arrayOfTags = (props, propName) => {
   check(props, Object);
   check(propName, String);
-
+  const TagSchema = Schemas.Tag.newContext();
   if (_.isEmpty(props[propName]) === false && _.isArray(props[propName])) {
     const valid = _.every(props[propName], (tag) => TagSchema.validate(tag));
 


### PR DESCRIPTION
Resolves #4046  
Impact: **minor**  
Type: **bugfix**

## Issue
It's not possible to replace the Tag schema without browser console errors shown up in console.


## Solution / Changes
- Instead of including the Schema directly, the code refers to the Tags schema through the schema registry via getSchemas()
- Don't create validation context instance once during application bootstrap. Instead the context instantiation is defered, until the schema is validated. This ensures that the latest, registered schema is used for validation.

## Breaking changes
None


## Testing
1. Put this code snippet somewhere in a plugin:
```
import { Tag } from "/lib/collections/schemas";
const TagSchema = Tag.clone().extend({
  newProp: {
    type: String,
    optional: true
  }
});
registerSchema("Tag", TagSchema);
```
2. modify at least one `Tag` document in the mongo db to have a property called `newProp`
3. Navigate to landing page with console open. There should be no error message.
