### PR TITLE
Fix for "react-addons-create-fragment should be removed"

### DIFF
--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -16,8 +16,9 @@ import { getRootNode } from "/imports/plugins/core/router/client/browserRouter.j
  */
 
 const getAlertWrapper = () => {
-  const rootNode = getRootNode();
-  
+  getRootNode();
+  const rootNode = document.getElementById("react-root");
+
   rootNode.insertAdjacentHTML("beforebegin", "<div id='s-alert-wrapper'></div>");
   return document.getElementById("s-alert-wrapper");
 };

--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -16,9 +16,8 @@ import { getRootNode } from "/imports/plugins/core/router/client/browserRouter.j
  */
 
 const getAlertWrapper = () => {
-  getRootNode();
-  const rootNode = document.getElementById("react-root");
-
+  const rootNode = getRootNode();
+  
   rootNode.insertAdjacentHTML("beforebegin", "<div id='s-alert-wrapper'></div>");
   return document.getElementById("s-alert-wrapper");
 };

--- a/imports/plugins/core/ui/client/components/button/button.jsx
+++ b/imports/plugins/core/ui/client/components/button/button.jsx
@@ -61,7 +61,7 @@ class Button extends Component {
   renderOnStateIcon() {
     if (this.props.onIcon) {
       return (
-        <Components.Icon key={"icon"} icon={this.props.onIcon} />
+        <Components.Icon icon={this.props.onIcon} />
       );
     }
     return null;
@@ -70,7 +70,7 @@ class Button extends Component {
   renderNormalStateIcon() {
     if (this.props.icon) {
       return (
-        <Components.Icon key={"icon"} icon={this.props.icon} />
+        <Components.Icon icon={this.props.icon} />
       );
     }
     return null;
@@ -82,6 +82,7 @@ class Button extends Component {
         return this.renderOnStateIcon();
       }
     }
+
     return this.renderNormalStateIcon();
   }
 
@@ -109,7 +110,6 @@ class Button extends Component {
         if (this.props.toggleOn && this.props.toggleOnLabel) {
           return (
             <Components.Translation
-              key={"label"}
               defaultValue={this.props.toggleOnLabel}
               i18nKey={this.props.i18nKeyToggleOnLabel}
             />
@@ -119,7 +119,6 @@ class Button extends Component {
 
       return (
         <Components.Translation
-          key={"label"}
           defaultValue={this.props.label}
           i18nKey={this.props.i18nKeyLabel}
         />
@@ -129,10 +128,26 @@ class Button extends Component {
     return null;
   }
 
-  renderChildren() {
+  getFragments(iconAfter) {
     return (
-      <React.Fragment key={"children"}>
-        {this.props.children}
+      <React.Fragment>
+        {iconAfter
+          ? <React.Fragment key={"label"}>
+              {this.renderLabel()}
+            </React.Fragment>
+          : <React.Fragment key={"icon"}>
+              {this.renderIcon()}
+            </React.Fragment>}
+        {iconAfter
+          ? <React.Fragment key={"icon"}>
+              {this.renderIcon()}
+            </React.Fragment>
+          : <React.Fragment key={"label"}>
+              {this.renderLabel()}
+            </React.Fragment>}
+        <React.Fragment key={"children"}>
+          {this.props.children}
+        </React.Fragment>
       </React.Fragment>
     );
   }
@@ -195,30 +210,14 @@ class Button extends Component {
       "type": buttonType || "button"
     }, attrs, extraProps);
 
-
-    // Create a react fragment for all the button children
-    let buttonChildren;
-
-    if (iconAfter) {
-      buttonChildren = [
-        this.renderLabel(),
-        this.renderIcon(),
-        this.renderChildren()
-      ];
-    } else {
-      buttonChildren = [
-        this.renderIcon(),
-        this.renderLabel(),
-        this.renderChildren()
-      ];
-    }
-
     // Button with tooltip gets some special treatment
     if (tooltip) {
-      return React.createElement(tagName, buttonProps,
+      return React.createElement(
+        tagName,
+        buttonProps,
         <span className="rui btn-tooltip" style={{ display: "inline-flex", ...containerStyle }}>
           <Components.Tooltip attachment={tooltipAttachment} tooltipContent={this.renderTooltipContent()}>
-            {buttonChildren}
+            {this.getFragments(iconAfter)}
           </Components.Tooltip>
         </span>
       );
@@ -226,15 +225,16 @@ class Button extends Component {
 
     // Add a wrapped container with styles for standard button
     if (containerStyle) {
-      buttonChildren = (
+      return React.createElement(
+        tagName,
+        buttonProps,
         <div style={containerStyle}>
-          {buttonChildren}
-        </div>
-      );
+          {this.getFragments(iconAfter)}
+        </div>);
     }
 
     // Normal button, without tooltip
-    return React.createElement(tagName, buttonProps, buttonChildren);
+    return React.createElement(tagName, buttonProps, this.getFragments(iconAfter));
   }
 }
 

--- a/imports/plugins/core/ui/client/components/button/button.jsx
+++ b/imports/plugins/core/ui/client/components/button/button.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import createFragment from "react-addons-create-fragment";
 import classnames from "classnames/dedupe";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 
@@ -62,7 +61,7 @@ class Button extends Component {
   renderOnStateIcon() {
     if (this.props.onIcon) {
       return (
-        <Components.Icon icon={this.props.onIcon} />
+        <Components.Icon key={"icon"} icon={this.props.onIcon} />
       );
     }
     return null;
@@ -71,7 +70,7 @@ class Button extends Component {
   renderNormalStateIcon() {
     if (this.props.icon) {
       return (
-        <Components.Icon icon={this.props.icon} />
+        <Components.Icon key={"icon"} icon={this.props.icon} />
       );
     }
     return null;
@@ -83,7 +82,6 @@ class Button extends Component {
         return this.renderOnStateIcon();
       }
     }
-
     return this.renderNormalStateIcon();
   }
 
@@ -111,6 +109,7 @@ class Button extends Component {
         if (this.props.toggleOn && this.props.toggleOnLabel) {
           return (
             <Components.Translation
+              key={"label"}
               defaultValue={this.props.toggleOnLabel}
               i18nKey={this.props.i18nKeyToggleOnLabel}
             />
@@ -120,6 +119,7 @@ class Button extends Component {
 
       return (
         <Components.Translation
+          key={"label"}
           defaultValue={this.props.label}
           i18nKey={this.props.i18nKeyLabel}
         />
@@ -127,6 +127,14 @@ class Button extends Component {
     }
 
     return null;
+  }
+
+  renderChildren() {
+    return (
+      <div key={"children"}>
+        {this.props.children}
+      </div>
+    );
   }
 
   render() {
@@ -192,17 +200,17 @@ class Button extends Component {
     let buttonChildren;
 
     if (iconAfter) {
-      buttonChildren = createFragment({
-        label: this.renderLabel(),
-        icon: this.renderIcon(),
-        children: this.props.children
-      });
+      buttonChildren = [
+        this.renderLabel(),
+        this.renderIcon(),
+        this.renderChildren()
+      ];
     } else {
-      buttonChildren = createFragment({
-        icon: this.renderIcon(),
-        label: this.renderLabel(),
-        children: this.props.children
-      });
+      buttonChildren = [
+        this.renderIcon(),
+        this.renderLabel(),
+        this.renderChildren()
+      ];
     }
 
     // Button with tooltip gets some special treatment

--- a/imports/plugins/core/ui/client/components/button/button.jsx
+++ b/imports/plugins/core/ui/client/components/button/button.jsx
@@ -131,9 +131,9 @@ class Button extends Component {
 
   renderChildren() {
     return (
-      <div key={"children"}>
+      <React.Fragment key={"children"}>
         {this.props.children}
-      </div>
+      </React.Fragment>
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10589,16 +10589,6 @@
         "prop-types": "15.6.0"
       }
     },
-    "react-addons-create-fragment": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz",
-      "integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "react-addons-pure-render-mixin": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-15.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "radium": "^0.22.0",
     "ramda": "^0.25.0",
     "react": "16.2.0",
-    "react-addons-create-fragment": "15.6.2",
     "react-addons-pure-render-mixin": "15.6.2",
     "react-addons-shallow-compare": "^15.6.2",
     "react-autosuggest": "^9.3.3",


### PR DESCRIPTION
This PR closes issue #4163

Changes:
  Remove package react-addons-create-fragment.
  The migration path is to use arrays with explicit keys on individual elements.

Resolves #4163   
Impact: **minor**  
Type: **chore**

## Issue
The package react-addons-create-fragment should be removed for 2 reasons:

It's a legacy React addon and it's not longer maintained. New code should not rely on it
It causes problems when combined with ReactDOM.hydrate() / SSR, because it does not use the special React property key for order determination.


## Breaking changes
none
