### PR TITLE
Fix #2780: Styling shop slug box for Shopify

### DIFF
--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.html
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.html
@@ -7,9 +7,9 @@
       {{> afQuickField name="settings.sharedSecret" class='form-control'}}
       <label class="control-label">Shop slug</label>
       <div>
-        <div style="display: inline-block">https://</div>
+        <div style="display: inline-block" class="custom-form-label">https://</div>
         {{> afFieldInput name="settings.shopName" class='form-control shop-slug'}}
-        <div style="display: inline-block">.shopify.com</div>
+        <div style="display: inline-block" class="custom-form-label">.shopify.com</div>
       </div>
       {{> shopSettingsSubmitButton}}
     {{/autoForm}}

--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.html
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.html
@@ -5,7 +5,12 @@
       {{> afQuickField name="settings.apiKey" class='form-control'}}
       {{> afQuickField name="settings.password" class='form-control' type="password"}}
       {{> afQuickField name="settings.sharedSecret" class='form-control'}}
-      {{> afQuickField name="settings.shopName" class='form-control'}}
+      <label class="control-label">Shop slug</label>
+      <div>
+        <div style="display: inline-block">https://</div>
+        {{> afFieldInput name="settings.shopName" class='form-control shop-slug'}}
+        <div style="display: inline-block">.shopify.com</div>
+      </div>
       {{> shopSettingsSubmitButton}}
     {{/autoForm}}
   </div>

--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.less
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.less
@@ -3,6 +3,20 @@
     margin: 4px 0 4px 0;
 }
 
+.form-control.shop-slug {
+    display: inline-block;
+    width: auto;
+    min-width: 150px;
+    border: none;
+    padding: 0px;
+    height: 18px;
+    border-radius: 0px;
+    border-bottom: 1px solid black;
+    margin-bottom: 12px;
+    box-shadow: none;
+    -webkit-box-shadow: none;
+}
+
 #webhooksDomain {
     width: 100%;
     padding: 5px 0px 5px 10px;

--- a/imports/plugins/included/connectors-shopify/client/settings/shopify.less
+++ b/imports/plugins/included/connectors-shopify/client/settings/shopify.less
@@ -17,6 +17,12 @@
     -webkit-box-shadow: none;
 }
 
+.custom-form-label {
+    font-size: 14px;
+    line-height: 1.42857143;
+    color: #595959;
+}
+
 #webhooksDomain {
     width: 100%;
     padding: 5px 0px 5px 10px;


### PR DESCRIPTION
Resolves #2780   
Impact: **minor**  
Type: **style**

## Issue
The shop slug that is needed for making API calls to Shopify is not labelled anywhere in the Shopify dashboard. It is a part of the shop's URL. So it was not very apparent as a user what slug RC wanted.

## Solution
Changed the input field to look like the screenshot below.

<img width="306" alt="screen shot 2018-03-29 at 12 17 48 pm" src="https://user-images.githubusercontent.com/7762605/38074100-4518bba6-334b-11e8-8cc6-1e4396d71611.png">



Looking at this the user can easily guess what part of the URL we actually want.

## Testing
1. Go to shopify settings(in connector)
1. See the new styling
1. Try entering shopify creds and importing products to check that everything is working fine.