### PR TITLE
Fix #4057: Admin should have media editable

### DIFF
--- a/imports/plugins/core/ui/client/components/media/mediaGallery.js
+++ b/imports/plugins/core/ui/client/components/media/mediaGallery.js
@@ -112,7 +112,7 @@ class MediaGallery extends Component {
   }
 
   renderFeaturedMedia() {
-    const { editable, onMouseEnterMedia, onMoveMedia, onRemoveMedia } = this.props;
+    const { editable, onMouseEnterMedia, onMouseLeaveMedia, onMoveMedia, onRemoveMedia } = this.props;
     const { width, height } = this.state.dimensions;
 
     const media = this.featuredMedia;
@@ -138,6 +138,7 @@ class MediaGallery extends Component {
               mediaHeight={height}
               mediaWidth={width}
               onMouseEnter={onMouseEnterMedia}
+              onMouseLeave={onMouseLeaveMedia}
               onMove={onMoveMedia}
               onRemoveMedia={onRemoveMedia}
               source={this.featuredMedia}
@@ -150,7 +151,7 @@ class MediaGallery extends Component {
   }
 
   renderMediaThumbnails() {
-    const { editable, media: mediaList, onMouseEnterMedia, onMoveMedia, onRemoveMedia } = this.props;
+    const { editable, media: mediaList, onMouseEnterMedia, onMouseLeaveMedia, onMoveMedia, onRemoveMedia } = this.props;
 
     return (mediaList || []).map((media, index) => (
       <Components.MediaItem
@@ -158,6 +159,7 @@ class MediaGallery extends Component {
         key={media._id}
         index={index} // index prop is required for SortableItem HOC to work
         onMouseEnter={onMouseEnterMedia}
+        onMouseLeave={onMouseLeaveMedia}
         onMove={onMoveMedia}
         onRemoveMedia={onRemoveMedia}
         size="small"

--- a/imports/plugins/core/ui/client/containers/mediaGallery.js
+++ b/imports/plugins/core/ui/client/containers/mediaGallery.js
@@ -85,7 +85,7 @@ const wrapComponent = (Comp) => (
 
       // It is confusing for an admin to know what the actual featured media is if it
       // changes on hover of the other media.
-      if (!editable) {
+      if (editable) {
         this.setState({ featuredMedia: media });
       }
     };

--- a/imports/plugins/core/ui/client/containers/mediaGallery.js
+++ b/imports/plugins/core/ui/client/containers/mediaGallery.js
@@ -85,7 +85,7 @@ const wrapComponent = (Comp) => (
 
       // It is confusing for an admin to know what the actual featured media is if it
       // changes on hover of the other media.
-      if (editable) {
+      if (!editable) {
         this.setState({ featuredMedia: media });
       }
     };


### PR DESCRIPTION
Resolves #4057  
Impact: **major**  
Type: **bugfix**

## Issue
The `featuredImage` is set when the mouse enter the image region and is unset when the mouse leaves the image region. But `onMouseLeave` wasn't being passed to the `MediaItem` component. Hence the image was only getting set and never unset.
When clicking on the variants, `featuredImage` is always given precedence over `variant`'s image.  Since the `featuredImage` was not null, the variants image was not being displayed.

## Solution
Passed the `onMouseLeave` to the `MediaItem` component which set's the `featuredImage` to null as soon as the mouse leaves the image. The `onMouseLeave` already had correct logic in place.

## Breaking changes
None

## Testing
1. Create a product with multiple options and multiple variants
2. Add images to each variant and option
3. Make the product public
4. As a customer, visit the PDP for that product
5. Be careful not to hover over the featured image, select between various options and variants.
6. Now hover over the featured image
7. Again, select various options and variants
8. Observe that the featured image is **now updated** when you change the selected option or variant