### PR TITLE
Fix for "TaxCloud service not calculating tax"

### DIFF
--- a/imports/plugins/included/taxes-taxcloud/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-taxcloud/server/hooks/hooks.js
@@ -90,11 +90,15 @@ MethodHooks.after("taxes/calculate", (options) => {
           };
 
           try {
-            let response = HTTP.post(url, request);
+            const response = HTTP.post(url, request);
             let taxRate = 0;
             // ResponseType 3 is a successful call.
             if (response.data.ResponseType !== 3) {
-              throw new Error("Error calling taxcloud API", JSON.stringify(response.data));
+              let errMsg = "Unable to access service. Check credentials.";
+              if (response && response.data.Messages[0].Message) {
+                errMsg = response.data.Messages[0].Message;
+              }
+              throw new Error("Error calling taxcloud API", errMsg);
             }
 
             let totalTax = 0;
@@ -111,11 +115,7 @@ MethodHooks.after("taxes/calculate", (options) => {
             const taxes = []; // only populated for Avalara
             Meteor.call("taxes/setRate", cartId, taxRate, taxes);
           } catch (error) {
-            let errMsg = "Unable to access service. Check credentials.";
-            if (response && response.data.Messages[0].Message) {
-              errMsg = response.data.Messages[0].Message;
-            }
-            Logger.warn("Error fetching tax rate from TaxCloud:", errMsg);
+            Logger.warn("Error fetching tax rate from TaxCloud:", error.message);
           }
         }
       }

--- a/imports/plugins/included/taxes-taxcloud/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-taxcloud/server/hooks/hooks.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { HTTP } from "meteor/http";
-import { Logger, MethodHooks } from "/server/api";
-import { Shops, Cart, Packages } from "/lib/collections";
+import { Logger, MethodHooks, Reaction } from "/server/api";
+import { Shops, Cart } from "/lib/collections";
 
 //
 // this entire method will run after the core/taxes
@@ -19,15 +19,10 @@ MethodHooks.after("taxes/calculate", (options) => {
   if (cartToCalc) {
     const { shopId } = cartToCalc;
     const shop = Shops.findOne(shopId);
-    const pkg = Packages.findOne({
-      name: "taxes-taxcloud",
-      shopId,
-      enabled: true
-    });
+    const pkgSettings = Reaction.getPackageSettings("taxes-taxcloud");
 
-    // check if package is configured
-    if (shop && pkg && pkg.settings.taxcloud) {
-      const { apiKey, apiLoginId } = pkg.settings.taxcloud;
+    if (pkgSettings && pkgSettings.settings.taxcloud.enabled === true) {
+      const { apiKey, apiLoginId } = pkgSettings.settings.taxcloud;
 
       // get shop address
       // this will need some refactoring
@@ -42,85 +37,82 @@ MethodHooks.after("taxes/calculate", (options) => {
         };
       }
 
-      // check if plugin is enabled and this calculation method is enabled
-      if (pkg && pkg.enabled === true && pkg.settings.taxcloud.enabled === true) {
-        if (!apiKey || !apiLoginId) {
-          Logger.warn("TaxCloud API Key is required.");
-        }
-        if (Array.isArray(cartToCalc.shipping) && cartToCalc.shipping.length > 0 && cartToCalc.items) {
-          const shippingAddress = cartToCalc.shipping[0].address;
+      if (!apiKey || !apiLoginId) {
+        Logger.warn("TaxCloud API Key is required.");
+      }
+      if (Array.isArray(cartToCalc.shipping) && cartToCalc.shipping.length > 0 && cartToCalc.items) {
+        const shippingAddress = cartToCalc.shipping[0].address;
 
-          if (shippingAddress) {
-            Logger.debug("TaxCloud triggered on taxes/calculate for cartId:", cartId);
-            const url = "https://api.taxcloud.net/1.0/TaxCloud/Lookup";
-            const cartItems = [];
-            const destination = {
-              Address1: shippingAddress.address1,
-              City: shippingAddress.city,
-              State: shippingAddress.region,
-              Zip5: shippingAddress.postal
-            };
+        if (shippingAddress) {
+          Logger.debug("TaxCloud triggered on taxes/calculate for cartId:", cartId);
+          const url = "https://api.taxcloud.net/1.0/TaxCloud/Lookup";
+          const cartItems = [];
+          const destination = {
+            Address1: shippingAddress.address1,
+            City: shippingAddress.city,
+            State: shippingAddress.region,
+            Zip5: shippingAddress.postal
+          };
 
-            // format cart items to TaxCloud structure
-            let index = 0;
-            for (const items of cartToCalc.items) {
-              // only processs taxable products
-              if (items.variants.taxable === true) {
-                const item = {
-                  Index: index,
-                  ItemID: items.variants._id,
-                  TIC: "00000",
-                  Price: items.variants.price,
-                  Qty: items.quantity
-                };
-                index += 1;
-                cartItems.push(item);
-              }
+          // format cart items to TaxCloud structure
+          let index = 0;
+          for (const items of cartToCalc.items) {
+            // only processs taxable products
+            if (items.variants.taxable === true) {
+              const item = {
+                Index: index,
+                ItemID: items.variants._id,
+                TIC: "00000",
+                Price: items.variants.price,
+                Qty: items.quantity
+              };
+              index += 1;
+              cartItems.push(item);
             }
-
-            // request object
-            const request = {
-              headers: {
-                "accept": "application/json",
-                "content-type": "application/json"
-              },
-              data: {
-                apiKey,
-                apiLoginId,
-                customerID: cartToCalc.userId,
-                cartItems,
-                origin,
-                destination,
-                cartID: cartId,
-                deliveredBySeller: false
-              }
-            };
-
-            HTTP.post(url, request, (error, response) => {
-              let taxRate = 0;
-              // ResponseType 3 is a successful call.
-              if (!error && response.data.ResponseType === 3) {
-                let totalTax = 0;
-                for (const item of response.data.CartItemsResponse) {
-                  totalTax += item.TaxAmount;
-                }
-                // don't run this calculation if there isn't tax.
-                if (totalTax > 0) {
-                  taxRate = (totalTax / cartToCalc.getSubTotal());
-                }
-                // we should consider if we want percentage and dollar
-                // as this is assuming that subTotal actually contains everything
-                // taxable
-                Meteor.call("taxes/setRate", cartId, taxRate, response.CartItemsResponse);
-              } else {
-                let errMsg = "Unable to access service. Check credentials.";
-                if (response && response.data.Messages[0].Message) {
-                  errMsg = response.data.Messages[0].Message;
-                }
-                Logger.warn("Error fetching tax rate from TaxCloud:", errMsg);
-              }
-            });
           }
+
+          // request object
+          const request = {
+            headers: {
+              "accept": "application/json",
+              "content-type": "application/json"
+            },
+            data: {
+              apiKey,
+              apiLoginId,
+              customerID: cartToCalc.userId,
+              cartItems,
+              origin,
+              destination,
+              cartID: cartId,
+              deliveredBySeller: false
+            }
+          };
+
+          HTTP.post(url, request, (error, response) => {
+            let taxRate = 0;
+            // ResponseType 3 is a successful call.
+            if (!error && response.data.ResponseType === 3) {
+              let totalTax = 0;
+              for (const item of response.data.CartItemsResponse) {
+                totalTax += item.TaxAmount;
+              }
+              // don't run this calculation if there isn't tax.
+              if (totalTax > 0) {
+                taxRate = (totalTax / cartToCalc.getSubTotal());
+              }
+              // we should consider if we want percentage and dollar
+              // as this is assuming that subTotal actually contains everything
+              // taxable
+              Meteor.call("taxes/setRate", cartId, taxRate, response.CartItemsResponse);
+            } else {
+              let errMsg = "Unable to access service. Check credentials.";
+              if (response && response.data.Messages[0].Message) {
+                errMsg = response.data.Messages[0].Message;
+              }
+              Logger.warn("Error fetching tax rate from TaxCloud:", errMsg);
+            }
+          });
         }
       }
     }


### PR DESCRIPTION
Resolves #3973  
Impact: **major**  
Type: **bugfix**

## Issue
When enabled, the TaxCloud service is not calculating tax in the cart. There are no errors on the client or server console and I am using the current API key

## Solution/Changes
- Use Reaction.getPackageSetting to retrieve the package settings
- Don't check the state of the pkgSettings.enabled which formerly
  indicated if a plugin is "installed" (e.g. enabled is a misnomer).
  If so, it would have been displayed in the dashboard. This seems no
  longer be true for any of the plugins, i.e. they appear in dashboard
  regardlesss of the state of that boolean. Also it will be obsolete
  anyway as soon as we're transitioning to plugins as NPM packages.
  Because then the plugin is installed not through toggling a checkbox,
  but rather through a dedicated `npm install`. I'm going to create a separate
  issue for this TODO.


## Notes

The diff that is being displayed is pretty weird, essentially only the branch condition was changed, the other changes results through indentation only.


## Breaking changes
None expected

## Testing
1. As an admin, enable TaxCloud tax service
2. As an user, add an item to cart and enter address during checkout
3. Observe that tax is calculated
