### PR TITLE
Limit Tags Publication to Those for the Current Shop

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -607,6 +607,15 @@ export default {
   },
 
   /**
+   * @name isShopPrimary
+   * @summary Whether the current shop is the Primary Shop (vs a Merchant Shop)
+   * @return {Boolean}
+   */
+  isShopPrimary() {
+    return this.getShopId() === this.getPrimaryShopId();
+  },
+
+  /**
    * @name getShopName
    * @method
    * @memberof Core/Client

--- a/imports/plugins/core/ui/client/containers/tagListContainer.js
+++ b/imports/plugins/core/ui/client/containers/tagListContainer.js
@@ -241,7 +241,7 @@ function composer(props, onData) {
 
   if (props.product) {
     if (_.isArray(props.product.hashtags)) {
-      tags = _.map(props.product.hashtags, (id) => Tags.findOne(id));
+      tags = Tags.find({ _id: { $in: props.product.hashtags } }).fetch();
     }
   }
 

--- a/imports/plugins/included/product-admin/client/containers/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/containers/productAdmin.js
@@ -105,7 +105,7 @@ function composer(props, onData) {
 
   if (product) {
     if (_.isArray(product.hashtags)) {
-      tags = _.map(product.hashtags, (id) => Tags.findOne(id));
+      tags = Tags.find({ _id: { $in: product.hashtags } }).fetch();
     }
 
     const selectedVariant = ReactionProduct.selectedVariant();

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
@@ -315,7 +315,7 @@ function composer(props, onData) {
     if (product) {
       let tags;
       if (_.isArray(product.hashtags)) {
-        tags = _.map(product.hashtags, (id) => Tags.findOne(id));
+        tags = Tags.find({ _id: { $in: product.hashtags } }).fetch();
       }
 
       Meteor.subscribe("ProductMedia", product._id);

--- a/server/api/core/core.app-test.js
+++ b/server/api/core/core.app-test.js
@@ -129,7 +129,31 @@ describe("Server/API/Core", () => {
     });
   });
 
+  describe("#isShopPrimary", () => {
+    let primaryShopId;
+
+    beforeEach(() => {
+      primaryShopId = randomString();
+    });
+
+    it("is true when the current shop is the Primary Shop", () => {
+      sandbox.stub(core, "getShopId", () => primaryShopId);
+      sandbox.stub(core, "getPrimaryShopId", () => primaryShopId);
+
+      expect(core.isShopPrimary()).to.be.true;
+    });
+
+    it("is false when the current shop is a Merchant Shop", () => {
+      const shopId = `xxx${primaryShopId}xxx`;
+
+      sandbox.stub(core, "getShopId", () => shopId);
+      sandbox.stub(core, "getPrimaryShopId", () => primaryShopId);
+
+      expect(core.isShopPrimary()).to.be.false;
+    });
+  });
+
   function randomString() {
-    return new Date().getTime().toString();
+    return Math.random().toString(36);
   }
 });

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -413,6 +413,17 @@ export default {
   },
 
   /**
+   * @name isShopPrimary
+   * @summary Whether the current shop is the Primary Shop (vs a Merchant Shop)
+   * @method
+   * @memberof Core
+   * @return {Boolean}
+   */
+  isShopPrimary() {
+    return this.getShopId() === this.getPrimaryShopId();
+  },
+
+  /**
    * @name getShopIdByDomain
    * @method
    * @memberof Core

--- a/server/publications/collections/tags.app-test.js
+++ b/server/publications/collections/tags.app-test.js
@@ -1,0 +1,90 @@
+import { Random } from "meteor/random";
+import { expect } from "meteor/practicalmeteor:chai";
+import { Factory } from "meteor/dburles:factory";
+import { sinon } from "meteor/practicalmeteor:sinon";
+import { PublicationCollector } from "meteor/johanbrook:publication-collector";
+import * as Collections from "/lib/collections";
+import { Reaction } from "/server/api";
+import Fixtures from "/server/imports/fixtures";
+import { createActiveShop } from "/server/imports/fixtures/shops";
+
+Fixtures();
+
+describe("Tags Publication", () => {
+  let sandbox;
+  let collector;
+  let primaryShop;
+  let shop;
+  let tags;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    collector = new PublicationCollector({ userId: Random.id() });
+
+    primaryShop = createActiveShop();
+    shop = Factory.create("shop");
+
+    sandbox.stub(Reaction, "getPrimaryShopId", () => primaryShop._id);
+
+    Collections.Tags.remove({});
+
+    tags = [1, 2, 3].map(() => {
+      const tag = createTag({ shopId: primaryShop._id });
+      Collections.Tags.insert(tag);
+      return tag;
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("ensures our test is set up properly", () => {
+    expect(primaryShop._id).to.not.equal(shop._id);
+  });
+
+  it("returns all Tags when the current shop is the Primary Shop", (done) => {
+    // create a tag for a Merchant Shop
+    const tag = createTag({ shopId: shop._id });
+    Collections.Tags.insert(tag);
+
+    const expectedTags = [...tags, tag];
+
+    sandbox.stub(Reaction, "getShopId", () => primaryShop._id);
+
+    collector.collect("Tags", (collections) => {
+      const collectionTags = collections.Tags;
+
+      expect(collectionTags.map((t) => t.name))
+        .to.eql(expectedTags.map((t) => t.name));
+    }).then(() => done()).catch(done);
+  });
+
+  it("scopes the list of Tags to the current merchant shop", (done) => {
+    // create a tag for a Merchant Shop
+    const tag = createTag({ shopId: shop._id });
+    Collections.Tags.insert(tag);
+
+    sandbox.stub(Reaction, "getShopId", () => shop._id);
+
+    collector.collect("Tags", (collections) => {
+      const collectionTags = collections.Tags;
+
+      expect(collectionTags.map((t) => t.name))
+        .to.eql([tag.name]);
+    }).then(() => done()).catch(done);
+  });
+
+  function randomString() {
+    return Math.random().toString(36);
+  }
+
+  function createTag(tagData = {}) {
+    return Object.assign({
+      name: randomString(),
+      slug: randomString(),
+      isTopLevel: true
+    }, tagData);
+  }
+});

--- a/server/publications/collections/tags.js
+++ b/server/publications/collections/tags.js
@@ -6,11 +6,19 @@ import { Reaction } from "/server/api";
  * tags
  */
 Meteor.publish("Tags", function () {
+  const selector = {};
+
   const shopId = Reaction.getShopId();
+
   if (!shopId) {
     return this.ready();
   }
+
+  if (!Reaction.isShopPrimary()) {
+    selector.shopId = shopId;
+  }
+
   // TODO: filter tag results based on permissions and isVisible or some other
   // publication quality
-  return Tags.find({});
+  return Tags.find(selector);
 });


### PR DESCRIPTION
Resolves: n/a
Impact: **minor/major**  
Type: **bugfix**

## Issue
The `"Tags"` publication exposes all tags from all shops.

## Solution
Scope the Tags query to those of the current shop.

## Breaking changes
If it was intended that the Primary Shop see all tags from all shops, this is a breaking change and can be easily changed to restore that behavior.

## Testing
1. Create a new merchant shop
2. Notice that the Primary Shop's "Shop" tag appears in the Navigation Bar.
3. Merchant Shop Admins are given the impression they can edit, or remove it, but those requests fail without notification (that is perhaps a different issue, but reiterates the need for this change).

