### PR TITLE
feat(GraphQL): add primaryShopId query

### DIFF
--- a/imports/plugins/core/graphql/server/queries.js
+++ b/imports/plugins/core/graphql/server/queries.js
@@ -4,10 +4,12 @@ import { groupQuery, groupsQuery } from "/imports/plugins/core/accounts/server/m
 import { rolesQuery } from "/imports/plugins/core/accounts/server/methods/rolesQuery";
 import tags from "/imports/plugins/core/catalog/server/queries/tags";
 import tagsByIds from "/imports/plugins/core/catalog/server/queries/tagsByIds";
+import getShopIdByDomain from "/imports/plugins/core/accounts/server/no-meteor/getShopIdByDomain";
 
 export default {
   group: groupQuery,
   groups: groupsQuery,
+  primaryShopId: getShopIdByDomain,
   roles: rolesQuery,
   shopAdministrators: shopAdministratorsQuery,
   shopById: (context, _id) => context.collections.Shops.findOne({ _id }),

--- a/imports/plugins/core/graphql/server/resolvers/shop/Query/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Query/index.js
@@ -1,5 +1,7 @@
+import primaryShopId from "./primaryShopId";
 import shop from "./shop";
 
 export default {
+  primaryShopId,
   shop
 };

--- a/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.js
@@ -1,0 +1,15 @@
+import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+
+/**
+ * @name primaryShopId
+ * @method
+ * @summary Gets the primary shop ID
+ * @param {Object} parentObject - unused
+ * @param {Object} args - unused
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<String>} The shop ID based on the domain in ROOT_URL
+ */
+export default async function primaryShopId(_, __, context) {
+  const shopId = await context.queries.primaryShopId(context.collections);
+  return encodeShopOpaqueId(shopId);
+}

--- a/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.test.js
@@ -1,0 +1,13 @@
+import primaryShopId from "./primaryShopId";
+
+const fakeShopId = "W64ZQe9RUMuAoKrli";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDpXNjRaUWU5UlVNdUFvS3JsaQ==";
+
+test("calls queries.primaryShopId and returns the requested ID", async () => {
+  const primaryShopIdQuery = jest.fn().mockName("primaryShopId").mockReturnValueOnce(Promise.resolve(fakeShopId));
+
+  const result = await primaryShopId(null, null, { queries: { primaryShopId: primaryShopIdQuery } });
+
+  expect(result).toBe(opaqueShopId);
+  expect(primaryShopIdQuery).toHaveBeenCalled();
+});

--- a/imports/plugins/core/graphql/server/schemas/shop.graphql
+++ b/imports/plugins/core/graphql/server/schemas/shop.graphql
@@ -76,4 +76,7 @@ extend type Mutation {
 extend type Query {
   "Returns a shop by ID"
   shop(id: ID!): Shop
+
+  "Returns the ID of the primary shop for the domain"
+  primaryShopId: ID
 }


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Changes
Add `Query.primaryShopId` to GraphQL schema and resolvers. It returns an `ID`. Clients can query this once when loading and then cache it for use in any shop queries that require an ID.

## Breaking changes
None

## Testing
Verify that you get the correct shop ID back based on its `domains` prop containing the current domain that's in `ROOT_URL` env variable.
