### PR TITLE
Fix for "Changing handle and hitting publish throw a 404"

### DIFF
--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -188,6 +188,10 @@ Meteor.methods({
     if (revisions) {
       for (const revision of revisions) {
         if (!revision.documentType || revision.documentType === "product") {
+          const oldDocument = Products.findOne(revision.documentId);
+          if (oldDocument && revision.documentData.handle !== oldDocument.handle) {
+            revision.documentData.changedHandleWas = oldDocument.handle;
+          }
           const res = publishCatalogProduct(
             this.userId,
             {

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -22,10 +22,7 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
     $or: [{
       _id: productIdOrHandle
     }, {
-      handle: {
-        $regex: productIdOrHandle,
-        $options: "i"
-      }
+      handle: productIdOrHandle
     }]
   };
 

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -22,7 +22,10 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
     $or: [{
       _id: productIdOrHandle
     }, {
-      handle: productIdOrHandle
+      handle: {
+        $regex: productIdOrHandle,
+        $options: "i"
+      }
     }]
   };
 


### PR DESCRIPTION
Resolves #4023   
Impact: **major**  
Type: **bugfix**

## Issue
If you change the handle of a previously published product and hit publish you get a 404 error

## Solution

Re-apply the changes from [PR 3755](https://github.com/reactioncommerce/reaction/pull/3755/files) for file `imports/plugins/core/revisions/server/methods.js` which somehow got lost.

## Breaking changes
None expected


## Testing
1. As an admin, create a product and publish
2. Change the title and handle
3. Publish
4. The URL in the browser's address bar should change and the product should still be displayed
