### PR TITLE
(fix) Wait for slugify to show up before returning slug

### DIFF
--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -199,8 +199,8 @@ export function getCurrentTag() {
  */
 export function getSlug(slugString) {
   let slug;
-  Promise.resolve(lazyLoadSlugify());
-  if (slugString && slugify) {
+  Promise.await(lazyLoadSlugify());
+  if (slugString) {
     slug = slugify(slugString.toLowerCase());
   } else {
     slug = "";


### PR DESCRIPTION
Resolves #4011 
Impact: **major**  
Type: **bugfix**

## Issue
We weren't waiting for slugify to be resolve and if it wasn't resolved we just returned an empty string, which completely crashes the app

## Solution
`await` rather than `resolve`. I also removed the check for `slugify` that just bailed and returned an empty string because I can't see why we would want that.


## Testing
1. Fully load the app with built in data and `devtools` loaded
1. Choose "Reset Data"
1. Stop the app
1. Restart it
1. Observe that the data loads properly and the app doesn't crash
