### PR TITLE
Fix for "Can't remove discount code in checkout once applied"

### DIFF
--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -181,7 +181,7 @@ export const methods = {
     const result = Collection.update(
       { _id: id },
       { $set: { discount: currentDiscount }, $pull: { billing: { _id: codeId } } },
-      { multi: true }
+      { multi: true, bypassCollection2: true }
     );
 
     // calculate discounts


### PR DESCRIPTION
Resolves #4081  
Impact: **major**  
Type: **bugfix**

## Issue
Once you apply a discount code to your cart, you can't remove it even though there is an X next to it which seems to imply you can

## Solution
Set bypassCollection2 as the new npm schema obviously does not honor the
$pull operator in its current form.

## Breaking changes
None

## Testing
1. As an admin, enable discount codes and example payment provider. Enable a shipping method.
2. As an admin, create a new discount code
3. As a user put an item to cart and checkout
4. In step 5 of the checkout process, apply the discount code entered in step 2
5. As soon as the discount code is applied, remove it again via the cross icon.
6. The discount should disappear.
