### PR TITLE
docs(GraphQL): add some missing schema docs

### DIFF
--- a/imports/plugins/core/graphql/server/schemas/account.js
+++ b/imports/plugins/core/graphql/server/schemas/account.js
@@ -114,24 +114,52 @@ export const typeDefs = `
 
   # Per-account tax exemption settings used by the Avalara plugin
   type TaxSettings {
+    # Exemption number for an account
     exemptionNo: String
+
+    # Customer usage type. A value matching the \`code\` field of one TaxEntityCode, or any custom string.
     customerUsageType: String
   }
 
   # Represents a single user account
   type Account implements Node {
+    # The account ID
     _id: ID!
+
+    # A list of physical or mailing addresses associated with this account
     addressBook(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt): AddressConnection
+
+    # The date and time at which this account was created
     createdAt: DateTime!
+
+    # The preferred currency used by this account
     currency: Currency
+
+    # A list of email records associated with this account
     emailRecords: [EmailRecord]
-    groups(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt): GroupConnection
+
+    # A paged list of the permission groups in which this account is listed
+    groups(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: GroupSortByField = createdAt): GroupConnection
+
+    # Arbitrary additional metadata about this account
     metafields: [Metafield]
+
+    # The full name of the person this account represents, if known
     name: String
+
+    # Some note about this account
     note: String
+
+    # An object storing plugin-specific preferences for this account
     preferences: JSONObject
+
+    # The shop to which this account belongs, if it is associated with a specific shop
     shop: Shop
+
+    # Per-account tax exemption settings used by the Avalara plugin
     taxSettings: TaxSettings
+
+    # The date and time at which this account was last updated
     updatedAt: DateTime!
   }
 
@@ -188,15 +216,6 @@ export const typeDefs = `
     clientMutationId: String
   }
 
-  # The response from the \`updateAccount\` mutation
-  type UpdateAccountPayload {
-    # The updated account
-    account: Account
-
-    # The same string you sent with the mutation params, for matching mutation calls with their responses
-    clientMutationId: String
-  }
-
   # The response from the \`updateAccountAddressBookEntry\` mutation
   type UpdateAccountAddressBookEntryPayload {
     # The updated address
@@ -216,14 +235,22 @@ export const typeDefs = `
   }
 
   extend type Mutation {
-    # Provide the ID of an \`Account\` and an \`AddressInput\` object. The address will be added to the \`addressBook\`
-    # of that account, and the added \`Address\` object is returned.
+    # Add a new address to the \`addressBook\` field for an account
     addAccountAddressBookEntry(input: AddAccountAddressBookEntryInput!): AddAccountAddressBookEntryPayload
+
+    # Add an email address to an account
     addAccountEmailRecord(input: AddAccountEmailRecordInput!): AddAccountEmailRecordPayload
+
+    # Remove an address from the \`addressBook\` field for an account
     removeAccountAddressBookEntry(input: RemoveAccountAddressBookEntryInput!): RemoveAccountAddressBookEntryPayload
+
+    # Remove an email address from an account
     removeAccountEmailRecord(input: RemoveAccountEmailRecordInput!): RemoveAccountEmailRecordPayload
+
+    # Set the preferred currency for an account
     setAccountProfileCurrency(input: SetAccountProfileCurrencyInput!): SetAccountProfileCurrencyPayload
-    updateAccount(input: UpdateAccountInput!): UpdateAccountPayload
+
+    # Remove an address that exists in the \`addressBook\` field for an account
     updateAccountAddressBookEntry(input: UpdateAccountAddressBookEntryInput!): UpdateAccountAddressBookEntryPayload
   }
 

--- a/imports/plugins/core/graphql/server/schemas/address.js
+++ b/imports/plugins/core/graphql/server/schemas/address.js
@@ -29,38 +29,91 @@ export const typeDefs = `
 
   # The details of an \`Address\` to be created or updated
   input AddressInput {
+    # The street address / first line
     address1: String!
+
+    # Optional second line
     address2: String
+
+    # City
     city: String!
+
+    # Optional company name, if it's a business address
     company: String
+
+    # Country
     country: String!
-    failedValidation: Boolean
+
+    # The full name of a person at this address
     fullName: String!
+
+    # Is this the default address for billing purposes?
     isBillingDefault: Boolean!
+
+    # Is this a commercial address?
     isCommercial: Boolean!
+
+    # Is this the default address to use when selecting a shipping address at checkout?
     isShippingDefault: Boolean!
+
+    # Arbitrary additional metadata about this address
     metafields: [MetafieldInput]
+
+    # A phone number for someone at this address
     phone: String!
+
+    # Postal code
     postal: String!
+
+    # Region. For example, a U.S. state
     region: String!
   }
 
   # Represents a physical or mailing address somewhere on Earth
   type Address implements Node {
+    # The address ID
     _id: ID!
+
+    # The street address / first line
     address1: String!
+
+    # Optional second line
     address2: String
+
+    # City
     city: String!
+
+    # Optional company name, if it's a business address
     company: String
+
+    # Country
     country: String!
+
+    # Whether this address failed external address validation the last time it was checked
     failedValidation: Boolean
+
+    # The full name of a person at this address
     fullName: String!
+
+    # Is this the default address for billing purposes?
     isBillingDefault: Boolean!
+
+    # Is this a commercial address?
     isCommercial: Boolean!
+
+    # Is this the default address to use when selecting a shipping address at checkout?
     isShippingDefault: Boolean!
+
+    # Arbitrary additional metadata about this address
     metafields: [Metafield]
+
+    # A phone number for someone at this address
     phone: String!
+
+    # Postal code
     postal: String!
+
+    # Region. For example, a U.S. state
     region: String!
   }
 

--- a/imports/plugins/core/graphql/server/schemas/email.js
+++ b/imports/plugins/core/graphql/server/schemas/email.js
@@ -5,7 +5,11 @@ export const typeDefs = `
   # A confirmable email record
   type EmailRecord {
     provides: String
+
+    # The actual email address
     address: Email
+
+    # Has this address been verified?
     verified: Boolean
   }
 `;

--- a/imports/plugins/core/graphql/server/schemas/group.js
+++ b/imports/plugins/core/graphql/server/schemas/group.js
@@ -10,9 +10,16 @@ export const typeDefs = `
 
   # A group definition
   input GroupInput {
+    # A free text description of this group
     description: String
+
+    # A unique name for the group
     name: String!
+
+    # A list of the account permissions implied by membership in this group
     permissions: [String]
+
+    # A unique URL-safe string representing this group
     slug: String!
   }
 
@@ -78,14 +85,31 @@ export const typeDefs = `
 
   # Represents an account group
   type Group implements Node {
+    # The group ID
     _id: ID!
+
+    # The date and time at which this group was created
     createdAt: DateTime!
+
+    # The account that created this group
     createdBy: Account
+
+    # A free text description of this group
     description: String
+
+    # A unique name for the group
     name: String!
+
+    # A list of the account permissions implied by membership in this group
     permissions: [String]
+
+    # The shop to which this group belongs
     shop: Shop
+
+    # A unique URL-safe string representing this group
     slug: String!
+
+    # The date and time at which this group was last updated
     updatedAt: DateTime!
   }
 
@@ -149,16 +173,26 @@ export const typeDefs = `
   }
 
   extend type Mutation {
+    # Add an account to a group
     addAccountToGroup(input: AddAccountToGroupInput!): AddAccountToGroupPayload
+
+    # Create a new permission group
     createGroup(input: CreateGroupInput!): CreateGroupPayload
+
+    # Update an existing permission group
     updateGroup(input: UpdateGroupInput!): UpdateGroupPayload
+
+    # Remove an account from a group
     removeAccountFromGroup(input: RemoveAccountFromGroupInput!): RemoveAccountFromGroupPayload
+
+    # Remove an existing permission group
     removeGroup(input: RemoveGroupInput!): RemoveGroupPayload
   }
 
   extend type Query {
     # Returns a single group by ID.
     group(id: ID!): Group
+
     # Returns a list of groups for the shop with ID \`shopId\`, as a Relay-compatible connection.
     groups(shopId: ID!, after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: GroupSortByField = createdAt): GroupConnection
   }

--- a/imports/plugins/core/graphql/server/schemas/role.js
+++ b/imports/plugins/core/graphql/server/schemas/role.js
@@ -8,7 +8,10 @@ export const typeDefs = `
 
   # Represents a named role
   type Role implements Node {
+    # The role ID
     _id: ID!
+
+    # A unique name for the role
     name: String!
   }
 
@@ -27,6 +30,7 @@ export const typeDefs = `
   }
 
   extend type Query {
+    # Returns a paged list of all roles associated with a shop
     roles(shopId: ID!, after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: RoleSortByField = name): RoleConnection
   }
 `;


### PR DESCRIPTION
Impact: **minor**  
Type: **docs**

## Changes
Added some missing GraphQL schema docs

## Breaking changes
None

## Testing
1. Run devserver
2. Connect to http://localhost:3030/graphql-alpha with a graphql UI client, expand the schema docs, and make sure the documentation changes look good.