### PR TITLE
Fix for "Error when enabling Shopify inventory hooks"

### DIFF
--- a/imports/plugins/included/connectors-shopify/server/methods/webhooks/webhooks.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/webhooks/webhooks.js
@@ -50,16 +50,25 @@ export const methods = {
 
     const host = options.webhooksDomain || Meteor.absoluteUrl();
     const webhookAddress = `${host}webhooks/shopify/${options.topic.replace(/\//g, "-")}?shopId=${Reaction.getShopId()}`;
-    try {
-      // Create webhook on Shopify
-      const webhookResponse = await shopify.webhook.create({
-        topic: options.topic,
-        address: webhookAddress,
-        format: "json"
-      });
 
+    try {
+      let shopifyId;
+      // Create webhook on Shopify if it isn't installed yet
+      const webhooks = await shopify.webhook.list({
+        address: webhookAddress
+      });
+      if (webhooks.length === 0) {
+        const webhookResponse = await shopify.webhook.create({
+          topic: options.topic,
+          address: webhookAddress,
+          format: "json"
+        });
+        shopifyId = webhookResponse.id;
+      } else {
+        shopifyId = webhooks[0].id;
+      }
       const webhook = {
-        shopifyId: webhookResponse.id,
+        shopifyId,
         topic: options.topic,
         address: webhookAddress,
         format: "json",
@@ -67,6 +76,7 @@ export const methods = {
         // TODO: Add method to update an existing webhook if we want to change the integrations that use it
         //       E.g. turn on inventory sync, but turn off order sync - both might use the same webhook subscription
       };
+
 
       // Add webhook to webhooks array in Shop specific connectors-shopify pkg
       Packages.update({ _id: shopifyPkg._id }, {

--- a/imports/plugins/included/connectors-shopify/server/methods/webhooks/webhooks.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/webhooks/webhooks.js
@@ -10,7 +10,6 @@ import { Packages } from "/lib/collections";
  *       synchronization between a Shopify store and a Reaction shop
  * @module connectors-shopify
  */
-
 export const methods = {
   /**
    * Meteor method for creating a shopify webhook for the active shop


### PR DESCRIPTION
Resolves #3974  
Impact: **minor**  
Type: **bugfix**

## Issue
Receive "Error setting up Shopify Sync" in browser and error in server console when enabling shopify inventory sync

## Solution
- Before creating the webhook the API is queried for the webhook URI
that's going to be installed. If it's already installed, we skip the
webhook creation.


## Breaking changes
none

## Testing
1. As an admin, go to the shopify connector and setup the order creating webhook "Update Inventory on Shopify Order"
2. Don't use localhost as webhook callback domain, but any other valid URL
3. Setup Sync
4. Go to Robo-Mongo and delete the newly created webhook in the array db.getCollection('Packages').find({name: "reaction-connectors-shopify"})
5. Go to the dashboard and try to install the sync hook again with the same domain URL.
6. Observe that this action should work without error
7. Go to RoboMongo and see that the webhook is updated again in database: `webhooks array`

