### PR TITLE
(fix) Make shipping discount code case-insensitive

### DIFF
--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -92,13 +92,13 @@ export const methods = {
     let discount = 0;
     const discountMethod = Discounts.findOne(discountId);
     const cart = Cart.findOne(cartId);
-
-    for (const shipping of cart.shipping) {
-      if (shipping.shipmentMethod && shipping.shipmentMethod.name === discountMethod.discount) {
-        discount += Math.max(0, shipping.shipmentMethod.rate);
+    if (cart.shipping && cart.shipping.length) {
+      for (const shipping of cart.shipping) {
+        if (shipping.shipmentMethod && shipping.shipmentMethod.name.toUpperCase() === discountMethod.discount.toUpperCase()) {
+          discount += Math.max(0, shipping.shipmentMethod.rate);
+        }
       }
     }
-
     return discount;
   },
 


### PR DESCRIPTION
Resolves #4150 
Impact: **minor**  
Type: **bugfix**

## Issue
When creating a shipping discount you need to put the name of the method you want to discount and currently the comparison is case-sensitive. When I looked into why the code wasn't working I saw what I going on so I fixed it. I also saw a case where it was trying to calculate shipping when `cart.shipping` was empty so I added a check around the calculation.

## Solution
Make the comparison case-insensitive


## Testing
1. Login as admin
1. Enable the Standard Flat Rate shipping type
1. Create a discount with the Calculation method being "shipping" and the discount set to "StAnDaRd" and the code as "FreeShipping"
1. Add an item to cart and go to checkout
1. Select Standard Shipping
1. In the payment section apply the "FreeShipping" payment code.
1. Observe that it works even though the case of the discount doesn't match

