### PR TITLE
client side validation on address book

### DIFF
--- a/imports/plugins/core/accounts/client/components/addressBook.js
+++ b/imports/plugins/core/accounts/client/components/addressBook.js
@@ -272,10 +272,6 @@ class AddressBook extends Component {
             mode: "review",
             validationResults: result
           });
-        } else {
-          this.setState({
-            mode: "grid"
-          });
         }
       })
       .catch(onError);

--- a/imports/plugins/core/accounts/client/components/addressBookForm.js
+++ b/imports/plugins/core/accounts/client/components/addressBookForm.js
@@ -80,6 +80,42 @@ class AddressBookForm extends Component {
   }
   // Address Book Form helpers
 
+  fieldLabelMap = {
+    region: {
+      label: "Region",
+      i18nKeyLabel: "address.region"
+    },
+    country: {
+      label: "Country",
+      i18nKeyLabel: "address.country"
+    },
+    fullName: {
+      label: "Full Name",
+      i18nKeyLabel: "address.fullName"
+    },
+    address1: {
+      label: "Address",
+      i18nKeyLabel: "address.address1"
+    },
+    address2: {
+      label: "Address",
+      i18nKeyLabel: "address.address2"
+    },
+    postal: {
+      label: "Postal",
+      i18nKeyLabel: "address.postal"
+    },
+    city: {
+      label: "City",
+      i18nKeyLabel: "address.city"
+    },
+    phone: {
+      label: "Phone",
+      i18nKeyLabel: "address.phone"
+    }
+  }
+
+
   /**
    * @method setRegionOptions
    * @summary creates an array of region options for the regions select field.
@@ -103,6 +139,30 @@ class AddressBookForm extends Component {
     }
   }
 
+  clientValidation = (enteredAddress) => {
+    const requiredFields = ["country", "fullName", "address1", "postal", "city", "region", "phone"];
+    const validation = { messages: {} };
+    let isValid = true;
+    Object.keys(enteredAddress).forEach((key) => {
+      if (requiredFields.indexOf(key) > -1 && !enteredAddress[key]) {
+        validation.messages[key] = {
+          message: `${this.fieldLabelMap[key].label} is required`
+        };
+        isValid = false;
+      }
+    });
+    if (!isValid) {
+      this.setState({
+        validation
+      });
+    } else {
+      this.setState({
+        validation: null
+      })
+    }
+    return isValid;
+  }
+
   // Address Book Form Actions
 
   /**
@@ -115,7 +175,9 @@ class AddressBookForm extends Component {
     const { add } = this.props;
     const { fields: enteredAddress } = this.state; // fields object as enteredAddress
     // TODO: field validatiion
-    add(enteredAddress);
+    if (this.clientValidation(enteredAddress)) {
+      add(enteredAddress);
+    }
   }
 
   /**
@@ -243,18 +305,19 @@ class AddressBookForm extends Component {
 
   render() {
     const { countries } = this.props;
-    const { regions, fields } = this.state;
+    const { regions, fields, validation } = this.state;
     let regionField;
     if (regions.length === 0) {
       // if no region optioins
       // render a TextField
       regionField = (
         <Components.TextField
-          i18nKeyLabel="address.region"
-          label="Region"
+          i18nKeyLabel={this.fieldLabelMap.region.i18nKeyLabel}
+          label={this.fieldLabelMap.region.label}
           name="region"
           onChange={this.onFieldChange}
           value={fields.region}
+          validation={validation}
         />
       );
     } else {
@@ -262,12 +325,13 @@ class AddressBookForm extends Component {
       // render a Select
       regionField = (
         <Components.Select
-          i18nKeyLabel="address.region"
-          label="Region"
+          i18nKeyLabel={this.fieldLabelMap.region.i18nKeyLabel}
+          label={this.fieldLabelMap.region.label}
           name="region"
           options={regions}
           onChange={this.onSelectChange}
           value={fields.region}
+          validation={validation}
         />
       );
     }
@@ -276,13 +340,14 @@ class AddressBookForm extends Component {
         <div className="row">
           <div className="col-md-6">
             <Components.Select
-              i18nKeyLabel="address.country"
-              label="Country"
+              i18nKeyLabel={this.fieldLabelMap.country.i18nKeyLabel}
+              label={this.fieldLabelMap.country.label}
               name="country"
               options={countries}
               onChange={this.onSelectChange}
               placeholder="Country"
               value={fields.country}
+              validation={validation}
             />
           </div>
         </div>
@@ -290,11 +355,12 @@ class AddressBookForm extends Component {
         <div className="row">
           <div className="col-md-6">
             <Components.TextField
-              i18nKeyLabel="address.fullName"
-              label="Full Name"
+              i18nKeyLabel={this.fieldLabelMap.fullName.i18nKeyLabel}
+              label={this.fieldLabelMap.fullName.label}
               name="fullName"
               onChange={this.onFieldChange}
               value={fields.fullName}
+              validation={validation}
             />
           </div>
         </div>
@@ -302,20 +368,22 @@ class AddressBookForm extends Component {
         <div className="row">
           <div className="col-md-6">
             <Components.TextField
-              i18nKeyLabel="address.address1"
-              label="Address"
+              i18nKeyLabel={this.fieldLabelMap.address1.i18nKeyLabel}
+              label={this.fieldLabelMap.address1.label}
               name="address1"
               onChange={this.onFieldChange}
               value={fields.address1}
+              validation={validation}
             />
           </div>
           <div className="col-md-6">
             <Components.TextField
-              i18nKeyLabel="address.address2"
-              label="Address"
+              i18nKeyLabel={this.fieldLabelMap.address2.i18nKeyLabel}
+              label={this.fieldLabelMap.address2.label}
               name="address2"
               onChange={this.onFieldChange}
               value={fields.address2}
+              validation={validation}
             />
           </div>
         </div>
@@ -323,20 +391,22 @@ class AddressBookForm extends Component {
         <div className="row">
           <div className="col-md-4">
             <Components.TextField
-              i18nKeyLabel="address.postal"
-              label="Postal"
+              i18nKeyLabel={this.fieldLabelMap.postal.i18nKeyLabel}
+              label={this.fieldLabelMap.postal.label}
               name="postal"
               onChange={this.onFieldChange}
               value={fields.postal}
+              validation={validation}
             />
           </div>
           <div className="col-md-4">
             <Components.TextField
-              i18nKeyLabel="address.city"
-              label="City"
+              i18nKeyLabel={this.fieldLabelMap.city.i18nKeyLabel}
+              label={this.fieldLabelMap.city.label}
               name="city"
               onChange={this.onFieldChange}
               value={fields.city}
+              validation={validation}
             />
           </div>
           <div className="col-md-4">
@@ -347,11 +417,12 @@ class AddressBookForm extends Component {
         <div className="row">
           <div className="col-md-4">
             <Components.TextField
-              i18nKeyLabel="address.phone"
-              label="Phone"
+              i18nKeyLabel={this.fieldLabelMap.phone.i18nKeyLabel}
+              label={this.fieldLabelMap.phone.label}
               name="phone"
               onChange={this.onFieldChange}
               value={fields.phone}
+              validation={validation}
             />
           </div>
         </div>

--- a/imports/plugins/core/accounts/client/components/addressBookForm.js
+++ b/imports/plugins/core/accounts/client/components/addressBookForm.js
@@ -158,7 +158,7 @@ class AddressBookForm extends Component {
     } else {
       this.setState({
         validation: null
-      })
+      });
     }
     return isValid;
   }

--- a/imports/plugins/core/accounts/client/components/addressBookForm.js
+++ b/imports/plugins/core/accounts/client/components/addressBookForm.js
@@ -134,7 +134,11 @@ class AddressBookForm extends Component {
       // setting the fields region to be the
       // first region in options array
       const [firstRegion] = regions;
-      fields.region = firstRegion;
+      if (firstRegion !== null && typeof firstRegion === "object") {
+        fields.region = firstRegion.value;
+      } else {
+        fields.region = firstRegion;
+      }
       this.setState({ regions, fields });
     }
   }
@@ -144,7 +148,10 @@ class AddressBookForm extends Component {
     const validation = { messages: {} };
     let isValid = true;
     Object.keys(enteredAddress).forEach((key) => {
-      if (requiredFields.indexOf(key) > -1 && !enteredAddress[key].trim()) {
+      if (enteredAddress[key] && typeof enteredAddress[key] === "string" && requiredFields.indexOf(key) > -1) {
+        enteredAddress[key] = enteredAddress[key].trim();
+      }
+      if (requiredFields.indexOf(key) > -1 && !enteredAddress[key]) {
         validation.messages[key] = {
           message: `${this.fieldLabelMap[key].label} is required`
         };

--- a/imports/plugins/core/accounts/client/components/addressBookForm.js
+++ b/imports/plugins/core/accounts/client/components/addressBookForm.js
@@ -157,7 +157,7 @@ class AddressBookForm extends Component {
       });
     } else {
       this.setState({
-        validation: null
+        validation: undefined
       });
     }
     return isValid;

--- a/imports/plugins/core/accounts/client/components/addressBookForm.js
+++ b/imports/plugins/core/accounts/client/components/addressBookForm.js
@@ -144,7 +144,7 @@ class AddressBookForm extends Component {
     const validation = { messages: {} };
     let isValid = true;
     Object.keys(enteredAddress).forEach((key) => {
-      if (requiredFields.indexOf(key) > -1 && !enteredAddress[key]) {
+      if (requiredFields.indexOf(key) > -1 && !enteredAddress[key].trim()) {
         validation.messages[key] = {
           message: `${this.fieldLabelMap[key].label} is required`
         };

--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -13,7 +13,7 @@ class TextField extends Component {
    */
   get value() {
     // if the props.value is not a number
-    // return ether the value or and empty string
+    // return either the value or and empty string
     if (isNaN(this.props.value)) {
       return this.props.value || "";
     }


### PR DESCRIPTION
Resolves #4155  
Impact: **major**  
Type: **bugfix**

## Issue
There was no client side validation on the addressBookForm.

## Solution
Added client side validation by checking individual values. Right now only empty fields are checked.

## Breaking changes
None

## Testing
1. Add product to the cart and go to checkout screen.
2. Proceed without filling the address.
3. Notice the validation errors.
4. Fix some of them and again submit.
5. Notice error on rest of them.
6. Fix the errors and proceed.
7. Address should be saved.

