### PR TITLE
fix: 4186 nnnnat first value pagination

### DIFF
--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
@@ -36,8 +36,6 @@ export default async function applyPaginationToMongoCursor(cursor, { first, last
 
   resultCount = await cursor.clone().count();
 
-  console.log("apply mongo cursor", totalCount, resultCount);
-
   return {
     pageInfo: {
       hasNextPage: !!maybeFirst && resultCount >= maybeFirst,

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
@@ -1,42 +1,46 @@
 /**
  * Mostly borrowed from https://www.reindex.io/blog/relay-graphql-pagination-with-mongodb/
  */
-export default async function applyPaginationToMongoCursor(cursor, { first, last } = {}) {
-  const totalCount = await cursor.clone().count();
+export default async function applyPaginationToMongoCursor(cursor, { first, last } = {}, totalCount) {
   let resultCount = totalCount;
+  let limit;
+  let skip;
 
-  if (first || last) {
-    let limit;
-    let skip;
-
-    if (first && totalCount > first) {
-      limit = first;
-    }
-
-    if (last) {
-      if (limit && limit > last) {
-        skip = limit - last;
-        limit -= skip;
-      } else if (!limit && totalCount > last) {
-        skip = totalCount - last;
-      }
-    }
-
-    if (skip) {
-      cursor.skip(skip);
-    }
-
-    if (limit) {
-      cursor.limit(limit);
-    }
-
-    resultCount = await cursor.clone().count();
+  let maybeFirst;
+  if (!first && !last) {
+    maybeFirst = 50;
+  } else {
+    maybeFirst = first;
   }
 
+  if (maybeFirst && totalCount > maybeFirst) {
+    limit = maybeFirst;
+  }
+
+  if (last) {
+    if (limit && limit > last) {
+      skip = limit - last;
+      limit -= skip;
+    } else if (!limit && totalCount > last) {
+      skip = totalCount - last;
+    }
+  }
+
+  if (skip) {
+    cursor.skip(skip);
+  }
+
+  if (limit) {
+    cursor.limit(limit);
+  }
+
+  resultCount = await cursor.clone().count();
+
+  console.log("apply mongo cursor", totalCount, resultCount);
+
   return {
-    totalCount,
     pageInfo: {
-      hasNextPage: !!first && resultCount >= first,
+      hasNextPage: !!maybeFirst && resultCount >= maybeFirst,
       hasPreviousPage: !!last && resultCount >= last
     }
   };

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.test.js
@@ -3,85 +3,72 @@ import getFakeMongoCursor from "/imports/test-utils/helpers/getFakeMongoCursor";
 
 const mockCursor = getFakeMongoCursor("Test", new Array(100));
 
-test("with neither first nor last", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(100));
-  expect(applyPaginationToMongoCursor(mockCursor)).resolves.toEqual({
+test("with neither first nor last limits to 50", () => {
+  mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
+  expect(applyPaginationToMongoCursor(mockCursor, undefined, 100)).resolves.toEqual({
     pageInfo: {
-      hasNextPage: false,
+      hasNextPage: true,
       hasPreviousPage: false
-    },
-    totalCount: 100
+    }
   });
 });
 
 test("with first and maybe more, returns hasNextPage true", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(100));
   mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 })).resolves.toEqual({
+  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 }, 100)).resolves.toEqual({
     pageInfo: {
       hasNextPage: true,
       hasPreviousPage: false
-    },
-    totalCount: 100
+    }
   });
 });
 
 test("with first and definitely more, returns hasNextPage true", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(100));
   mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 })).resolves.toEqual({
+  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 }, 100)).resolves.toEqual({
     pageInfo: {
       hasNextPage: true,
       hasPreviousPage: false
-    },
-    totalCount: 100
+    }
   });
 });
 
 test("with first and no more, returns hasNextPage false", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(100));
   mockCursor.count.mockReturnValueOnce(Promise.resolve(40));
-  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 })).resolves.toEqual({
+  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 }, 100)).resolves.toEqual({
     pageInfo: {
       hasNextPage: false,
       hasPreviousPage: false
-    },
-    totalCount: 100
+    }
   });
 });
 
 test("with last and maybe more, returns hasPreviousPage true", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(100));
   mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 })).resolves.toEqual({
+  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 }, 100)).resolves.toEqual({
     pageInfo: {
       hasNextPage: false,
       hasPreviousPage: true
-    },
-    totalCount: 100
+    }
   });
 });
 
 test("with last and definitely more, returns hasPreviousPage true", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(100));
   mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 })).resolves.toEqual({
+  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 }, 100)).resolves.toEqual({
     pageInfo: {
       hasNextPage: false,
       hasPreviousPage: true
-    },
-    totalCount: 100
+    }
   });
 });
 
 test("with last and no more, returns hasPreviousPage false", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(100));
   mockCursor.count.mockReturnValueOnce(Promise.resolve(40));
-  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 })).resolves.toEqual({
+  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 }, 100)).resolves.toEqual({
     pageInfo: {
       hasNextPage: false,
       hasPreviousPage: false
-    },
-    totalCount: 100
+    }
   });
 });

--- a/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
@@ -4,17 +4,19 @@ import getCollectionFromCursor from "./getCollectionFromCursor";
 import getMongoSort from "./getMongoSort";
 
 const getPaginatedResponse = async (query, args) => {
-  const { totalCount, pageInfo } = await applyPaginationToMongoCursor(query, args);
-
+  const totalCount = await query.clone().count();
   const collection = getCollectionFromCursor(query);
-  const baseFilter = query.cmd.query;
 
+  const baseFilter = query.cmd.query;
   const updatedFilter = await applyBeforeAfterToFilter({ collection, baseFilter, ...args });
   const sort = getMongoSort(args);
 
-  const nodes = await query.filter(updatedFilter).sort(sort).toArray();
+  query.filter(updatedFilter).sort(sort);
 
+  const { pageInfo } = await applyPaginationToMongoCursor(query, args, totalCount);
+  const nodes = await query.toArray();
   const count = nodes.length;
+
   if (count) {
     pageInfo.startCursor = nodes[0]._id;
     pageInfo.endCursor = nodes[count - 1]._id;

--- a/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.test.js
@@ -1,15 +1,27 @@
 import getPaginatedResponse from "./getPaginatedResponse";
 import getFakeMongoCursor from "/imports/test-utils/helpers/getFakeMongoCursor";
-import { restore as restore$applyBeforeAfterToFilter, rewire as rewire$applyBeforeAfterToFilter } from "./applyBeforeAfterToFilter";
-import { restore as restore$applyPaginationToMongoCursor, rewire as rewire$applyPaginationToMongoCursor } from "./applyPaginationToMongoCursor";
+import {
+  restore as restore$applyBeforeAfterToFilter,
+  rewire as rewire$applyBeforeAfterToFilter
+} from "./applyBeforeAfterToFilter";
+import {
+  restore as restore$applyPaginationToMongoCursor,
+  rewire as rewire$applyPaginationToMongoCursor
+} from "./applyPaginationToMongoCursor";
 import { restore as restore$getMongoSort, rewire as rewire$getMongoSort } from "./getMongoSort";
 
 const baseQuery = { _id: "BASE_QUERY" };
-const mockCursor = getFakeMongoCursor("COLLECTIONss", [], { query: baseQuery });
-mockCursor.options.db.collection = jest.fn().mockName("db.collection").mockReturnValue("COLLECTION");
+const mockCursor = getFakeMongoCursor("COLLECTIONss", ["1", "2", "3", "4", "5"], { query: baseQuery });
+mockCursor.options.db.collection = jest
+  .fn()
+  .mockName("db.collection")
+  .mockReturnValue("COLLECTION");
 
 const applyBeforeAfterToFilterMock = jest.fn().mockName("applyBeforeAfterToFilter");
-const applyPaginationToMongoCursorMock = jest.fn().mockName("applyPaginationToMongoCursor").mockReturnValue({ totalCount: 5, pageInfo: { info: true } });
+const applyPaginationToMongoCursorMock = jest
+  .fn()
+  .mockName("applyPaginationToMongoCursor")
+  .mockReturnValue({ pageInfo: { info: true } });
 const getMongoSortMock = jest.fn().mockName("getMongoSort");
 
 const mockArgs = { arg1: "test" };
@@ -28,12 +40,16 @@ afterAll(() => {
 
 test("calls applyPaginationToMongoCursor with mongo cursor and args", async () => {
   await getPaginatedResponse(mockCursor, mockArgs);
-  expect(applyPaginationToMongoCursorMock).toHaveBeenCalledWith(mockCursor, mockArgs);
+  expect(applyPaginationToMongoCursorMock).toHaveBeenCalledWith(mockCursor, mockArgs, 5);
 });
 
 test("calls applyBeforeAfterToFilter with correct args", async () => {
   await getPaginatedResponse(mockCursor, mockArgs);
-  expect(applyBeforeAfterToFilterMock).toHaveBeenCalledWith({ arg1: "test", baseFilter: baseQuery, collection: "COLLECTION" });
+  expect(applyBeforeAfterToFilterMock).toHaveBeenCalledWith({
+    arg1: "test",
+    baseFilter: baseQuery,
+    collection: "COLLECTION"
+  });
 });
 
 test("calls getMongoSort with correct args", async () => {

--- a/tests/tag/tags.test.js
+++ b/tests/tag/tags.test.js
@@ -49,8 +49,6 @@ test("get the first 50 tags when neither first or last is in query", async () =>
     return;
   }
 
-  result.tags.nodes.forEach((tag, i) => console.log("tags", tag.position))
-
   expect(result.tags.nodes.length).toBe(50);
   expect(result.tags.totalCount).toBe(55);
   expect(result.tags.pageInfo).toEqual({ endCursor: "MTQ5", hasNextPage: true, hasPreviousPage: false, startCursor: "MTAw" });
@@ -61,8 +59,6 @@ test("get the first 50 tags when neither first or last is in query", async () =>
     expect(error).toBeUndefined();
     return;
   }
-
-  result.tags.nodes.forEach((tag, i) => console.log("tags", tag.position))
 
   expect(result.tags.nodes.length).toBe(5);
   expect(result.tags.totalCount).toBe(55);

--- a/tests/tag/tags.test.js
+++ b/tests/tag/tags.test.js
@@ -1,0 +1,70 @@
+import GraphTester from "../GraphTester";
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const shopName = "Test Shop";
+const tags = [];
+for (let i = 100; i < 155; i += 1) {
+  const tagName = i.toString();
+  const tagId = i.toString();
+  const tagPosition = i;
+  tags.push({ _id: tagId, name: tagName, shopId: internalShopId, position: tagPosition });
+}
+
+const tagsQuery = `($shopId: ID!, $after: ConnectionCursor) {
+  tags(shopId: $shopId, after: $after) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    nodes {
+      _id
+      position
+    }
+  }
+}`;
+
+let tester;
+let query;
+beforeAll(async () => {
+  tester = new GraphTester();
+  await tester.startServer();
+  query = tester.query(tagsQuery);
+});
+
+afterAll(() => tester.stopServer());
+
+test("get the first 50 tags when neither first or last is in query", async () => {
+  await tester.collections.Shops.insert({ _id: internalShopId, name: shopName });
+  await Promise.all(tags.map((tag) => tester.collections.Tags.insert(tag)));
+
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  result.tags.nodes.forEach((tag, i) => console.log("tags", tag.position))
+
+  expect(result.tags.nodes.length).toBe(50);
+  expect(result.tags.totalCount).toBe(55);
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTQ5", hasNextPage: true, hasPreviousPage: false, startCursor: "MTAw" });
+
+  try {
+    result = await query({ shopId: opaqueShopId, after: result.tags.pageInfo.endCursor });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  result.tags.nodes.forEach((tag, i) => console.log("tags", tag.position))
+
+  expect(result.tags.nodes.length).toBe(5);
+  expect(result.tags.totalCount).toBe(55);
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTU0", hasNextPage: false, hasPreviousPage: false, startCursor: "MTUw" });
+});


### PR DESCRIPTION
Resolves #4186   
Impact: **minor**  
Type: **bugfix**

## Issue
If GQL query didn't have an explicit `first` or `last` param the query would return the entire data set

## Solution
 *  Created a tag query integration test that mocks 55 tags and verifies the `tags` query respects the `first` and `last` params when not provided.
 *  Updated the GraphTester class to return the count of the classes toArray method, apply missing props to the clone method, Moved options getter outside of the Object and used `defineProperty` to create the options getter.
 *  Updated `getPaginatedResponse` to get the items `totalCount` from the query, filter the query then call `applyPaginationToMongoCursor` later in the function.
 *  Updated `applyPaginationToMongo` to take `totalCount` as a param, and set a default `first` to 50 if neither `first` or `last` are provided. 
 * Updated the related test.

## Breaking changes
N/A

## Testing
 1.  Spin up a fresh RC shop and devserver.
 2. Use reaction-devtools medium set to populate the tags and products (remember to publish products to the catalog).
 3.  From graphiql query for the tags
```graphql
tags(shopId: "ID") {
    totalCount
    edges {
      node {
        _id
      }
    }
  }
```
The totalCount should be 143 while the edges array has only 50 nodes.
4. repeat the above steps for the catalogItems query