### PR TITLE
Bug Fix: s/`in`/`.indexOf`

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -378,7 +378,8 @@ export default {
     if (Meteor.user()) {
       // "reaction" package settings should be synced to
       // the Accounts collection.
-      if (packageName in ["reaction"]) {
+      const syncedPackages = ["reaction"];
+      if (syncedPackages.indexOf(packageName) > -1) {
         Accounts.update(Meteor.userId(), {
           $set: {
             [`profile.preferences.${packageName}.${preference}`]: value


### PR DESCRIPTION
Impact: **major** (for marketplace users, less so otherwise)
Type: **bugfix**

## Issue
`setUserPreferences` was recently modified to reduce the number of preferences written to the database. A logic mixup prevented nearly all preferences to be written.

## Solution
Replace the `in` operator (which treats Arrays as Objects in JS) with a call to `Array#indexOf`


## Testing
1. I tried like hell to write a unit test for this, but `npm jest` is still giving me fits.
