### PR TITLE
(fix) Remove _sleepForMs from tests

### DIFF
--- a/imports/plugins/core/discounts/server/methods/methods.app-test.js
+++ b/imports/plugins/core/discounts/server/methods/methods.app-test.js
@@ -48,8 +48,6 @@ describe("discounts methods", function () {
       expect(discountInsertSpy).to.have.been.called;
 
       Meteor.call("discounts/deleteRate", discountId);
-      Meteor._sleepForMs(500);
-
       const discountCount = Discounts.find(discountId).count();
       expect(discountCount).to.equal(0);
       return done();

--- a/imports/plugins/core/taxes/server/methods/methods.app-test.js
+++ b/imports/plugins/core/taxes/server/methods/methods.app-test.js
@@ -6,7 +6,6 @@ import { sinon } from "meteor/practicalmeteor:sinon";
 
 before(function () {
   this.timeout(10000);
-  Meteor._sleepForMs(7000);
 });
 
 describe("taxes methods", function () {

--- a/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
+++ b/imports/plugins/included/inventory/server/hooks/inventory-hooks.app-test.js
@@ -130,7 +130,6 @@ describe("Inventory Hooks", function () {
     const order = Orders.findOne({ cartId: cart._id });
     const shipping = { items: [] };
     Meteor.call("orders/shipmentShipped", order, shipping, () => {
-      Meteor._sleepForMs(500);
       const shippedInventoryItem = Inventory.findOne(inventoryItem._id);
       expect(shippedInventoryItem.workflow.status).to.equal("shipped");
       return done();

--- a/server/methods/accounts/accounts.app-test.js
+++ b/server/methods/accounts/accounts.app-test.js
@@ -17,7 +17,6 @@ Fixtures();
 
 before(function () {
   this.timeout(10000);
-  Meteor._sleepForMs(7000);
 });
 
 describe("Account Meteor method ", function () {

--- a/server/methods/catalog.app-test.js
+++ b/server/methods/catalog.app-test.js
@@ -112,7 +112,6 @@ describe("core product methods", function () {
       let variants = Products.find({ ancestors: [product._id] }).fetch();
       expect(variants.length).to.equal(1);
       Meteor.call("products/createVariant", product._id);
-      Meteor._sleepForMs(500);
       variants = Products.find({ ancestors: [product._id] }).fetch();
       expect(variants.length).to.equal(2);
       return done();
@@ -129,7 +128,6 @@ describe("core product methods", function () {
       expect(options.length).to.equal(2);
 
       Meteor.call("products/createVariant", variant._id);
-      Meteor._sleepForMs(500);
       options = Products.find({
         ancestors: { $in: [variant._id] }
       }).fetch();
@@ -148,7 +146,6 @@ describe("core product methods", function () {
       expect(variants.length).to.equal(1);
 
       Meteor.call("products/createVariant", product._id, newVariant);
-      Meteor._sleepForMs(500);
       variants = Products.find({ ancestors: [product._id] }).fetch();
       const createdVariant = variants.filter((v) => v._id !== firstVariantId);
       expect(variants.length).to.equal(2);
@@ -926,7 +923,6 @@ describe("core product methods", function () {
       Meteor.call("products/updateVariantsPosition", [
         variant2._id, variant3._id, variant1._id
       ]);
-      Meteor._sleepForMs(500);
       const modifiedVariant1 = Products.findOne(variant1._id);
       const modifiedVariant2 = Products.findOne(variant2._id);
       const modifiedVariant3 = Products.findOne(variant3._id);
@@ -948,7 +944,6 @@ describe("core product methods", function () {
       Meteor.call("products/updateVariantsPosition", [
         variant2._id, variant3._id, variant1._id
       ]);
-      Meteor._sleepForMs(500);
       const modifiedVariantRevision1 = Revisions.findOne({ documentId: variant1._id });
       const modifiedVariantRevision2 = Revisions.findOne({ documentId: variant2._id });
       const modifiedVariantRevision3 = Revisions.findOne({ documentId: variant3._id });
@@ -970,7 +965,6 @@ describe("core product methods", function () {
       Meteor.call("products/updateVariantsPosition", [
         variant2._id, variant3._id, variant1._id
       ]);
-      Meteor._sleepForMs(500);
       Meteor.call("revisions/publish", [
         variant1._id, variant2._id, variant3._id
       ]);
@@ -1053,7 +1047,6 @@ describe("core product methods", function () {
       const { isVisible } = product;
       expect(() => Meteor.call("products/publishProduct", product._id)).to.not.throw(Meteor.Error, /Access Denied/);
       Meteor.call("revisions/publish", product._id);
-      Meteor._sleepForMs(500);
       product = Products.findOne(product._id);
       // We switch the visible state in `products/publishProdct` for revisions
       expect(product.isVisible).to.equal(!isVisible);

--- a/server/methods/core/cart-create.app-test.js
+++ b/server/methods/core/cart-create.app-test.js
@@ -117,7 +117,6 @@ describe("Add/Create cart methods", function () {
       const items = cart.items.length;
       spyOnMethod("addToCart", cart.userId);
       Meteor.call("cart/addToCart", productId, variantId, quantity);
-      Meteor._sleepForMs(500);
       cart = Cart.findOne(cart._id);
       expect(cart.items.length).to.equal(items + 1);
       expect(cart.items[cart.items.length - 1].productId).to.equal(productId);

--- a/server/methods/core/cart-remove.app-test.js
+++ b/server/methods/core/cart-remove.app-test.js
@@ -55,7 +55,6 @@ describe("cart methods", function () {
       // The cart/removeFromCart method will trigger the hook
       // afterCartUpdateCalculateDiscount 4 times.
       assert.equal(updateSpy.callCount, 4, "update should be called four times");
-      Meteor._sleepForMs(1000);
       const updatedCart = Collections.Cart.findOne(cart._id);
       assert.equal(updatedCart.items.length, 1, "there should be one item left in cart");
       return done();
@@ -75,7 +74,6 @@ describe("cart methods", function () {
       const cartFromCollection = Collections.Cart.findOne(cart._id);
       const cartItemId = cartFromCollection.items[0]._id;
       Meteor.call("cart/removeFromCart", cartItemId, 1);
-      Meteor._sleepForMs(500);
       const updatedCart = Collections.Cart.findOne(cart._id);
       expect(updatedCart.items[0].quantity).to.equal(1);
     });
@@ -95,7 +93,6 @@ describe("cart methods", function () {
       const cartItemId = cartFromCollection.items[0]._id;
       const originalQty = cartFromCollection.items[0].quantity;
       Meteor.call("cart/removeFromCart", cartItemId, originalQty);
-      Meteor._sleepForMs(500);
       const updatedCart = Collections.Cart.findOne(cart._id);
       expect(updatedCart.items.length).to.equal(0);
     });


### PR DESCRIPTION
Resolves #3937 
Impact: **minor**  
Type: **chore**

## Issue
Some methods (mostly things that write to the database) would return but they were not actually complete. So to test these as reliably as possible, I "hacked" this by putting in `_sleepForMs`. Now that the collection hook package is removed this is no longer necessary.

Also I think a couple of sleeps were in there just out of "copy and paste". I think the global sleep is still necessary to make sure that packages get loaded before tests run so that is still in there.

## Solution
This PR does nothing but just remove the sleeps. Tests are running fine for me locally.

## Breaking changes
You no longer have as much time to get coffee when tests run. Also removes a large psychological burden from me knowing this hack was in there.


## Testing
1. Run tests
1. Observe they don't fail
1. Should take ~20 seconds less time to run

