### PR TITLE
Fix for "Product publication handle regex match issues with similar product handles

### DIFF
--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -314,7 +314,7 @@ describe("Publication", function () {
         });
       });
 
-      it("should not return a product based on exacte handle match if it isn't visible", function (done) {
+      it("should not return a product based on exact handle match if it isn't visible", function (done) {
         sandbox.stub(Reaction, "getShopId", () => shopId);
         sandbox.stub(Roles, "userIsInRole", () => false);
 

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -298,36 +298,36 @@ describe("Publication", function () {
         });
       });
 
-      it("should return a product based on a regex", function (done) {
+      it("should not return a product if handle does not match exactly", function (done) {
         sandbox.stub(Reaction, "getShopId", () => shopId);
 
         const collector = new PublicationCollector({ userId: Random.id() });
 
         collector.collect("Product", "shopkins", (collections) => {
           const products = collections.Products;
-          const data = products[0];
-
-          expect(data.title).to.equal("Shopkins - Peachy");
-
+          if (products) {
+            expect(products.length).to.equal(0);
+          } else {
+            expect(products).to.be.undefined;
+          }
           done();
         });
       });
 
-      it("should not return a product based on a regex if it isn't visible", function (done) {
+      it("should not return a product based on exacte handle match if it isn't visible", function (done) {
         sandbox.stub(Reaction, "getShopId", () => shopId);
         sandbox.stub(Roles, "userIsInRole", () => false);
 
         const collector = new PublicationCollector({ userId: Random.id() });
         let isDone = false;
 
-        collector.collect("Product", "my", (collections) => {
+        collector.collect("Product", "my-little-pony", (collections) => {
           const products = collections.Products;
           if (products) {
             expect(products.length).to.equal(0);
           } else {
             expect(products).to.be.undefined;
           }
-
 
           if (!isDone) {
             isDone = true;
@@ -336,7 +336,7 @@ describe("Publication", function () {
         });
       });
 
-      it("should return a product based on a regex to admin even if it isn't visible", function (done) {
+      it("should return a product to admin based on a exact handle match even if it isn't visible", function (done) {
         sandbox.stub(Reaction, "getShopId", () => shopId);
         sandbox.stub(Roles, "userIsInRole", () => true);
         sandbox.stub(Reaction, "hasPermission", () => true);
@@ -344,7 +344,7 @@ describe("Publication", function () {
         const collector = new PublicationCollector({ userId: Random.id() });
         let isDone = false;
 
-        collector.collect("Product", "my", (collections) => {
+        collector.collect("Product", "my-little-pony", (collections) => {
           const products = collections.Products;
           const data = products[0];
 

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -22,10 +22,7 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
     $or: [{
       _id: productIdOrHandle
     }, {
-      handle: {
-        $regex: productIdOrHandle,
-        $options: "i"
-      }
+      handle: productIdOrHandle
     }]
   };
 


### PR DESCRIPTION
Resolves #4008
Impact: **major**  
Type: **bugfix**

## Issue
Product handle in Product publication matches using a regex, which causes issues if your product handle that is a subset of another product's handle.

With the two product handles below

1. basic-example-product-copy
2. t-copy

The product with handle t-copy will match basic-example-product-copy because of t-copy

## Solution / Changes
- Remove the regex match in the Product publication, in favor of an exact match.

## Breaking changes
None expected 

## Testing
1. As an admin
2. Duplicate the default "Basic Reaction Product"
3. Create yet another new product
4. Set the product title to t-copy
5. fill out required fields and publish
6. Variants previously created for t-copy should NOT disappear

