### PR TITLE
Fix 3978 Product visibility when revisions are turned off

### DIFF
--- a/imports/plugins/core/dashboard/client/components/toolbar.js
+++ b/imports/plugins/core/dashboard/client/components/toolbar.js
@@ -67,28 +67,6 @@ class PublishControls extends Component {
     }
   }
 
-  renderViewControls() {
-    if (this.props.showViewAsControls) {
-      return (
-        <FlatButton
-          label="Private"
-          i18nKeyLabel="app.private"
-          i18nKeyToggleOnLabel="app.public"
-          toggleOnLabel="Public"
-          icon="fa fa-eye-slash"
-          onIcon="fa fa-eye"
-          toggle={true}
-          value="public"
-          onValue="private"
-          toggleOn={this.isVisible === "public"}
-          onToggle={this.handleVisibilityChange}
-        />
-      );
-    }
-
-    return null;
-  }
-
   renderShopSelect() {
     // If a user has owner, admin, or marketplace permissions for more than one (1) shops
     // show the shop switcher to allow for easy switching between the shops
@@ -171,13 +149,8 @@ class PublishControls extends Component {
 
   renderCustomControls() {
     if (this.props.dashboardHeaderTemplate && this.props.hasCreateProductAccess) {
-      if (this.props.isEnabled) {
-        return [
-          <div className="hidden-xs" key="customControlsVerticaldivider"><VerticalDivider/></div>,
-          <Blaze key="customControls" template={this.props.dashboardHeaderTemplate} />
-        ];
-      }
       return [
+        <div className="hidden-xs" key="customControlsVerticaldivider"><VerticalDivider/></div>,
         <Blaze key="customControls" template={this.props.dashboardHeaderTemplate} />
       ];
     }

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -343,7 +343,7 @@ class PublishControls extends Component {
         {this.props.isEnabled && this.renderUndoButton()}
         {this.renderArchiveButton()}
         {this.renderViewControls()}
-        {this.renderPublishButton()}
+        {this.props.isEnabled && this.renderPublishButton()}
       </Components.ToolbarGroup>
     );
   }

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -378,20 +378,16 @@ class PublishControls extends Component {
   }
 
   render() {
-    if (this.props.isEnabled) {
-      return (
-        <Components.ToolbarGroup lastChild={true}>
-          {this.renderDeletionStatus()}
-          {this.renderUndoButton()}
-          {this.renderArchiveButton()}
-          {this.renderViewControls()}
-          {this.renderPublishButton()}
-          {/* this.renderMoreOptionsButton() */}
-        </Components.ToolbarGroup>
-      );
-    }
-
-    return null;
+    return (
+      <Components.ToolbarGroup lastChild={true}>
+        {this.props.isEnabled && this.renderDeletionStatus()}
+        {this.props.isEnabled && this.renderUndoButton()}
+        {this.props.isEnabled && this.renderArchiveButton()}
+        {this.renderViewControls()}
+        {this.renderPublishButton()}
+        {/* this.renderMoreOptionsButton() */}
+      </Components.ToolbarGroup>
+    );
   }
 }
 

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -4,10 +4,6 @@ import { Components } from "@reactioncommerce/reaction-components";
 import {
   Button,
   FlatButton,
-  IconButton,
-  Divider,
-  DropDownMenu,
-  MenuItem,
   Switch,
   Icon
 } from "/imports/plugins/core/ui/client/components";

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -189,6 +189,11 @@ class PublishControls extends Component {
     return null;
   }
 
+  /**
+   * Allows an archived variant to be restored if revision control is enabled (and
+   * it's not published yet). Once an archived product/variant is published, it's gone
+   * forever.
+   */
   renderDeletionStatus() {
     if (this.hasChanges) {
       if (this.primaryRevision && this.primaryRevision.documentData.isDeleted) {
@@ -229,48 +234,6 @@ class PublishControls extends Component {
           {...buttonProps}
         />
       </div>
-    );
-  }
-
-  renderMoreOptionsButton() {
-    return (
-      <DropDownMenu
-        buttonElement={<IconButton icon={"fa fa-ellipsis-v"}/>}
-        handleMenuItemChange={this.handleAction}
-      >
-        <MenuItem label="Administrator" value="administrator" />
-        <MenuItem label="Customer" value="customer" />
-        <Divider />
-        <MenuItem
-          i18nKeyLabel="app.public"
-          icon="fa fa-unlock"
-          label="Public"
-          selectLabel="Public"
-          value="public"
-        />
-        <MenuItem
-          i18nKeyLabel="app.private"
-          label="Private"
-          icon="fa fa-lock"
-          selectLabel="Public"
-          value="private"
-        />
-        <Divider />
-        <MenuItem
-          disabled={this.hasChanges === false}
-          i18nKeyLabel="revisions.discardChanges"
-          icon="fa fa-undo"
-          label="Discard Changes"
-          value="discard"
-        />
-        <Divider />
-        <MenuItem
-          i18nKeyLabel="app.archive"
-          icon="fa fa-trash-o"
-          label="Archive"
-          value="archive"
-        />
-      </DropDownMenu>
     );
   }
 
@@ -382,10 +345,9 @@ class PublishControls extends Component {
       <Components.ToolbarGroup lastChild={true}>
         {this.props.isEnabled && this.renderDeletionStatus()}
         {this.props.isEnabled && this.renderUndoButton()}
-        {this.props.isEnabled && this.renderArchiveButton()}
+        {this.renderArchiveButton()}
         {this.renderViewControls()}
         {this.renderPublishButton()}
-        {/* this.renderMoreOptionsButton() */}
       </Components.ToolbarGroup>
     );
   }

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -940,7 +940,7 @@ Meteor.methods({
         "documentData.isDeleted": true
       }).count();
     } else {
-      //eslint-disable-next-line no-shadow
+      // eslint-disable-next-line no-shadow
       productsWithVariants.forEach((product) => {
         Products.update({
           _id: product._id

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -5,7 +5,7 @@ import { EJSON } from "meteor/ejson";
 import { Meteor } from "meteor/meteor";
 import { ReactionProduct } from "/lib/api";
 import { ProductRevision as Catalog } from "/imports/plugins/core/revisions/server/hooks";
-import { publishProductsToCatalog } from "/imports/plugins/core/catalog/server/methods/catalog"
+import { publishProductsToCatalog } from "/imports/plugins/core/catalog/server/methods/catalog";
 import { RevisionApi } from "/imports/plugins/core/revisions/lib/api/revisions";
 import { Hooks, Logger, Reaction } from "/server/api";
 import { MediaRecords, Products, Revisions, Tags } from "/lib/collections";
@@ -940,18 +940,18 @@ Meteor.methods({
         "documentData.isDeleted": true
       }).count();
     } else {
+      //eslint-disable-next-line no-shadow
       productsWithVariants.forEach((product) => {
         Products.update({
-            _id: product._id
-          }, {
-            $set: {
-              isDeleted: true
-            }
-          }, {
-            bypassCollection2: true,
-            publish: true
+          _id: product._id
+        }, {
+          $set: {
+            isDeleted: true
           }
-        );
+        }, {
+          bypassCollection2: true,
+          publish: true
+        });
       });
       numFlaggedAsDeleted = Products.find({
         _id: {


### PR DESCRIPTION
Resolves #3978   
Impact: **major**  
Type: **bugfix**

## Issue
If Product Revisioning is turned off, one can't publish products to the catalog.sal.

## Solution
Publishing & Archiving products should also work when Products Revisions are    disabled.

## Changes:
- Show visibility and publish button, even if Catalog Revisions are turned off.
- Remove unused function `renderViewControls`
- If revision control is disabled, the archive action does set property isDeleted directly on the selected variants (instead of writing to revisions as intermediary)
- Because product variants with `isDeleted === true` are not available any longer in admin view, the Publish button for that product will no longer be available (the product vanishes immediately). Therefore the code does publish the changes to the catalog immediately through calling `publishProductsToCatalog`

## Breaking changes
None expected

## Testing

Test 1)
1. As an admin, turn-off Revision control
2. Navigate to the product grid and change visibility of example product
3. Hit publish button
4. Product should be invisible/visible for non-admin users.

Test 2)
1. As an admin, turn-off Revision control.
2. Navigate to the PDP of the example product and change values there
3. You should be able to publish changes through the "Publish" button
4. HOWEVER, because the PDP does not retrieve it's data from the Catalog, all changes are displayed immediately for non-admin users (changes are not held in revision collection, but saved directly in `Products` collection). This is a bug which will be addressed once the PDP is also retrieving it's data from catalog. I'm creating a new ticket for that:  PLACEHOLDER NEW TICKET