### PR TITLE
GraphQL invite shop member

### DIFF
--- a/imports/plugins/core/graphql/server/methods.js
+++ b/imports/plugins/core/graphql/server/methods.js
@@ -4,7 +4,8 @@ const methods = {};
 
 [
   "accounts/addressBookAdd",
-  "accounts/addressBookUpdate"
+  "accounts/addressBookUpdate",
+  "accounts/inviteShopMember"
 ].forEach((methodName) => {
   methods[methodName] = (context, args) => (
     runMeteorMethodWithContext(context, methodName, args)

--- a/imports/plugins/core/graphql/server/methods.js
+++ b/imports/plugins/core/graphql/server/methods.js
@@ -6,7 +6,7 @@ const methods = {};
   "accounts/addressBookAdd",
   "accounts/addressBookUpdate",
   "accounts/addressBookRemove",
-  "accounts/inviteShopMember"
+  "accounts/inviteShopMember",
   "group/addUser"
 ].forEach((methodName) => {
   methods[methodName] = (context, args) => (

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/index.js
@@ -1,7 +1,9 @@
 import addAccountAddressBookEntry from "./addAccountAddressBookEntry";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry";
+import inviteShopMember from "./inviteShopMember";
 
 export default {
   addAccountAddressBookEntry,
-  updateAccountAddressBookEntry
+  updateAccountAddressBookEntry,
+  inviteShopMember
 };

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/inviteShopMember.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/inviteShopMember.js
@@ -1,0 +1,32 @@
+import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
+import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+import { xformAccountResponse } from "@reactioncommerce/reaction-graphql-xforms/account";
+
+/**
+ * @name inviteShopMember
+ * @method
+ * @summary resolver for the inviteShopMember GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} args.input.email - The email address of the person to invite
+ * @param {String} args.input.groupId - The permission group for this person's new account
+ * @param {String} args.input.name - The permission group for this person's new account
+ * @param {String} args.input.shopId - The ID of the shop to which you want to invite this person
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @return {Object} InviteShopMemberPayload
+ */
+export default function inviteShopMember(_, { input }, context) {
+  const { email, groupId, name, shopId, clientMutationId = null } = input;
+  const options = {
+    email,
+    groupId: decodeGroupOpaqueId(groupId),
+    name,
+    shopId: decodeShopOpaqueId(shopId)
+  };
+  const account = context.methods["accounts/inviteShopMember"](context, [options]);
+  return {
+    account: xformAccountResponse(account),
+    clientMutationId
+  };
+}

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/inviteShopMember.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/inviteShopMember.test.js
@@ -1,0 +1,37 @@
+import { encodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
+import { encodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
+import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+import inviteShopMember from "./inviteShopMember";
+
+test("correctly passes through to accounts/inviteShopMember method", () => {
+  const accountId = encodeAccountOpaqueId("1");
+  const groupId = encodeGroupOpaqueId("g1");
+  const shopId = encodeShopOpaqueId("s1");
+
+  const account = { name: "test name", addressBook: null, currency: null, preferences: null };
+
+  const fakeResult = { _id: "1", ...account };
+
+  const mockMethod = jest.fn().mockName("accounts/inviteShopMember method");
+  mockMethod.mockReturnValueOnce(fakeResult);
+  const context = {
+    methods: {
+      "accounts/inviteShopMember": mockMethod
+    }
+  };
+
+  const result = inviteShopMember(null, {
+    input: {
+      email: "test@email.com",
+      groupId,
+      name: "test name",
+      shopId,
+      clientMutationId: "clientMutationId"
+    }
+  }, context);
+
+  expect(result).toEqual({
+    account: { _id: accountId, ...account },
+    clientMutationId: "clientMutationId"
+  });
+});

--- a/imports/plugins/core/graphql/server/schemas/shop.js
+++ b/imports/plugins/core/graphql/server/schemas/shop.js
@@ -29,6 +29,9 @@ export const typeDefs = `
 
     # The ID of the shop to which you want to invite this person
     shopId: ID!
+
+    # An optional string identifying the mutation call, which will be returned in the response payload
+    clientMutationId: String
   }
 
   # The response from the \`inviteShopMember\` mutation

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -781,7 +781,7 @@ export function inviteShopMember(options) {
     html: SSR.render(tpl, dataForEmail)
   });
 
-  return true;
+  return Accounts.findOne({ userId });
 }
 
 /**


### PR DESCRIPTION
Resolves #3927   
Impact: **minor**  
Type: **feature**

## Issue

Adds the `inviteShopMember` GraphQL mutation

## Solution

Add a mutation to invite a shop member. The mutation is very similar to other mutations so it was mostly copy-paste.

Update the `accounts/inviteShopMember` method to return the invited user account instead of `true`.

## Breaking changes

**Possible**

Update the `accounts/inviteShopMember` method to return the invited user account instead of `true`. It doesn't seem that any of the places where this method was called cared about the result, only that it exists.

## Testing
1. Look in the shops collection in the database
1. Encode the shop id like so `reaction/shop:<shopId>` as a utf8 base64 string
1. Look in the groups collection in the database and grab the "shop manager" group
1. Encode the group id like so `reaction/group:<groupId>` as a utf8 base64 string
1. Run the following mutation with the id's you generated

```
mutation {
    inviteShopMember(input: {
      clientMutationId: "adadad"
    	name: "test 1"
      email: "validemail@address.com"
      shopId: "b64ShopId"
    	groupId: "b64GroupId"
  }) {
    clientMutationId,
    account {
      name
      _id
    }
}
}
```

6. Result should have new user, and if the email was valid, you should even receive the invite.