### PR TITLE
Fix for "document.getElementBuId("react-root") may fail"

### DIFF
--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -16,8 +16,7 @@ import { getRootNode } from "/imports/plugins/core/router/client/browserRouter.j
  */
 
 const getAlertWrapper = () => {
-  getRootNode();
-  const rootNode = document.getElementById("react-root");
+  const rootNode = getRootNode();
 
   rootNode.insertAdjacentHTML("beforebegin", "<div id='s-alert-wrapper'></div>");
   return document.getElementById("s-alert-wrapper");


### PR DESCRIPTION
Resolves #4171  
Impact: **minor**  
Type: **bugfix**

## Issue
Description of the issue this PR is solving, why it's happening, and how to reproduce it. This may differ from the original ticket as you now have more information at your disposal.

## Solution
Use the return value of getRootNode() which always contains the correct node, no matter how it is named.

## Breaking changes
none
