### PR TITLE
Bug Fix: Admins Acting on Behalf of Other Users

### DIFF
--- a/imports/plugins/included/connectors-shopify/server/methods/import/customers.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/import/customers.js
@@ -166,11 +166,11 @@ export const methods = {
 
             // Insert customer, save id
             const reactionCustomerId = Accounts.insert(reactionCustomer, { publish: true });
-            Hooks.Events.run("afterAccountsInsert", Meteor.userId(), reactionCustomerId);
+            Hooks.Events.run("afterAccountsInsert", reactionCustomer._id, reactionCustomerId);
             ids.push(reactionCustomerId);
 
             Accounts.update({ _id: reactionCustomerId }, { publish: true });
-            Hooks.Events.run("afterAccountsUpdate", Meteor.userId(), {
+            Hooks.Events.run("afterAccountsUpdate", reactionCustomer._id, {
               accountId: reactionCustomerId,
               updatedFields: ["forceIndex"]
             });

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -357,7 +357,7 @@ export function addressBookAdd(address, accountUserId) {
           "profile.addressBook.$.isShippingDefault": false
         }
       });
-      Hooks.Events.run("afterAccountsUpdate", Meteor.userId(), {
+      Hooks.Events.run("afterAccountsUpdate", userId, {
         accountId: account._id,
         updatedFields: ["isShippingDefault"]
       });
@@ -371,7 +371,7 @@ export function addressBookAdd(address, accountUserId) {
           "profile.addressBook.$.isBillingDefault": false
         }
       });
-      Hooks.Events.run("afterAccountsUpdate", Meteor.userId(), {
+      Hooks.Events.run("afterAccountsUpdate", userId, {
         accountId: account._id,
         updatedFields: ["isBillingDefault"]
       });
@@ -397,7 +397,7 @@ export function addressBookAdd(address, accountUserId) {
     accountsUpdateQuery.$set.name = address.fullName;
   }
 
-  Meteor.users.update(Meteor.userId(), userUpdateQuery);
+  Meteor.users.update(userId, userUpdateQuery);
 
   const result = Accounts.upsert({
     userId
@@ -523,7 +523,7 @@ export function addressBookUpdate(address, accountUserId, type) {
   }
 
   // Update the Meteor.users collection with new address info
-  Meteor.users.update(Meteor.userId(), userUpdateQuery);
+  Meteor.users.update(userId, userUpdateQuery);
 
   // Update the Reaction Accounts collection with new address info
   const updatedAccountResult = Accounts.update({
@@ -540,7 +540,7 @@ export function addressBookUpdate(address, accountUserId, type) {
   });
 
   // Run afterAccountsUpdate hook to update Accounts Search
-  Hooks.Events.run("afterAccountsUpdate", Meteor.userId(), {
+  Hooks.Events.run("afterAccountsUpdate", userId, {
     accountId: account._id,
     updatedFields
   });
@@ -598,7 +598,7 @@ export function addressBookRemove(addressId, accountUserId) {
   }, { bypassCollection2: true });
 
   // forceIndex when removing an address
-  Hooks.Events.run("afterAccountsUpdate", Meteor.userId(), {
+  Hooks.Events.run("afterAccountsUpdate", userId, {
     accountId: account._id,
     updatedFields: ["forceIndex"]
   });

--- a/server/methods/core/groups.app-test.js
+++ b/server/methods/core/groups.app-test.js
@@ -4,7 +4,7 @@ import { check, Match } from "meteor/check";
 import { Factory } from "meteor/dburles:factory";
 import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";
-import { Reaction } from "/server/api";
+import { Reaction, Hooks } from "/server/api";
 import { Accounts, Groups } from "/lib/collections";
 import Fixtures from "/server/imports/fixtures";
 import { getUser } from "/server/imports/fixtures/users";
@@ -132,9 +132,14 @@ describe("Group test", function () {
     let updatedUser = Meteor.users.findOne({ _id: user._id });
     expect(updatedUser.roles[shop._id]).to.include.members(sampleGroup.permissions);
 
+    const hooksSpy = sandbox.spy(Hooks.Events, "run");
+
     Meteor.call("group/removeUser", user._id, group._id);
     updatedUser = Meteor.users.findOne({ _id: user._id });
     expect(updatedUser.roles[shop._id]).to.include.members(sampleCustomerGroup.permissions);
+
+    expect(hooksSpy)
+      .to.have.been.calledWith("afterAccountsUpdate", user._id, sinon.match.any);
   });
 
   it("should ensure a user's permissions does not include roles from previous group", function () {

--- a/server/methods/core/groups.js
+++ b/server/methods/core/groups.js
@@ -178,7 +178,7 @@ Meteor.methods({
     try {
       setUserPermissions({ _id: userId }, permissions, shopId);
       Accounts.update({ _id: userId }, { $set: { groups: newGroups } });
-      Hooks.Events.run("afterAccountsUpdate", loggedInUserId, {
+      Hooks.Events.run("afterAccountsUpdate", userId, {
         accountId: userId,
         updatedFields: ["groups"]
       });

--- a/server/methods/core/groups.js
+++ b/server/methods/core/groups.js
@@ -230,7 +230,7 @@ Meteor.methods({
     try {
       setUserPermissions(user, defaultCustomerGroupForShop.permissions, shopId);
       Accounts.update({ _id: userId, groups: groupId }, { $set: { "groups.$": defaultCustomerGroupForShop._id } }); // replace the old id with new id
-      Hooks.Events.run("afterAccountsUpdate", Meteor.userId(), {
+      Hooks.Events.run("afterAccountsUpdate", userId, {
         accountId: userId,
         updatedFields: ["groups"]
       });


### PR DESCRIPTION
Resolves _n/a_
Impact: **minor**  
Type: **bugfix**

## Issue
I noticed a few places where we kick off events using `Meteor.userId()`, however there are cases where an Admin may be acting on behalf of another user, so I _think_ we should be passing the target user's id instead.

## Testing
1. I added an additional expectation to the applicable tests.
