### PR TITLE
fix: no access-denied in "accounts/setProfileCurrency" for self

### DIFF
--- a/client/modules/i18n/main.js
+++ b/client/modules/i18n/main.js
@@ -3,7 +3,7 @@ import { values } from "lodash";
 import SimpleSchema from "simpl-schema";
 import { Meteor } from "meteor/meteor";
 import { Tracker } from "meteor/tracker";
-import { Reaction } from "/client/api";
+import { Logger, Reaction } from "/client/api";
 
 /**
  * @file **Internationalization**
@@ -99,16 +99,19 @@ Meteor.startup(() => {
     if (Reaction.Subscriptions.PrimaryShop.ready() && merchantShopsReadyOrSkipped) {
       // use i18n detected language to getLocale info and set it client side
       Meteor.call("shop/getLocale", (error, result) => {
-        if (result) {
-          const locale = result;
-          locale.language = getBrowserLanguage();
-
-          Reaction.Locale.set(locale);
-          localeDep.changed();
-
-          // Stop the tracker
-          c.stop();
+        if (error || !result) {
+          Logger.error(error, "Unable to get shop locale");
+          return;
         }
+
+        const locale = result;
+        locale.language = getBrowserLanguage();
+
+        Reaction.Locale.set(locale);
+        localeDep.changed();
+
+        // Stop the tracker
+        c.stop();
       });
     }
   });

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -1072,14 +1072,14 @@ export function setProfileCurrency(currencyName, accountId) {
   check(currencyName, String);
   check(accountId, Match.Maybe(String));
 
-  const userId = accountId || this.userId;
-  if (!userId) throw new Meteor.Error("access-denied", "You must be logged in to set your profile currency");
+  const currentUserId = this.userId;
+  const userId = accountId || currentUserId;
+  if (!userId) throw new Meteor.Error("access-denied", "You must be logged in to set profile currency");
 
   const account = Accounts.findOne({ userId }, { fields: { shopId: 1 } });
-
   if (!account) throw new Meteor.Error("not-found", "Account not found");
 
-  if (!Reaction.hasPermission("reaction-accounts", Meteor.userId(), account.shopId)) {
+  if (userId !== currentUserId && !Reaction.hasPermission("reaction-accounts", currentUserId, account.shopId)) {
     throw new Meteor.Error("access-denied", "Access denied");
   }
 


### PR DESCRIPTION
Resolves #4191 
Impact: **patch**  
Type: **bugfix**

## Issue
"accounts/setProfileCurrency" method was throwing "access-denied" when called from within "shop/getLocale" method on startup. This was because it was checking for "reaction-accounts" permission even when setting one's own profile.

## Solution
Do the permission check only when setting profile currency for other accounts.

## Breaking changes
None

## Testing
With a fresh database, start the app and make sure the default product's price shows up in the grid. You can also check the console to verify there were no errors.
