### PR TITLE
feat(GraphQL): uniqueId schema directives

### DIFF
--- a/imports/plugins/core/graphql/server/resolvers/account/Query/account.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Query/account.js
@@ -1,5 +1,3 @@
-import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
-
 /**
  * @name account
  * @method
@@ -11,6 +9,5 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
  * @return {Promise<Object>} user account object
  */
 export default function account(_, { id }, context) {
-  const dbAccountId = decodeAccountOpaqueId(id);
-  return context.queries.userAccount(context, dbAccountId);
+  return context.queries.userAccount(context, id);
 }

--- a/imports/plugins/core/graphql/server/resolvers/account/Query/account.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Query/account.test.js
@@ -1,7 +1,5 @@
 import account from "./account";
 
-const base64ID = "cmVhY3Rpb24vYWNjb3VudDoxMjM="; // reaction/account:123
-
 const mockAccount = {
   _id: "123",
   name: "Reaction"
@@ -10,7 +8,7 @@ const mockAccount = {
 test("calls queries.userAccount and returns the requested user", async () => {
   const userAccount = jest.fn().mockName("queries.userAccount").mockReturnValueOnce(Promise.resolve(mockAccount));
 
-  const user = await account(null, { id: base64ID }, {
+  const user = await account(null, { id: mockAccount._id }, {
     queries: { userAccount },
     userId: "999"
   });

--- a/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.js
@@ -1,5 +1,3 @@
-import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
-
 /**
  * @name primaryShopId
  * @method
@@ -10,6 +8,5 @@ import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
  * @return {Promise<String>} The shop ID based on the domain in ROOT_URL
  */
 export default async function primaryShopId(_, __, context) {
-  const shopId = await context.queries.primaryShopId(context.collections);
-  return encodeShopOpaqueId(shopId);
+  return context.queries.primaryShopId(context.collections);
 }

--- a/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.test.js
@@ -1,13 +1,12 @@
 import primaryShopId from "./primaryShopId";
 
 const fakeShopId = "W64ZQe9RUMuAoKrli";
-const opaqueShopId = "cmVhY3Rpb24vc2hvcDpXNjRaUWU5UlVNdUFvS3JsaQ==";
 
 test("calls queries.primaryShopId and returns the requested ID", async () => {
   const primaryShopIdQuery = jest.fn().mockName("primaryShopId").mockReturnValueOnce(Promise.resolve(fakeShopId));
 
   const result = await primaryShopId(null, null, { queries: { primaryShopId: primaryShopIdQuery } });
 
-  expect(result).toBe(opaqueShopId);
+  expect(result).toBe(fakeShopId);
   expect(primaryShopIdQuery).toHaveBeenCalled();
 });

--- a/imports/plugins/core/graphql/server/resolvers/util/namespaces.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/namespaces.js
@@ -1,13 +1,16 @@
+const PREFIX = "reaction/";
+
 export default {
-  Account: "reaction/account",
-  Address: "reaction/address",
-  CatalogItem: "reaction/catalogItem",
-  CatalogProduct: "reaction/catalogProduct",
-  CatalogProductVariant: "reaction/catalogProductVariant",
-  Currency: "reaction/currency",
-  Group: "reaction/group",
-  Product: "reaction/product",
-  Role: "reaction/role",
-  Shop: "reaction/shop",
-  Tag: "reaction/tag"
+  PREFIX,
+  Account: `${PREFIX}account`,
+  Address: `${PREFIX}address`,
+  CatalogItem: `${PREFIX}catalogItem`,
+  CatalogProduct: `${PREFIX}catalogProduct`,
+  CatalogProductVariant: `${PREFIX}catalogProductVariant`,
+  Currency: `${PREFIX}currency`,
+  Group: `${PREFIX}group`,
+  Product: `${PREFIX}product`,
+  Role: `${PREFIX}role`,
+  Shop: `${PREFIX}shop`,
+  Tag: `${PREFIX}tag`
 };

--- a/imports/plugins/core/graphql/server/schema.js
+++ b/imports/plugins/core/graphql/server/schema.js
@@ -1,5 +1,6 @@
 import { makeExecutableSchema } from "graphql-tools";
 import resolvers from "./resolvers";
 import typeDefs from "./schemas";
+import schemaDirectives from "./schemaDirectives";
 
-export default makeExecutableSchema({ typeDefs, resolvers });
+export default makeExecutableSchema({ resolvers, schemaDirectives, typeDefs });

--- a/imports/plugins/core/graphql/server/schemaDirectives/index.js
+++ b/imports/plugins/core/graphql/server/schemaDirectives/index.js
@@ -1,0 +1,7 @@
+import uniqueId from "./uniqueId";
+import uniqueIdArg from "./uniqueIdArg";
+
+export default {
+  uniqueId,
+  uniqueIdArg
+};

--- a/imports/plugins/core/graphql/server/schemaDirectives/uniqueId.js
+++ b/imports/plugins/core/graphql/server/schemaDirectives/uniqueId.js
@@ -1,0 +1,58 @@
+import { defaultFieldResolver, DirectiveLocation, GraphQLDirective, GraphQLNonNull, GraphQLString } from "graphql";
+import { SchemaDirectiveVisitor } from "graphql-tools";
+import { namespaces } from "@reactioncommerce/reaction-graphql-utils";
+import { decodeOpaqueIdForNamespace, encodeOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/id";
+
+class UniqueIdDirective extends SchemaDirectiveVisitor {
+  // https://www.apollographql.com/docs/graphql-tools/schema-directives.html#Declaring-schema-directives
+  static getDirectiveDeclaration(directiveName, schema) {
+    const previousDirective = schema.getDirective(directiveName);
+    if (previousDirective) return previousDirective;
+
+    return new GraphQLDirective({
+      name: directiveName,
+      locations: [
+        DirectiveLocation.FIELD_DEFINITION,
+        DirectiveLocation.INPUT_FIELD_DEFINITION
+      ],
+      args: {
+        namespace: {
+          type: new GraphQLNonNull(GraphQLString)
+        }
+      }
+    });
+  }
+
+  /**
+   * @name visitFieldDefinition
+   * @summary Given an "ID" type field, transforms the resolved string to be globally unique
+   * @param {GraphQLField} field Any GraphQL field on which the schema author has used this directive
+   * @returns Globally unique string, with the `namespace` argument value encoded into it
+   */
+  visitFieldDefinition(field) {
+    const { resolve = defaultFieldResolver } = field;
+    const { namespace } = this.args;
+    field.resolve = async function uniqueIdResolve(...args) {
+      const result = await resolve.apply(this, args);
+      return encodeOpaqueId(namespaces.PREFIX + namespace, result);
+    };
+  }
+
+  /**
+   * @name visitInputFieldDefinition
+   * @summary Given an "ID" type input field, transforms the globally unique input ID to be an internal ID.
+   *   Also verifies that the encoded namespace matches the expected namespace using the `namespace` argument.
+   * @param {GraphQLField} field Any GraphQL input field on which the schema author has used this directive
+   * @returns Decoded internal ID
+   */
+  visitInputFieldDefinition(field) {
+    const { resolve = defaultFieldResolver } = field;
+    const { namespace } = this.args;
+    field.resolve = async function uniqueIdResolve(...args) {
+      const result = await resolve.apply(this, args);
+      return decodeOpaqueIdForNamespace(namespaces.PREFIX + namespace, result);
+    };
+  }
+}
+
+export default UniqueIdDirective;

--- a/imports/plugins/core/graphql/server/schemaDirectives/uniqueIdArg.js
+++ b/imports/plugins/core/graphql/server/schemaDirectives/uniqueIdArg.js
@@ -1,0 +1,46 @@
+import { defaultFieldResolver, DirectiveLocation, GraphQLDirective, GraphQLNonNull, GraphQLString } from "graphql";
+import { SchemaDirectiveVisitor } from "graphql-tools";
+import { namespaces } from "@reactioncommerce/reaction-graphql-utils";
+import { decodeOpaqueIdForNamespace } from "@reactioncommerce/reaction-graphql-xforms/id";
+
+class UniqueIdArgDirective extends SchemaDirectiveVisitor {
+  // https://www.apollographql.com/docs/graphql-tools/schema-directives.html#Declaring-schema-directives
+  static getDirectiveDeclaration(directiveName, schema) {
+    const previousDirective = schema.getDirective(directiveName);
+    if (previousDirective) return previousDirective;
+
+    return new GraphQLDirective({
+      name: directiveName,
+      locations: [
+        DirectiveLocation.FIELD_DEFINITION
+      ],
+      args: {
+        argument: {
+          type: new GraphQLNonNull(GraphQLString)
+        },
+        namespace: {
+          type: new GraphQLNonNull(GraphQLString)
+        }
+      }
+    });
+  }
+
+  /**
+   * @name visitFieldDefinition
+   * @summary Given an "ID" type field, transforms the resolved string to be globally unique
+   * @param {GraphQLField} field Any GraphQL field on which the schema author has used this directive
+   * @returns Globally unique string, with the `namespace` argument value encoded into it
+   */
+  visitFieldDefinition(field) {
+    const { resolve = defaultFieldResolver } = field;
+    const { namespace, argument } = this.args;
+    field.resolve = async function uniqueIdArgResolve(...args) {
+      const params = { ...args[1] };
+      if (typeof params[argument] === "string") params[argument] = decodeOpaqueIdForNamespace(namespaces.PREFIX + namespace, params[argument]);
+      const newArgs = [args[0], params, args[2], args[3]];
+      return resolve.apply(this, newArgs);
+    };
+  }
+}
+
+export default UniqueIdArgDirective;

--- a/imports/plugins/core/graphql/server/schemas/account.graphql
+++ b/imports/plugins/core/graphql/server/schemas/account.graphql
@@ -248,7 +248,7 @@ extend type Query {
   viewer: Account
 
   "Returns the account with the provided ID"
-  account(id: ID!): Account
+  account(id: ID!): Account @uniqueIdArg(namespace: "account", argument: "id")
 
   """
   Returns a list of administrators for the shop with ID `shopId`, as a Relay-compatible connection.

--- a/imports/plugins/core/graphql/server/schemas/shop.graphql
+++ b/imports/plugins/core/graphql/server/schemas/shop.graphql
@@ -78,5 +78,5 @@ extend type Query {
   shop(id: ID!): Shop
 
   "Returns the ID of the primary shop for the domain"
-  primaryShopId: ID
+  primaryShopId: ID @uniqueId(namespace: "shop")
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1207,10 +1207,16 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@types/graphql": {
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
+      "integrity": "sha512-wXAVyLfkG1UMkKOdMijVWFky39+OD/41KftzqfX1Oejd0Gm6dOIKjCihSVECg6X7PHjftxXmfOKA/d1H79ZfvQ=="
+    },
     "@types/node": {
       "version": "9.4.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
+      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "dev": true
     },
     "abab": {
       "version": "1.0.4",
@@ -1414,13 +1420,13 @@
       }
     },
     "apollo-link": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.1.tgz",
-      "integrity": "sha512-6Ghf+j3cQLCIvjXd2dJrLw+16HZbWbwmB1qlTc41BviB2hv+rK1nJr17Y9dWK0UD4p3i9Hfddx3tthpMKrueHg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.2.tgz",
+      "integrity": "sha512-Uk/BC09dm61DZRDSu52nGq0nFhq7mcBPTjy5EEH1eunJndtCaNXQhQz/BjkI2NdrfGI+B+i5he6YSoRBhYizdw==",
       "requires": {
-        "@types/node": "9.4.6",
-        "apollo-utilities": "1.0.10",
-        "zen-observable-ts": "0.8.8"
+        "@types/graphql": "0.12.6",
+        "apollo-utilities": "1.0.11",
+        "zen-observable-ts": "0.8.9"
       }
     },
     "apollo-server-core": {
@@ -1456,9 +1462,9 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.10.tgz",
-      "integrity": "sha512-m3cjHeCWFevkDMDARWD7ZdiW3oWFX6e0/tCLykvcIgNRf62I1nqHfJohRKGPu58/QUY8c4IZSAj5NS/Foh82qQ=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.11.tgz",
+      "integrity": "sha512-SAjRTqcYVHwpct+bcwX3x3zGEQOkNzj3Ri7Iy+vFIozxS8xtdkQqPiML7S6EI9Q2IuimQ7gvuYFHY0HQK0O1AA=="
     },
     "append-transform": {
       "version": "0.4.0",
@@ -5864,12 +5870,12 @@
       "integrity": "sha1-WAUM/hYRhZX4KrOqv8l0VGznVag="
     },
     "graphql-tools": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.21.0.tgz",
-      "integrity": "sha512-AmG4WGdpL1OHwnA20ouP7BVB3KnvUOvsc7+4ULWRzEunyRFUYqxrgnEf20iZnYAha8JCb7AP4WPMwWKmGT91rg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.24.0.tgz",
+      "integrity": "sha512-Mz9I7jyizrd+RafC/5EogJKTVzBbIddDCrW0sP5QLmsVVM3ujfhqVYu2lEXOaJW8Sy18f3ZICHirmKcn6oMAcA==",
       "requires": {
-        "apollo-link": "1.2.1",
-        "apollo-utilities": "1.0.10",
+        "apollo-link": "1.2.2",
+        "apollo-utilities": "1.0.11",
         "deprecated-decorator": "0.1.6",
         "iterall": "1.2.2",
         "uuid": "3.1.0"
@@ -14854,16 +14860,16 @@
       }
     },
     "zen-observable": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
-      "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg=="
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.8.tgz",
+      "integrity": "sha512-HnhhyNnwTFzS48nihkCZIJGsWGFcYUz+XPDlPK5W84Ifji8SksC6m7sQWOf8zdCGhzQ4tDYuMYGu5B0N1dXTtg=="
     },
     "zen-observable-ts": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.8.tgz",
-      "integrity": "sha512-oGjFvBbAA94uh/HvAwJDwMHtNq4lZRtupJx8XsyreOTYvH8x1ef9hIeH/M+IqiAXtNpglq/Klh5rbpYWEeRSOQ==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz",
+      "integrity": "sha512-KJz2O8FxbAdAU5CSc8qZ1K2WYEJb1HxS6XDRF+hOJ1rOYcg6eTMmS9xYHCXzqZZzKw6BbXWyF4UpwSsBQnHJeA==",
       "requires": {
-        "zen-observable": "0.7.1"
+        "zen-observable": "0.8.8"
       }
     },
     "zip": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "graphql-fields": "^1.0.2",
     "graphql-iso-date": "^3.5.0",
     "graphql-relay": "^0.5.4",
-    "graphql-tools": "2.21.0",
+    "graphql-tools": "2.24.0",
     "handlebars": "^4.0.11",
     "history": "^4.7.2",
     "hoist-non-react-statics": "^2.3.1",


### PR DESCRIPTION
 Impact: **minor**  
Type: **feature**

## Issue
We've been implementing very similar logic throughout our resolvers to transform between globally unique GraphQL IDs and our internal, collection-specific Mongo `_id`s. This manual effort slows us down and is not necesary.

## Solution
This PR introduces two new [GraphQL schema directives](https://www.apollographql.com/docs/graphql-tools/schema-directives.html).

Usage for arguments that are of `ID` type:

```
account(id: ID!): Account @uniqueIdArg(namespace: "account", argument: "id")
```

(Include multiple directives if there are multiple arguments that need transformation.

Usage for input and type fields that have an `ID` type value:

```
primaryShopId: ID @uniqueId(namespace: "shop")
```

This is implemented in just two placed in the schema so far. We can switch everything to use this after this is reviewed and merged.

## Breaking changes
None

## Testing
Verify the two IDs that are now using this in the schema are still translating IDs properly.
