### PR TITLE
feat: add description and name to shop query

### DIFF
--- a/imports/plugins/core/graphql/server/schemas/shop.graphql
+++ b/imports/plugins/core/graphql/server/schemas/shop.graphql
@@ -16,6 +16,12 @@ type Shop implements Node {
   "Returns a list of groups for this shop, as a Relay-compatible connection."
   groups(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: GroupSortByField = createdAt): GroupConnection
 
+  "Returns shop description"
+  description: String
+
+  "Returns shop name"
+  name: String
+
   "Returns a list of roles for this shop, as a Relay-compatible connection."
   roles(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: RoleSortByField = name): RoleConnection
 


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
We need to make shop description and name data available for use

## Solution
Add `description` and `name` data to GraphQL shop query

## Breaking changes
none

## Testing
1. Navigate to 
2. Run the following query
```
query {
  shop(id: {base64shopId}) {
    _id
    description
    name
  }
}

```
3. See `name` and `description` data