### PR TITLE
feat: GraphQL add account to group mutation

### DIFF
--- a/imports/plugins/core/graphql/server/methods.js
+++ b/imports/plugins/core/graphql/server/methods.js
@@ -4,7 +4,8 @@ const methods = {};
 
 [
   "accounts/addressBookAdd",
-  "accounts/addressBookUpdate"
+  "accounts/addressBookUpdate",
+  "group/addUser"
 ].forEach((methodName) => {
   methods[methodName] = (context, args) => (
     runMeteorMethodWithContext(context, methodName, args)

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountToGroup.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountToGroup.js
@@ -1,0 +1,25 @@
+import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
+import { decodeGroupOpaqueId, xformGroupResponse } from "@reactioncommerce/reaction-graphql-xforms/group";
+
+/**
+ * @name addAccountToGroup
+ * @method
+ * @summary resolver for the addAccountToGroup GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} args.input.accoundId - The account ID
+ * @param {String} args.input.groupId - The group ID
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @return {Object} AddAccountToGroupPayload
+ */
+export default function addAccountToGroup(_, { input }, context) {
+  const { accountId, groupId, clientMutationId = null } = input;
+  const dbAccountId = decodeAccountOpaqueId(accountId);
+  const dbGroupId = decodeGroupOpaqueId(groupId);
+  const updatedAddress = context.methods["group/addUser"](context, [dbAccountId, dbGroupId]);
+  return {
+    group: xformGroupResponse(updatedAddress),
+    clientMutationId
+  };
+}

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountToGroup.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountToGroup.js
@@ -17,9 +17,9 @@ export default function addAccountToGroup(_, { input }, context) {
   const { accountId, groupId, clientMutationId = null } = input;
   const dbAccountId = decodeAccountOpaqueId(accountId);
   const dbGroupId = decodeGroupOpaqueId(groupId);
-  const updatedAddress = context.methods["group/addUser"](context, [dbAccountId, dbGroupId]);
+  const group = context.methods["group/addUser"](context, [dbAccountId, dbGroupId]);
   return {
-    group: xformGroupResponse(updatedAddress),
+    group: xformGroupResponse(group),
     clientMutationId
   };
 }

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountToGroup.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountToGroup.test.js
@@ -1,0 +1,32 @@
+import { encodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
+import { encodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
+import addAccountToGroup from "./addAccountToGroup";
+
+test("correctly passes through to group/addUser method", () => {
+  const accountId = encodeAccountOpaqueId("1");
+  const groupId = encodeGroupOpaqueId("g1");
+  const group = { name: "customer" };
+
+  const fakeResult = { _id: "g1", ...group };
+
+  const mockMethod = jest.fn().mockName("group/addUser method");
+  mockMethod.mockReturnValueOnce(fakeResult);
+  const context = {
+    methods: {
+      "group/addUser": mockMethod
+    }
+  };
+
+  const result = addAccountToGroup(null, {
+    input: {
+      accountId,
+      groupId,
+      clientMutationId: "clientMutationId"
+    }
+  }, context);
+
+  expect(result).toEqual({
+    group: { _id: encodeGroupOpaqueId("g1"), ...group },
+    clientMutationId: "clientMutationId"
+  });
+});

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/index.js
@@ -1,7 +1,9 @@
 import addAccountAddressBookEntry from "./addAccountAddressBookEntry";
+import addAccountToGroup from "./addAccountToGroup";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry";
 
 export default {
   addAccountAddressBookEntry,
+  addAccountToGroup,
   updateAccountAddressBookEntry
 };

--- a/server/methods/core/groups.js
+++ b/server/methods/core/groups.js
@@ -190,7 +190,8 @@ Meteor.methods({
         Meteor.call("group/addUser", Meteor.userId(), currentUserGrpInShop);
       }
 
-      return { status: 200 };
+      // Return the group the account as added to
+      return Groups.findOne({ _id: groupId });
     } catch (error) {
       Logger.error(error);
       throw new Meteor.Error("server-error", "Could not add user");


### PR DESCRIPTION
Resolves #3925   
Impact: **minor**  
Type: **feature**

## Issue

Adds the `addAccountToGroup` GraphQL mutation

## Solution

Add a mutation to add an account to a group. The mutation is very similar to other mutations so it was mostly copy-pasta.

Update the `group/addUser` method to return the group the user was added to as the result instead of `{ status: 200 }`.

## Breaking changes

**Possible**

Updated the `group/addUser` method to return the group the user was added to as the result instead of `{ status: 200 }`. It doesn't seem that any of the places where this method was called cared about the result, only that it exists.

## Testing
1. As an admin, invite a user
1. In the database, find the user you created and get the ID
1. Encode the account id like so `reaction/account:<accountId>` as a utf8 base64 string
1. Also, take note of the ID of the group the user is a member of
1. In the `Groups` collection, find a group the user is not already a part of. The `customer` customer should do.
1. Encode the group id like so `reaction/group:<groupId>` as a utf8 base64 string
1. Run the following mutation with the id's you generated

```
mutation {
    addAccountToGroup(input: {
    accountId: "b64AccountId"
    groupId: "b64GroupId"
  }) {
    clientMutationId,
    group {
      name
      _id
    }
}
}
```

8. Check the database for the account you updated and see that the group has changed. **seems users can only be a member of one group per shop**