### PR TITLE
Fix #4058: onClick to image too

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/components/childVariant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/childVariant.js
@@ -83,7 +83,10 @@ class ChildVariant extends Component {
     if (!media) return null;
 
     return (
-      <Components.MediaItem source={media} />
+      <Components.MediaItem
+        source={media}
+        onClick={this.handleClick}
+      />
     );
   }
 


### PR DESCRIPTION
Resolves #4058   
Impact: **major**  
Type: **bugfix**

## Issue
`MediaItem` was being used in the component which has it's own `onClick` which was absorbing the click event.

## Solution
Passed the `onClick` to the media item too.

## Testing

1. Create, make visible and publish a product with at least one variant and at least two options and images for each option
1. As a customer, browse the PDP of the product created
1. Attempt to select an option by clicking on the images
1. Observe that the option gets selected when you click on the option title.

