### PR TITLE
Fix 4152: Currency as object

### DIFF
--- a/client/modules/i18n/currency.js
+++ b/client/modules/i18n/currency.js
@@ -38,7 +38,7 @@ export function findCurrency(defaultCurrency, useDefaultShopCurrency) {
     }
     return userCurrency;
   }
-  return shopCurrency;
+  return shop.currencies[shopCurrency];
 }
 
 /**

--- a/imports/plugins/core/ui/client/components/numericInput/numericInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numericInput.js
@@ -197,6 +197,7 @@ class NumericInput extends Component {
           disabled={this.props.disabled}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
+          ref="input"
           onChange={this.handleChange}
           value={this.displayValue}
         />


### PR DESCRIPTION
Resolves #4152  
Impact: **major**  
Type: **bugfix**

## Issue
1. The `findCurrecny` function was returning `shop.currency` when it was unable to find the user's currency. But that function is supposed to return an object of type `Currency`.
2. While animating the background of `input`, a undefined value was being passed. This was happening because ref prop was not being set on the `input` inside `NumericInput` component.

## Solution
1. Made the function to return `shop.currencies[shop.currency]`, which is the actual value expected.
2. Passed `ref=input` to NumericInput.

## Breaking changes
None

## Testing
1. Reset reaction
1. Login as admin
1. Create a product
1. Click on the first variant so that the variant/option panel opens
1. Observe no error in console
1. After updating the price, observe no error about undefined promise.