### PR TITLE
docs: clean up jsdoc comments, namespace organization

### DIFF
--- a/client/collections/countries.js
+++ b/client/collections/countries.js
@@ -1,8 +1,8 @@
 import { Mongo } from "meteor/mongo";
 
 /**
- * Client side collections
- * @ignore
+ * @name Countries
+ * @memberof Collections/ClientOnly
+ * @type {MongoCollection}
  */
-
 export const Countries = new Mongo.Collection(null);

--- a/client/collections/taxEntitycodes.js
+++ b/client/collections/taxEntitycodes.js
@@ -1,7 +1,8 @@
 import { Mongo } from "meteor/mongo";
 
 /**
- * Client side collections
- * @ignore
+ * @name TaxEntityCodes
+ * @memberof Collections/ClientOnly
+ * @type {MongoCollection}
  */
 export const TaxEntityCodes = new Mongo.Collection(null);

--- a/client/modules/core/helpers/apps.js
+++ b/client/modules/core/helpers/apps.js
@@ -29,6 +29,7 @@ import { Packages, Shops } from "/lib/collections";
  *   @type {optionHash}
  *
  *  @return {optionHash} returns an array of filtered, structure reactionApps
+ *  ```
  *  [{
  *   enabled: true
  *   label: "Stripe"
@@ -40,6 +41,8 @@ import { Packages, Shops } from "/lib/collections";
  *   etc: "additional properties as defined in Packages.registry"
  *   ...
  *  }]
+ *  ```
+ *  @ignore
  */
 
 export function Apps(optionHash) {

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -14,6 +14,11 @@ import { localeDep } from "/client/modules/i18n";
 import { Packages, Shops, Accounts } from "/lib/collections";
 import { Router } from "/client/modules/router";
 
+/**
+ * Reaction core namespace for client code
+ * @namespace Core/Client
+ */
+
 // Global, private state object for client side
 // This is placed outside the main object to make it a private variable.
 // access using `Reaction.state`
@@ -22,17 +27,41 @@ const reactionState = new ReactiveDict();
 export const userPrefs = new ReactiveVar(undefined, (val, newVal) => JSON.stringify(val) === JSON.stringify(newVal));
 
 const deps = new Map();
-/**
- * Reaction namespace
- * Global reaction shop permissions methods and shop initialization
- */
-export default {
-  _shopId: new ReactiveVar(null), // The active shop
-  _primaryShopId: new ReactiveVar(null), // The first shop created
-  marketplace: { _ready: false }, // Marketplace Settings
 
+export default {
+  /**
+   * @summary The active shop
+   * @memberof Core/Client
+   * @private
+   */
+  _shopId: new ReactiveVar(null),
+
+  /**
+   * @summary The first shop created
+   * @memberof Core/Client
+   * @private
+   */
+  _primaryShopId: new ReactiveVar(null),
+
+  /**
+   * @summary Marketplace Settings
+   * @memberof Core/Client
+   * @private
+   */
+  marketplace: { _ready: false },
+
+  /**
+   * @summary Current locale
+   * @memberof Core/Client
+   * @type {ReactiveVar}
+   */
   Locale: new ReactiveVar({}),
 
+  /**
+   * @summary Initialization code
+   * @memberof Core/Client
+   * @method
+   */
   init() {
     Tracker.autorun(() => {
       // marketplaceSettings come over on the PrimaryShopPackages subscription
@@ -159,16 +188,19 @@ export default {
     });
   },
 
-  // Return global "reactionState" Reactive Dict
+  /**
+   * @summary Return global "reactionState" Reactive Dict
+   * @memberof Core/Client
+   */
   get state() {
     return reactionState;
   },
 
   /**
-   * hasPermission - client
-   * client permissions checks
-   * hasPermission exists on both the server and the client.
-   *
+   * @name hasPermission
+   * @summary client permissions checks. hasPermission exists on both the server and the client.
+   * @method
+   * @memberof Core/Client
    * @param {String | Array} checkPermissions -String or Array of permissions if empty, defaults to "admin, owner"
    * @param {String} checkUserId - userId, defaults to Meteor.userId()
    * @param {String} checkGroup group - default to shopId
@@ -280,9 +312,10 @@ export default {
 
 
   /**
-   * hasDashboardAccessForAnyShop - client
-   * client permission check for any "owner", "admin", or "dashboard" permissions for any shop.
-   *
+   * @name hasDashboardAccessForAnyShop
+   * @summary client permission check for any "owner", "admin", or "dashboard" permissions for any shop.
+   * @method
+   * @memberof Core/Client
    * @todo This could be faster with a dedicated hasAdminDashboard boolean on the user object
    * @param { Object } options - options object that can be passed a user and/or a set of permissions
    * @return {Boolean} Boolean - true if has dashboard access for any shop
@@ -304,7 +337,9 @@ export default {
   },
 
   /**
-   * hasDashboardAccessForAnyShop - client
+   * @name hasDashboardAccessForAnyShop
+   * @method
+   * @memberof Core/Client
    * @summary - client permission check for any "owner", "admin", or "dashboard" permissions for more than one shop.
    * @return {Boolean} Boolean - true if has dashboard access for more than one shop
    */
@@ -313,6 +348,11 @@ export default {
     return Array.isArray(adminShopIds) && adminShopIds.length > 1;
   },
 
+  /**
+   * @name hasOwnerAccess
+   * @method
+   * @memberof Core/Client
+   */
   hasOwnerAccess() {
     const ownerPermissions = ["owner"];
     return this.hasPermission(ownerPermissions);
@@ -321,10 +361,11 @@ export default {
   /**
    * Checks to see if the user has admin permissions. If a shopId is optionally
    * passed in, we check for that shopId, otherwise we check against the default
-   * @method hasAdminAccess
+   * @name hasAdminAccess
+   * @method
+   * @memberof Core/Client
    * @param  {string} [shopId] Optional shopId to check access against
-   * @return {Boolean} true if the user has admin or owner permission,
-   *                   otherwise false
+   * @return {Boolean} true if the user has admin or owner permission, otherwise false
    */
   hasAdminAccess(shopId) {
     const adminPermissions = ["owner", "admin"];
@@ -334,15 +375,30 @@ export default {
     return this.hasPermission(adminPermissions);
   },
 
+  /**
+   * @name hasDashboardAccess
+   * @method
+   * @memberof Core/Client
+   */
   hasDashboardAccess() {
     const dashboardPermissions = ["owner", "admin", "dashboard"];
     return this.hasPermission(dashboardPermissions);
   },
 
+  /**
+   * @name hasShopSwitcherAccess
+   * @method
+   * @memberof Core/Client
+   */
   hasShopSwitcherAccess() {
     return this.hasDashboardAccessForMultipleShops();
   },
 
+  /**
+   * @name getSellerShopId
+   * @method
+   * @memberof Core/Client
+   */
   getSellerShopId(userId = Meteor.userId(), noFallback = false) {
     if (userId) {
       const group = Roles.getGroupsForUser(userId, "admin")[0];
@@ -358,6 +414,11 @@ export default {
     return this.getShopId();
   },
 
+  /**
+   * @name getUserPreferences
+   * @method
+   * @memberof Core/Client
+   */
   getUserPreferences(packageName, preference, defaultValue) {
     getDep(`${packageName}.${preference}`).depend();
     if (Meteor.user()) {
@@ -371,6 +432,11 @@ export default {
     return defaultValue || undefined;
   },
 
+  /**
+   * @name setUserPreferences
+   * @method
+   * @memberof Core/Client
+   */
   setUserPreferences(packageName, preference, value) {
     getDep(`${packageName}.${preference}`).changed();
     // User preferences are not stored in Meteor.user().profile
@@ -392,6 +458,11 @@ export default {
     return store.set(packageName, packageSettings);
   },
 
+  /**
+   * @name updateUserPreferences
+   * @method
+   * @memberof Core/Client
+   */
   updateUserPreferences(packageName, preference, values) {
     const currentPreference = this.getUserPreferences(packageName, preference, {});
     return this.setUserPreferences(packageName, preference, {
@@ -400,20 +471,40 @@ export default {
     });
   },
 
-  // primaryShopId is the first created shop. In a marketplace setting it's
-  // the shop that controls the marketplace and can see all other shops.
+  /**
+   * primaryShopId is the first created shop. In a marketplace setting it's
+   * the shop that controls the marketplace and can see all other shops.
+   * @name primaryShopId
+   * @memberof Core/Client
+   */
   get primaryShopId() {
     return this._primaryShopId.get();
   },
 
+  /**
+   * primaryShopId is the first created shop. In a marketplace setting it's
+   * the shop that controls the marketplace and can see all other shops.
+   * @name primaryShopId
+   * @memberof Core/Client
+   */
   set primaryShopId(shopId) {
     this._primaryShopId.set(shopId);
   },
 
+  /**
+   * @name getPrimaryShopId
+   * @method
+   * @memberof Core/Client
+   */
   getPrimaryShopId() {
     return this.primaryShopId;
   },
 
+  /**
+   * @name getPrimaryShopName
+   * @method
+   * @memberof Core/Client
+   */
   getPrimaryShopName() {
     const shopId = this.getPrimaryShopId();
     const shop = Shops.findOne({
@@ -428,11 +519,21 @@ export default {
     return "";
   },
 
-  // Primary Shop should probably not have a prefix (or should it be /shop?)
+  /**
+   * Primary Shop should probably not have a prefix (or should it be /shop?)
+   * @name getPrimaryShopPrefix
+   * @method
+   * @memberof Core/Client
+   */
   getPrimaryShopPrefix() {
     return `/${this.getSlug(this.getPrimaryShopName().toLowerCase())}`;
   },
 
+  /**
+   * @name getPrimaryShopSettings
+   * @method
+   * @memberof Core/Client
+   */
   getPrimaryShopSettings() {
     const settings = Packages.findOne({
       name: "core",
@@ -441,6 +542,11 @@ export default {
     return settings.settings || {};
   },
 
+  /**
+   * @name getPrimaryShopCurrency
+   * @method
+   * @memberof Core/Client
+   */
   getPrimaryShopCurrency() {
     const shop = Shops.findOne({
       _id: this.getPrimaryShopId()
@@ -449,21 +555,48 @@ export default {
     return (shop && shop.currency) || "USD";
   },
 
-  // shopId refers to the active shop. For most shoppers this will be the same
-  // as the primary shop, but for administrators this will usually be the shop
-  // they administer.
+  /**
+   * shopId refers to the active shop. For most shoppers this will be the same
+   * as the primary shop, but for administrators this will usually be the shop
+   * they administer.
+   * @name shopId
+   * @memberof Core/Client
+   */
   get shopId() {
     return this._shopId.get();
   },
 
+  /**
+   * shopId refers to the active shop. For most shoppers this will be the same
+   * as the primary shop, but for administrators this will usually be the shop
+   * they administer.
+   * @name getShopId
+   * @method
+   * @memberof Core/Client
+   */
   getShopId() {
     return this.shopId || this.getUserPreferences("reaction", "activeShopId");
   },
 
+  /**
+   * shopId refers to the active shop. For most shoppers this will be the same
+   * as the primary shop, but for administrators this will usually be the shop
+   * they administer.
+   * @name shopId
+   * @memberof Core/Client
+   */
   set shopId(id) {
     this._shopId.set(id);
   },
 
+  /**
+   * shopId refers to the active shop. For most shoppers this will be the same
+   * as the primary shop, but for administrators this will usually be the shop
+   * they administer.
+   * @name setShopId
+   * @method
+   * @memberof Core/Client
+   */
   setShopId(id) {
     if (!id || this.shopId === id) { return; }
 
@@ -474,7 +607,9 @@ export default {
   },
 
   /**
-   * getShopName
+   * @name getShopName
+   * @method
+   * @memberof Core/Client
    * @summary gets name of shop by provided shopId, or current active shop if shopId is not provided
    * @param {String} providedShopID - shopId of shop to return name of
    * @return {String} - shop name
@@ -487,6 +622,11 @@ export default {
     return shop && shop.name;
   },
 
+  /**
+   * @name getShopPrefix
+   * @method
+   * @memberof Core/Client
+   */
   getShopPrefix() {
     const shopName = this.getShopName();
     if (shopName) {
@@ -498,6 +638,11 @@ export default {
     }
   },
 
+  /**
+   * @name getShopSettings
+   * @method
+   * @memberof Core/Client
+   */
   getShopSettings() {
     const settings = Packages.findOne({
       name: "core",
@@ -506,6 +651,11 @@ export default {
     return settings.settings || {};
   },
 
+  /**
+   * @name getShopCurrency
+   * @method
+   * @memberof Core/Client
+   */
   getShopCurrency() {
     const shop = Shops.findOne({
       _id: this.shopId
@@ -514,6 +664,11 @@ export default {
     return (shop && shop.currency) || "USD";
   },
 
+  /**
+   * @name isPreview
+   * @method
+   * @memberof Core/Client
+   */
   isPreview() {
     const viewAs = this.getUserPreferences("reaction-dashboard", "viewAs", "administrator");
 
@@ -524,6 +679,11 @@ export default {
     return false;
   },
 
+  /**
+   * @name getPackageSettings
+   * @method
+   * @memberof Core/Client
+   */
   getPackageSettings(name) {
     const shopId = this.getShopId();
     const query = { name };
@@ -535,18 +695,32 @@ export default {
     return Packages.findOne(query);
   },
 
+  /**
+   * @name getPackageSettingsWithOptions
+   * @method
+   * @memberof Core/Client
+   */
   getPackageSettingsWithOptions(options) {
     const query = options;
     return Packages.findOne(query);
   },
 
+  /**
+   * @name allowGuestCheckout
+   * @method
+   * @memberof Core/Client
+   */
   allowGuestCheckout() {
     const settings = this.getShopSettings();
     // we can disable in admin, let's check.
     return !!(settings.public && settings.public.allowGuestCheckout);
   },
+
   /**
-   * canInviteToGroup - client (similar to server/api canInviteToGroup)
+   * (similar to server/api canInviteToGroup)
+   * @name canInviteToGroup
+   * @method
+   * @memberof Core/Client
    * @summary checks if the user making the request is allowed to make invitation to that group
    * @param {Object} options -
    * @param {Object} options.group - group to invite to
@@ -571,9 +745,11 @@ export default {
     // we are not using Reaction.hasPermission here because it returns true if the user has at least one
     return _.difference(groupPermissions, userPermissions).length === 0;
   },
+
   /**
-   * @description showActionView
-   *
+   * @name showActionView
+   * @method
+   * @memberof Core/Client
    * @param {String} viewData {label, template, data}
    * @returns {String} Session "admin/showActionView"
    */
@@ -582,14 +758,29 @@ export default {
     this.setActionView(viewData);
   },
 
+  /**
+   * @name isActionViewOpen
+   * @method
+   * @memberof Core/Client
+   */
   isActionViewOpen() {
     return Session.equals("admin/showActionView", true);
   },
 
+  /**
+   * @name isActionViewDetailOpen
+   * @method
+   * @memberof Core/Client
+   */
   isActionViewDetailOpen() {
     return Session.equals("admin/showActionViewDetail", true);
   },
 
+  /**
+   * @name setActionView
+   * @method
+   * @memberof Core/Client
+   */
   setActionView(viewData) {
     this.hideActionViewDetail();
     if (viewData) {
@@ -615,6 +806,11 @@ export default {
     }
   },
 
+  /**
+   * @name pushActionView
+   * @method
+   * @memberof Core/Client
+   */
   pushActionView(viewData) {
     Session.set("admin/showActionView", true);
 
@@ -634,6 +830,11 @@ export default {
     }
   },
 
+  /**
+   * @name isActionViewAtRootView
+   * @method
+   * @memberof Core/Client
+   */
   isActionViewAtRootView() {
     const actionViewStack = Session.get("admin/actionView");
 
@@ -644,6 +845,11 @@ export default {
     return false;
   },
 
+  /**
+   * @name popActionView
+   * @method
+   * @memberof Core/Client
+   */
   popActionView() {
     const actionViewStack = Session.get("admin/actionView");
     actionViewStack.pop();
@@ -653,6 +859,11 @@ export default {
     this.setActionViewDetail({}, { open: false });
   },
 
+  /**
+   * @name setActionViewDetail
+   * @method
+   * @memberof Core/Client
+   */
   setActionViewDetail(viewData, options = {}) {
     const { open } = options;
 
@@ -661,6 +872,11 @@ export default {
     Session.set("admin/detailView", [viewData]);
   },
 
+  /**
+   * @name pushActionViewDetail
+   * @method
+   * @memberof Core/Client
+   */
   pushActionViewDetail(viewData) {
     Session.set("admin/showActionView", true);
     Session.set("admin/showActionViewDetail", true);
@@ -673,6 +889,11 @@ export default {
     }
   },
 
+  /**
+   * @name popActionViewDetail
+   * @method
+   * @memberof Core/Client
+   */
   popActionViewDetail() {
     const detailViewStack = Session.get("admin/detailView");
     detailViewStack.pop();
@@ -680,6 +901,11 @@ export default {
     Session.set("admin/detailView", detailViewStack);
   },
 
+  /**
+   * @name isActionViewDetailAtRootView
+   * @method
+   * @memberof Core/Client
+   */
   isActionViewDetailAtRootView() {
     const actionViewDetailStack = Session.get("admin/detailView");
 
@@ -690,6 +916,11 @@ export default {
     return false;
   },
 
+  /**
+   * @name getActionView
+   * @method
+   * @memberof Core/Client
+   */
   getActionView() {
     const actionViewStack = Session.get("admin/actionView");
 
@@ -700,6 +931,11 @@ export default {
     return {};
   },
 
+  /**
+   * @name getActionViewDetail
+   * @method
+   * @memberof Core/Client
+   */
   getActionViewDetail() {
     const detailViewStack = Session.get("admin/detailView");
 
@@ -710,16 +946,31 @@ export default {
     return {};
   },
 
+  /**
+   * @name hideActionView
+   * @method
+   * @memberof Core/Client
+   */
   hideActionView() {
     Session.set("admin/showActionView", false);
     this.clearActionView();
   },
 
+  /**
+   * @name hideActionViewDetail
+   * @method
+   * @memberof Core/Client
+   */
   hideActionViewDetail() {
     Session.set("admin/showActionViewDetail", false);
     this.clearActionViewDetail();
   },
 
+  /**
+   * @name clearActionView
+   * @method
+   * @memberof Core/Client
+   */
   clearActionView() {
     Session.set("admin/actionView", [{
       label: "",
@@ -731,6 +982,11 @@ export default {
     }]);
   },
 
+  /**
+   * @name clearActionViewDetail
+   * @method
+   * @memberof Core/Client
+   */
   clearActionViewDetail() {
     Session.set("admin/detailView", [{
       label: "",
@@ -738,12 +994,22 @@ export default {
     }]);
   },
 
+  /**
+   * @name getCurrentTag
+   * @method
+   * @memberof Core/Client
+   */
   getCurrentTag() {
     if (this.Router.getRouteName() === "tag") {
       return this.Router.current().params.slug;
     }
   },
 
+  /**
+   * @name getRegistryForCurrentRoute
+   * @method
+   * @memberof Core/Client
+   */
   getRegistryForCurrentRoute(provides = "dashboard") {
     this.Router.watchPathChange();
     const currentRouteName = this.Router.getRouteName();
@@ -773,9 +1039,10 @@ export default {
   },
 
   /**
-   * getMarketplaceSettingsFromPackages finds the enabled `reaction-marketplace` package for
-   * the primary shop and returns the settings
-   * @method getMarketplaceSettingsFromPackages
+   * @name getMarketplaceSettings
+   * @method
+   * @memberof Core/Client
+   * @summary finds the enabled `reaction-marketplace` package for the primary shop and returns the settings
    * @return {Object} The marketplace settings from the primary shop or undefined
    */
   getMarketplaceSettings() {
@@ -791,11 +1058,13 @@ export default {
 };
 
 /**
- * createCountryCollection
  * Create a client-side only collection of Countries for a dropdown form
  * properly sorted*
+ * @name createCountryCollection
+ * @method
  * @param {Object} countries -  The countries array on the Shop collection
  * @returns {Array} countryOptions - Sorted array of countries
+ * @private
  */
 function createCountryCollection(countries) {
   check(countries, Object);
@@ -826,11 +1095,13 @@ function createCountryCollection(countries) {
 }
 
 /**
- * getDep
  * Gets the dependency for the key if available, else creates
  * a new dependency for the key and returns it.
+ * @name getDep
+ * @method
  * @param {String} -  The key to get the dependency for
  * @returns {Tracker.Dependency}
+ * @private
  */
 function getDep(key) {
   if (!deps.has(key)) {

--- a/imports/plugins/core/accounts/client/components/addressBook.js
+++ b/imports/plugins/core/accounts/client/components/addressBook.js
@@ -114,6 +114,7 @@ class AddressBook extends Component {
    * @summary setter for mode in state
    * @since 2.0.0
    * @param {String} mode - the mode to be set.
+   * @ignore
    */
   set mode(mode) {
     this.setState({
@@ -125,6 +126,7 @@ class AddressBook extends Component {
    * @method setEntryMode
    * @summary changes the mode to "entry"
    * @since 2.0.0
+   * @ignore
    */
   setEntryMode = () => {
     this.mode = "entry";
@@ -137,6 +139,7 @@ class AddressBook extends Component {
    * @param {String} newMode - new mode to be set
    * @param {String} editAddress - the address to be set for the form.
    * @return {Object} - address object.
+   * @ignore
    */
   switchMode = (newMode, editAddress) => {
     this.setState({
@@ -153,6 +156,7 @@ class AddressBook extends Component {
    * @since 2.0.0
    * @param {String} _id - address object _id.
    * @return {Object} - address object.
+   * @ignore
    */
   findAddress(_id) {
     const { addressBook } = this;
@@ -163,6 +167,7 @@ class AddressBook extends Component {
    * @method clearForm
    * @summary removes the editAddress from state this will clear the address book form.
    * @since 2.0.0
+   * @ignore
    */
   clearForm() {
     if (this.hasEditAddress) this.setState({ editAddress: {} });
@@ -173,6 +178,7 @@ class AddressBook extends Component {
    * @summary getter that returns the addressBook array if avalible on the props or an empty array.
    * @since 2.0.0
    * @return {Array} addressBook - array of address object or an empty array.
+   * @ignore
    */
   get addressBook() {
     let { addressBook } = this.props;
@@ -185,6 +191,7 @@ class AddressBook extends Component {
    * @summary getter that returns true if there is an editAddress in state.
    * @since 2.0.0
    * @return {Boolean}
+   * @ignore
    */
   get hasEditAddress() {
     const { editAddress } = this.state;
@@ -196,6 +203,7 @@ class AddressBook extends Component {
    * @summary getter that returns true if there is at least 1 address in the addressBook array.
    * @since 2.0.0
    * @return {Boolean}
+   * @ignore
    */
   get hasAddress() {
     const { addressBook } = this;
@@ -210,6 +218,7 @@ class AddressBook extends Component {
    * @since 2.0.0
    * @param {String} _id - address object _id.
    * @param {String} usage - the address usage "shipping" or "billing".
+   * @ignore
    */
   onSelect = (_id, usage) => {
     const { onError, updateAddress } = this.props;
@@ -231,6 +240,7 @@ class AddressBook extends Component {
    * @summary using the provided _id to call the removeAddress reducer that removes an address.
    * @since 2.0.0
    * @param {String} _id - address object _id.
+   * @ignore
    */
   onRemove = (_id) => {
     const { onError, removeAddress } = this.props;
@@ -242,6 +252,7 @@ class AddressBook extends Component {
    * @summary adds or updates an address in the addressBook.
    * @since 2.0.0
    * @param {Object} address - new or updated address object.
+   * @ignore
    */
   onAdd = (address, validateAddress = true) => {
     const { addAddress, onError, updateAddress } = this.props;
@@ -284,6 +295,7 @@ class AddressBook extends Component {
    * @summary sets mode to "grid" and clears the address book form.
    * this will only be called from the address book form.
    * @since 2.0.0
+   * @ignore
    */
   onCancel = () => {
     this.mode = "grid";
@@ -295,6 +307,7 @@ class AddressBook extends Component {
    * @summary sets the address to be edited and makes the mode as "entry".
    * this will only be called form the address book grid.
    * @since 2.0.0
+   * @ignore
    */
   onEdit = (_id) => {
     const editAddress = this.findAddress(_id);
@@ -310,6 +323,7 @@ class AddressBook extends Component {
    * the address book is being called from checkout
    * @since 2.0.0
    * @return {Object} - JSX
+   * @ignore
    */
   renderCheckoutIcon() {
     const { checkout: { icon, position } } = this.props.heading;
@@ -322,6 +336,7 @@ class AddressBook extends Component {
    * based on where in the app this component is being used
    * @since 2.0.0
    * @return {Object} - JSX
+   * @ignore
    */
   renderHeading() {
     const { heading } = this.props;
@@ -341,6 +356,7 @@ class AddressBook extends Component {
    * renders an add address button if the grid is showiing.
    * @since 2.0.0
    * @return {Object} - JSX
+   * @ignore
    */
   renderControlBar() {
     const { mode } = this.state;
@@ -392,6 +408,7 @@ class AddressBook extends Component {
    * based on mode.
    * @since 2.0.0
    * @return {Object} - JSX and child component.
+   * @ignore
    */
   renderContent() {
     const { addressBook } = this;

--- a/imports/plugins/core/accounts/client/components/addressBookForm.js
+++ b/imports/plugins/core/accounts/client/components/addressBookForm.js
@@ -7,14 +7,17 @@ class AddressBookForm extends Component {
   static propTypes = {
     /**
      * add addess callback
+     * @ignore
      */
     add: PropTypes.func,
     /**
      * cancel address entry and render AddressBookGrid
+     * @ignore
      */
     cancel: PropTypes.func,
     /**
      * country options for select
+     * @ignore
      */
     countries: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string,
@@ -22,14 +25,17 @@ class AddressBookForm extends Component {
     })),
     /**
      * address object
+     * @ignore
      */
     editAddress: PropTypes.object,
     /**
      * has address in addressBook
+     * @ignore
      */
     hasAddress: PropTypes.bool,
     /**
      * regions by county
+     * @ignore
      */
     regionsByCountry: PropTypes.object
   }
@@ -121,6 +127,7 @@ class AddressBookForm extends Component {
    * @summary creates an array of region options for the regions select field.
    * @since 2.0.0
    * @param {String} country - country code "US" "CA" "JP"
+   * @ignore
    */
   setRegionOptions(country) {
     const { regionsByCountry, editAddress } = this.props;
@@ -176,6 +183,7 @@ class AddressBookForm extends Component {
    * @method onSubmit
    * @summary takes the entered address and adds or updates it to the addressBook.
    * @since 2.0.0
+   * @ignore
    */
   onSubmit = (event) => {
     event.preventDefault();
@@ -191,6 +199,7 @@ class AddressBookForm extends Component {
    * @method onFieldChange
    * @summary when field values change update the value in state
    * @since 2.0.0
+   * @ignore
    */
   onFieldChange = (event, value, name) => {
     const { fields } = this.state;
@@ -204,6 +213,7 @@ class AddressBookForm extends Component {
    * @method onSelectChange
    * @summary normalizes the select components onChange.
    * @since 2.0.0
+   * @ignore
    */
   onSelectChange = (value, name) => {
     // the reaction select component doesn't return
@@ -222,6 +232,7 @@ class AddressBookForm extends Component {
    * since a first address will always be the default shipping/billing address.
    * @since 2.0.0
    * @return {Object} - JSX and Checkbox components.
+   * @ignore
    */
   renderAddressOptions() {
     const { hasAddress } = this.props;
@@ -283,6 +294,7 @@ class AddressBookForm extends Component {
    * since the user needs to add a default address.
    * @since 2.0.0
    * @return {Object} - JSX
+   * @ignore
    */
   renderButtons() {
     const { cancel, hasAddress } = this.props;

--- a/imports/plugins/core/accounts/client/components/addressBookGrid.js
+++ b/imports/plugins/core/accounts/client/components/addressBookGrid.js
@@ -62,6 +62,7 @@ class AddressBookGrid extends Component {
    * @since 2.0.0
    * @param {String} _id - address object _id.
    * @param {String} usage - the address usage "shipping" or "billing".
+   * @ignore
    */
   setDefaultAddress(_id, usage) {
     if (usage === "shipping") {
@@ -81,6 +82,7 @@ class AddressBookGrid extends Component {
    * @summary getter that returns the addressBook array if avalible on the props or an empty array.
    * @since 2.0.0
    * @return {Array} addressBook - array of address object or an empty array.
+   * @ignore
    */
   get addressBook() {
     let { addressBook } = this.props;
@@ -93,6 +95,7 @@ class AddressBookGrid extends Component {
    * @summary getter that returns ether the default shipping address _id or and empty string.
    * @since 2.0.0
    * @return {String} - default shipping address _id or empty string.
+   * @ignore
    */
   get defaultShippingAddressId() {
     const { addressBook } = this;
@@ -105,6 +108,7 @@ class AddressBookGrid extends Component {
    * @summary getter that returns ether the default billing address _id or and empty string.
    * @since 2.0.0
    * @return {String} - default billing address _id or empty string.
+   * @ignore
    */
   get defaultBillingAddressId() {
     const { addressBook } = this;
@@ -122,6 +126,7 @@ class AddressBookGrid extends Component {
    * @since 2.0.0
    * @param {String} _id - address object _id.
    * @param {String} usage - the address usage "shipping" or "billing".
+   * @ignore
    */
   onSelect = (_id, usage) => {
     const { select } = this.props;
@@ -134,6 +139,7 @@ class AddressBookGrid extends Component {
    * @summary renders address book grid heading content
    * @since 2.0.0
    * @return {Object} - JSX
+   * @ignore
    */
   renderHeading() {
     return (
@@ -159,6 +165,7 @@ class AddressBookGrid extends Component {
    * @since 2.0.0
    * @param {Object} address - address object that we destructor to get the needed property
    * @return {Object} - JSX
+   * @ignore
    */
   renderAddress({ address1, address2, city, region, postal, country, phone }) {
     return (
@@ -175,6 +182,7 @@ class AddressBookGrid extends Component {
    * @summary renders address grid by mapping over the addressBook array
    * @since 2.0.0
    * @return {Object} - JSX
+   * @ignore
    */
   renderAddressGrid() {
     const { addressBook } = this;

--- a/imports/plugins/core/accounts/client/components/addressBookReview.js
+++ b/imports/plugins/core/accounts/client/components/addressBookReview.js
@@ -41,8 +41,8 @@ class AddressBookReview extends Component {
         isCommercal: PropTypes.bool
       }),
       /**
-       * map of all fields and
-       * errors in them.
+       * A map of all fields and errors in them.
+       * @ignore
        */
       fieldErrors: PropTypes.object
     })
@@ -57,6 +57,7 @@ class AddressBookReview extends Component {
    * @method handleSelection
    * @summary either saves the suggested or entered address
    * @since 2.0.0
+   * @ignore
    */
   handleSelection = (event) => {
     event.preventDefault();
@@ -76,6 +77,7 @@ class AddressBookReview extends Component {
    * @method handleEdit
    * @summary takes user back to the edit address screen
    * @since 2.0.0
+   * @ignore
    */
   handleEdit = (event) => {
     event.preventDefault();
@@ -88,6 +90,7 @@ class AddressBookReview extends Component {
    * @method selectEntered
    * @summary select the entered address
    * @since 2.0.0
+   * @ignore
    */
   selectEntered = () => {
     this.setState({
@@ -99,6 +102,7 @@ class AddressBookReview extends Component {
    * @method selectSuggested
    * @summary select the suggested address
    * @since 2.0.0
+   * @ignore
    */
   selectSuggested = () => {
     this.setState({
@@ -112,6 +116,7 @@ class AddressBookReview extends Component {
    * with error if present
    * @since 2.0.0
    * @return {Object} - JSX and child component.
+   * @ignore
    */
   renderField(field, value, showError) {
     const { fieldErrors } = this.props.validationResults;

--- a/imports/plugins/core/accounts/client/components/loginInline.js
+++ b/imports/plugins/core/accounts/client/components/loginInline.js
@@ -40,6 +40,7 @@ class LoginInline extends Component {
    * @param {String} value - the new value for the field
    * @param {String} field - which field to modify it's value
    * @return {undefined} undefined
+   * @private
    */
   handleFieldChange = (event, value, field) => {
     this.setState({

--- a/imports/plugins/core/accounts/client/containers/addressBookContainer.js
+++ b/imports/plugins/core/accounts/client/containers/addressBookContainer.js
@@ -9,14 +9,16 @@ import AddressBook from "../components/addressBook";
 
 
 const handlers = {
-/**
- * @method updateAddress
- * @summary helper function that validates and updates an address in the account's addressBook via a meteor method.
- * @since 2.0.0
- * @param {Object} address - address to be updated.
- * @param{String} property - property to be updated.
- * @return {Promise}
- */
+  /**
+   * @name updateAddress
+   * @method
+   * @memberof Helpers
+   * @summary helper function that validates and updates an address in the account's addressBook via a meteor method.
+   * @since 2.0.0
+   * @param {Object} address - address to be updated.
+   * @param{String} property - property to be updated.
+   * @return {Promise}
+   */
   updateAddress(address, property, validateAddress = true) {
     return new Promise((resolve, reject) => {
       if (validateAddress) {
@@ -60,12 +62,14 @@ const handlers = {
   },
 
   /**
- * @method removeAddress
- * @summary helper function that updates an address in the account's addressBook via a meteor method.
- * @since 2.0.0
- * @param {String} _id - _id of address to be removed.
- * @return {Promise}
- */
+   * @name removeAddress
+   * @method
+   * @memberof Helpers
+   * @summary helper function that updates an address in the account's addressBook via a meteor method.
+   * @since 2.0.0
+   * @param {String} _id - _id of address to be removed.
+   * @return {Promise}
+   */
   removeAddress(_id) {
     return new Promise((resolve, reject) => {
       Meteor.call("accounts/addressBookRemove", _id, (error, result) => {
@@ -79,12 +83,14 @@ const handlers = {
   },
 
   /**
- * @method addAddress
- * @summary helper function that validates and adds an address in the account's addressBook via a meteor method.
- * @since 2.0.0
- * @param {Object} address - address to be added.
- * @return {Promise}
- */
+   * @name addAddress
+   * @method
+   * @memberof Helpers
+   * @summary helper function that validates and adds an address in the account's addressBook via a meteor method.
+   * @since 2.0.0
+   * @param {Object} address - address to be added.
+   * @return {Promise}
+   */
   addAddress(address, validateAddress = true) {
     return new Promise((resolve, reject) => {
     // This address was tried for validation
@@ -125,6 +131,7 @@ const handlers = {
     });
   },
 
+
   markCart(address, isEnteredSelected) {
     if (!isEnteredSelected) {
       Meteor.call("accounts/markAddressValidationBypassed", false, (error) => {
@@ -147,11 +154,13 @@ const handlers = {
   },
 
   /**
- * @method onError
- * @summary helper function that shows an error message in an alert toast.
- * @since 2.0.0
- * @param {Object} errorMessage - error message object.
- */
+   * @name onError
+   * @method
+   * @memberof Helpers
+   * @summary helper function that shows an error message in an alert toast.
+   * @since 2.0.0
+   * @param {Object} errorMessage - error message object.
+   */
   onError(errorMessage) {
     Alerts.toast(errorMessage, "error");
   }

--- a/imports/plugins/core/accounts/client/containers/loginInline.js
+++ b/imports/plugins/core/accounts/client/containers/loginInline.js
@@ -60,6 +60,7 @@ class LoginInlineContainer extends Component {
    * @param {Event} event - the event that fired
    * @param {String} email - anonymous user's email
    * @return {undefined} undefined
+   * @private
    */
   handleEmailSubmit = (event, email) => {
     event.preventDefault();

--- a/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
+++ b/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
@@ -8,9 +8,6 @@ import { Reaction, i18next } from "/client/api";
 import * as Collections from "/lib/collections";
 import { ServiceConfigHelper } from "../../helpers/util";
 
-/**
- * Accounts helpers
- */
 Template.accountsDashboard.onCreated(function () {
   this.autorun(() => {
     this.subscribe("ShopMembers");
@@ -21,6 +18,7 @@ Template.accountsDashboard.helpers({
   /**
    * isShopMember
    * @return {Boolean} True if the memnber is an administrator
+   * @ignore
    */
   isShopMember() {
     return _.includes(["dashboard", "admin", "owner"], this.role);
@@ -29,6 +27,7 @@ Template.accountsDashboard.helpers({
   /**
    * isShopGuest
    * @return {Boolean} True if the member is a guest
+   * @ignore
    */
   isShopGuest() {
     return !_.includes(["dashboard", "admin", "owner"], this.role);
@@ -36,6 +35,7 @@ Template.accountsDashboard.helpers({
   /**
    * members
    * @return {Boolean} True array of adminsitrative members
+   * @ignore
    */
   members() {
     if (Reaction.hasPermission("reaction-accounts")) {
@@ -89,21 +89,16 @@ Template.accountsDashboard.helpers({
   }
 });
 
-/**
- * Account Settings Helpers
- */
 Template.accountsSettings.onCreated(function () {
   this.subscribe("ServiceConfiguration", Meteor.userId());
 });
 
-/**
- * Account Settings Helpers
- */
 Template.accountsSettings.helpers({
 
   /**
    * services
    * @return {Array} available services
+   * @ignore
    */
   services() {
     const serviceHelper = new ServiceConfigHelper();
@@ -125,6 +120,7 @@ Template.accountsSettings.helpers({
    * Template helper to add a hidden class if the condition is false
    * @param  {Boolean} enabled Service enabled
    * @return {String}          "hidden" or ""
+   * @ignore
    */
   shown(enabled) {
     return enabled !== true ? "hidden" : "";
@@ -134,6 +130,7 @@ Template.accountsSettings.helpers({
    * Return checked classname if true
    * @param  {Boolean} enabled Boolean value true/false
    * @return {String}          "checked" or ""
+   * @ignore
    */
   checked(enabled) {
     return enabled === true ? "checked" : "";
@@ -144,6 +141,7 @@ Template.accountsSettings.helpers({
    * @param  {String} fieldName name of field to retrive the value for.
    * @param  {Object} service   Service object to find the value in.
    * @return {String}           A value or blank string if nothing is found.
+   * @ignore
    */
   valueForField(fieldName, service) {
     return service[fieldName] || "";
@@ -151,12 +149,6 @@ Template.accountsSettings.helpers({
 });
 
 Template.accountsSettings.events({
-
-  /**
-   * Account settings form submit
-   * @param  {event} event    jQuery event
-   * @return {void}
-   */
   "submit form": (event) => {
     event.preventDefault();
 
@@ -180,11 +172,6 @@ Template.accountsSettings.events({
     });
   },
 
-  /**
-   * Account settings update enabled status for login service on change
-   * @param  {event} event    jQuery Event
-   * @return {void}
-   */
   "change input[name=enabled]": (event) => {
     const service = event.target.value;
     const fields = [{
@@ -195,11 +182,6 @@ Template.accountsSettings.events({
     Meteor.call("accounts/updateServiceConfiguration", service, fields);
   },
 
-  /**
-   * Account settings show/hide secret key for a service
-   * @param  {event} event    jQuery Event
-   * @return {void}
-   */
   "click [data-event-action=showSecret]": (event) => {
     const button = Template.instance().$(event.currentTarget);
     const input = button.closest(".form-group").find("input[name=secret]");

--- a/imports/plugins/core/accounts/client/templates/members/member.js
+++ b/imports/plugins/core/accounts/client/templates/members/member.js
@@ -124,9 +124,11 @@ Template.memberSettings.helpers({
   hasManyPermissions(permissions) {
     return Boolean(permissions.length);
   },
+
   /**
    * showAvalaraTaxSettings
    * @return {Boolean} True if avalara is enabled. Defaults to false if not found
+   * @ignore
    */
   showAvalaraTaxSettings() {
     const avalara = Packages.findOne({

--- a/imports/plugins/core/accounts/client/templates/profile/profile.js
+++ b/imports/plugins/core/accounts/client/templates/profile/profile.js
@@ -7,6 +7,7 @@ import { Components } from "@reactioncommerce/reaction-components";
 
 /**
  * @method isOwnerOfProfile
+ * @memberof Accounts
  * @summary checks whether or not the user viewing this profile is also
  * its owner.
  * @since 1.5.0
@@ -21,6 +22,7 @@ function isOwnerOfProfile() {
 
 /**
  * @method getTargetAccount
+ * @memberof Accounts
  * @summary gets the account of the userId in the route, or the current user.
  * @since 1.5.0
  * @return {Object} - the account of the identified user.
@@ -32,9 +34,6 @@ function getTargetAccount() {
   return account;
 }
 
-/**
- * onCreated: Account Profile View
- */
 Template.accountProfile.onCreated(() => {
   const template = Template.instance();
 
@@ -47,15 +46,13 @@ Template.accountProfile.onCreated(() => {
   Reaction.hideActionView();
 });
 
-/**
- * Helpers: Account Profile View
- */
 Template.accountProfile.helpers({
   /**
    * @method doesUserExist
    * @summary confirms that a given userId belongs to an existing user.
    * @since 1.5.0
    * @return {Boolean} - whether or not a user with a given ID exists.
+   * @ignore
    */
   doesUserExist() {
     const targetUserId = Reaction.Router.getQueryParam("userId");
@@ -73,8 +70,8 @@ Template.accountProfile.helpers({
    * @summary checks whether or not the user viewing this profile is also
    * its owner.
    * @since 1.5.0
-   * @return {Boolean} - whether or not the current user is also this
-   * profile's owner.
+   * @return {Boolean} - whether or not the current user is also this profile's owner.
+   * @ignore
    */
   isOwnerOfProfile() {
     return isOwnerOfProfile();
@@ -85,6 +82,7 @@ Template.accountProfile.helpers({
    * @summary returns a component for updating a user's email.
    * @since 1.5.0
    * @return {Object} - contains the component for updating a user's email.
+   * @ignore
    */
   UpdateEmail() {
     return {
@@ -97,6 +95,7 @@ Template.accountProfile.helpers({
    * @summary returns a component that displays a user's avatar.
    * @since 1.5.0
    * @return {Object} - contains the component that displays a user's avatar.
+   * @ignore
    */
   ReactionAvatar() {
     const account = Collections.Accounts.findOne({ _id: Meteor.userId() });
@@ -119,6 +118,7 @@ Template.accountProfile.helpers({
    * @summary returns a component for updating a user's address.
    * @since 2.0.0
    * @return {Object} - contains the component for updating a user's address.
+   * @ignore
    */
   AddressBook() {
     return {
@@ -130,8 +130,8 @@ Template.accountProfile.helpers({
    * @method userHasPassword
    * @summary checks whether a user has set a password for his/her account.
    * @since 1.5.0
-   * @return {Boolean} - returns true if the current user has a password
-   * and false if otherwise.
+   * @return {Boolean} - returns true if the current user has a password and false if otherwise.
+   * @ignore
    */
   userHasPassword() {
     return Template.instance().userHasPassword.get();
@@ -142,6 +142,7 @@ Template.accountProfile.helpers({
    * @summary returns a user's order history, up to the 25 most recent ones.
    * @since 1.5.0
    * @return {Array|null} - an array of a user's orders.
+   * @ignore
    */
   userOrders() {
     const targetUserId = Reaction.Router.getQueryParam("userId") || Meteor.userId();
@@ -163,6 +164,7 @@ Template.accountProfile.helpers({
    * @summary returns the name of a user.
    * @since 1.5.0
    * @return {String} - the name of a given user.
+   * @ignore
    */
   displayName() {
     if (Reaction.Subscriptions && Reaction.Subscriptions.Account && Reaction.Subscriptions.Account.ready()) {
@@ -189,6 +191,7 @@ Template.accountProfile.helpers({
    * @summary returns a user's email.
    * @since 1.5.0
    * @return {String} - the email of a given user.
+   * @ignore
    */
   displayEmail() {
     if (Reaction.Subscriptions && Reaction.Subscriptions.Account && Reaction.Subscriptions.Account.ready()) {
@@ -206,8 +209,8 @@ Template.accountProfile.helpers({
    * @summary determines whether or not to show the button for signing up
    * as a merchant/seller.
    * @since 1.5.0
-   * @return {Boolean} - true if the merchant signup button is to be shown,
-   * and false if otherwise.
+   * @return {Boolean} - true if the merchant signup button is to be shown, and false if otherwise.
+   * @ignore
    */
   showMerchantSignup() {
     if (Reaction.Subscriptions && Reaction.Subscriptions.Account && Reaction.Subscriptions.Account.ready()) {

--- a/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
+++ b/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
@@ -69,13 +69,6 @@ Template.loginFormChangePassword.helpers(LoginFormSharedHelpers);
  * Events: Login Form Change Password
  */
 Template.loginFormChangePassword.events({
-
-  /**
-   * Submit form for password update
-   * @param  {Event} event - jQuery Event
-   * @param  {Template} template - Blaze Template
-   * @return {void}
-   */
   "submit form"(event, template) {
     event.preventDefault();
     event.stopPropagation();

--- a/imports/plugins/core/accounts/server/index.js
+++ b/imports/plugins/core/accounts/server/index.js
@@ -1,2 +1,8 @@
 import "./i18n";
 import "./init.js";
+
+/**
+ * Query functions that do not import or use any Meteor packages or globals. These can be used both
+ * by Meteor methods or publications, and by GraphQL resolvers.
+ * @namespace Accounts/NoMeteorQueries
+ */

--- a/imports/plugins/core/accounts/server/methods/groupQuery.js
+++ b/imports/plugins/core/accounts/server/methods/groupQuery.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 /**
  * @name groupQuery
  * @method
+ * @memberof Accounts/NoMeteorQueries
  * @summary query the Groups collection and return group data
  * @param {Object} context - an object containing the per-request state
  * @param {String} id - id of group to query
@@ -37,6 +38,7 @@ export async function groupQuery(context, id) {
 /**
  * @name groupsQuery
  * @method
+ * @memberof Accounts/NoMeteorQueries
  * @summary query the Groups collection and return a MongoDB cursor
  * @param {Object} context - an object containing the per-request state
  * @param {String} shopId - shop ID to get groups for

--- a/imports/plugins/core/accounts/server/methods/rolesQuery.js
+++ b/imports/plugins/core/accounts/server/methods/rolesQuery.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 /**
  * @name rolesQuery
  * @method
+ * @memberof Accounts/NoMeteorQueries
  * @summary query the Shops collection, filter over packages, and return available roles data
  * @param {Object} context - an object containing the per-request state
  * @param {String} shopId - ID of Shop to query

--- a/imports/plugins/core/accounts/server/methods/shopAdministratorsQuery.js
+++ b/imports/plugins/core/accounts/server/methods/shopAdministratorsQuery.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 /**
  * @name shopAdministratorsQuery
  * @method
+ * @memberof Accounts/NoMeteorQueries
  * @summary return Account object for all users who are "owner" or "admin" role for the shop
  * @param {Object} context - an object containing the per-request state
  * @param {String} id - ID of shop

--- a/imports/plugins/core/accounts/server/methods/userAccountQuery.js
+++ b/imports/plugins/core/accounts/server/methods/userAccountQuery.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 /**
  * @name userAccountQuery
  * @method
+ * @memberof Accounts/NoMeteorQueries
  * @summary query the Accounts collection and return user account data
  * @param {Object} context - an object containing the per-request state
  * @param {String} id - id of user to query

--- a/imports/plugins/core/accounts/server/no-meteor/hasPermission.js
+++ b/imports/plugins/core/accounts/server/no-meteor/hasPermission.js
@@ -3,12 +3,12 @@ const GLOBAL_GROUP = "__global_roles__";
 /**
  * @name hasPermission
  * @method
- * @memberof Core
+ * @memberof Accounts
  * @param {Object} user - The user object, with `roles` property, to check.
  * @param {String[]} permissions - Array of permission strings. The account must have at least one of them either globally or for the roleGroup.
  * @param {String} [roleGroup] - The shop ID for which the permissions are needed, or a more specific roles group. If not set,
  *   only global roles will be checked.
- * @return {Promise<Boolean>} True if the account with ID accountId has at least one of the requested permissions in the roleGroup group
+ * @return {Boolean} True if the account with ID accountId has at least one of the requested permissions in the roleGroup group
  */
 export default function hasPermission(user, permissions, roleGroup) {
   if (!user || !user.roles) return false;

--- a/imports/plugins/core/catalog/client/templates/settings.js
+++ b/imports/plugins/core/catalog/client/templates/settings.js
@@ -17,11 +17,6 @@ Template.catalogSettings.helpers({
 });
 
 Template.catalogSettings.events({
-  /**
-   * settings update enabled status for services on change
-   * @param  {event} event    jQuery Event
-   * @return {void}
-   */
   "change input[name=enabled]": (event) => {
     const settingsKey = event.target.getAttribute("data-key");
     const packageId = event.target.getAttribute("data-id");

--- a/imports/plugins/core/catalog/server/index.js
+++ b/imports/plugins/core/catalog/server/index.js
@@ -1,2 +1,8 @@
 import "./i18n";
 import "./methods/catalog";
+
+/**
+ * Query functions that do not import or use any Meteor packages or globals. These can be used both
+ * by Meteor methods or publications, and by GraphQL resolvers.
+ * @namespace Catalog/NoMeteorQueries
+ */

--- a/imports/plugins/core/catalog/server/queries/catalogItemProduct.js
+++ b/imports/plugins/core/catalog/server/queries/catalogItemProduct.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 /**
  * @name catalogItemProduct
  * @method
+ * @memberof Catalog/NoMeteorQueries
  * @summary query the Catalog for a single Product by id or slug
  * id takes priority if both are provided, throws meteor error if neither
  * @param {Object} context - an object containing the per-request state

--- a/imports/plugins/core/catalog/server/queries/catalogItems.js
+++ b/imports/plugins/core/catalog/server/queries/catalogItems.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 /**
  * @name catalogItems
  * @method
+ * @memberof Catalog/NoMeteorQueries
  * @summary query the Catalog by shop ID and/or tag ID
  * @param {Object} context - an object containing the per-request state
  * @param {Object} params - request parameters

--- a/imports/plugins/core/catalog/server/queries/tags.js
+++ b/imports/plugins/core/catalog/server/queries/tags.js
@@ -1,6 +1,7 @@
 /**
  * @name tags
  * @method
+ * @memberof Catalog/NoMeteorQueries
  * @summary query the Tags collection by shop ID and optionally by isTopLevel
  * @param {Object} context - an object containing the per-request state
  * @param {String} shopId - ID of shop to query

--- a/imports/plugins/core/catalog/server/queries/tagsByIds.js
+++ b/imports/plugins/core/catalog/server/queries/tagsByIds.js
@@ -1,6 +1,7 @@
 /**
  * @name tagsByIds
  * @method
+ * @memberof Catalog/NoMeteorQueries
  * @summary query the Tags collection by a list of IDs
  * @param {Object} context - an object containing the per-request state
  * @param {String[]} tagIds - tag IDs to get

--- a/imports/plugins/core/checkout/client/components/completedOrder.js
+++ b/imports/plugins/core/checkout/client/components/completedOrder.js
@@ -8,6 +8,7 @@ import AddEmail from "./addEmail";
 
 /**
  * @summary Displays a summary/information about the order the user has just completed
+ * @memberof Components
  * @param {Object} props - React PropTypes
  * @property {Object} order - An object representing the order
  * @property {Array} shops - An Array contains information broken down by shop

--- a/imports/plugins/core/checkout/client/components/completedOrderItem.js
+++ b/imports/plugins/core/checkout/client/components/completedOrderItem.js
@@ -5,6 +5,7 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
 
 /**
  * @summary Shows the individual line items for a completed order
+ * @memberof Components
  * @param {Object} props - React PropTypes
  * @property {Object} item - An object representing each item on the order
  * @return {Node} React node containing each line item on an order

--- a/imports/plugins/core/checkout/client/components/completedOrderPaymentMethods.js
+++ b/imports/plugins/core/checkout/client/components/completedOrderPaymentMethods.js
@@ -11,6 +11,7 @@ const creditCardClasses = {
 
 /**
  * @summary Displays one of possibly many payment methods on an order
+ * @memberof Components
  * @param {Object} props - React PropTypes
  * @property {Object} paymentMethod - An object representing the payment method
  * @return {Node} React node containing each payment method

--- a/imports/plugins/core/checkout/client/components/completedOrderSummary.js
+++ b/imports/plugins/core/checkout/client/components/completedOrderSummary.js
@@ -6,6 +6,7 @@ import ShopOrderSummary from "./shopOrderSummary";
 
 /**
  * @summary Display the summary/total information for an order
+ * @memberof Components
  * @param {Object} props - React PropTypes
  * @property {Array} shops - An array of summary information broken down by shop
  * @property {Object} orderSummary - An object representing the "bottom line" summary for the order

--- a/imports/plugins/core/checkout/client/components/completedShopOrders.js
+++ b/imports/plugins/core/checkout/client/components/completedShopOrders.js
@@ -5,6 +5,7 @@ import CompletedOrderItem from "./completedOrderItem";
 
 /**
  * @summary Displays the order breakdown for each Shop
+ * @memberof Components
  * @param {Object} props - React PropTypes
  * @property {String} shopName - The name of the shop
  * @property {Array} items - an array of individual items for this shop

--- a/imports/plugins/core/checkout/client/components/shopOrderSummary.js
+++ b/imports/plugins/core/checkout/client/components/shopOrderSummary.js
@@ -4,6 +4,7 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
 
 /**
  * @summary Displays the order summary for each shop
+ * @memberof Components
  * @param {Object} props - React PropTypes
  * @property {Object} shopSummary - An object representing the summary information for this Shop
  * @property {boolean} isProfilePage - Checks if current page is profile page (unused)

--- a/imports/plugins/core/checkout/client/templates/checkout/addressBook/addressBook.js
+++ b/imports/plugins/core/checkout/client/templates/checkout/addressBook/addressBook.js
@@ -1,15 +1,13 @@
 import { Template } from "meteor/templating";
 import { Components } from "@reactioncommerce/reaction-components";
 
-/**
- * Helpers: Checkout Address Book
- */
 Template.checkoutAddressBook.helpers({
   /**
    * @method AddressBook
    * @summary returns a component for updating a user's address.
    * @since 2.0.0
    * @return {Object} - contains the component for updating a user's address.
+   * @ignore
    */
   AddressBook() {
     const { status, position } = Template.currentData();

--- a/imports/plugins/core/checkout/server/methods/workflow.js
+++ b/imports/plugins/core/checkout/server/methods/workflow.js
@@ -8,14 +8,13 @@ import { Hooks, Logger, Reaction } from "/server/api";
 /* eslint no-shadow: 0 */
 
 /**
- * @method updateOrderWorkflow
  * @summary Updates a hook to update orders status before updating an order.
- *
  * @param {String} userId - currently logged in user
  * @param {Object} selector - selector for product to update
  * @param {Object} modifier - Object describing what parts of the document to update.
  * @param {Object} validation
  * @return {String} _id of updated document
+ * @private
  */
 function updateOrderWorkflow(userId, selector, modifier, validation) {
   const order = Orders.findOne(selector);
@@ -40,12 +39,13 @@ function updateOrderWorkflow(userId, selector, modifier, validation) {
  * @file Methods for Workflow. Run these methods using `Meteor.call()`.
  * @example Meteor.call("workflow/pushCartWorkflow", "coreCartWorkflow", "checkoutLogin");
  *
- * @namespace Methods/Workflow
-*/
+ * @namespace Workflow/Methods
+ */
+
 Meteor.methods({
   /**
    * @name workflow/pushCartWorkflow
-   * @memberof Methods/Workflow
+   * @memberof Workflow/Methods
    * @method
    * @example Meteor.call("workflow/pushCartWorkflow", "coreCartWorkflow", "checkoutLogin");
    * @summary updates cart workflow status
@@ -244,7 +244,7 @@ Meteor.methods({
 
   /**
    * @name workflow/revertCartWorkflow
-   * @memberof Methods/Workflow
+   * @memberof Workflow/Methods
    * @method
    * @summary if something was changed on the previous `cartWorkflow` steps,
    * we need to revert to this step to renew the order
@@ -290,7 +290,7 @@ Meteor.methods({
    * Step 2 (this method) of the "workflow/pushOrderWorkflow" flow; Try to update the current status
    *
    * @method
-   * @memberof Methods/Workflow
+   * @memberof Workflow/Methods
    * @param  {String} workflow workflow to push to
    * @param  {String} status - Workflow status
    * @param  {Order} order - Schemas.Order, an order object
@@ -331,7 +331,7 @@ Meteor.methods({
    * @description Push the status as the current workflow step, move the current status to completed worflow steps
    * @summary Pull a previous order status
    * @method
-   * @memberof Methods/Workflow
+   * @memberof Workflow/Methods
    * @param  {String} workflow workflow to push to
    * @param  {String} status - Workflow status
    * @param  {Order} order - Schemas.Order, an order object
@@ -365,7 +365,7 @@ Meteor.methods({
   /**
    * @name workflow/pushItemWorkflow
    * @method
-   * @memberof Methods/Workflow
+   * @memberof Workflow/Methods
    * @param  {String} status  Workflow status
    * @param  {Object} order   Schemas.Order, an order object
    * @param  {String[]} itemIds Array of item IDs

--- a/imports/plugins/core/components/lib/components.js
+++ b/imports/plugins/core/components/lib/components.js
@@ -16,7 +16,7 @@ export const ComponentsTable = {}; // storage for separate elements of each comp
  * }
  * @name registerComponent
  * @method
- * @memberof Components
+ * @memberof Components/Helpers
  * @param {String} name The name of the component to register.
  * @param {React.Component} rawComponent Interchangeable/extendable component.
  * @param {Function|Array} hocs The HOCs to wrap around the raw component.
@@ -44,7 +44,7 @@ export function registerComponent(name, rawComponent, hocs = []) {
  * If some containers already exist for the component, they will be extended.
  * @param {String} name The name of the component to register.
  * @param {Function|Array} hocs The HOCs to wrap around the raw component.
- * @memberof Components
+ * @memberof Components/Helpers
  * @returns {undefined}
  */
 export function registerHOC(name, hocs = []) {
@@ -83,7 +83,7 @@ export function registerHOC(name, hocs = []) {
  * @summary Get a component registered with registerComponent(name, component, ...hocs).
  * @param {String} name The name of the component to get.
  * @return {Function|React.Component} A (wrapped) React component
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function getComponent(name) {
   const component = ComponentsTable[name];
@@ -107,7 +107,7 @@ export function getComponent(name) {
  * @param {React.Component} newComponent Interchangeable/extendable component.
  * @param {Function|Array} hocs The HOCs to compose with the raw component.
  * @returns {Function|React.Component} A component callable with Components[name]
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function replaceComponent(name, newComponent, hocs = []) {
   const previousComponent = ComponentsTable[name];
@@ -128,7 +128,7 @@ export function replaceComponent(name, newComponent, hocs = []) {
  * @summary Get the raw UI component without any possible HOCs wrapping it.
  * @param {String} name The name of the component to get.
  * @returns {Function|React.Component} A React component
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export const getRawComponent = (name) => ComponentsTable[name].rawComponent;
 
@@ -139,7 +139,7 @@ export const getRawComponent = (name) => ComponentsTable[name].rawComponent;
  * @summary Get the raw UI component without any possible HOCs wrapping it.
  * @param {String} name The name of the component to get.
  * @returns {Function|React.Component} Array of HOCs
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export const getHOCs = (name) => ComponentsTable[name].hocs;
 
@@ -151,7 +151,7 @@ export const getHOCs = (name) => ComponentsTable[name].hocs;
  * @param {String} sourceComponentName The name of the component to get the HOCs from
  * @param {Function|React.Component} targetComponent Component to wrap
  * @returns {Function|React.Component} A new component wrapped with the HOCs of the source component
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function copyHOCs(sourceComponentName, targetComponent) {
   const sourceComponent = ComponentsTable[sourceComponentName];
@@ -165,7 +165,7 @@ export function copyHOCs(sourceComponentName, targetComponent) {
  * @summary Populate the final Components object with the contents of the lookup table.
  * This should only be called once on app startup.
  * @returns {Object} An object containing all of the registered components
- * @memberof Components
+ * @memberof Components/Helpers
  **/
 export function loadRegisteredComponents() {
   Object.keys(ComponentsTable).forEach((name) => {

--- a/imports/plugins/core/components/lib/composer/tracker.js
+++ b/imports/plugins/core/components/lib/composer/tracker.js
@@ -20,12 +20,16 @@ import compose from "./compose";
  */
 
 /**
+ * @namespace Components/Helpers
+ */
+
+/**
  * @name getTrackerLoader
  * @summary getTrackerLoader creates a Meteor Tracker to watch dep updates from
  * the passed in reactiveMapper function
  * @param  {Function} reactiveMapper data fetching function to bind to a tracker
  * @return {Function} composed function
- * @memberof Components
+ * @memberof Components/Helpers
  * @private
  */
 function getTrackerLoader(reactiveMapper) {
@@ -51,7 +55,7 @@ function getTrackerLoader(reactiveMapper) {
  * @param {Function} reactiveMapper data fetching function to bind to a tracker
  * @param {React.Component|Boolean|Object} options can be a custom loader, false (to disable), or a full options object
  * @return {Function} composed function
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function composeWithTracker(reactiveMapper, options) {
   let composeOptions = {};

--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -23,7 +23,7 @@ if (Meteor.isClient) {
  * @summary A wrapper to reactively inject the current user into a component
  * @param {Function|React.Component} component - the component to wrap
  * @return {Function} the new wrapped component with a "currentUser" prop
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function withCurrentUser(component) {
   return composeWithTracker((props, onData) => {
@@ -38,7 +38,7 @@ export function withCurrentUser(component) {
  * @summary A wrapper to reactively inject the moment package into a component
  * @param {Function|React.Component} component - the component to wrap
  * @return {Function} the new wrapped component with a "moment" prop
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function withMoment(component) {
   return lifecycle({
@@ -64,7 +64,7 @@ export function withMoment(component) {
  * @summary A wrapper to reactively inject the moment package into a component
  * @param {Function|React.Component} component - the component to wrap
  * @return {Function} the new wrapped component with a "moment" prop
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function withMomentTimezone(component) {
   return lifecycle({
@@ -90,7 +90,7 @@ export function withMomentTimezone(component) {
  * This assumes you have signed up and are not an anonymous user.
  * @param {Function|React.Component} component - the component to wrap
  * @return {Function} the new wrapped component with a "currentAccount" prop
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function withCurrentAccount(component) {
   return composeWithTracker((props, onData) => {
@@ -125,7 +125,7 @@ export function withCurrentAccount(component) {
  * Sets a boolean 'isAdmin' prop on the wrapped component.
  * @param {Function|React.Component} component - the component to wrap
  * @return {Function} the new wrapped component with an "isAdmin" prop
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function withIsAdmin(component) {
   return composeWithTracker((props, onData) => {
@@ -141,7 +141,7 @@ export function withIsAdmin(component) {
  * @param  {Array|String} roles String or array of strings of permissions to check. default: roles=["guest", "anonymous"]
  * @param  {String} group Slug title of a group to check against. Group option supercedes roles option. default: group="customer".
  * @return {Function} the new wrapped component with a "hasPermissions" prop
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function withPermissions({ roles = ["guest", "anonymous"], group }) {
   return composeWithTracker((props, onData) => {
@@ -177,7 +177,7 @@ export function withPermissions({ roles = ["guest", "anonymous"], group }) {
  * Sets a boolean 'isOwner' prop on the wrapped component.
  * @param {Function|React.Component} component - the component to wrap
  * @return {Function} the new wrapped component with an "isOwner" prop
- * @memberof Components
+ * @memberof Components/Helpers
  */
 export function withIsOwner(component) {
   return composeWithTracker((props, onData) => {

--- a/imports/plugins/core/connectors/client/templates/settings/connectors.js
+++ b/imports/plugins/core/connectors/client/templates/settings/connectors.js
@@ -19,11 +19,6 @@ Template.connectorSettings.helpers({
 // toggle connector methods visibility
 // also toggles connector method settings
 Template.connectorSettings.events({
-  /**
-   * connectorSettings settings update enabled status for connector service on change
-   * @param  {event} event    jQuery Event
-   * @return {void}
-   */
   "change input.checkbox-switch.connector-settings[name=enabled]": (event) => {
     event.preventDefault();
     const settingsKey = event.target.getAttribute("data-key");

--- a/imports/plugins/core/connectors/server/methods/methods.js
+++ b/imports/plugins/core/connectors/server/methods/methods.js
@@ -6,14 +6,14 @@ import { connectorsRoles } from "../lib/roles";
 
 /**
  *
- * @namespace Methods/Connectors
+ * @namespace Connectors/Methods
  */
 
 export const methods = {
   /**
    * @name connectors/connection/toggle
    * @method
-   * @memberof Methods/Connectors
+   * @memberof Connectors/Methods
    * @example Meteor.call("connectors/connection/toggle", packageId, settingsKey)
    * @summary Toggle enabled connection
    * @param { String } packageId - packageId

--- a/imports/plugins/core/dashboard/client/containers/packageListContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/packageListContainer.js
@@ -6,18 +6,20 @@ import { Roles } from "meteor/alanning:roles";
 import { Reaction } from "/client/api";
 
 /**
- * handleShowPackage - Push package into action view navigation stack
+ * Push package into action view navigation stack
  * @param  {SyntheticEvent} event Original event
  * @param  {Object} app Package data
  * @return {undefined} No return value
+ * @private
  */
 function handleShowPackage(event, app) {
   Reaction.pushActionView(app);
 }
 
 /**
- * handleShowDashboard - Open full dashbaord menu
+ * Open full dashbaord menu
  * @return {undefined} No return value
+ * @private
  */
 function handleShowDashboard() {
   Reaction.hideActionViewDetail();
@@ -29,10 +31,11 @@ function handleShowDashboard() {
 }
 
 /**
- * handleOpenShortcut - Push dashbaord & package into action view navigation stack
+ * Push dashbaord & package into action view navigation stack
  * @param  {SyntheticEvent} event Original event
  * @param  {Object} app Package data
  * @return {undefined} No return value
+ * @private
  */
 function handleOpenShortcut(event, app) {
   Reaction.hideActionViewDetail();

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -32,11 +32,12 @@ const handleAddProduct = () => {
 };
 
 /**
-* Handler that fires when the shop selector is changed
-* @param {Object} event - the `event` coming from the select change event
-* @param {String} shopId - The `value` coming from the select change event
-* @returns {undefined}
-*/
+ * @summary Handler that fires when the shop selector is changed
+ * @param {Object} event - the `event` coming from the select change event
+ * @param {String} shopId - The `value` coming from the select change event
+ * @returns {undefined}
+ * @private
+ */
 const handleShopSelectChange = (event, shopId) => {
   if (/^[A-Za-z0-9]{17}$/.test(shopId)) { // Make sure shopId is a valid ID
     Reaction.setShopId(shopId);

--- a/imports/plugins/core/dashboard/client/templates/packages/grid/package.js
+++ b/imports/plugins/core/dashboard/client/templates/packages/grid/package.js
@@ -3,13 +3,19 @@ import { Reaction } from "/client/api";
 /* eslint no-loop-func: 0 */
 
 /**
- * gridPackage helpers
+ * @typedef CardProps
+ * @type Object
+ * @property {Object} controls Reaction UI Button or other control props
+ * @property {function} onContentClick y The Y
+ * @ignore
  */
+
 Template.gridPackage.helpers({
   /**
    * Properties for the card
    * @see packages/reaction-ui/client/components/cards/cards.js
    * @return {CardProps} Object of properties for the card component
+   * @ignore
    */
   cardProps() {
     const instance = Template.instance();

--- a/imports/plugins/core/dashboard/client/templates/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/settings/settings.js
@@ -3,14 +3,12 @@ import { Template } from "meteor/templating";
 import { Reaction } from "/client/api";
 import { Packages } from "/lib/collections";
 
-/**
- * Helpers for Settings Header (actionView)
- */
 Template.settingsHeader.helpers({
 
   /**
    * Data pased to action view
    * @return {Object} Registry entry for item
+   * @ignore
    */
   registry() {
     return Reaction.getActionView() || {};
@@ -23,6 +21,7 @@ Template.settingsHeader.helpers({
   /**
    * thisApp
    * @return {Object} Registry entry for item
+   * @ignore
    */
   thisApp() {
     const reactionApp = Packages.findOne({
@@ -45,9 +44,6 @@ Template.settingsHeader.helpers({
 
 });
 
-/**
- * Events for Setting Header (actionView)
- */
 Template.settingsHeader.events({
   "click [data-event-action=closeSettings]": () => {
     Reaction.hideActionView();
@@ -58,14 +54,11 @@ Template.settingsHeader.events({
   }
 });
 
-/**
- * Helpers for Settings Sidebar (actionView)
- */
 Template.settingsSidebar.helpers({
-
   /**
    * pkgPermissions Check package permissions
    * @return {Boolean} user has permission to see settings for this package
+   * @ignore
    */
   pkgPermissions() {
     if (Reaction.hasPermission("dashboard")) {
@@ -81,10 +74,10 @@ Template.settingsSidebar.helpers({
 });
 
 Template.settingsSidebarItem.helpers({
-
   /**
    * label
    * @return {String} Label for item
+   * @ignore
    */
   label() {
     return Template.parentData(1).label || this.label;

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -138,11 +138,6 @@ AutoForm.hooks({
 });
 
 Template.shopSettings.events({
-  /**
-   * settings update enabled status for services on change
-   * @param  {event} event    jQuery Event
-   * @return {void}
-   */
   "change input[name=enabled]": (event) => {
     const settingsKey = event.target.getAttribute("data-key");
     const packageId = event.target.getAttribute("data-id");

--- a/imports/plugins/core/discounts/lib/collections/collections.js
+++ b/imports/plugins/core/discounts/lib/collections/collections.js
@@ -2,12 +2,11 @@ import { Mongo } from "meteor/mongo";
 import * as Schemas from "./schemas";
 
 /**
-* Discounts Collection
-* @type {Object}
-* @desc Collection for custom discount rates
-* for dollar, percentage, and shipping
-* discount rates.
-*/
+ * @name Discounts
+ * @memberof Collections
+ * @summary Collection for custom discount rates for dollar, percentage, and shipping discount rates.
+ * @type {MongoCollection}
+ */
 export const Discounts = new Mongo.Collection("Discounts");
 
 Discounts.attachSchema(Schemas.Discounts);

--- a/imports/plugins/core/discounts/lib/collections/schemas/config.js
+++ b/imports/plugins/core/discounts/lib/collections/schemas/config.js
@@ -3,9 +3,10 @@ import { PackageConfig } from "/lib/collections/schemas/registry";
 import { Discounts } from "./discounts";
 
 /**
-* DiscountsPackageConfig Schema
-*/
-
+ * @name DiscountsPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const DiscountsPackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {

--- a/imports/plugins/core/discounts/lib/collections/schemas/discounts.js
+++ b/imports/plugins/core/discounts/lib/collections/schemas/discounts.js
@@ -4,13 +4,14 @@ import { Tracker } from "meteor/tracker";
 import { shopIdAutoValue } from "/lib/collections/schemas/helpers";
 import { registerSchema } from "@reactioncommerce/schemas";
 
-// The Discounts Schema validates using multiple schemas
-// be sure to use `{ selector: { discountMethod: "code" } }`
-// to indicate which schema to apply in all updates
-
-/*
-* Discounts Tranaction History Schema
-*/
+/**
+ * The Discounts Schema validates using multiple schemas.
+ * Be sure to use `{ selector: { discountMethod: "code" } }` to indicate which schema to apply in all updates
+ * @name Transactions
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary Discounts Tranaction History Schema
+ */
 export const Transactions = new SimpleSchema({
   cartId: {
     type: String,
@@ -28,10 +29,12 @@ export const Transactions = new SimpleSchema({
 
 registerSchema("Transactions", Transactions);
 
-/*
-* Discounts Schema
-*/
-
+/**
+ * @name Discounts
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary Discounts schema
+ */
 export const Discounts = new SimpleSchema({
   "shopId": {
     type: String,

--- a/imports/plugins/core/discounts/server/hooks/cart.js
+++ b/imports/plugins/core/discounts/server/hooks/cart.js
@@ -2,15 +2,6 @@ import { Meteor } from "meteor/meteor";
 import { Cart } from "/lib/collections";
 import { Hooks } from "/server/api";
 
-/**
-* Cart Hooks for Discounts
-* @type {Object}
-* @desc After cart update apply discounts.
-* if items are changed, recalculating discounts
-* we could have done this in the core/cart transform
-* but this way this file controls the events from
-* the core/discounts plugin.
-*/
 Hooks.Events.add("afterCartUpdateCalculateDiscount", (cartId) => {
   if (cartId) {
     const cart = Cart.findOne({ _id: cartId });

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -6,14 +6,14 @@ import Reaction from "../api";
 
 /**
  *
- * @namespace Methods/Discounts
+ * @namespace Discounts/Methods
  */
 
 export const methods = {
   /**
    * @name discounts/deleteRate
    * @method
-   * @memberof Methods/Discounts
+   * @memberof Discounts/Methods
    * @param  {String} discountId discount id to delete
    * @return {String} returns update/insert result
    */
@@ -31,7 +31,7 @@ export const methods = {
   /**
    * @name discounts/setRate
    * @method
-   * @memberof Methods/Discounts
+   * @memberof Discounts/Methods
    * @summary Update the cart discounts without hooks
    * @param  {String} cartId cartId
    * @param  {Number} discountRate discountRate
@@ -54,7 +54,7 @@ export const methods = {
   /**
    * @name discounts/transaction
    * @method
-   * @memberof Methods/Discounts
+   * @memberof Discounts/Methods
    * @summary Applies a transaction to discounts for history
    * @param  {String} cartId cartId
    * @param  {String} discountId discountId
@@ -81,7 +81,7 @@ export const methods = {
   /**
    * @name discounts/calculate
    * @method
-   * @memberof Methods/Discounts
+   * @memberof Discounts/Methods
    * @param  {String} cart cartId
    * @return {Object}  returns discount object
    */

--- a/imports/plugins/core/files/server/methods.js
+++ b/imports/plugins/core/files/server/methods.js
@@ -6,14 +6,20 @@ import { Media } from "/imports/plugins/core/files/server";
 import { RevisionApi } from "/imports/plugins/core/revisions/lib/api";
 
 /**
+ * Media-related Meteor methods
+ * @namespace Media/Methods
+ */
+
+/**
  * @method updateMediaMetadata
- * @memberof media
+ * @memberof Media/Methods
  * @summary updates media record in revision control.
  * @param {String} fileRecordId - _id of updated file record.
  * @param {Object} metadata - metadata from updated media file.
  * @return {Boolean}
+ * @private
  */
-export async function updateMediaMetadata(fileRecordId, metadata) {
+async function updateMediaMetadata(fileRecordId, metadata) {
   check(fileRecordId, String);
   check(metadata, Object);
   if (RevisionApi.isRevisionControlEnabled()) {
@@ -63,8 +69,9 @@ export async function updateMediaMetadata(fileRecordId, metadata) {
 }
 
 /**
- * @method insertMedia
- * @memberof media
+ * @name media/insert
+ * @method
+ * @memberof Media/Methods
  * @summary insert a new media record and add it to revision control.
  * @param {Object} fileRecord - document from file collection upload.
  * @return {String} - _id of the new inserted media record.
@@ -109,8 +116,9 @@ export async function insertMedia(fileRecord) {
 }
 
 /**
- * @method removeMedia
- * @memberof media
+ * @name media/remove
+ * @method
+ * @memberof Media/Methods
  * @summary removes media file and updates record in revision control.
  * @param {String} fileRecordId - _id of file record to be deleted.
  * @return {Boolean}
@@ -141,9 +149,10 @@ export async function removeMedia(fileRecordId) {
 }
 
 /**
- * updateMediaPriorities
+ * @name media/updatePriorities
+ * @method
+ * @memberof Media/Methods
  * @summary sorting media by array indexes
- * @type {Method}
  * @param {String[]} sortedMediaIDs
  * @return {Boolean} true
  */

--- a/imports/plugins/core/graphql/server/ReactionError.js
+++ b/imports/plugins/core/graphql/server/ReactionError.js
@@ -1,5 +1,12 @@
 import ExtendableError from "es6-error";
 
+/**
+ * @name ReactionError
+ * @class
+ * @memberof GraphQL
+ * @summary A type of error that allows additional details to be provided, which can
+ *   then be sent back to the client for a GraphQL request.
+ */
 export default class ReactionError extends ExtendableError {
   constructor(error, message, eventData = {}) {
     super(message);

--- a/imports/plugins/core/graphql/server/buildContext.js
+++ b/imports/plugins/core/graphql/server/buildContext.js
@@ -2,7 +2,14 @@ import { curryN } from "ramda";
 import hasPermission from "/imports/plugins/core/accounts/server/no-meteor/hasPermission";
 import getShopIdForContext from "/imports/plugins/core/accounts/server/no-meteor/getShopIdForContext";
 
-// mutates the context object
+/**
+ * @name buildContext
+ * @method
+ * @memberof GraphQL
+ * @summary Mutates the provided context object, adding `user`, `userId`, `shopId`, and
+ *   `userHasPermission` properties.
+ * @returns {undefined} No return
+ */
 export default async function buildContext(context, user) {
   context.user = user || null;
   context.userId = (user && user._id) || null;

--- a/imports/plugins/core/graphql/server/createApolloServer.js
+++ b/imports/plugins/core/graphql/server/createApolloServer.js
@@ -18,6 +18,14 @@ const defaultServerConfig = {
   }
 };
 
+/**
+ * @name createApolloServer
+ * @method
+ * @memberof GraphQL
+ * @summary Creates an express app, adds graphql and optionally graphiql routes to it,
+ *   and the returns it.
+ * @returns {ExpressApp} The express app
+ */
 export default function createApolloServer(options = {}) {
   // the Meteor GraphQL server is an Express server
   const expressServer = express();

--- a/imports/plugins/core/graphql/server/defineCollections.js
+++ b/imports/plugins/core/graphql/server/defineCollections.js
@@ -1,6 +1,11 @@
 /**
+ * @name defineCollections
+ * @method
+ * @memberof GraphQL
+ * @summary Adds Collection instances to the provided `collections` map
  * @param {MongoDatabase} db A database instance from Node Mongo client
  * @param {Object} collections An object to mutate with all of the Reaction collections
+ * @returns {undefined} No return
  */
 export default function defineCollections(db, collections) {
   Object.assign(collections, {

--- a/imports/plugins/core/graphql/server/getErrorFormatter.js
+++ b/imports/plugins/core/graphql/server/getErrorFormatter.js
@@ -1,6 +1,16 @@
 import cuid from "cuid";
 import { Logger } from "./logger";
 
+/**
+ * @name getErrorFormatter
+ * @method
+ * @memberof GraphQL
+ * @summary Given the current context, returns a context-specific error formatting
+ *   function for use as the `formatError` option when calling `graphqlExpress` from
+ *   the `apollo-server-express` package.
+ * @param {Object} context An object with request-specific state
+ * @returns {Function} The error formatter function
+ */
 function getErrorFormatter(context = {}) {
   return (err) => {
     const { originalError } = err;

--- a/imports/plugins/core/graphql/server/getUserFromToken.js
+++ b/imports/plugins/core/graphql/server/getUserFromToken.js
@@ -9,6 +9,21 @@ function hashLoginToken(loginToken) {
   return hash.digest("base64");
 }
 
+/**
+ * Given a login token and the current context, returns the user document
+ * for that token, using the same lookup logic that Meteor's accounts packages use.
+ *
+ * If the provided token is not associated with any user or is associated but is
+ * expired, this function throws an "access-denied" ReactionError.
+ *
+ * @name getUserFromToken
+ * @method
+ * @memberof GraphQL
+ * @summary Looks up a user by token
+ * @param {String} loginToken An object with request-specific state
+ * @param {Object} context An object with request-specific state
+ * @returns {Function} The error formatter function
+ */
 async function getUserFromToken(loginToken, context) {
   const { collections } = context;
   const { users } = collections;

--- a/imports/plugins/core/graphql/server/index.js
+++ b/imports/plugins/core/graphql/server/index.js
@@ -6,6 +6,11 @@ import defineCollections from "./defineCollections";
 import methods from "./methods";
 import queries from "./queries";
 
+/**
+ * Functions used by the GraphQL server configuration
+ * @namespace GraphQL
+ */
+
 const collections = {};
 
 const { db } = MongoInternals.defaultRemoteCollectionDriver().mongo;

--- a/imports/plugins/core/graphql/server/meteorTokenMiddleware.js
+++ b/imports/plugins/core/graphql/server/meteorTokenMiddleware.js
@@ -1,6 +1,23 @@
 import getUserFromToken from "./getUserFromToken";
 
-export default function meteorTokenMiddleware(headerName, contextFromOptions) {
+/**
+ * This middleware wraps the `getUserFromToken` function. Given a header name, it
+ * checks to see if that header was provided. If it was, the token value from that
+ * header is passed to `getUserFromToken` and the result is saved on `req.user`.
+ *
+ * If `getUserFromToken` throws, a 401 response is sent. If the request header is
+ * not set, then the middleware finishes. This means that a token need not be
+ * provided, but if one is present, it must be valid to avoid a 401.
+ *
+ * @name meteorTokenMiddleware
+ * @method
+ * @memberof GraphQL
+ * @summary Express middleware to find user by token.
+ * @param {String} headerName The name of the HTTP header that should have a token
+ * @param {Object} context An object with request-specific state. Just passed through to `getUserFromToken`.
+ * @returns {Function} An Express middleware function
+ */
+export default function meteorTokenMiddleware(headerName, context) {
   return async (req, res, next) => {
     // get the login token from the headers request, given by the Meteor's
     // network interface middleware if enabled
@@ -13,7 +30,7 @@ export default function meteorTokenMiddleware(headerName, contextFromOptions) {
 
     try {
       // get the current user
-      req.user = await getUserFromToken(token, contextFromOptions);
+      req.user = await getUserFromToken(token, context);
       next();
     } catch (error) {
       res.sendStatus(401);

--- a/imports/plugins/core/graphql/server/resolvers/account/Account/addressBook.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Account/addressBook.js
@@ -2,8 +2,9 @@ import { get } from "lodash";
 import { xformArrayToConnection } from "@reactioncommerce/reaction-graphql-xforms/connection";
 
 /**
- * @name addressBook
+ * @name "Account.addressBook"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary converts the `addressBook` prop on the provided account to a connection
  * @param {Object} account - result of the parent resolver, which is an Account object in GraphQL schema format
  * @return {Promise<Object>} A connection object

--- a/imports/plugins/core/graphql/server/resolvers/account/Group/createdBy.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Group/createdBy.js
@@ -1,6 +1,7 @@
 /**
- * @name createdBy
+ * @name "Group.createdBy"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary query the Accounts collection and return user account data
  * @param {Object} args - an object of all arguments that were sent by the previous resolver
  * @param {Object} args.createdBy - a string account id

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountAddressBookEntry.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountAddressBookEntry.js
@@ -1,8 +1,9 @@
 import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
 
 /**
- * @name addAccountAddressBookEntry
+ * @name "Mutation.addAccountAddressBookEntry"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary resolver for the addAccountAddressBookEntry GraphQL mutation
  * @param {Object} _ - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountToGroup.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/addAccountToGroup.js
@@ -2,8 +2,9 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
 
 /**
- * @name addAccountToGroup
+ * @name "Mutation.addAccountToGroup"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary resolver for the addAccountToGroup GraphQL mutation
  * @param {Object} _ - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/inviteShopMember.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/inviteShopMember.js
@@ -2,8 +2,9 @@ import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/g
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name inviteShopMember
+ * @name "Mutation.inviteShopMember"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary resolver for the inviteShopMember GraphQL mutation
  * @param {Object} _ - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/removeAccountAddressBookEntry.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/removeAccountAddressBookEntry.js
@@ -2,8 +2,9 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { decodeAddressOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/address";
 
 /**
- * @name removeAccountAddressBookEntry
+ * @name "Mutation.removeAccountAddressBookEntry"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary resolver for the removeAccountAddressBookEntry GraphQL mutation
  * @param {Object} _ - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/removeAccountFromGroup.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/removeAccountFromGroup.js
@@ -2,8 +2,9 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
 
 /**
- * @name removeAccountFromGroup
+ * @name "Mutation.removeAccountFromGroup"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary resolver for the removeAccountFromGroup GraphQL mutation
  * @param {Object} _ - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/setAccountProfileCurrency.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/setAccountProfileCurrency.js
@@ -1,8 +1,9 @@
 import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
 
 /**
- * @name setAccountProfileCurrency
+ * @name "Mutation.setAccountProfileCurrency"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary resolver for the setAccountProfileCurrency GraphQL mutation
  * @param {Object} _ - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Mutation/updateAccountAddressBookEntry.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Mutation/updateAccountAddressBookEntry.js
@@ -2,8 +2,9 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { xformAddressInput } from "@reactioncommerce/reaction-graphql-xforms/address";
 
 /**
- * @name updateAccountAddressBookEntry
+ * @name "Mutation.updateAccountAddressBookEntry"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary resolver for the updateAccountAddressBookEntry GraphQL mutation
  * @param {Object} _ - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Query/account.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Query/account.js
@@ -1,8 +1,9 @@
 import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
 
 /**
- * @name account
+ * @name "Query.account"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary query the Accounts collection and return user account data
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Query/administrators.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Query/administrators.js
@@ -2,8 +2,9 @@ import { getPaginatedResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name administrators
+ * @name "Query.administrators"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary find and return the administrators (users with "admin" or "owner" role) for a shop
  * @param {Object} _ - unused
  * @param {ConnectionArgs} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Query/group.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Query/group.js
@@ -1,8 +1,9 @@
 import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
 
 /**
- * @name group
+ * @name "Query.group"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary query the Groups collection and return a group by id
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Query/groups.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Query/groups.js
@@ -3,6 +3,7 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 
 /**
  * Arguments passed by the client a groups query
+ * @memberof Accounts/GraphQL
  * @typedef {ConnectionArgs} GroupConnectionArgs - An object of all arguments that were sent by the client
  * @property {ConnectionArgs} args - An object of all arguments that were sent by the client. {@link ConnectionArgs|See default connection arguments}
  * @property {String} args.shopId - The id of shop to filter groups by
@@ -10,8 +11,9 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
  */
 
 /**
- * @name groups
+ * @name "Query.groups"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary find and return the administrators (users with "admin" or "owner" role) for a shop
  * @param {Object} _ - unused
  * @param {GroupConnectionArgs} args - an object of all arguments that were sent by the client. {@link ConnectionArgs|See default connection arguments}

--- a/imports/plugins/core/graphql/server/resolvers/account/Query/roles.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Query/roles.js
@@ -2,8 +2,9 @@ import { getPaginatedResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name roles
+ * @name "Query.roles"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary find and return the roles for a shop
  * @param {Object} _ - unused
  * @param {ConnectionArgs} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/Query/viewer.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/Query/viewer.js
@@ -1,8 +1,9 @@
 import { optimizeIdOnly } from "@reactioncommerce/reaction-graphql-utils";
 
 /**
- * @name viewer
+ * @name "Query.viewer"
  * @method
+ * @memberof Accounts/GraphQL
  * @summary query the Accounts collection and return user account data for the current user
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/account/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/index.js
@@ -10,6 +10,11 @@ import Query from "./Query";
 import RoleConnection from "./RoleConnection";
 import RoleEdge from "./RoleEdge";
 
+/**
+ * Account-related GraphQL resolvers
+ * @namespace Accounts/GraphQL
+ */
+
 export default {
   Account,
   AccountConnection,

--- a/imports/plugins/core/graphql/server/resolvers/catalog/CatalogItemProduct/positions.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/CatalogItemProduct/positions.js
@@ -2,8 +2,9 @@ import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 import { encodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag";
 
 /**
- * @name positions
+ * @name "CatalogItemProduct.positions"
  * @method
+ * @memberof Catalog/GraphQL
  * @summary Adjusts the positions prop of a product
  * @param {Object} product - CatalogProduct response from parent resolver
  * @return {Promise<Object[]>} Promise that resolves with an array of positions

--- a/imports/plugins/core/graphql/server/resolvers/catalog/CatalogItemProduct/product.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/CatalogItemProduct/product.js
@@ -1,8 +1,9 @@
 import { xformProductMedia } from "@reactioncommerce/reaction-graphql-xforms/catalogProduct";
 
 /**
- * @name product
+ * @name "CatalogItemProduct.product"
  * @method
+ * @memberof Catalog/GraphQL
  * @summary Returns the product for a catalog item
  * @param {Object} item - CatalogItem response from parent resolver
  * @return {Object} Adjusted product object

--- a/imports/plugins/core/graphql/server/resolvers/catalog/CatalogProduct/tagIds.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/CatalogProduct/tagIds.js
@@ -1,8 +1,9 @@
 import { encodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag";
 
 /**
- * @name tagIds
+ * @name "CatalogProduct.tagIds"
  * @method
+ * @memberof Catalog/GraphQL
  * @summary Returns the product tagIds prop to opaque IDs
  * @param {Object} product - CatalogProduct response from parent resolver
  * @return {String[]} Array of tag IDs

--- a/imports/plugins/core/graphql/server/resolvers/catalog/CatalogProduct/tags.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/CatalogProduct/tags.js
@@ -2,8 +2,9 @@ import { getPaginatedResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { xformArrayToConnection } from "@reactioncommerce/reaction-graphql-xforms/connection";
 
 /**
- * @name tags
+ * @name "CatalogProduct.tags"
  * @method
+ * @memberof Catalog/GraphQL
  * @summary Returns the tags for a product
  * @param {Object} product - CatalogProduct response from parent resolver
  * @param {TagConnectionArgs} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}

--- a/imports/plugins/core/graphql/server/resolvers/catalog/CatalogProduct/variants.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/CatalogProduct/variants.js
@@ -1,6 +1,7 @@
 /**
- * @name variants
+ * @name "CatalogProduct.variants"
  * @method
+ * @memberof Catalog/GraphQL
  * @summary Adjusts the variants prop of a product
  * @param {Object} product - CatalogProduct response from parent resolver
  * @return {Promise<Object[]>} Promise that resolves with an array of variants

--- a/imports/plugins/core/graphql/server/resolvers/catalog/Query/catalogItemProduct.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/Query/catalogItemProduct.js
@@ -1,8 +1,9 @@
 import { decodeCatalogItemOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/catalogItem";
 
 /**
- * @name catalogItemProduct
+ * @name "Query.catalogItemProduct"
  * @method
+ * @memberof Catalog/GraphQL
  * @summary Get a CatalogItemProduct from the Catalog
  * @param {Object} _ - unused
  * @param {ConnectionArgs} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/catalog/Query/catalogItems.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/Query/catalogItems.js
@@ -3,8 +3,9 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 import { decodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag";
 
 /**
- * @name catalogItems
+ * @name "Query.catalogItems"
  * @method
+ * @memberof Catalog/GraphQL
  * @summary Get a list of catalogItems
  * @param {Object} _ - unused
  * @param {ConnectionArgs} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/catalog/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/index.js
@@ -6,6 +6,11 @@ import CatalogProduct from "./CatalogProduct";
 import CatalogProductVariant from "./CatalogProductVariant";
 import Query from "./Query";
 
+/**
+ * Catalog-related GraphQL resolvers
+ * @namespace Catalog/GraphQL
+ */
+
 export default {
   CatalogItem: {
     __resolveType() {

--- a/imports/plugins/core/graphql/server/resolvers/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/index.js
@@ -11,6 +11,7 @@ export default merge({}, account, catalog, core, scalar, ping, shop, tag);
 
 /**
  * Arguments passed by the client for a query
+ * @memberof GraphQL
  * @typedef {Object} ConnectionArgs - an object of all arguments that were sent by the client
  * @property {String} args.after - Connection argument
  * @property {String} args.before - Connection argument
@@ -22,6 +23,7 @@ export default merge({}, account, catalog, core, scalar, ping, shop, tag);
 
 /**
  * Arguments passed by the client a groups query
+ * @memberof GraphQL
  * @typedef {Object} AddressInput - Address
  * @property {String} address1 - Address line 1
  * @property {String} [address2] - Address line 2
@@ -41,6 +43,7 @@ export default merge({}, account, catalog, core, scalar, ping, shop, tag);
 
 /**
  * Metafield input
+ * @memberof GraphQL
  * @typedef {Object} MetafieldInput - Metafield
  * @property {String} key - Key
  * @property {String} [value] - Value
@@ -48,4 +51,9 @@ export default merge({}, account, catalog, core, scalar, ping, shop, tag);
  * @property {String} [scope] - Scope
  * @property {String} [description] - Description
  * @property {String} [valueType] - Value type
+ */
+
+/**
+ * Utility functions for use by GraphQL resolvers
+ * @namespace GraphQL/Transforms
  */

--- a/imports/plugins/core/graphql/server/resolvers/scalar/ConnectionLimitInt.js
+++ b/imports/plugins/core/graphql/server/resolvers/scalar/ConnectionLimitInt.js
@@ -4,11 +4,8 @@ import { Kind } from "graphql/language";
 const MAX_LIMIT = 50;
 
 /**
- * @name parseValue
- * @method
- * @summary Adjusts value to be between 1 and MAX_LIMIT, inclusive
- * @param {Number} value An integer provided by the client for the requested limit
- * @returns The adjusted integer value.
+ * Adjusts value to be between 1 and MAX_LIMIT, inclusive
+ * @private
  */
 function parseValue(value) {
   // Note that we do not have to do isNaN(value) check here because GraphQLScalarType will not call this for isNaN.

--- a/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Query/primaryShopId.js
@@ -1,8 +1,9 @@
 import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name primaryShopId
+ * @name "Query.primaryShopId"
  * @method
+ * @memberof Shop/GraphQL
  * @summary Gets the primary shop ID
  * @param {Object} parentObject - unused
  * @param {Object} args - unused

--- a/imports/plugins/core/graphql/server/resolvers/shop/Query/shop.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Query/shop.js
@@ -1,8 +1,9 @@
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name shop
+ * @name "Query.shop"
  * @method
+ * @memberof Shop/GraphQL
  * @summary query the Shops collection and return shop data
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/shop/Shop/administrators.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Shop/administrators.js
@@ -2,8 +2,9 @@ import { getPaginatedResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name administrators
+ * @name "Shop.administrators"
  * @method
+ * @memberof Shop/GraphQL
  * @summary find and return the administrators (users with "admin" or "owner" role) for a shop
  * @param {Object} shop - The shop object returned by the parent resolver
  * @param {ConnectionArgs} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/shop/Shop/groups.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Shop/groups.js
@@ -2,8 +2,9 @@ import { getPaginatedResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name groups
+ * @name "Shop.groups"
  * @method
+ * @memberof Shop/GraphQL
  * @summary find and return the groups for a shop
  * @param {Object} resolverArgs - an object containing the result returned from the resolver
  * @param {String} resolverArgs._id - id of group to query

--- a/imports/plugins/core/graphql/server/resolvers/shop/Shop/roles.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Shop/roles.js
@@ -2,8 +2,9 @@ import { getPaginatedResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name roles
+ * @name "Shop.roles"
  * @method
+ * @memberof Shop/GraphQL
  * @summary find and return the roles for a shop
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/shop/Shop/tags.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Shop/tags.js
@@ -2,17 +2,9 @@ import { getPaginatedResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * Arguments passed by the client for a tags query
- * @typedef {ConnectionArgs} TagConnectionArgs - An object of all arguments that were sent by the client
- * @property {ConnectionArgs} args - An object of all arguments that were sent by the client. {@link ConnectionArgs|See default connection arguments}
- * @property {Boolean} args.includeDeleted - If set to true, include deleted. Default false.
- * @property {Boolean} args.isTopLevel - If set to a boolean, filter by this.
- * @property {Number} args.sortBy - Sort results by a TagSortByField enum value of `_id`, `name`, `position`, `createdAt`, `updatedAt`
- */
-
-/**
- * @name tags
+ * @name "Shop.tags"
  * @method
+ * @memberof Shop/GraphQL
  * @summary Returns the tags for the parent resolver shop
  * @param {Object} _ - unused
  * @param {TagConnectionArgs} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}

--- a/imports/plugins/core/graphql/server/resolvers/shop/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/index.js
@@ -1,6 +1,11 @@
 import Query from "./Query";
 import Shop from "./Shop";
 
+/**
+ * Shop-related GraphQL resolvers
+ * @namespace Shop/GraphQL
+ */
+
 export default {
   Query,
   Shop

--- a/imports/plugins/core/graphql/server/resolvers/tag/Query/tags.js
+++ b/imports/plugins/core/graphql/server/resolvers/tag/Query/tags.js
@@ -4,6 +4,7 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 /**
  * Arguments passed by the client for a tags query
  * @typedef {ConnectionArgs} TagConnectionArgs - An object of all arguments that were sent by the client
+ * @memberof Tag/GraphQL
  * @property {ConnectionArgs} args - An object of all arguments that were sent by the client. {@link ConnectionArgs|See default connection arguments}
  * @property {Boolean} args.shouldIncludeDeleted - If set to true, include deleted. Default false.
  * @property {Boolean} args.isTopLevel - If set to a boolean, filter by this.
@@ -12,8 +13,9 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
  */
 
 /**
- * @name tags
+ * @name "Query.tags"
  * @method
+ * @memberof Tag/GraphQL
  * @summary Returns the tags for a shop
  * @param {Object} _ - unused
  * @param {TagConnectionArgs} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}

--- a/imports/plugins/core/graphql/server/resolvers/tag/Tag/subTags.js
+++ b/imports/plugins/core/graphql/server/resolvers/tag/Tag/subTags.js
@@ -3,6 +3,7 @@ import { xformArrayToConnection } from "@reactioncommerce/reaction-graphql-xform
 
 /**
  * Arguments passed by the client for a tags query
+ * @memberof Tag/GraphQL
  * @typedef {ConnectionArgs} SubTagConnectionArgs - An object of all arguments that were sent by the client
  * @property {ConnectionArgs} args - An object of all arguments that were sent by the client. {@link ConnectionArgs|See default connection arguments}
  * @property {Boolean} args.shouldIncludeDeleted - If set to true, include deleted. Default false.
@@ -10,8 +11,9 @@ import { xformArrayToConnection } from "@reactioncommerce/reaction-graphql-xform
  */
 
 /**
- * @name subTags
+ * @name "Tag.subTags"
  * @method
+ * @memberof Tag/GraphQL
  * @summary Returns the child tags for a tag
  * @param {Object} tag - Tag response from parent resolver
  * @param {SubTagConnectionArgs} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}

--- a/imports/plugins/core/graphql/server/resolvers/tag/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/tag/index.js
@@ -3,6 +3,11 @@ import Tag from "./Tag";
 import TagConnection from "./TagConnection";
 import TagEdge from "./TagEdge";
 
+/**
+ * Tag-related GraphQL resolvers
+ * @namespace Tag/GraphQL
+ */
+
 export default {
   Query,
   Tag,

--- a/imports/plugins/core/graphql/server/resolvers/util/applyBeforeAfterToFilter.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyBeforeAfterToFilter.js
@@ -1,5 +1,12 @@
 import { decodeOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/id";
 
+/**
+ * @name applyBeforeAfterToFilter
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Adjusts a MongoDB filter based on GraphQL `before` and `after` params
+ * @return {Promise<Object>} The potentially-modified filter object
+ */
 export default async function applyBeforeAfterToFilter({
   after,
   baseFilter = {},

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
@@ -1,5 +1,11 @@
 /**
- * Mostly borrowed from https://www.reindex.io/blog/relay-graphql-pagination-with-mongodb/
+ * Inspired by https://www.reindex.io/blog/relay-graphql-pagination-with-mongodb/
+ * @name applyPaginationToMongoCursor
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Adds `skip` and `limit` to a MongoDB cursor as necessary, based on GraphQL
+ *   `first` and `last` params
+ * @return {Promise<Object>} `{ pageInfo }`
  */
 export default async function applyPaginationToMongoCursor(cursor, { first, last } = {}, totalCount) {
   let resultCount = totalCount;

--- a/imports/plugins/core/graphql/server/resolvers/util/getCollectionFromCursor.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getCollectionFromCursor.js
@@ -1,3 +1,9 @@
+/**
+ * @name getCollectionFromCursor
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Get the associated Mongo Collection instance for a given Cursor instance
+ */
 export default function getCollectionFromCursor(cursor) {
   const { db } = cursor.options;
   const collectionName = cursor.ns.slice(db.databaseName.length + 1);

--- a/imports/plugins/core/graphql/server/resolvers/util/getMongoSort.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getMongoSort.js
@@ -3,6 +3,14 @@ const sortOrderEnumToMongo = {
   desc: -1
 };
 
+/**
+ * @name getMongoSort
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Converts GraphQL `sortBy` and `sortOrder` params to the sort array format
+ *   that MongoDB uses.
+ * @return {Array[]} Sort array
+ */
 export default function getMongoSort({ sortBy, sortOrder } = {}) {
   const mongoSort = sortOrderEnumToMongo[sortOrder || "asc"];
   const sortList = [["_id", mongoSort]];

--- a/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
@@ -3,7 +3,18 @@ import applyPaginationToMongoCursor from "./applyPaginationToMongoCursor";
 import getCollectionFromCursor from "./getCollectionFromCursor";
 import getMongoSort from "./getMongoSort";
 
-const getPaginatedResponse = async (query, args) => {
+/**
+ * Resolvers that return multiple documents in the form of a connection should construct a
+ * MongoDB query, pass that cursor to this function, and then return the result.
+ *
+ * @name getPaginatedResponse
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Given a MongoDB cursor, adds skip, limit, sort, and other filters as necessary
+ *   based on GraphQL resolver arguments.
+ * @return {Promise<Object>} `{ nodes, pageInfo, totalCount }`
+ */
+async function getPaginatedResponse(query, args) {
   const totalCount = await query.clone().count();
   const collection = getCollectionFromCursor(query);
 
@@ -23,6 +34,6 @@ const getPaginatedResponse = async (query, args) => {
   }
 
   return { nodes, pageInfo, totalCount };
-};
+}
 
 export default getPaginatedResponse;

--- a/imports/plugins/core/graphql/server/resolvers/util/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/index.js
@@ -1,3 +1,8 @@
+/**
+ * Utility functions for use by GraphQL resolvers
+ * @namespace GraphQL/ResolverUtilities
+ */
+
 export { default as applyPaginationToMongoCursor } from "./applyPaginationToMongoCursor";
 export { default as getPaginatedResponse } from "./getPaginatedResponse";
 export { default as namespaces } from "./namespaces";

--- a/imports/plugins/core/graphql/server/resolvers/util/optimizeIdOnly.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/optimizeIdOnly.js
@@ -1,5 +1,16 @@
 import graphqlFields from "graphql-fields";
 
+/**
+ * This is an optimization so that we can avoid a database lookup if, for example, the client
+ * has requested only `shop { _id }` and we already have `shopId` prop from the parent resolver.
+ *
+ * @name optimizeIdOnly
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Wraps a query function, and calls it only if fields other than `_id` were requested
+ *   in the GraphQL query.
+ * @return {Object} `{ nodes, pageInfo, totalCount }`
+ */
 export default function optimizeIdOnly(_id, info, queryFunc) {
   const topLevelFields = Object.keys(graphqlFields(info));
 

--- a/imports/plugins/core/graphql/server/resolvers/util/resolveShopFromShopId.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/resolveShopFromShopId.js
@@ -1,6 +1,7 @@
 /**
  * @name resolveShopFromShopId
  * @method
+ * @memberof GraphQL/ResolverUtilities
  * @summary A generic resolver that gets the shop object for the provided parent result, assuming it has a `shopId` property
  * @param {Object} parent - result of the parent resolver
  * @param {Object} args - an object of all arguments that were sent by the client

--- a/imports/plugins/core/graphql/server/resolvers/xforms/catalogProduct.js
+++ b/imports/plugins/core/graphql/server/resolvers/xforms/catalogProduct.js
@@ -10,6 +10,7 @@ export const encodeCatalogProductOpaqueId = encodeOpaqueId(namespaces.CatalogPro
 /**
  * @name xformProductMedia
  * @method
+ * @memberof GraphQL/Transforms
  * @param {Object} mediaItem object from a catalog product
  * @return transformed product media array
  */

--- a/imports/plugins/core/graphql/server/resolvers/xforms/connection.js
+++ b/imports/plugins/core/graphql/server/resolvers/xforms/connection.js
@@ -1,5 +1,13 @@
 import { connectionFromArray, connectionFromPromisedArray } from "graphql-relay";
 
+/**
+ * @name xformArrayToConnection
+ * @method
+ * @memberof GraphQL/Transforms
+ * @param {Object} connectionArgs GraphQL connection arguments
+ * @param {Array} result The array of results
+ * @return {Object} A connection shaped object of the results array
+ */
 export async function xformArrayToConnection(connectionArgs, result) {
   let connection;
   if (Array.isArray(result)) {

--- a/imports/plugins/core/graphql/server/resolvers/xforms/currency.js
+++ b/imports/plugins/core/graphql/server/resolvers/xforms/currency.js
@@ -9,7 +9,7 @@ export const decodeCurrencyOpaqueId = decodeOpaqueIdForNamespace(namespaces.Curr
 export const encodeCurrencyOpaqueId = encodeOpaqueId(namespaces.Currency);
 
 // add `code` and `_id` keys to each currency object
-export const xformCurrencyEntry = ([k, v]) => compose(
+const xformCurrencyEntry = ([k, v]) => compose(
   assoc("code", k),
   assoc("_id", k)
 )(v);
@@ -18,6 +18,13 @@ export const xformCurrencyEntry = ([k, v]) => compose(
 // and convert them to the format that GraphQL needs
 export const xformLegacyCurrencies = compose(map(xformCurrencyEntry), toPairs);
 
+/**
+ * @name getXformedCurrenciesByShop
+ * @method
+ * @memberof GraphQL/Transforms
+ * @param {Object} shop A shop object
+ * @return {Object} A potentially-empty array of currency objects for this shop
+ */
 export function getXformedCurrenciesByShop(shop) {
   if (!shop || !shop.currencies) return [];
   return xformLegacyCurrencies(shop.currencies);
@@ -29,7 +36,16 @@ async function getXformedCurrenciesByShopId(context, shopId) {
   return getXformedCurrenciesByShop(shop);
 }
 
-// Find an individual xformed currency
+/**
+ * @name getXformedCurrencyByCode
+ * @method
+ * @memberof GraphQL/Transforms
+ * @summary Get an individual transformed currency
+ * @param {Object} context Context object with `collections` on it
+ * @param {String} shopId A shop ID
+ * @param {String} code The code that must match the `currency.code`
+ * @return {Object} A Currency object
+ */
 export async function getXformedCurrencyByCode(context, shopId, code) {
   if (!code) return null;
   if (!shopId) throw new Meteor.Error("invalid", "shopId is required to build a Currency object");

--- a/imports/plugins/core/graphql/server/resolvers/xforms/id.js
+++ b/imports/plugins/core/graphql/server/resolvers/xforms/id.js
@@ -1,6 +1,9 @@
 import { assoc, curry } from "ramda";
 
 /**
+ * @name encodeOpaqueId
+ * @method
+ * @memberof GraphQL/Transforms
  * @summary Transforms an internal ID to an opaque ID
  * @param {String} namespace The namespace of the ID
  * @param {String} id The ID to transform
@@ -13,6 +16,9 @@ export const encodeOpaqueId = curry((namespace, id) => {
 });
 
 /**
+ * @name decodeOpaqueId
+ * @method
+ * @memberof GraphQL/Transforms
  * @summary Transforms an opaque ID to an internal ID
  * @param {String} opaqueId The ID to transform
  * @returns {String} An internal ID
@@ -25,6 +31,9 @@ export const decodeOpaqueId = (opaqueId) => {
 };
 
 /**
+ * @name decodeOpaqueIdForNamespace
+ * @method
+ * @memberof GraphQL/Transforms
  * @summary Transforms an opaque ID to an internal ID, throwing an error if the namespace is wrong
  * @param {String} namespace The namespace that you expect the decoded ID to have
  * @param {String} opaqueId The ID to transform
@@ -39,6 +48,9 @@ export const decodeOpaqueIdForNamespace = curry((namespace, opaqueId, error = ne
 });
 
 /**
+ * @name assocOpaqueId
+ * @method
+ * @memberof GraphQL/Transforms
  * @summary Assoc an opaque ID onto an object by transforming its existing _id
  *   Assumes key is _id but key could be provided as another curried param.
  * @param {String} namespace The namespace
@@ -48,6 +60,9 @@ export const assocOpaqueId = curry((namespace, item) =>
   assoc("_id", encodeOpaqueId(namespace, item._id), item));
 
 /**
+ * @name assocInternalId
+ * @method
+ * @memberof GraphQL/Transforms
  * @summary Assoc an internal ID onto an object by decoding its existing opaque _id
  *   Assumes key is _id but key could be provided as another curried param.
  * @param {String} namespace The namespace

--- a/imports/plugins/core/graphql/server/runMeteorMethodWithContext.js
+++ b/imports/plugins/core/graphql/server/runMeteorMethodWithContext.js
@@ -3,7 +3,10 @@ import { DDPCommon } from "meteor/ddp-common";
 import { Meteor } from "meteor/meteor";
 
 /**
- * Applies args to a Meteor method with a GraphQL context.
+ * @name runMeteorMethodWithContext
+ * @method
+ * @memberof GraphQL
+ * @summary Applies args to a Meteor method with a GraphQL context.
  * @param {Object} context - A GraphQL context.
  * @param {String} name - The Meteor method name.
  * @param {Array} args - an array of Meteor method args.

--- a/imports/plugins/core/graphql/server/tokenExpiration.js
+++ b/imports/plugins/core/graphql/server/tokenExpiration.js
@@ -5,7 +5,14 @@ const LOGIN_UNEXPIRING_TOKEN_DAYS = 365 * 100;
 // This is what Meteor's Accounts._getTokenLifetimeMs returns for Reaction's current settings
 const tokenLifetimeMs = LOGIN_UNEXPIRING_TOKEN_DAYS * 24 * 60 * 60 * 1000;
 
-// This is Meteor's Accounts._tokenExpiration
+/**
+ * @name tokenExpiration
+ * @method
+ * @memberof GraphQL
+ * @summary Meteor's Accounts._tokenExpiration
+ * @param {Date} when - A date from which token expiration date should be calculated
+ * @return {Date} A date that is `tokenLifetimeMs` after the "when" date
+ */
 export default function tokenExpiration(when) {
   // We pass when through the Date constructor for backwards compatibility;
   // `when` used to be a number.

--- a/imports/plugins/core/layout/client/templates/theme/theme.js
+++ b/imports/plugins/core/layout/client/templates/theme/theme.js
@@ -11,6 +11,7 @@ import { Shops } from "/lib/collections";
  * Adds body classes to help themes distinguish pages and components based on the current route name and layout theme
  * @param  {Object} context - route context
  * @returns {undefined}
+ * @private
  */
 function addBodyClasses(context) {
   let classes;

--- a/imports/plugins/core/logging/server/methods.js
+++ b/imports/plugins/core/logging/server/methods.js
@@ -6,13 +6,13 @@ import { Reaction } from "/server/api";
 
 /**
  *
- * @namespace Methods/Logging
+ * @namespace Logging/Methods
  */
 
 /**
  * @name writeToLog
  * @method
- * @memberof Methods/Logging
+ * @memberof Logging/Methods
  * @summary Writes a log entry into log
  * @param  {String} logType Type
  * @param  {String} logLevel Level
@@ -38,7 +38,7 @@ export function writeToLog(logType, logLevel, logData, source = "client") {
 /**
  * @name logging/logError
  * @method
- * @memberof Methods/Logging
+ * @memberof Logging/Methods
  * @param  {String} logType Type
  * @param  {Object} logData Data
  * @return {null}
@@ -54,7 +54,7 @@ function logError(logType, logData) {
 /**
  * @name logging/logWarning
  * @method
- * @memberof Methods/Logging
+ * @memberof Logging/Methods
  * @param  {String} logType Type
  * @param  {Object} logData Data
  * @return {null}

--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -457,10 +457,10 @@ class InvoiceContainer extends Component {
 }
 
 /**
- * @method orderCreditMethod
  * @summary helper method to return the order payment object
  * @param {Object} order - object representing an order
  * @return {Object} object representing entire payment method
+ * @private
  */
 function orderCreditMethod(order) {
   const billingInfo = getBillingInfo(order);
@@ -475,6 +475,7 @@ function orderCreditMethod(order) {
  * @summary helper method to approve payment
  * @param {Object} order - object representing an order
  * @return {null} null
+ * @private
  */
 function approvePayment(order) {
   const paymentMethod = orderCreditMethod(order);
@@ -530,6 +531,7 @@ function approvePayment(order) {
  * @param {object} order - object representing an order
  * @param {function} onCancel - called on clicking cancel in alert dialog
  * @return {null} null
+ * @private
  */
 function capturePayments(order, onCancel) {
   const capture = () => {

--- a/imports/plugins/core/orders/client/containers/orderTableContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderTableContainer.js
@@ -146,11 +146,10 @@ const wrapComponent = (Comp) => (
     }
 
     /**
-     * updateBulkStatusHelper
-     *
      * @summary return formatted shipping object to update state
      * @param {String} status - the shipping status to be set
      * @return {Object} the formatted shipping object
+     * @private
      */
     updateBulkStatusHelper = (status) => {
       const statusIndex = shippingStrings.indexOf(status);
@@ -161,11 +160,10 @@ const wrapComponent = (Comp) => (
     }
 
     /**
-     * updateBulkLoadingHelper
-     *
      * @summary return formatted isLoading object to update state
      * @param {String} status - the shipping status to be set
      * @return {Object} the formatted isLoading object
+     * @private
      */
     updateBulkLoadingHelper = (status) => {
       const statusIndex = shippingStrings.indexOf(status);
@@ -190,12 +188,11 @@ const wrapComponent = (Comp) => (
     }
 
     /**
-     * shippingStatusUpdateCall
-     *
      * @summary set selected order(s) to the provided shipping state
      * @param {Array} selectedOrders - array of selected orders
      * @param {String} status - the shipping status to be set
      * @return {null} no return value
+     * @private
      */
     shippingStatusUpdateCall = (selectedOrders, status) => {
       const filteredSelectedOrders = selectedOrders.filter((order) => order.shipping && Object.keys(getShippingInfo(order)).length);
@@ -579,13 +576,12 @@ const wrapComponent = (Comp) => (
     }
 
     /**
-     * setShippingStatus
-     *
      * @summary call the relevant method based on the provided shipping status
      * @param {String} status - the selected shipping status to be set
      * @param {Array} selectedOrdersIds - array of ids of the selected orders
      * @param {Array} orders - array of orders
      * @return {null} no return value
+     * @private
      */
     setShippingStatus = (status, selectedOrdersIds, orders) => {
       this.setState({
@@ -611,9 +607,10 @@ const wrapComponent = (Comp) => (
     }
 
     /**
-     * orderCreditMethod: Finds the credit record in order.billing for the active shop
+     * Finds the credit record in order.billing for the active shop
      * @param order: The order where to find the billing record in.
      * @return: The billing record with paymentMethod.method === credit of currently active shop
+     * @private
      */
     orderCreditMethod(order) {
       const creditBillingRecords = order.billing.filter((value) => value.paymentMethod.method === "credit");

--- a/imports/plugins/core/orders/client/helpers/index.js
+++ b/imports/plugins/core/orders/client/helpers/index.js
@@ -59,8 +59,9 @@ export function getTaxRiskStatus(order) {
 }
 
 /**
- * filterWorkflowStatus
- *
+ * @name filterWorkflowStatus
+ * @method
+ * @memberof Helpers
  * @summary get query for a given filter
  * @param {String} filter - filter string to check against
  * @return {Object} query for the workflow status
@@ -119,8 +120,8 @@ export function filterWorkflowStatus(filter) {
 }
 
 /**
- * filterShippingStatus
- *
+ * @name filterShippingStatus
+ * @memberof Helpers
  * @summary get query for a given filter
  * @param {String} filter - filter string to check against
  * @return {Object} query for the shipping status
@@ -160,8 +161,8 @@ export function filterShippingStatus(filter) {
 }
 
 /**
- * getBillingInfo
- *
+ * @name getBillingInfo
+ * @memberof Helpers
  * @summary get proper billing object as per current active shop
  * @param {Object} order - order object to check against
  * @return {Object} proper billing object to use
@@ -172,8 +173,8 @@ export function getBillingInfo(order) {
 }
 
 /**
- * getShippingInfo
- *
+ * @name getShippingInfo
+ * @memberof Helpers
  * @summary get proper shipping object as per current active shop
  * @param {Object} order - order object to check against
  * @return {Object} proper shipping object to use

--- a/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingInvoice.js
@@ -108,12 +108,6 @@ Template.coreOrderShippingInvoice.helpers({
  * coreOrderAdjustments events
  */
 Template.coreOrderShippingInvoice.events({
-  /**
-   * Click Start Cancel Order
-   * @param {Event} event - Event Object
-   * @param {Template} instance - Blaze Template
-   * @return {void}
-   */
   "click [data-event-action=cancelOrder]": (event, instance) => {
     event.preventDefault();
     const order = instance.state.get("order");

--- a/imports/plugins/core/orders/client/templates/workflow/workflow.js
+++ b/imports/plugins/core/orders/client/templates/workflow/workflow.js
@@ -2,16 +2,13 @@ import { Template } from "meteor/templating";
 import { Reaction } from "/client/api";
 import { Orders } from "/lib/collections";
 
-/**
- * coreOrderWorkflowHelpers
- */
 Template.coreOrderWorkflow.helpers({
   /**
-   * orderFulfillmentData
    * @summary Creates an Object with order id and a fulfillment object
    * @param  {String} orderId - An order id
    * @param  {Object} fulfillment - An order fulfillment. e.g. a shipment
    * @return {Object} An object witht the order id and fulfillment
+   * @ignore
    */
   orderFulfillmentData(orderId, fulfillment) {
     return {
@@ -21,17 +18,8 @@ Template.coreOrderWorkflow.helpers({
   },
 
   /**
-   * baseOrder
-   * @todo may be unnecessary
-   * @return {Object} contents of Template.currentData(), non-reactive
-   */
-  baseOrder() {
-    return Template.currentData();
-  },
-
-  /**
-   * order
    * @return {Object|Boolean} An order or false
+   * @ignore
    */
   order() {
     const id = this.order ? this.order._id : Reaction.Router.getQueryParam("_id");
@@ -42,18 +30,18 @@ Template.coreOrderWorkflow.helpers({
   },
 
   /**
-   * fulfillmentNumber
    * @param  {Number} index - A number
    * @return {Number} index + 1
+   * @ignore
    */
   fulfillmentNumber(index) {
     return index + 1;
   },
 
   /**
-   * isCompleted
    * @todo may need to be refactored
    * @return {String|Boolean} order completion status or false
+   * @ignore
    */
   isCompleted() {
     const order = Template.parentData(1);
@@ -64,9 +52,9 @@ Template.coreOrderWorkflow.helpers({
   },
 
   /**
-   * isPending
    * @todo may need to be refactored
    * @return {String|Boolean} status or false
+   * @ignore
    */
   isPending() {
     if (this.status === this.template) {

--- a/imports/plugins/core/orders/server/startup.js
+++ b/imports/plugins/core/orders/server/startup.js
@@ -11,13 +11,12 @@ import { Hooks } from "/server/api";
 */
 
 /**
- * @method beforeUpdateOrderWorkflow hook
- *
  * @summary Updates an order's workflow before persisting order.
  *
  * @param {Order} order - Order object, before any modifications
  * @param {Object} options - Includes userId, modifier and validation
  * @return {Boolean} true if document should be updated, false otherwise
+ * @private
 */
 Hooks.Events.add("beforeUpdateOrderWorkflow", (order, options) => {
   const { userId, modifier } = options;

--- a/imports/plugins/core/revisions/server/functions.js
+++ b/imports/plugins/core/revisions/server/functions.js
@@ -9,11 +9,12 @@ import { getSlug } from "/lib/api";
 
 
 /**
- * @method insertRevision
+ * @name insertRevision
+ * @method
  * @summary Inserts a new revision for a given product
- *
  * @param {Object} product
  * @returns {undefined}
+ * @private
  */
 export function insertRevision(product) {
   if (RevisionApi.isRevisionControlEnabled() === false) {
@@ -72,13 +73,14 @@ export function insertRevision(product) {
 }
 
 /**
- * @method updateRevision
+ * @name updateRevision
+ * @method
  * @summary Update a product's revision
- *
  * @param {String} userId
  * @param {Object} product - Product to update
  * @param {Object} options - Options include userId, modifier and validation properties
  * @returns {Boolean} true if underlying product should be updated, otherwise false.
+ * @private
  */
 export function updateRevision(product, options = {}) {
   if (RevisionApi.isRevisionControlEnabled() === false) {
@@ -401,12 +403,13 @@ export function updateRevision(product, options = {}) {
   return false;
 }
 /**
- * @method markRevisionAsDeleted
+ * @name markRevisionAsDeleted
+ * @method
  * @summary Flag a product's revision as deleted
- *
  * @param {Object} product - The product whose revision will be flagged as deleted.
  * @param {Object} options - Contains userId
  * @returns {undefined}
+ * @private
  */
 export function markRevisionAsDeleted(product, options) {
   if (RevisionApi.isRevisionControlEnabled() === false) {

--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -174,14 +174,12 @@ export const ProductRevision = {
 };
 
 /**
- * @function
- * @name beforeInsertCatalogProductInsertRevision
- *
  * @summary Executes the provided function when beforeInsertCatalogProductInsertRevision
  * hook is ran. The hook is ran before a product is inserted, and it will insert a
  * corresponding revision for the provided product.
  * @param {Function} Callback to execute
  * @return {Object} product - the product in which the callback was called on.
+ * @private
  */
 Hooks.Events.add("beforeInsertCatalogProductInsertRevision", (product) => {
   insertRevision(product);
@@ -190,14 +188,12 @@ Hooks.Events.add("beforeInsertCatalogProductInsertRevision", (product) => {
 });
 
 /**
- * @function
- * @name afterInsertCatalogProductInsertRevision
- *
  * @summary Executes the provided function when beforeInsertCatalogProductInsertRevision
  * hook is ran. The hook is ran after a product is inserted, and it will insert a
  * corresponding revision for the provided product.
  * @param {Function} Callback to execute
  * @return {Object} product - the product in which the callback was called on.
+ * @private
  */
 Hooks.Events.add("afterInsertCatalogProductInsertRevision", (product) => {
   insertRevision(product);
@@ -206,26 +202,22 @@ Hooks.Events.add("afterInsertCatalogProductInsertRevision", (product) => {
 });
 
 /**
- * @function
- * @name beforeUpdateCatalogProduct
- *
  * @summary Executes the provided function when beforeUpdateCatalogProduct
  * hook is ran. The hook is ran before a product is updated, and it will updated the
  * corresponding revisions for the provided product.
  * @param {Function} Callback to execute
  * @return {Boolean} true|false - Used to determine whether the underlying product should be updated.
+ * @private
  */
 Hooks.Events.add("beforeUpdateCatalogProduct", (product, options) => updateRevision(product, options));
 
 /**
- * @function
- * @name beforeRemoveCatalogProduct
- *
  * @summary Executes the provided function when beforeRemoveCatalogProduct
  * hook is ran. The hook is ran before a product or variant is archived, and it will updated the
  * corresponding revisions for the provided product or variant.
  * @param {Function} Callback to execute
  * @return {Boolean} true|false - Used to determine whether the underlying product should be updated.
+ * @private
  */
 Hooks.Events.add("beforeRemoveCatalogProduct", (product, options) => markRevisionAsDeleted(product, options));
 

--- a/imports/plugins/core/revisions/server/methods.js
+++ b/imports/plugins/core/revisions/server/methods.js
@@ -56,15 +56,16 @@ export function updateSettings(settings) {
 }
 
 /**
- * @function
  * @name publishCatalogProduct
- * @description Updates revision and publishes a product.
+ * @method
+ * @summary Updates revision and publishes a product.
  *
  * @param {String} userId - currently logged in user
  * @param {Object} selector - selector for product to update
  * @param {Object} modifier - Object describing what parts of the document to update.
  * @param {Object} validation - simple schema validation
  * @return {String} _id of updated document
+ * @private
  */
 function publishCatalogProduct(userId, selector, modifier, validation) {
   const product = Products.findOne(selector);

--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -177,7 +177,6 @@ class Router {
 }
 
 /**
- * pathFor
  * @summary get current router path
  * @param {String} path - path to fetch
  * @param {Object} options - url params
@@ -339,11 +338,10 @@ Router.isActiveClassName = (routeName) => {
 };
 
 /**
- * hasRoutePermission
  * check if user has route permissions
- * @access private
  * @param  {Object} route - route context
  * @return {Boolean} returns `true` if user is allowed to see route, `false` otherwise
+ * @private
  */
 function hasRoutePermission(route) {
   const routeName = route.name;
@@ -355,12 +353,11 @@ function hasRoutePermission(route) {
 
 
 /**
- * getRegistryRouteName
- * assemble route name to be standard
- * prefix/package name + registry name or route
+ * assemble route name to be standard prefix/package name + registry name or route
  * @param  {String} packageName  [package name]
  * @param  {Object} registryItem [registry object]
  * @return {String}              [route name]
+ * @private
  */
 function getRegistryRouteName(packageName, registryItem) {
   let routeName;
@@ -381,11 +378,11 @@ function getRegistryRouteName(packageName, registryItem) {
 
 /**
  * selectLayout
- * @access private
  * @param {Object} layout - element of shops.layout array
  * @param {Object} setLayout - layout
  * @param {Object} setWorkflow - workflow
  * @returns {Object} layout - return object of template definitions for Blaze Layout
+ * @private
  */
 function selectLayout(layout, setLayout, setWorkflow) {
   const currentLayout = setLayout || Session.get("DEFAULT_LAYOUT") || "coreLayout";
@@ -397,15 +394,16 @@ function selectLayout(layout, setLayout, setWorkflow) {
 }
 
 /**
- * ReactionLayout
- * sets and returns reaction layout structure
- * @access public
+ * @name ReactionLayout
+ * @method
+ * @summary sets and returns reaction layout structure
  * @param {Object} options - this router context
  * @param {String} options.layout - string of shop.layout.layout (defaults to coreLayout)
  * @param {String} options.workflow - string of shop.layout.workflow (defaults to coreLayout)
  * @returns {Object} layout - return object of template definitions for Blaze Layout
+ * @private
  */
-export function ReactionLayout(options = {}) {
+function ReactionLayout(options = {}) {
   // Find a workflow layout to render
 
   // By default we'll use the primary shop for layouts

--- a/imports/plugins/core/shipping/client/templates/checkout/shipping.js
+++ b/imports/plugins/core/shipping/client/templates/checkout/shipping.js
@@ -21,15 +21,12 @@ function uniqObjects(objs) {
   return uniqueBlobs.map((blob) => EJSON.parse(blob));
 }
 
-// cartShippingQuotes
-// returns multiple methods
 /**
- * cartShippingQuotes - returns a list of all the shipping costs/quotations
- * of each available shipping carrier like UPS, Fedex etc.
- * @param {Object} currentCart - The current cart that's about
- * to be checked out.
- * @returns {Array} - an array of the quotations of multiple shipping
- * carriers.
+ * @name cartShippingQuotes
+ * @summary returns a list of all the shipping costs/quotations of each available shipping carrier like UPS, Fedex etc.
+ * @param {Object} currentCart - The current cart that's about to be checked out.
+ * @returns {Array} - an array of the quotations of multiple shipping carriers.
+ * @private
  */
 function cartShippingQuotes(currentCart) {
   const cart = currentCart || Cart.findOne();
@@ -71,9 +68,10 @@ function shippingMethodsQueryStatus(currentCart) {
 }
 
 /**
- * cartShipmentMethods - gets current shipment methods.
- * @return {Array} - Returns multiple methods if more than one
- * carrier has been chosen.
+ * @name cartShipmentMethods
+ * @summary gets current shipment methods.
+ * @return {Array} - Returns multiple methods if more than one carrier has been chosen.
+ * @ignore
  */
 function cartShipmentMethods() {
   const cart = Cart.findOne();
@@ -200,6 +198,7 @@ Template.coreCheckoutShipping.helpers({
    * `merchantShippingRates` is enabled in marketplace
    * @method isAdmin
    * @return {Boolean} true if the user has admin access, otherwise false
+   * @ignore
    */
   isAdmin() {
     const marketplaceSettings = Reaction.marketplace;

--- a/imports/plugins/core/shipping/client/templates/settings/shipping.js
+++ b/imports/plugins/core/shipping/client/templates/settings/shipping.js
@@ -27,11 +27,6 @@ Template.shippingSettings.helpers({
 // toggle shipping methods visibility
 // also toggles shipping method settings
 Template.shippingSettings.events({
-  /**
-   * shippingSettings settings update enabled status for shipping service on change
-   * @param  {event} event    jQuery Event
-   * @return {void}
-   */
   "change input.checkbox-switch.shipping-settings[name=enabled]": (event) => {
     event.preventDefault();
     const settingsKey = event.target.getAttribute("data-key");

--- a/imports/plugins/core/shipping/server/methods/methods.js
+++ b/imports/plugins/core/shipping/server/methods/methods.js
@@ -6,14 +6,14 @@ import { shippingRoles } from "../lib/roles";
 
 /**
  *
- * @namespace Methods/Shipping
+ * @namespace Shipping/Methods
  */
 
 export const methods = {
   /**
    * @name shipping/status/refresh
    * @method
-   * @memberof Methods/Shipping
+   * @memberof Shipping/Methods
    * @todo This is a stub for future core processing
    * @summary Blank method. Serves as a place for Method Hooks,
    * in other shipping packages, like Shippo
@@ -31,7 +31,7 @@ export const methods = {
   /**
    * @name shipping/provider/toggle
    * @method
-   * @memberof Methods/Shipping
+   * @memberof Shipping/Methods
    * @example Meteor.call("shipping/provider/toggle", packageId, settingsKey)
    * @summary Toggle enabled provider
    * @param { String } packageId packageId

--- a/imports/plugins/core/taxes/client/settings/settings.js
+++ b/imports/plugins/core/taxes/client/settings/settings.js
@@ -50,11 +50,6 @@ Template.taxSettings.helpers({
 });
 
 Template.taxSettings.events({
-  /**
-   * taxSettings settings update enabled status for tax service on change
-   * @param  {event} event    jQuery Event
-   * @return {void}
-   */
   "change input[name=enabled]": (event) => {
     const settingsKey = event.target.getAttribute("data-key");
     const packageId = event.target.getAttribute("data-id");
@@ -65,12 +60,6 @@ Template.taxSettings.events({
     // save tax registry updates
     Meteor.call("registry/update", packageId, settingsKey, fields);
   },
-
-  /**
-   * taxSettings settings show/hide secret key for a tax service
-   * @param  {event} event    jQuery Event
-   * @return {void}
-   */
   "click [data-event-action=showSecret]": (event) => {
     const button = Template.instance().$(event.currentTarget);
     const input = button.closest(".form-group").find("input[name=secret]");

--- a/imports/plugins/core/taxes/lib/collections/collections.js
+++ b/imports/plugins/core/taxes/lib/collections/collections.js
@@ -2,20 +2,19 @@ import { Mongo } from "meteor/mongo";
 import * as Schemas from "./schemas";
 
 /**
-* ReactionCore Collections TaxCodes
-*/
-
-/**
-* Taxes Collection
-*/
+ * @name Taxes
+ * @memberof Collections
+ * @type {MongoCollection}
+ */
 export const Taxes = new Mongo.Collection("Taxes");
 
 Taxes.attachSchema(Schemas.Taxes);
 
-
 /**
-* TaxCodes Collection
-*/
+ * @name TaxCodes
+ * @memberof Collections
+ * @type {MongoCollection}
+ */
 export const TaxCodes = new Mongo.Collection("TaxCodes");
 
 TaxCodes.attachSchema(Schemas.TaxCodes);

--- a/imports/plugins/core/taxes/lib/collections/schemas/config.js
+++ b/imports/plugins/core/taxes/lib/collections/schemas/config.js
@@ -3,9 +3,10 @@ import { PackageConfig } from "/lib/collections/schemas/registry";
 import { Taxes } from "./taxes";
 
 /**
-* TaxPackageConfig Schema
-*/
-
+ * @name TaxPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const TaxPackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {

--- a/imports/plugins/core/taxes/lib/collections/schemas/taxcodes.js
+++ b/imports/plugins/core/taxes/lib/collections/schemas/taxcodes.js
@@ -4,9 +4,11 @@ import { Tracker } from "meteor/tracker";
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* TaxCodes Schema
-*/
-
+ * @name TaxCodes
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary TaxCodes schema
+ */
 export const TaxCodes = new SimpleSchema({
   "id": {
     type: String,

--- a/imports/plugins/core/taxes/lib/collections/schemas/taxes.js
+++ b/imports/plugins/core/taxes/lib/collections/schemas/taxes.js
@@ -5,9 +5,11 @@ import { shopIdAutoValue } from "/lib/collections/schemas/helpers";
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* Taxes Schema
-*/
-
+ * @name Taxes
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary Taxes schema
+ */
 export const Taxes = new SimpleSchema({
   "shopId": {
     type: String,

--- a/imports/plugins/core/taxes/lib/collections/schemas/taxrates.js
+++ b/imports/plugins/core/taxes/lib/collections/schemas/taxrates.js
@@ -4,9 +4,11 @@ import { Tracker } from "meteor/tracker";
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* TaxRates Schema
-*/
-
+ * @name TaxRates
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary TaxRates schema
+ */
 export const TaxRates = new SimpleSchema({
   country: {
     type: String

--- a/imports/plugins/core/taxes/server/hooks/taxes.js
+++ b/imports/plugins/core/taxes/server/hooks/taxes.js
@@ -2,17 +2,13 @@ import { Meteor } from "meteor/meteor";
 import { Hooks } from "/server/api";
 
 /**
- * Cart Hooks for Taxes
-*/
-
-/**
  * After cart update apply taxes.
  * if items are changed, recalculating taxes
  * we could have done this in the core/cart transform
  * but this way this file controls the events from
  * the core/taxes plugin.
+ * @private
  */
-
 Hooks.Events.add("afterCartUpdateCalculateTaxes", (cartId) => {
   Meteor.call("taxes/calculate", cartId);
 });

--- a/imports/plugins/core/taxes/server/methods/methods.js
+++ b/imports/plugins/core/taxes/server/methods/methods.js
@@ -9,14 +9,14 @@ import { Logger } from "/server/api";
  * @file Methods for Taxes. Run these methods using `Meteor.call()`.
  *
  *
- * @namespace Methods/Taxes
+ * @namespace Taxes/Methods
 */
 
 export const methods = {
   /**
    * @name taxes/deleteRate
    * @method
-   * @memberof Methods/Taxes
+   * @memberof Taxes/Methods
    * @param  {String} taxId tax taxId to delete
    * @return {String} returns update/insert result
    */
@@ -34,7 +34,7 @@ export const methods = {
   /**
    * @name taxes/addRate
    * @method
-   * @memberof Methods/Taxes
+   * @memberof Taxes/Methods
    * @param  {Object} doc A Taxes document to be inserted
    * @param  {String} [docId] DEPRECATED. Existing ID to trigger an update. Use taxes/editRate method instead.
    * @return {String} Insert result
@@ -53,7 +53,7 @@ export const methods = {
   /**
    * @name taxes/editRate
    * @method
-   * @memberof Methods/Taxes
+   * @memberof Taxes/Methods
    * @param  {Object} details An object with _id and modifier props
    * @return {String} Update result
    */
@@ -71,7 +71,7 @@ export const methods = {
    * @name taxes/setRate
    * @summary Update the cart without hooks
    * @method
-   * @memberof Methods/Taxes
+   * @memberof Taxes/Methods
    * @param  {String} cartId cartId
    * @param  {Number} taxRate taxRate
    * @param  {Object} taxes taxes
@@ -93,7 +93,7 @@ export const methods = {
   /**
    * @name taxes/setRateByShopAndItem
    * @method
-   * @memberof Methods/Taxes
+   * @memberof Taxes/Methods
    * @summary Update the cart without hooks
    * @param  {String} cartId cartId
    * @param  {Object} options - Options object
@@ -127,7 +127,7 @@ export const methods = {
   /**
    * @name taxes/calculate
    * @method
-   * @memberof Methods/Taxes
+   * @memberof Taxes/Methods
    * @param  {String} cartId cartId
    * @return {Object}  returns tax object
    */

--- a/imports/plugins/core/templates/lib/collections/schemas/emailtemplates.js
+++ b/imports/plugins/core/templates/lib/collections/schemas/emailtemplates.js
@@ -6,9 +6,11 @@ import { shopIdAutoValue } from "/lib/collections/schemas/helpers";
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
- * EmailTemplates Schema
-*/
-
+ * @name EmailTemplates
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary EmailTemplates schema
+ */
 export const EmailTemplates = new SimpleSchema({
   "shopId": {
     type: String,

--- a/imports/plugins/core/templates/server/methods.js
+++ b/imports/plugins/core/templates/server/methods.js
@@ -7,14 +7,14 @@ import { Templates } from "/lib/collections";
  * @file Methods for Templates. Run these methods using `Meteor.call()`.
  *
  *
- * @namespace Methods/Templates
+ * @namespace Templates/Methods
 */
 
 export const methods = {
   /**
    * @name templates/email/update
    * @method
-   * @memberof Methods/Templates
+   * @memberof Templates/Methods
    * @todo Add permissions
    * @summary Updates email template in Templates collection
    * @param {String} templateId - id of template to remove

--- a/imports/plugins/core/ui-navbar/client/containers/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/containers/navbar.js
@@ -30,18 +30,18 @@ export function composer(props, onData) {
   }
 
   /**
-   * handleShopSelectChange
    * @method
    * @summary Handle change in selected shop
    * @param {script} event
    * @param {String} shopId - selected shopId
    * @since 1.5.8
    * @return {void}
-  */
+   * @private
+   */
   const handleShopSelectChange = (event, shopId) => {
-    // set shopId
     Reaction.setShopId(shopId);
   };
+
   if (searchPackage.length) {
     searchEnabled = true;
     searchTemplate = searchPackage[0].template;

--- a/imports/plugins/core/ui-tagnav/client/helpers/tags.js
+++ b/imports/plugins/core/ui-tagnav/client/helpers/tags.js
@@ -6,7 +6,8 @@ import { Session } from "meteor/session";
 import { Template } from "meteor/templating";
 
 /**
- * Reaction TagNav shared helpers
+ * @memberof Helpers
+ * @summary Reaction TagNav shared helpers
  * @type {Object}
  */
 export const TagHelpers = {

--- a/imports/plugins/core/ui/client/components/button/editButton.js
+++ b/imports/plugins/core/ui/client/components/button/editButton.js
@@ -10,6 +10,8 @@ import IconButton from "./iconButton";
  * Use this button in places where you need a pre-styled button for toggling editing
  * states of components.
  *
+ * @memberof Components
+ * @summary EditButton component
  * @param {Object} props Props passed into component
  * @returns {IconButton} Retruns an IconButton component with pre-configured icons for editing
  */

--- a/imports/plugins/core/ui/client/components/button/handle.js
+++ b/imports/plugins/core/ui/client/components/button/handle.js
@@ -7,7 +7,7 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
  * It uses the fa-bars icon by default, and does not have click or hover states
  *
  * Use this button in places where you need a pre-styled button for drag handles
- *
+ * @memberof Components
  * @param {Object} props Props passed into component
  * @returns {node} component with pre-configured icon for dragging
  */

--- a/imports/plugins/core/ui/client/components/button/visibilityButton.js
+++ b/imports/plugins/core/ui/client/components/button/visibilityButton.js
@@ -9,6 +9,7 @@ import IconButton from "./iconButton";
  * Use this button in places where you need a pre-styled button for toggling visibility
  * states of components.
  *
+ * @memberof Components
  * @param {Object} props Props passed into component
  * @returns {IconButton} Retruns an IconButton component with pre-configured icons for visibility
  */

--- a/imports/plugins/core/ui/client/components/cards/cards.js
+++ b/imports/plugins/core/ui/client/components/cards/cards.js
@@ -1,10 +1,4 @@
 import { Template } from "meteor/templating";
-/**
-* @typedef CardProps
-* @type Object
-* @property {Object} controls Reaction UI Button or other control props
-* @property {function} onContentClick y The Y
-*/
 
 Template.card.events({
   "click .content"(event, instance) {

--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -26,6 +26,7 @@ class Form extends Component {
   * @property {Boolean} renderFromFields - this controls whether form is rendered from schema or from fields.
   * @property {Object} schema - the schema used for validation and rendering.
   * @return {Array} React propTypes
+  * @ignore
   */
   static propTypes = {
     autoSave: PropTypes.bool,

--- a/imports/plugins/core/ui/client/components/notFound/notFound.js
+++ b/imports/plugins/core/ui/client/components/notFound/notFound.js
@@ -5,6 +5,7 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
 import { Icon } from "../icon";
 
 /**
+ * @memberof Components
  * @summary React component for displaying a not-found view
  * @param {Object} props - React PropTypes
  * @property {String|Object} className - String className or `classnames` compatible object for the base wrapper

--- a/imports/plugins/core/ui/client/components/toolbar/toolbarGroup.js
+++ b/imports/plugins/core/ui/client/components/toolbar/toolbarGroup.js
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { registerComponent } from "@reactioncommerce/reaction-components";
 
 /**
- * Toobar Text
+ * @memberof Components
  * @param {Object} props component props
  * @return {node} react element node
  */

--- a/imports/plugins/core/ui/client/components/toolbar/toolbarText.js
+++ b/imports/plugins/core/ui/client/components/toolbar/toolbarText.js
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { registerComponent } from "@reactioncommerce/reaction-components";
 
 /**
- * Toobar Text
+ * @memberof Components
  * @param {Object} props component props
  * @return {node} react element node
  */

--- a/imports/plugins/core/ui/client/containers/sortableItem.js
+++ b/imports/plugins/core/ui/client/containers/sortableItem.js
@@ -7,6 +7,7 @@ import { DragSource, DropTarget } from "react-dnd";
  * @param {DragSourceConnector} connect An onject containing functions to assign roles to a component's DOM nodes
  * @param {DragSourceMonitor} monitor An object containing functions that return information about drag state
  * @return {Object} Props for drag source
+ * @private
  */
 function collectDropSource(connect, monitor) {
   return {

--- a/imports/plugins/included/connectors-shopify/lib/collections/schemas/shopifyConnect.js
+++ b/imports/plugins/included/connectors-shopify/lib/collections/schemas/shopifyConnect.js
@@ -12,6 +12,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name Webhook
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {Number} shopifyId Shopify webhook ID
  * @property {String} topic Shopify webhook topic
@@ -57,6 +58,7 @@ registerSchema("Webhook", Webhook);
 
 /**
  * @name Synchook
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} topic - General topic this event is under
  * @property {String} event - The type of event that we are capturing
@@ -83,6 +85,7 @@ registerSchema("Synchook", Synchook);
 /**
  * @name ShopifyConnectPackageConfig
  * @type {SimpleSchema}
+ * @memberof Schemas
  * @property {String} settings.apiKey Shopify API key
  * @property {String} settings.password Shopify API password
  * @property {String} settings.sharedSecret Shopify API shared secret

--- a/imports/plugins/included/connectors-shopify/server/collections/shopifyCustomer.js
+++ b/imports/plugins/included/connectors-shopify/server/collections/shopifyCustomer.js
@@ -11,8 +11,9 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name ShopifyCustomer
- * @summary ShopifyCustomer schema attached to Accounts
+ * @memberof Schemas
  * @type {SimpleSchema}
+ * @summary ShopifyCustomer schema attached to Accounts
  * @property {Number} shopifyId Shopify ID
  */
 export const ShopifyCustomer = new SimpleSchema({

--- a/imports/plugins/included/connectors-shopify/server/collections/shopifyProduct.js
+++ b/imports/plugins/included/connectors-shopify/server/collections/shopifyProduct.js
@@ -12,8 +12,9 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name ShopifyProduct
- * @summary ShopifyProduct schema attached to Products type "simple" and "variant"
+ * @memberof Schemas
  * @type {SimpleSchema}
+ * @summary ShopifyProduct schema attached to Products type "simple" and "variant"
  * @property {Number} shopifyId Shopify ID
  */
 export const ShopifyProduct = new SimpleSchema({

--- a/imports/plugins/included/connectors-shopify/server/methods/export/orders.js
+++ b/imports/plugins/included/connectors-shopify/server/methods/export/orders.js
@@ -216,6 +216,7 @@ function convertShipping(order, index) {
 
 /**
  * @summary Export an order to Shopify
+ * @memberof Helpers
  * @param {Object} doc - The order to convert
  * @returns {Promise.<Array>} - An array of exported orders
  */

--- a/imports/plugins/included/default-theme/client/favicons.js
+++ b/imports/plugins/included/default-theme/client/favicons.js
@@ -57,10 +57,11 @@ const metaTags = [
 
 
 /**
- * Add a tag to the <head> of the page
+ * Add a tag to the `<head>` of the page
  * @param {String} type - tag type (link, meta, etc.)
  * @param {Object} details - key/value pairs for tag attributes
  * @return {undefined} no return value
+ * @private
  */
 function addTag(type, details) {
   let props = "";

--- a/imports/plugins/included/discount-codes/client/collections/codes.js
+++ b/imports/plugins/included/discount-codes/client/collections/codes.js
@@ -1,9 +1,10 @@
 import { Mongo } from "meteor/mongo";
 import { DiscountCodes as DiscountSchema } from "../../lib/collections/schemas";
 
-
 /**
- * Client side collections
+ * @name DiscountCodes
+ * @memberof Collections/ClientOnly
+ * @type {MongoCollection}
  */
 export const DiscountCodes = new Mongo.Collection("DiscountCodes");
 // attach discount code specific schema

--- a/imports/plugins/included/discount-codes/lib/collections/schemas/codes.js
+++ b/imports/plugins/included/discount-codes/lib/collections/schemas/codes.js
@@ -3,11 +3,10 @@ import { Discounts } from "/imports/plugins/core/discounts/lib/collections/schem
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* Discount Codes Schema
-* @type {Object}
-* @desc schema that extends discount schema
-* with properties for discount codes.
-*/
+ * @name DiscountCodes
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const DiscountCodes = Discounts.clone().extend({
   "discountMethod": {
     label: "Method",

--- a/imports/plugins/included/discount-codes/lib/collections/schemas/config.js
+++ b/imports/plugins/included/discount-codes/lib/collections/schemas/config.js
@@ -2,11 +2,11 @@ import { DiscountsPackageConfig } from "/imports/plugins/core/discounts/lib/coll
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* Discount Codes Package Config Schema
-* @type {Object}
-* @desc schema that extends discount schema
-* with properties for discount rates.
-*/
+ * @name DiscountCodesPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary A schema that extends discount schema with properties for discount codes.
+ */
 export const DiscountCodesPackageConfig = DiscountsPackageConfig.clone().extend({
   "settings.codes": {
     type: Object,

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -6,20 +6,23 @@ import { Cart } from "/lib/collections";
 import { Discounts } from "/imports/plugins/core/discounts/lib/collections";
 import { DiscountCodes as DiscountSchema } from "../../lib/collections/schemas";
 
+/**
+ * @namespace Discounts/Codes/Methods
+ */
+
 // attach discount code specific schema
 Discounts.attachSchema(DiscountSchema, { selector: { discountMethod: "code" } });
 
-//
-// make all discount methods available
-//
 export const methods = {
   /**
-   * discounts/codes/discount
-   * calculates percentage off discount rates
    * we intentionally passed ids, instead
    * of the cart,discount Object
    * for a smaller request providing an
    * additional level of validation.
+   * @name discounts/codes/discount
+   * @method
+   * @memberof Discounts/Codes/Methods
+   * @summary calculates percentage off discount rates
    * @param  {String} cartId cartId
    * @param  {String} discountId discountId
    * @return {Number} returns discount total
@@ -38,10 +41,12 @@ export const methods = {
 
     return discount;
   },
+
   /**
-   * TODO discounts/codes/credit
-   * calculates a credit off cart
-   * for discount codes
+   * @name discounts/codes/credit
+   * @method
+   * @memberof Discounts/Codes/Methods
+   * @summary calculates a credit off cart for discount codes
    * @param  {String} cartId cartId
    * @param  {String} discountId discountId
    * @return {Number} returns discount total
@@ -54,9 +59,12 @@ export const methods = {
     ({ discount } = discountMethod);
     return discount;
   },
+
   /**
-   * TODO discounts/codes/sale
-   * calculates a new price for an item
+   * @name discounts/codes/sale
+   * @method
+   * @memberof Discounts/Codes/Methods
+   * @summary calculates a new price for an item
    * @param  {String} cartId cartId
    * @param  {String} discountId discountId
    * @return {Number} returns discount total
@@ -78,10 +86,12 @@ export const methods = {
 
     return discount;
   },
+
   /**
-   * TODO discounts/codes/shipping
-   * calculates a discount based on the value
-   * of a calculated shipping rate in the cart.
+   * @name discounts/codes/shipping
+   * @method
+   * @memberof Discounts/Codes/Methods
+   * @summary calculates a discount based on the value of a calculated shipping rate in the cart.
    * @param  {String} cartId cartId
    * @param  {String} discountId discountId
    * @return {Number} returns discount total
@@ -105,6 +115,7 @@ export const methods = {
   /**
    * @name discounts/addCode
    * @method
+   * @memberof Discounts/Codes/Methods
    * @param  {Object} doc A Discounts document to be inserted
    * @param  {String} [docId] DEPRECATED. Existing ID to trigger an update. Use discounts/editCode method instead.
    * @return {String} Insert result
@@ -123,6 +134,7 @@ export const methods = {
   /**
    * @name discounts/editCode
    * @method
+   * @memberof Discounts/Codes/Methods
    * @param  {Object} details An object with _id and modifier props
    * @return {String} Update result
    */
@@ -137,9 +149,10 @@ export const methods = {
   },
 
   /**
-   * discounts/codes/remove
-   * removes discounts that have been previously applied
-   * to a cart.
+   * @name discounts/codes/remove
+   * @method
+   * @memberof Discounts/Codes/Methods
+   * @summary removes discounts that have been previously applied to a cart.
    * @param  {String} id cart id of which to remove a code
    * @param  {String} codeId discount Id from cart.billing
    * @param  {String} collection collection (either Orders or Cart)
@@ -189,10 +202,12 @@ export const methods = {
 
     return result;
   },
+
   /**
-   * discounts/codes/apply
-   * checks validity of code conditions and then
-   * applies a discount as a paymentMethod to cart
+   * @name discounts/codes/apply
+   * @method
+   * @memberof Discounts/Codes/Methods
+   * @summary checks validity of code conditions and then applies a discount as a paymentMethod to cart
    * @param  {String} id cart/order id of which to remove a code
    * @param  {String} code valid discount code
    * @param  {String} collection collection (either Orders or Cart)

--- a/imports/plugins/included/discount-rates/client/collections/rates.js
+++ b/imports/plugins/included/discount-rates/client/collections/rates.js
@@ -2,7 +2,9 @@ import { Mongo } from "meteor/mongo";
 import { DiscountRates as DiscountSchema } from "../../lib/collections/schemas";
 
 /**
- * Client side collections
+ * @name DiscountRates
+ * @memberof Collections/ClientOnly
+ * @type {MongoCollection}
  */
 export const DiscountRates = new Mongo.Collection("DiscountRates");
 // attach discount code specific schema

--- a/imports/plugins/included/discount-rates/lib/collections/schemas/config.js
+++ b/imports/plugins/included/discount-rates/lib/collections/schemas/config.js
@@ -2,11 +2,11 @@ import { DiscountsPackageConfig } from "/imports/plugins/core/discounts/lib/coll
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* Discount Rates Package Config Schema
-* @type {Object}
-* @desc schema that extends discount schema
-* with properties for discount rates.
-*/
+ * @name DiscountRatesPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary A schema that extends discount schema with properties for discount rates.
+ */
 export const DiscountRatesPackageConfig = DiscountsPackageConfig.clone().extend({
   "settings.rates": {
     type: Object,

--- a/imports/plugins/included/discount-rates/lib/collections/schemas/rates.js
+++ b/imports/plugins/included/discount-rates/lib/collections/schemas/rates.js
@@ -2,11 +2,11 @@ import { Discounts } from "/imports/plugins/core/discounts/lib/collections/schem
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* Discount Codes Schema
-* @type {Object}
-* @desc schema that extends discount schema
-* with properties for discount codes.
-*/
+ * @name DiscountRates
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary A schema that extends discounts schema with properties for discount rates.
+ */
 export const DiscountRates = Discounts.clone().extend({
   discountMethod: {
     label: "Calculation Method",

--- a/imports/plugins/included/discount-rates/server/methods/methods.js
+++ b/imports/plugins/included/discount-rates/server/methods/methods.js
@@ -4,19 +4,22 @@ import { Reaction } from "/server/api";
 import { Discounts } from "/imports/plugins/core/discounts/lib/collections";
 import { DiscountRates as DiscountSchema } from "../../lib/collections/schemas";
 
+/**
+ * @namespace Discounts/Rates/Methods
+ */
+
 // attach discount code specific schema
 Discounts.attachSchema(DiscountSchema, { selector: { discountMethod: "rate" } });
 
-//
-// make all discount methods available
-//
 export const methods = {
   /**
-   * discounts/rates/amount
-   * for discount rates
+   * @name discounts/rates/amount
+   * @summary for discount rates
+   * @method
+   * @memberof Discounts/Rates/Methods
    * @param  {String} cartId cartId
    * @param  {String} rateId rateid
-   * @return {Number} returns discount total
+   * @return {Number} discount total
    */
   "discounts/rates/amount"(cartId, rateId) {
     check(cartId, String);
@@ -38,6 +41,7 @@ export const methods = {
   /**
    * @name discounts/addRate
    * @method
+   * @memberof Discounts/Rates/Methods
    * @param  {Object} doc A Discounts document to be inserted
    * @param  {String} [docId] DEPRECATED. Existing ID to trigger an update. Use discounts/editCode method instead.
    * @return {String} Insert result
@@ -56,6 +60,7 @@ export const methods = {
   /**
    * @name discounts/editRate
    * @method
+   * @memberof Discounts/Rates/Methods
    * @param  {Object} details An object with _id and modifier props
    * @return {String} Update result
    */

--- a/imports/plugins/included/inventory/server/hooks/hooks.js
+++ b/imports/plugins/included/inventory/server/hooks/hooks.js
@@ -4,12 +4,12 @@ import { Logger, Hooks } from "/server/api";
 import { registerInventory } from "../methods/inventory";
 
 /**
-* @method afterAddItemsToCart
-* @summary reserves inventory when item is added to cart
-* @param {String} cartId - current cartId
-* @param {Object} options - product document
-* @return {undefined}
-*/
+ * @summary reserves inventory when item is added to cart
+ * @param {String} cartId - current cartId
+ * @param {Object} options - product document
+ * @return {undefined}
+ * @private
+ */
 Hooks.Events.add("afterAddItemsToCart", (cartId, options) => {
   // Adding a new product or variant to the cart
   Logger.debug("after cart update, call inventory/addReserve");
@@ -20,12 +20,12 @@ Hooks.Events.add("afterAddItemsToCart", (cartId, options) => {
 });
 
 /**
-* @method afterModifyQuantityInCart
-* @summary reserves inventory when cart quantity is updated
-* @param {String} cartId - current cartId
-* @param {Object} options - product document
-* @return {undefined}
-*/
+ * @summary reserves inventory when cart quantity is updated
+ * @param {String} cartId - current cartId
+ * @param {Object} options - product document
+ * @return {undefined}
+ * @private
+ */
 Hooks.Events.add("afterModifyQuantityInCart", (cartId, options) => {
   // Modifying item quantity in cart.
   Logger.debug("after variant increment, call inventory/addReserve");
@@ -40,12 +40,12 @@ Hooks.Events.add("afterModifyQuantityInCart", (cartId, options) => {
 
 
 /**
-* @method afterRemoveCatalogProduct
-* @summary updates product inventory after variant is removed
-* @param {String} userId - userId of user making the call
-* @param {Object} doc - product document
-* @return {undefined}
-*/
+ * @summary updates product inventory after variant is removed
+ * @param {String} userId - userId of user making the call
+ * @param {Object} doc - product document
+ * @return {undefined}
+ * @private
+ */
 Hooks.Events.add("afterRemoveCatalogProduct", (userId, doc) => {
   if (doc.type === "variant") {
     const variantItem = {
@@ -62,12 +62,12 @@ Hooks.Events.add("afterRemoveCatalogProduct", (userId, doc) => {
 });
 
 /**
-* @method afterUpdateCatalogProduct
-* @summary adjust inventory of variants after an update
-* @param {String} userId - userId of user making the call
-* @param {Object} doc - product document
-* @return {undefined}
-*/
+ * @summary adjust inventory of variants after an update
+ * @param {String} userId - userId of user making the call
+ * @param {Object} doc - product document
+ * @return {undefined}
+ * @private
+ */
 Hooks.Events.add("afterUpdateCatalogProduct", (doc) => {
   // Find the most recent version of the product document based on
   // the passed in doc._id
@@ -83,12 +83,12 @@ Hooks.Events.add("afterUpdateCatalogProduct", (doc) => {
 });
 
 /**
-* @method afterInsertCatalogProduct
-* @summary adds product inventory when new product is created
-* @param {String} userId - userId of user making the call
-* @param {Object} doc - product document
-* @return {undefined}
-*/
+ * @summary adds product inventory when new product is created
+ * @param {String} userId - userId of user making the call
+ * @param {Object} doc - product document
+ * @return {undefined}
+ * @private
+ */
 Hooks.Events.add("afterInsertCatalogProduct", (doc) => {
   if (doc.type !== "variant") {
     return false;
@@ -99,10 +99,10 @@ Hooks.Events.add("afterInsertCatalogProduct", (doc) => {
 });
 
 /**
- * markInventoryShipped
  * @summary check a product and update Inventory collection with inventory documents.
  * @param {Object} product - valid Schemas.Product object
  * @return {Number} - returns the total amount of new inventory created
+ * @private
  */
 function markInventoryShipped(doc) {
   const order = Orders.findOne(doc._id);
@@ -126,10 +126,10 @@ function markInventoryShipped(doc) {
 }
 
 /**
- * markInventorySold
  * @summary check a product and update Inventory collection with inventory documents.
  * @param {Object} doc - valid Schemas.Product object
  * @return {Number} - returns the total amount of new inventory created
+ * @private
  */
 function markInventorySold(doc) {
   const orderItems = doc.items;
@@ -153,11 +153,11 @@ function markInventorySold(doc) {
 }
 
 /**
-* @method afterOrderInsert
-* @summary marks inventory as sold when order is created
-* @param {Object} order - order document
-* @return {Object} order - order document
-*/
+ * @summary marks inventory as sold when order is created
+ * @param {Object} order - order document
+ * @return {Object} order - order document
+ * @private
+ */
 Hooks.Events.add("afterOrderInsert", (order) => {
   Logger.debug("Inventory module handling Order insert");
   markInventorySold(order);
@@ -166,11 +166,11 @@ Hooks.Events.add("afterOrderInsert", (order) => {
 });
 
 /**
-* @method onOrderShipmentShipped
-* @summary marks inventory as shipped when order workflow is completed
-* @param {Object} doc - order document
-* @return {undefined}
-*/
+ * @summary marks inventory as shipped when order workflow is completed
+ * @param {Object} doc - order document
+ * @return {undefined}
+ * @private
+ */
 Hooks.Events.add("onOrderShipmentShipped", (doc) => {
   Logger.debug("Inventory module handling Order update");
   markInventoryShipped(doc);

--- a/imports/plugins/included/inventory/server/methods/inventory.js
+++ b/imports/plugins/included/inventory/server/methods/inventory.js
@@ -4,7 +4,13 @@ import { Inventory, Products } from "/lib/collections";
 import { Logger, Reaction } from "/server/api";
 
 /**
- * inventory/register
+ * @namespace Inventory/Methods
+ */
+
+/**
+ * @name inventory/register
+ * @method
+ * @memberof Inventory/Methods
  * @summary check a product and update Inventory collection with inventory documents.
  * @param {Object} product - valid Schemas.Product object
  * @return {Number} - returns the total amount of new inventory created
@@ -70,6 +76,15 @@ export function registerInventory(product) {
   return totalNewInventory;
 }
 
+/**
+ * @name inventory/adjust
+ * @method
+ * @memberof Inventory/Methods
+ * @param {Object} product - valid Schemas.Product object
+ * @param {String} userId - ID of user who is adjusting
+ * @param {Object} context - Meteor method context
+ * @return {undefined} - No return
+ */
 function adjustInventory(product, userId, context) {
   // TODO: This can fail even if updateVariant succeeds.
   Products.simpleSchema(product).validate(product);

--- a/imports/plugins/included/inventory/server/methods/statusChanges.js
+++ b/imports/plugins/included/inventory/server/methods/statusChanges.js
@@ -30,15 +30,12 @@ import { Logger, Reaction } from "/server/api";
 
 /**
  * @file Methods for Inventory. Run these methods using `Meteor.call()`
- *
- *
- * @namespace Methods/Inventory
 */
 Meteor.methods({
   /**
    * @name inventory/setStatus
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @summary Sets status from one status to a new status. Defaults to `new` to `reserved`
    * @example Meteor.call("inventory/backorder", reservation, backOrderQty);
    * @param  {Array} cartItems array of objects of type Schemas.CartItems
@@ -151,7 +148,7 @@ Meteor.methods({
   /**
    * @name inventory/clearStatus
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @summary Used to reset status on inventory item (defaults to `new`)
    * @param  {Array} cartItems array of objects Schemas.CartItem
    * @param  {Array} status optional reset workflow.status, defaults to `new`
@@ -209,7 +206,7 @@ Meteor.methods({
   /**
    * @name inventory/clearReserve
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @example Meteor.call("inventory/clearReserve", cart.items)
    * @summary Resets `reserved` items to `new`
    * @param  {Array} cartItems array of objects Schemas.CartItem
@@ -225,7 +222,7 @@ Meteor.methods({
    * @summary Converts new items to reserved, or backorders
    * @method
    * @example Meteor.call("inventory/addReserve", cart.items)
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @param  {Array} cartItems array of objects Schemas.CartItem
    * @return {undefined}
    */
@@ -240,7 +237,7 @@ Meteor.methods({
    * but this could be used for inserting any custom inventory.
    * @method
    * A note on DDP Limits: As these are wide open we defined some {@link http://docs.meteor.com/#/full/ddpratelimiter ddp limiting rules}
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @param {Object} reservation Schemas.Inventory
    * @param {Number} backOrderQty number of backorder items to create
    * @returns {Number} number of inserted backorder documents
@@ -302,7 +299,7 @@ Meteor.methods({
    * @name inventory/lowStock
    * @summary Send low stock warnings
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @param  {Object} product object type Product
    * @return {undefined}
    * @todo implement inventory/lowstock calculations
@@ -317,7 +314,7 @@ Meteor.methods({
    * @name inventory/remove
    * @summary Delete an inventory item permanently
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @param  {Object} inventoryItem object type Schemas.Inventory
    * @return {String} return remove result
    */
@@ -343,7 +340,7 @@ Meteor.methods({
   /**
    * @name inventory/shipped
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @summary Mark inventory as shipped
    * @param  {Array} cartItems array of objects Schemas.CartItem
    * @return {undefined}
@@ -356,7 +353,7 @@ Meteor.methods({
   /**
    * @name inventory/sold
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @summary Mark inventory as sold
    * @param  {Array} cartItems array of objects Schemas.CartItem
    * @return {undefined}
@@ -369,7 +366,7 @@ Meteor.methods({
   /**
    * @name inventory/return
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @summary Mark inventory as returned
    * @param  {Array} cartItems array of objects Schemas.CartItem
    * @return {undefined}
@@ -382,7 +379,7 @@ Meteor.methods({
   /**
    * @name inventory/returnToStock
    * @method
-   * @memberof Methods/Inventory
+   * @memberof Inventory/Methods
    * @summary Mark inventory as return and available for sale
    * @param  {Array} cartItems array of objects Schemas.CartItem
    * @return {undefined}

--- a/imports/plugins/included/jobcontrol/server/jobs/cart.js
+++ b/imports/plugins/included/jobcontrol/server/jobs/cart.js
@@ -10,11 +10,10 @@ async function lazyLoadMoment() {
   moment = await import("moment");
 }
 
-
 /**
- * {Function} that fetches stale carts
  * @param {Object} olderThan older than date
  * @return {Object} stale carts
+ * @private
  */
 const getstaleCarts = (olderThan) => Cart.find({ updatedAt: { $lte: olderThan } }).fetch();
 

--- a/imports/plugins/included/marketplace/lib/collections/schemas/marketplace.js
+++ b/imports/plugins/included/marketplace/lib/collections/schemas/marketplace.js
@@ -5,6 +5,12 @@ import { PackageConfig } from "/lib/collections/schemas/registry";
 import { Shop } from "/lib/collections/schemas/shops.js";
 import { registerSchema } from "@reactioncommerce/schemas";
 
+/**
+ * @name ShopTypes
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary ShopTypes schema
+ */
 export const ShopTypes = new SimpleSchema({
   shopType: {
     type: String,
@@ -18,6 +24,12 @@ export const ShopTypes = new SimpleSchema({
 
 registerSchema("ShopTypes", ShopTypes);
 
+/**
+ * @name EnabledPackagesByShopType
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary EnabledPackagesByShopType schema
+ */
 export const EnabledPackagesByShopType = new SimpleSchema({
   shopType: String,
   enabledPackages: [String]
@@ -25,6 +37,12 @@ export const EnabledPackagesByShopType = new SimpleSchema({
 
 registerSchema("EnabledPackagesByShopType", EnabledPackagesByShopType);
 
+/**
+ * @name MarketplacePackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary MarketplacePackageConfig schema
+ */
 export const MarketplacePackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {
@@ -136,7 +154,10 @@ export const MarketplacePackageConfig = PackageConfig.clone().extend({
 registerSchema("MarketplacePackageConfig", MarketplacePackageConfig);
 
 /**
- * Seller Shop Schema
+ * @name SellerShop
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary SellerShop schema
  */
 export const SellerShop = Shop.clone().extend({
   stripeConnectSettings: {

--- a/imports/plugins/included/notifications/server/methods/notifications.js
+++ b/imports/plugins/included/notifications/server/methods/notifications.js
@@ -7,12 +7,12 @@ import { Notifications, Packages } from "/lib/collections";
  * @file Methods for Notifications. Run these methods using `Meteor.call()`.
  *
  *
- * @namespace Methods/Notification
+ * @namespace Notification/Methods
 */
 Meteor.methods({
   /**
   * @name notification/send
-  * @memberof Methods/Notification
+  * @memberof Notification/Methods
   * @method
   * @summary This send a notification to a user
   * @param {String} userId - The user
@@ -69,7 +69,7 @@ Meteor.methods({
 
   /**
    * @name notification/markOneAsRead
-   * @memberof Methods/Notification
+   * @memberof Notification/Methods
    * @method
    * @summary This marks all user's notification as ready
    * @param {String} id - The notification id
@@ -87,7 +87,7 @@ Meteor.methods({
 
   /**
    * @name notification/delete
-   * @memberof Methods/Notification
+   * @memberof Notification/Methods
    * @method
    * @summary This deletes a notification
    * @param {String} id - The notification id

--- a/imports/plugins/included/payments-authnet/lib/collections/schemas/authnet.js
+++ b/imports/plugins/included/payments-authnet/lib/collections/schemas/authnet.js
@@ -5,14 +5,10 @@ import { PackageConfig } from "/lib/collections/schemas/registry";
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
- * Meteor.settings.authnet =
- *   mode: false (sandbox)
- *   api_id: ""
- *   transaction_key: ""
- *   see: https://developer.authnet.com/webapps/developer/docs/api/
- *   see: https://github.com/authnet/rest-api-sdk-nodejs
+ * @name AuthNetPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
  */
-
 export const AuthNetPackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {
@@ -49,6 +45,11 @@ export const AuthNetPackageConfig = PackageConfig.clone().extend({
 
 registerSchema("AuthNetPackageConfig", AuthNetPackageConfig);
 
+/**
+ * @name AuthNetPayment
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const AuthNetPayment = new SimpleSchema({
   payerName: {
     type: String,

--- a/imports/plugins/included/payments-braintree/lib/collections/schemas/braintree.js
+++ b/imports/plugins/included/payments-braintree/lib/collections/schemas/braintree.js
@@ -5,14 +5,11 @@ import { PackageConfig } from "/lib/collections/schemas/registry";
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
- *  Meteor.settings.braintree =
- *    mode: false  #sandbox
- *    merchant_id: ""
- *    public_key: ""
- *    private_key: ""
- *  see: https://developers.braintreepayments.com/javascript+node/reference
+ * @name BraintreePackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @see {@link https://developers.braintreepayments.com/javascript+node/reference}
  */
-
 export const BraintreePackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {
@@ -56,6 +53,12 @@ export const BraintreePackageConfig = PackageConfig.clone().extend({
 
 registerSchema("BraintreePackageConfig", BraintreePackageConfig);
 
+/**
+ * @name BraintreePayment
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary BraintreePayment schema
+ */
 export const BraintreePayment = new SimpleSchema({
   payerName: {
     type: String,

--- a/imports/plugins/included/payments-braintree/server/methods/braintree.js
+++ b/imports/plugins/included/payments-braintree/server/methods/braintree.js
@@ -1,6 +1,10 @@
 import { Meteor } from "meteor/meteor";
 import * as BraintreeMethods from "./braintreeMethods";
 
+/**
+ * @namespace Payment/Braintree/Methods
+ */
+
 Meteor.methods({
   "braintreeSubmit": BraintreeMethods.paymentSubmit,
   "braintree/payment/capture": BraintreeMethods.paymentCapture,

--- a/imports/plugins/included/payments-braintree/server/methods/braintreeMethods.js
+++ b/imports/plugins/included/payments-braintree/server/methods/braintreeMethods.js
@@ -4,9 +4,10 @@ import { Logger } from "/server/api";
 import { PaymentMethodArgument } from "/lib/collections/schemas";
 
 /**
- * braintreeSubmit
- * Authorize, or authorize and capture payments from Braintree
- * https://developers.braintreepayments.com/reference/request/transaction/sale/node
+ * @name braintreeSubmit
+ * @method
+ * @memberof Payment/Braintree/Methods
+ * @summary Authorize, or authorize and capture payments from Braintree {@link https://developers.braintreepayments.com/reference/request/transaction/sale/node}
  * @param {String} transactionType - either authorize or capture
  * @param {Object} cardData - Object containing everything about the Credit card to be submitted
  * @param {Object} paymentData - Object containing everything about the transaction to be settled
@@ -53,9 +54,10 @@ export function paymentSubmit(transactionType, cardData, paymentData) {
 
 
 /**
- * paymentCapture
- * Capture payments from Braintree
- * https://developers.braintreepayments.com/reference/request/transaction/submit-for-settlement/node
+ * @name braintree/payment/capture
+ * @method
+ * @memberof Payment/Braintree/Methods
+ * @summary Capture payments from Braintree {@link https://developers.braintreepayments.com/reference/request/transaction/submit-for-settlement/node}
  * @param {Object} paymentMethod - Object containing everything about the transaction to be settled
  * @return {Object} results - Object containing the results of the transaction
  */
@@ -90,9 +92,10 @@ export function paymentCapture(paymentMethod) {
 
 
 /**
- * createRefund
- * Refund BrainTree payment
- * https://developers.braintreepayments.com/reference/request/transaction/refund/node
+ * @name braintree/refund/create
+ * @method
+ * @memberof Payment/Braintree/Methods
+ * @summary Refund BrainTree payment {@link https://developers.braintreepayments.com/reference/request/transaction/refund/node}
  * @param {Object} paymentMethod - Object containing everything about the transaction to be settled
  * @param {Number} amount - Amount to be refunded if not the entire amount
  * @return {Object} results - Object containing the results of the transaction
@@ -130,9 +133,10 @@ export function createRefund(paymentMethod, amount) {
 
 
 /**
- * listRefunds
- * List all refunds for a transaction
- * https://developers.braintreepayments.com/reference/request/transaction/find/node
+ * @name braintree/refund/list
+ * @method
+ * @memberof Payment/Braintree/Methods
+ * @summary List all refunds for a transaction {@link https://developers.braintreepayments.com/reference/request/transaction/find/node}
  * @param {Object} paymentMethod - Object containing everything about the transaction to be settled
  * @return {Array} results - An array of refund objects for display in admin
  */

--- a/imports/plugins/included/payments-example/lib/collections/schemas/example.js
+++ b/imports/plugins/included/payments-example/lib/collections/schemas/example.js
@@ -4,6 +4,11 @@ import { Tracker } from "meteor/tracker";
 import { PackageConfig } from "/lib/collections/schemas/registry";
 import { registerSchema } from "@reactioncommerce/schemas";
 
+/**
+ * @name ExamplePackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const ExamplePackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {
@@ -25,6 +30,12 @@ export const ExamplePackageConfig = PackageConfig.clone().extend({
 
 registerSchema("ExamplePackageConfig", ExamplePackageConfig);
 
+/**
+ * @name ExamplePayment
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary ExamplePayment schema
+ */
 export const ExamplePayment = new SimpleSchema({
   payerName: {
     type: String,

--- a/imports/plugins/included/payments-example/server/methods/example.js
+++ b/imports/plugins/included/payments-example/server/methods/example.js
@@ -27,10 +27,17 @@ import { PaymentMethodArgument } from "/lib/collections/schemas";
 //   };
 // }
 
+/**
+ * Meteor methods for Example Payment Plugin. Run these methods using `Meteor.call()`
+ * @namespace Payment/Example/Methods
+ */
+
 
 Meteor.methods({
   /**
    * Submit a card for Authorization
+   * @method
+   * @memberof Payment/Example/Methods
    * @param  {Object} transactionType authorize or capture
    * @param  {Object} cardData card Details
    * @param  {Object} paymentData The details of the Payment Needed
@@ -85,6 +92,8 @@ Meteor.methods({
 
   /**
    * Capture a Charge
+   * @method
+   * @memberof Payment/Example/Methods
    * @param {Object} paymentMethod Object containing data about the transaction to capture
    * @return {Object} results normalized
    */
@@ -108,6 +117,8 @@ Meteor.methods({
 
   /**
    * Create a refund
+   * @method
+   * @memberof Payment/Example/Methods
    * @param  {Object} paymentMethod object
    * @param  {Number} amount The amount to be refunded
    * @return {Object} result
@@ -134,6 +145,8 @@ Meteor.methods({
 
   /**
    * List refunds
+   * @method
+   * @memberof Payment/Example/Methods
    * @param  {Object} paymentMethod Object containing the pertinant data
    * @return {Object} result
    */

--- a/imports/plugins/included/payments-example/server/methods/exampleapi.js
+++ b/imports/plugins/included/payments-example/server/methods/exampleapi.js
@@ -67,6 +67,11 @@ const ThirdPartyAPI = {
 export const ExampleApi = {};
 ExampleApi.methods = {};
 
+/**
+ * @name cardSchema
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const cardSchema = new SimpleSchema({
   number: String,
   name: String,
@@ -78,6 +83,11 @@ export const cardSchema = new SimpleSchema({
 
 registerSchema("cardSchema", cardSchema);
 
+/**
+ * @name paymentDataSchema
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const paymentDataSchema = new SimpleSchema({
   total: String,
   currency: String

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/express/checkoutButton.js
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/express/checkoutButton.js
@@ -14,11 +14,13 @@ import "./checkoutButton.html";
  *
  * This is the PayPal Express Checkout button that displays opens a popup,
  * provided by paypal.
+ * @ignore
  */
 
 /**
  * Checkout - Open PayPal Express popup
  * @return {undefined} no return value
+ * @private
  */
 function checkout() {
   paypal.checkout.initXO();
@@ -44,16 +46,12 @@ function checkout() {
  * Validate express checkout settings object
  * @param  {Object} settings Object containing "merchantId" and "mode":
  * @return {Boolean} true if valid, false otherwise
+ * @private
  */
 function expressCheckoutSettingsValid(settings) {
   return _.isEmpty(settings.merchantId) === false && _.isEmpty(settings.mode) === false;
 }
 
-/**
- * PayPal checkout onCreate
- * @param  {Function} function to execute when template is created
- * @return {undefined} no return value
- */
 Template.paypalCheckoutButton.onCreated(function () {
   Meteor.call("getExpressCheckoutSettings", (error, expressCheckoutSettings) => {
     if (!error) {
@@ -68,11 +66,6 @@ Template.paypalCheckoutButton.onCreated(function () {
   });
 });
 
-/**
- * PayPal checkout onRendered
- * @param  {Function} function to execute when template is rendered
- * @return {undefined} no return value
- */
 Template.paypalCheckoutButton.onRendered(function () {
   const element = this.$(".js-paypal-express-checkout")[0];
 
@@ -99,33 +92,24 @@ Template.paypalCheckoutButton.onRendered(function () {
   });
 });
 
-/**
- * PayPal checkout button helpers
- */
 Template.paypalCheckoutButton.helpers({
   expressCheckoutEnabled() {
     const expressCheckoutSettings = Session.get("expressCheckoutSettings");
     return expressCheckoutSettings !== undefined ? expressCheckoutSettings.enabled : undefined;
   },
+
   /**
    * Check for proper configuration of PayPal Express Checkout settings.
    * This function only validates that the required settings exist and are not empty.
    * @return {Boolean} true if properly configured, false otherwise
+   * @ignore
    */
   isConfigured() {
     return Template.instance().state.equals("isConfigured", true);
   }
 });
 
-/**
- * PayPal checkout button events
- */
 Template.paypalCheckoutButton.events({
-
-  /**
-   * Click Event: Express Checkout Button
-   * @return {undefined} no return value
-   */
   "click .js-paypal-express-checkout"() {
     return checkout();
   }

--- a/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
+++ b/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
@@ -4,6 +4,11 @@ import { Tracker } from "meteor/tracker";
 import { PackageConfig } from "/lib/collections/schemas/registry";
 import { registerSchema } from "@reactioncommerce/schemas";
 
+/**
+ * @name PaypalPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const PaypalPackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {
@@ -89,6 +94,11 @@ export const PaypalPackageConfig = PackageConfig.clone().extend({
 
 registerSchema("PaypalPackageConfig", PaypalPackageConfig);
 
+/**
+ * @name PaypalPayment
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const PaypalPayment = new SimpleSchema({
   payerName: {
     type: String,

--- a/imports/plugins/included/payments-paypal/server/methods/express.js
+++ b/imports/plugins/included/payments-paypal/server/methods/express.js
@@ -369,9 +369,10 @@ function parseResponse(response) {
 }
 
 /**
- * Parse PayPal's 'unique' Transaction Query response to look for refunds
+ * @summary Parse PayPal's 'unique' Transaction Query response to look for refunds
  * @param  {Object} response The response from PayPal
  * @return {Object} Refunds, normalized to an Array
+ * @private
  */
 function parseRefundReponse(response) {
   const paypalArray = [];

--- a/imports/plugins/included/payments-paypal/server/methods/payflow.js
+++ b/imports/plugins/included/payments-paypal/server/methods/payflow.js
@@ -1,6 +1,10 @@
 import { Meteor } from "meteor/meteor";
 import * as PayflowproMethods from "./payflowproMethods";
 
+/**
+ * @namespace Payment/PayflowPro/Methods
+ */
+
 Meteor.methods({
   "payflowpro/payment/submit": PayflowproMethods.paymentSubmit,
   "payflowpro/payment/capture": PayflowproMethods.paymentCapture,

--- a/imports/plugins/included/payments-paypal/server/methods/payflowproMethods.js
+++ b/imports/plugins/included/payments-paypal/server/methods/payflowproMethods.js
@@ -5,8 +5,10 @@ import { PayPal } from "../../lib/api"; // PayPal is the reaction api
 import { PayflowproApi } from "./payflowproApi";
 
 /**
- * payflowpro/payment/submit
- * Create and Submit a PayPal PayFlow transaction
+ * @name payflowpro/payment/submit
+ * @method
+ * @memberof Payment/PayflowPro/Methods
+ * @summary Create and Submit a PayPal PayFlow transaction
  * @param  {Object} transactionType transactionType
  * @param  {Object} cardData cardData object
  * @param  {Object} paymentData paymentData object
@@ -43,8 +45,10 @@ export function paymentSubmit(transactionType, cardData, paymentData) {
 
 
 /**
- * payflowpro/payment/capture
- * Capture an authorized PayPal PayFlow transaction
+ * @name payflowpro/payment/capture
+ * @method
+ * @memberof Payment/PayflowPro/Methods
+ * @summary Capture an authorized PayPal PayFlow transaction
  * @param  {Object} paymentMethod A PaymentMethod object
  * @return {Object} results from PayPal normalized
  */
@@ -79,8 +83,10 @@ export function paymentCapture(paymentMethod) {
 
 
 /**
- * createRefund
- * Refund PayPal PayFlow payment
+ * @name payflowpro/refund/create
+ * @method
+ * @memberof Payment/PayflowPro/Methods
+ * @summary Refund PayPal PayFlow payment
  * @param {Object} paymentMethod - Object containing everything about the transaction to be settled
  * @param {Number} amount - Amount to be refunded if not the entire amount
  * @return {Object} results - Object containing the results of the transaction
@@ -118,9 +124,10 @@ export function createRefund(paymentMethod, amount) {
 
 
 /**
- * listRefunds
- * List all refunds for a PayPal PayFlow transaction
- * https://developers.braintreepayments.com/reference/request/transaction/find/node
+ * @name payflowpro/refund/list
+ * @method
+ * @memberof Payment/PayflowPro/Methods
+ * @summary List all refunds for a PayPal PayFlow transaction {@link https://developers.braintreepayments.com/reference/request/transaction/find/node}
  * @param {Object} paymentMethod - Object containing everything about the transaction to be settled
  * @return {Array} results - An array of refund objects for display in admin
  */
@@ -152,7 +159,13 @@ export function listRefunds(paymentMethod) {
   return result;
 }
 
-
+/**
+ * @name payflowpro/settings
+ * @method
+ * @memberof Payment/PayflowPro/Methods
+ * @summary Get Payflow settings
+ * @return {Object} Settings object with `mode` and `enabled` props
+ */
 export function getSettings() {
   const settings = PayPal.payflowAccountOptions();
   const payflowSettings = {

--- a/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
+++ b/imports/plugins/included/payments-stripe/lib/collections/schemas/stripe.js
@@ -3,14 +3,14 @@ import { check } from "meteor/check";
 import { Tracker } from "meteor/tracker";
 import { PackageConfig } from "/lib/collections/schemas/registry";
 import { registerSchema } from "@reactioncommerce/schemas";
-/*
- *  Meteor.settings.stripe =
- *    mode: false  #sandbox
- *    api_key: ""
- *  see: https://stripe.com/docs/api
- */
 
-const StripeConnectAuthorizationCredentials = new SimpleSchema({
+/**
+ * @name StripeConnectAuthorizationCredentials
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @see {@link https://stripe.com/docs/api}
+ */
+export const StripeConnectAuthorizationCredentials = new SimpleSchema({
   token_type: { // eslint-disable-line camelcase
     type: String
   },
@@ -36,6 +36,11 @@ const StripeConnectAuthorizationCredentials = new SimpleSchema({
 
 registerSchema("StripeConnectAuthorizationCredentials", StripeConnectAuthorizationCredentials);
 
+/**
+ * @name StripePackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const StripePackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {
@@ -90,6 +95,11 @@ export const StripePackageConfig = PackageConfig.clone().extend({
 
 registerSchema("StripePackageConfig", StripePackageConfig);
 
+/**
+ * @name StripePayment
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const StripePayment = new SimpleSchema({
   payerName: {
     type: String,

--- a/imports/plugins/included/payments-stripe/server/methods/stripe.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripe.js
@@ -38,6 +38,7 @@ utils.getStripeApi = function (paymentPackageId) {
  * @summary Capture the results of a previous charge
  * @param {object} paymentMethod - Object containing info about the previous transaction
  * @returns {object} Object indicating the result, saved = true means success
+ * @private
  */
 function stripeCaptureCharge(paymentMethod) {
   let result;
@@ -76,10 +77,10 @@ function stripeCaptureCharge(paymentMethod) {
 }
 
 /**
- * normalizes the status of a transaction
- * @method normalizeStatus
+ * @summary normalizes the status of a transaction
  * @param  {object} transaction - The transaction that we need to normalize
  * @return {string} normalized status string - either failed, settled, or created
+ * @private
  */
 function normalizeStatus(transaction) {
   if (!transaction) {
@@ -101,10 +102,10 @@ function normalizeStatus(transaction) {
 }
 
 /**
- * normalizes the mode of a transaction
- * @method normalizeMode
+ * @summary normalizes the mode of a transaction
  * @param  {object} transaction The transaction that we need to normalize
  * @return {string} normalized status string - either failed, capture, or authorize
+ * @private
  */
 function normalizeMode(transaction) {
   if (!transaction) {
@@ -126,11 +127,10 @@ function normalizeMode(transaction) {
 }
 
 /**
- * @method normalizeRiskLevel
- * @private
  * @summary Normalizes the risk level response of a transaction to the values defined in paymentMethod schema
  * @param  {object} transaction - The transaction that we need to normalize
  * @return {string} normalized status string - either elevated, high, or normal
+ * @private
  */
 function normalizeRiskLevel(transaction) {
   if (!transaction) {
@@ -357,6 +357,7 @@ export const methods = {
            * @param {object} options.shopId the shopId
            * @todo Consider abstracting the application fee out of the Stripe implementation, into core payments
            * @returns {number} the application fee after having been through all hooks (must be returned by ever hook)
+           * @private
            */
           const applicationFee = Hooks.Events.run("onCalculateStripeApplicationFee", coreApplicationFee, {
             cart, // The cart

--- a/imports/plugins/included/product-variant/containers/productsContainerAdmin.js
+++ b/imports/plugins/included/product-variant/containers/productsContainerAdmin.js
@@ -22,11 +22,11 @@ Tracker.autorun(() => {
 
 
 /**
- * loadMoreProducts
- * @summary whenever #productScrollLimitLoader becomes visible, retrieve more results
- * this basically runs this:
- * Session.set('productScrollLimit', Session.get('productScrollLimit') + ITEMS_INCREMENT);
+ * This basically runs this:
+ *   Session.set('productScrollLimit', Session.get('productScrollLimit') + ITEMS_INCREMENT);
+ * @summary whenever `#productScrollLimitLoader` becomes visible, retrieve more results.
  * @return {undefined}
+ * @private
  */
 function loadMoreProducts() {
   let threshold;

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -203,10 +203,10 @@ const wrapComponent = (Comp) => (
     }
 
     /**
-     * @method updateInventoryPolicyIfChildVariants
-     * @description update parent inventory policy if variant has children
+     * @summary update parent inventory policy if variant has children
      * @param {Object} variant product or variant document
      * @return {undefined} return nothing
+     * @private
      */
     updateInventoryPolicyIfChildVariants = (variant) => {
       // Get all siblings, including current variant

--- a/imports/plugins/included/search-mongo/lib/collections/schemas/search.js
+++ b/imports/plugins/included/search-mongo/lib/collections/schemas/search.js
@@ -2,6 +2,11 @@ import SimpleSchema from "simpl-schema";
 import { PackageConfig } from "/lib/collections/schemas/registry";
 import { registerSchema } from "@reactioncommerce/schemas";
 
+/**
+ * @name SearchPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const SearchPackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {

--- a/imports/plugins/included/search-mongo/server/hooks/search.js
+++ b/imports/plugins/included/search-mongo/server/hooks/search.js
@@ -60,6 +60,7 @@ Hooks.Events.add("afterUpdateOrderUpdateSearchRecord", (order) => {
 
 /**
  * if product is removed, remove product search record
+ * @private
  */
 Hooks.Events.add("afterRemoveProduct", (doc) => {
   if (ProductSearch && !Meteor.isAppTest && doc.type === "simple") {
@@ -72,8 +73,9 @@ Hooks.Events.add("afterRemoveProduct", (doc) => {
 });
 
 /**
-* after product update rebuild product search record
-*/
+ * after product update rebuild product search record
+ * @private
+ */
 Hooks.Events.add("afterUpdateCatalogProduct", (doc, options) => {
   // Find the most recent version of the product document based on
   // the passed in doc._id
@@ -111,6 +113,7 @@ Hooks.Events.add("afterUpdateCatalogProduct", (doc, options) => {
 /**
  * after insert
  * @summary should fires on create new variants, on clones products/variants
+ * @private
  */
 Hooks.Events.add("afterInsertProduct", (doc) => {
   if (ProductSearch && !Meteor.isAppTest && doc.type === "simple") {

--- a/imports/plugins/included/search-mongo/server/methods/formHandler.js
+++ b/imports/plugins/included/search-mongo/server/methods/formHandler.js
@@ -23,6 +23,7 @@ Meteor.methods({
   /**
    * @name search/updateSearchSettings
    * @method
+   * @memberof Search/Methods
    * @param  {Object} details An object with _id and modifier props
    * @param  {String} [docId] DEPRECATED. The _id, if details is the modifier.
    */

--- a/imports/plugins/included/search-mongo/server/methods/index.js
+++ b/imports/plugins/included/search-mongo/server/methods/index.js
@@ -1,4 +1,8 @@
 import "./searchcollections";
 import "./formHandler";
 
+/**
+ * @namespace Search/Methods
+ */
+
 export * from "./searchcollections";

--- a/imports/plugins/included/search-mongo/server/methods/searchcollections.js
+++ b/imports/plugins/included/search-mongo/server/methods/searchcollections.js
@@ -59,12 +59,12 @@ function getSearchLanguage() {
 }
 
 /**
- * handleIndexUpdateFailures
  * When using Collection.rawCollection() methods that return a Promise,
  * handle the errors in a catch. However, ignore errors with altering indexes
  * before a collection exists.
  * @param  {Error} error an error object returned from a Promise rejection
  * @return {undefined}   doesn't return anything
+ * @private
  */
 function handleIndexUpdateFailures(error) {
   // If we get an error from the Mongo driver because something tried to drop a

--- a/imports/plugins/included/shipping-rates/server/hooks/hooks.js
+++ b/imports/plugins/included/shipping-rates/server/hooks/hooks.js
@@ -14,6 +14,7 @@ import { Cart as CartSchema } from "/lib/collections/schemas";
  * be an updated list of shipping rates, and the second will contain info for
  * retrying this specific package if any errors occurred while retrieving the
  * shipping rates.
+ * @private
  */
 function getShippingRates(previousQueryResults, cart) {
   CartSchema.validate(cart);

--- a/imports/plugins/included/shipping-shippo/lib/collections/schemas/shippo.js
+++ b/imports/plugins/included/shipping-shippo/lib/collections/schemas/shippo.js
@@ -1,6 +1,11 @@
 import { PackageConfig } from "/lib/collections/schemas/registry";
 import { registerSchema } from "@reactioncommerce/schemas";
 
+/**
+ * @name ShippoPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const ShippoPackageConfig = PackageConfig.clone().extend({
   // Remove blackbox: true from settings obj
   "settings": {

--- a/imports/plugins/included/shipping-shippo/server/lib/shippoApiSchema.js
+++ b/imports/plugins/included/shipping-shippo/server/lib/shippoApiSchema.js
@@ -4,6 +4,11 @@ import { check } from "meteor/check";
 import { Tracker } from "meteor/tracker";
 import { registerSchema } from "@reactioncommerce/schemas";
 
+/**
+ * @name addressSchema
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const addressSchema = new SimpleSchema({
   object_purpose: { type: String, allowedValues: ["QUOTE", "PURCHASE"] },
   name: { type: String, optional: true },
@@ -24,9 +29,14 @@ export const addressSchema = new SimpleSchema({
 
 registerSchema("addressSchema", addressSchema);
 
-// Overrides the properties required for purchasing labels/shipping.
-// we don't override the purpose because for some cases like getRatesForCart we don't want to
-// purchase Labels(purpose="QUOTE" but we want all the fields required for purchasing to be present.
+/**
+ * We don't override the purpose because for some cases like getRatesForCart we don't want to
+ * purchase Labels(purpose="QUOTE" but we want all the fields required for purchasing to be present.
+ * @name purchaseAddressSchema
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @summary Overrides the properties required for purchasing labels/shipping
+ */
 export const purchaseAddressSchema = addressSchema.clone().extend({
   name: String,
   street1: String,
@@ -43,6 +53,11 @@ export const purchaseAddressSchema = addressSchema.clone().extend({
 
 registerSchema("purchaseAddressSchema", purchaseAddressSchema);
 
+/**
+ * @name parcelSchema
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const parcelSchema = new SimpleSchema({
   length: { type: Number, min: 0.0001 },
   width: { type: Number, min: 0.0001 },

--- a/imports/plugins/included/sms/server/methods/sms.js
+++ b/imports/plugins/included/sms/server/methods/sms.js
@@ -21,16 +21,14 @@ async function lazyLoadNexmo() {
 }
 
 /**
- * @file Meteor methods for SMS. Run these methods using `Meteor.call()`.
- *
- *
- * @namespace Methods/SMS
-*/
+ * Meteor methods for SMS. Run these methods using `Meteor.call()`
+ * @namespace SMS/Methods
+ */
 Meteor.methods({
   /**
    * @name sms/saveSettings
    * @method
-   * @memberof Methods/SMS
+   * @memberof SMS/Methods
    * @summary This save the sms provider settings
    * @param {Object} settings - settings
    * @return {object} returns result
@@ -51,7 +49,7 @@ Meteor.methods({
   /**
    * @name sms/send
    * @method
-   * @memberof Methods/SMS
+   * @memberof SMS/Methods
    * @summary This send the sms to the user
    * @param {String} message - The message to send
    * @param {String} userId - The user to receive the message

--- a/imports/plugins/included/taxes-avalara/client/accounts/exemption.js
+++ b/imports/plugins/included/taxes-avalara/client/accounts/exemption.js
@@ -103,6 +103,7 @@ AutoForm.addHooks(null, {
  * @summary Checks if customerUsageType is set to "custom"
  * @param {String} formId - Id of the Autoform instance..
  * @returns {boolean} - true if Custom Entity Type is set
+ * @private
  */
 function isCustomValue(formId) {
   const formData = AutoForm.getFormValues(formId);

--- a/imports/plugins/included/taxes-avalara/lib/collections/schemas/schema.js
+++ b/imports/plugins/included/taxes-avalara/lib/collections/schemas/schema.js
@@ -3,9 +3,10 @@ import { TaxPackageConfig } from "/imports/plugins/core/taxes/lib/collections/sc
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* TaxPackageConfig Schema
-*/
-
+ * @name AvalaraPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const AvalaraPackageConfig = TaxPackageConfig.clone().extend({
   "settings.avalara": {
     type: Object,

--- a/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
+++ b/imports/plugins/included/taxes-avalara/server/hooks/hooks.js
@@ -17,9 +17,9 @@ function linesToTaxes(lines) {
 }
 /**
  * @method markCartTax
- * @summary Calls the method accounts/markTaxCalculationFailed
- * through meteor.
+ * @summary Calls the method accounts/markTaxCalculationFailed through Meteor.
  * @param {Boolean} value - the value to be set
+ * @private
  */
 function markCartTax(value = true) {
   Meteor.call("accounts/markTaxCalculationFailed", value, (error) => {

--- a/imports/plugins/included/taxes-avalara/server/jobs/cleanup.js
+++ b/imports/plugins/included/taxes-avalara/server/jobs/cleanup.js
@@ -14,6 +14,7 @@ async function lazyLoadMoment() {
  * @summary Remove logs older than the configured number of days
  * @param {Function} callback - function to call when process complete
  * @returns {Number} results of remmoval query
+ * @private
  */
 function cleanupAvalaraJobs(callback) {
   Promise.await(lazyLoadMoment());

--- a/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
+++ b/imports/plugins/included/taxes-avalara/server/methods/taxCalc.js
@@ -20,7 +20,7 @@ const errorDetails = new SimpleSchema({
   }
 });
 
-  // Validate that whenever we return an error we return the same format
+// Validate that whenever we return an error, we return the same format
 const ErrorObject = new SimpleSchema({
   "type": {
     type: String
@@ -58,6 +58,7 @@ taxCalc.getPackageData = function () {
 /**
  * @summary Get the root URL for REST calls
  * @returns {String} Base url
+ * @private
  */
 function getUrl() {
   const packageData = taxCalc.getPackageData();
@@ -75,6 +76,7 @@ function getUrl() {
  * @summary Verify that we have all required configuration data before attempting to use the API
  * @param {Object} packageData - Package data retrieved from the database
  * @returns {boolean} - isValid Is the current configuration valid
+ * @private
  */
 function checkConfiguration(packageData = taxCalc.getPackageData()) {
   let isValid = true;
@@ -97,6 +99,7 @@ function checkConfiguration(packageData = taxCalc.getPackageData()) {
  * @summary Get the auth info to authenticate to REST API
  * @param {Object} packageData - Optionally pass in packageData if we already have it
  * @returns {String} Username/Password string
+ * @private
  */
 function getAuthData(packageData = taxCalc.getPackageData()) {
   if (checkConfiguration(packageData)) {
@@ -111,6 +114,7 @@ function getAuthData(packageData = taxCalc.getPackageData()) {
  * @summary Get exempt tax settings to pass to REST API
  * @param {String} userId id of user to find settings
  * @returns {Object} containing exemptCode and customerUsageType
+ * @private
  */
 function getTaxSettings(userId) {
   return _.get(Accounts.findOne({ _id: userId }), "taxSettings");
@@ -120,6 +124,7 @@ function getTaxSettings(userId) {
  * @summary: Break Avalara error object into consistent format
  * @param {Object} error The error result from Avalara
  * @returns {Object} Error object with code and errorDetails
+ * @private
  */
 function parseError(error) {
   let errorData;
@@ -171,6 +176,7 @@ function parseError(error) {
  * @param {Object} options - An object of other options
  * @param {Boolean} testCredentials - determines skipping of configuration check
  * @returns {Object} Response from call
+ * @private
  */
 function avaGet(requestUrl, options = {}, testCredentials = true) {
   const logObject = {};
@@ -226,6 +232,7 @@ function avaGet(requestUrl, options = {}, testCredentials = true) {
  * @param {String} requestUrl - The URL to make the request to
  * @param {Object} options - An object of others options, usually data
  * @returns {Object} Response from call
+ * @private
  */
 function avaPost(requestUrl, options) {
   const logObject = {};
@@ -282,6 +289,13 @@ function avaPost(requestUrl, options) {
 }
 
 /**
+ * @namespace Taxes/Avalara/Methods
+ */
+
+/**
+ * @name avalara/getEntityCodes
+ * @method
+ * @memberof Taxes/Avalara/Methods
  * @summary Gets the full list of Avalara-supported entity use codes.
  * @returns {Object[]} API response
  */
@@ -300,9 +314,10 @@ taxCalc.getEntityCodes = function () {
   throw new Meteor.Error("bad-configuration", "Avalara package is enabled, but is not properly configured");
 };
 
-// API Methods
-
 /**
+ * @name avalara/calcTaxable
+ * @method
+ * @memberof Taxes/Avalara/Methods
  * @summary Calculate the taxable subtotal for a cart
  * @param {Cart} cart - Cart to calculate subtotal for
  * @returns {Number} Taxable subtotal
@@ -318,6 +333,9 @@ taxCalc.calcTaxable = function (cart) {
 };
 
 /**
+ * @name avalara/addressValidation
+ * @method
+ * @memberof Taxes/Avalara/Methods
  * @summary Validate a particular address
  * @param {Object} address Address to validate
  * @returns {Object} The validated result
@@ -396,6 +414,9 @@ taxCalc.validateAddress = function (address) {
 };
 
 /**
+ * @name avalara/testCredentials
+ * @method
+ * @memberof Taxes/Avalara/Methods
  * @summary Tests supplied Avalara credentials by calling company endpoint
  * @param {Object} credentials callback Callback function for asynchronous execution
  * @param {Boolean} testCredentials To be set as false so avaGet skips config check
@@ -439,6 +460,9 @@ taxCalc.testCredentials = function (credentials, testCredentials = false) {
 };
 
 /**
+ * @name avalara/getTaxCodes
+ * @method
+ * @memberof Taxes/Avalara/Methods
  * @summary get Avalara Tax Codes
  * @returns {Array} An array of Tax code objects
  */
@@ -456,6 +480,7 @@ taxCalc.getTaxCodes = function () {
  * @summary Translate RC cart into format for submission
  * @param {Object} cart RC cart to send for tax estimate
  * @returns {Object} SalesOrder in Avalara format
+ * @private
  */
 function cartToSalesOrder(cart) {
   const pkgData = taxCalc.getPackageData();
@@ -534,6 +559,9 @@ function cartToSalesOrder(cart) {
 }
 
 /**
+ * @name avalara/estimateCart
+ * @method
+ * @memberof Taxes/Avalara/Methods
  * @summary Submit cart for tax calculation
  * @param {Cart} cart Cart object for estimation
  * @param {Function} callback callback when using async version
@@ -564,6 +592,7 @@ taxCalc.estimateCart = function (cart, callback) {
  * @summary Translate RC order into format for final submission
  * @param {Object} order RC order to send for tax reporting
  * @returns {Object} SalesOrder in Avalara format
+ * @private
  */
 function orderToSalesInvoice(order) {
   let documentType;
@@ -646,6 +675,9 @@ function orderToSalesInvoice(order) {
 }
 
 /**
+ * @name avalara/recordOrder
+ * @method
+ * @memberof Taxes/Avalara/Methods
  * @summary Submit order for tax reporting
  * @param {Order} order Order object for submission
  * @param {Function} callback callback when using async version
@@ -669,6 +701,9 @@ taxCalc.recordOrder = function (order, callback) {
 };
 
 /**
+ * @name avalara/reportRefund
+ * @method
+ * @memberof Taxes/Avalara/Methods
  * @summary Report refund to Avalara
  * @param {Order} order - The original order the refund was against
  * @param {Number} refundAmount - Amount to be refunded

--- a/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
+++ b/imports/plugins/included/taxes-taxcloud/client/settings/taxcloud.js
@@ -3,11 +3,10 @@ import { TaxCloudSettingsFormContainer } from "../containers";
 
 Template.taxCloudSettings.helpers({
   /**
-   * @method taxCloudForm
-   * @summary returns a component for updating the TaxCloud settings for
-   * this app.
+   * @summary returns a component for updating the TaxCloud settings for this app.
    * @since 1.5.2
    * @return {Object} - an object containing the component to render.
+   * @ignore
    */
   taxCloudForm() {
     return { component: TaxCloudSettingsFormContainer };

--- a/imports/plugins/included/taxes-taxcloud/lib/collections/schemas/schema.js
+++ b/imports/plugins/included/taxes-taxcloud/lib/collections/schemas/schema.js
@@ -2,9 +2,10 @@ import { TaxPackageConfig } from "/imports/plugins/core/taxes/lib/collections/sc
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* TaxPackageConfig Schema
-*/
-
+ * @name TaxCloudPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const TaxCloudPackageConfig = TaxPackageConfig.clone().extend({
   "settings.taxcloud": {
     type: Object,

--- a/imports/plugins/included/taxes-taxcloud/server/methods/methods.js
+++ b/imports/plugins/included/taxes-taxcloud/server/methods/methods.js
@@ -1,13 +1,19 @@
 import { Meteor } from "meteor/meteor";
 import { HTTP } from "meteor/http";
 
+/**
+ * Meteor methods for TaxCloud. Run these methods using `Meteor.call()`
+ * @namespace TaxCloud/Methods
+ */
+
 Meteor.methods({
   /**
-   * We're using https://taxcloud.net
-   * just to get an intial import data set
-   * this service doesn't require taxcloud id
-   * but other services need authorization
-   * use TAXCODE_SRC  to override source url
+   * We're using https://taxcloud.net just to get an intial import data set
+   * this service doesn't require taxcloud id but other services need authorization
+   * use TAXCODE_SRC to override source url
+   * @name taxcloud/getTaxCodes
+   * @method
+   * @memberof TaxCloud/Methods
    * @returns {Array} An array of Tax code objects
    */
   "taxcloud/getTaxCodes"() {

--- a/imports/plugins/included/taxes-taxjar/lib/collections/schemas/schema.js
+++ b/imports/plugins/included/taxes-taxjar/lib/collections/schemas/schema.js
@@ -2,9 +2,10 @@ import { TaxPackageConfig } from "/imports/plugins/core/taxes/lib/collections/sc
 import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
-* TaxPackageConfig Schema
-*/
-
+ * @name TaxJarPackageConfig
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const TaxJarPackageConfig = TaxPackageConfig.clone().extend({
   "settings.taxjar": {
     type: Object,

--- a/imports/test-utils/helpers/getFakeMongoCursor.js
+++ b/imports/test-utils/helpers/getFakeMongoCursor.js
@@ -1,5 +1,12 @@
 /**
+ * Helper functions for use in Jest tests
+ * @namespace TestHelpers
+ */
+
+/**
  * @name getFakeMongoCursor
+ * @method
+ * @memberof TestHelpers
  * @param {String} collectionName - name of the collection
  * @param {Any} results - results to be returned as part of the cursor
  * @return {Object} fake cursor

--- a/lib/api/account-validation.js
+++ b/lib/api/account-validation.js
@@ -7,14 +7,14 @@ import { check, Match } from "meteor/check";
  * `Meteor.call()` or `LoginFormValidation.method`.
  * @example LoginFormValidation.password(password, { validationLevel: "exists" })
  * @example Meteor.call("accounts/validation/email", newEmail, false, (result, error))
- * @namespace Methods/Accounts/Validation
+ * @namespace Accounts/Methods/Validation
  */
 
 const validationMethods = {
   /**
    * @name accounts/validation/username
    * @method
-   * @memberof Methods/Accounts/Validation
+   * @memberof Accounts/Methods/Validation
    * @summary Determines if a username meets the minimum requirement of 3 characters
    * @param  {String} username Username to validate
    * @return {Boolean|Object} true if valid, error object if invalid
@@ -38,7 +38,7 @@ const validationMethods = {
   /**
    * @name accounts/validation/email
    * @method
-   * @memberof Methods/Accounts/Validation
+   * @memberof Accounts/Methods/Validation
    * @summary Validates both required and optional email addresses.
    * @example LoginFormValidation.email(emailAddress)
    * @example Meteor.call("accounts/validation/email", newEmail, false, callbackFunction())
@@ -70,7 +70,7 @@ const validationMethods = {
   /**
    * @name accounts/validation/password
    * @method
-   * @memberof Methods/Accounts/Validation
+   * @memberof Accounts/Methods/Validation
    * @summary Passwords may be validated 2 ways.
    * 1. "exists" `(options.validationLevel = "exists")` - Password must not be blank.
    * Thats is the only rule. Used to validate a sign in.

--- a/lib/api/core.js
+++ b/lib/api/core.js
@@ -105,11 +105,11 @@ function getSellerShop(user, noFallback = false) {
 }
 
 /**
-  * getShopsForUser -
   * @summary gets shopIds of shops where user has provided permissions
   * @param {Array} roles - roles to check if user has
   * @param {Object} userId - userId to check permissions for (defaults to current user)
   * @return {Array} - shopIds user has provided permissions for
+  * @private
   */
 function getShopsForUser(roles, userId = Meteor.userId()) {
   // Get full user object, and get shopIds of all shops they are attached to
@@ -141,12 +141,12 @@ function getShopsForUser(roles, userId = Meteor.userId()) {
 }
 
 /**
-  * hasPermissionForAll -
   * @summary return if the user has permissions for all the shops
   * @param {Array} roles - roles to check if user has
   * @param {String} userId - userId to check permissions for (defaults to current user)
   * @param {Array} shopsOfUser - shopIds to be checked
   * @return {Boolean} - true if the user has permissions for all the shops
+  * @private
   */
 function hasPermissionForAll(roles, userId = Meteor.userId(), shopsOfUser) {
   return !isEqual(getShopsForUser(["admin"], userId), shopsOfUser);

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -81,7 +81,9 @@ export function getPrimaryShopId() {
 }
 
 /**
- * getShopSettings
+ * @name getShopSettings
+ * @method
+ * @memberof Helpers
  * @return {Object} returns current shop settings
  */
 export function getShopSettings() {
@@ -340,7 +342,7 @@ export function mergeDeep(target, source) {
 /**
  * @name convertWeight
  * @method
- * @memberOf Helpers
+ * @memberof Helpers
  * @summary Convert weight from/to different Units of Measure
  * @param {String} from The UOM to convert from
  * @param {String} to The UOM to convert to
@@ -424,6 +426,8 @@ export function convertWeight(from, to, weight) {
 
 /**
  * @name getPrimaryMediaForItem
+ * @method
+ * @memberof Helpers
  * @summary Gets the FileRecord for the primary media item associated with the variant or product
  *   for the given item
  * @param {Object} item Must have `productId` and/or `variantId` set to get back a result.
@@ -449,6 +453,8 @@ export function getPrimaryMediaForItem({ productId, variantId } = {}) {
 
 /**
  * @name getPrimaryMediaForOrderItem
+ * @method
+ * @memberof Helpers
  * @summary Gets the FileRecord for the primary media item associated with the variant or product
  *   for the given item
  * @param {Object} item Must have `productId` and/or `variants._id` set to get back a result.
@@ -459,13 +465,14 @@ export function getPrimaryMediaForOrderItem({ productId, variants } = {}) {
   return getPrimaryMediaForItem({ productId, variantId });
 }
 
-/*
+/**
  * @name luhnValid
  * @method
- * @memberOf Helpers
+ * @memberof Helpers
  * @summary Checks if a number passes Luhn's test
  * @param {String} cardNumber The card number to check
  * @returns {Boolean} The result of the test
+ * @private
  */
 function luhnValid(cardNumber) {
   return [...cardNumber].reverse().reduce((sum, c, i) => {

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -383,7 +383,6 @@ ReactionProduct.getSiblings = (variant, type) => Catalog.getSiblings(variant, ty
 
 /**
  * @method getVariantParent
- * @method
  * @memberof ReactionProduct
  * @summary Get direct parent variant - could be useful for lower level variants to get direct parents
  * @param {Object} [variant] - product / variant object
@@ -393,6 +392,7 @@ ReactionProduct.getVariantParent = (variant) => Catalog.getVariantParent(variant
 
 /**
  * @method getTopVariants
+ * @memberof ReactionProduct
  * @summary Get only product top level variants
  * @param {String} [id] - product _id
  * @return {Array} Product top level variants or empty array
@@ -518,6 +518,7 @@ ReactionProduct.toggleVisibility = function (productOrArray) {
  * A reactive data source that tells any dependents that they should resubscribe their
  * active publication.
  * @type {ReactiveVar}
+ * @ignore
  */
 export const resubscribeAfterCloning = new ReactiveVar(false);
 

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -5,6 +5,27 @@ import * as Schemas from "./schemas";
 import { cartOrderTransform } from "./transform/cartOrder";
 
 /**
+ * Meteor Mongo.Collection instance
+ * @typedef MongoCollection
+ * @type {Object}
+ */
+
+/**
+ * Meteor Mongo.Collection instances that are available in both Node and browser code
+ * @namespace Collections
+ */
+
+/**
+ * Meteor Mongo.Collection instances that are available only in Node code
+ * @namespace Collections/ServerOnly
+ */
+
+/**
+ * Meteor Mongo.Collection instances that are available only in browser code
+ * @namespace Collections/ClientOnly
+ */
+
+/**
  * @name mediaRecordsIndex
  * @private
  * @param {RawMongoCollection} rawMedia
@@ -26,14 +47,9 @@ async function mediaRecordsIndex(rawMedia) {
 }
 
 /**
- *
- * Reaction Core Collections
- * @ignore
- */
-
-/**
- * Accounts Collection
- * @ignore
+ * @name Accounts
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Accounts = new Mongo.Collection("Accounts");
 
@@ -41,9 +57,9 @@ Accounts.attachSchema(Schemas.Accounts);
 
 
 /**
- * Assets Collection
- * Store file asset paths or contents in a Collection
- * @ignore
+ * @name Assets
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Assets = new Mongo.Collection("Assets");
 
@@ -51,8 +67,9 @@ Assets.attachSchema(Schemas.Assets);
 
 
 /**
- * Cart Collection
- * @ignore
+ * @name Cart
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Cart = new Mongo.Collection("Cart", {
   transform(cart) {
@@ -65,8 +82,9 @@ Cart.attachSchema(Schemas.Cart);
 
 
 /**
- * Emails Collection
- * @ignore
+ * @name Emails
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Emails = new Mongo.Collection("Emails");
 
@@ -74,8 +92,9 @@ Emails.attachSchema(Schemas.Emails);
 
 
 /**
- * Inventory Collection
- * @ignore
+ * @name Inventory
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Inventory = new Mongo.Collection("Inventory");
 
@@ -83,8 +102,9 @@ Inventory.attachSchema(Schemas.Inventory);
 
 
 /**
- * Orders Collection
- * @ignore
+ * @name Orders
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Orders = new Mongo.Collection("Orders", {
   transform(order) {
@@ -96,23 +116,25 @@ export const Orders = new Mongo.Collection("Orders", {
 Orders.attachSchema(Schemas.OrderDocument);
 
 /**
- * Packages Collection
- * @ignore
+ * @name Packages
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Packages = new Mongo.Collection("Packages");
 
 Packages.attachSchema(Schemas.PackageConfig);
 
 /**
- * Catalog Collection
- * @todo: Attach a schema to the Catalog collection
- * @ignore
+ * @name Catalog
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Catalog = new Mongo.Collection("Catalog");
 
 /**
- * Products Collection
- * @ignore
+ * @name Products
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Products = new Mongo.Collection("Products");
 
@@ -120,40 +142,45 @@ Products.attachSchema(Schemas.Product, { selector: { type: "simple" } });
 Products.attachSchema(Schemas.ProductVariant, { selector: { type: "variant" } });
 
 /**
- * Revisions Collection
- * @ignore
+ * @name Revisions
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Revisions = new Mongo.Collection("Revisions");
 
 Revisions.attachSchema(Schemas.Revisions);
 
 /**
- * Shipping Collection
- * @ignore
+ * @name Shipping
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Shipping = new Mongo.Collection("Shipping");
 
 Shipping.attachSchema(Schemas.Shipping);
 
 /**
-* Shops Collection
-* @ignore
-*/
+ * @name Shops
+ * @memberof Collections
+ * @type {MongoCollection}
+ */
 export const Shops = new Mongo.Collection("Shops");
 
 Shops.attachSchema(Schemas.Shop);
 
 /**
- * Groups Collection
- * @ignore
+ * @name Groups
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Groups = new Mongo.Collection("Groups");
 
 Groups.attachSchema(Schemas.Groups);
 
 /**
- * SellerShops Collection (client-only)
- * @ignore
+ * @name SellerShops
+ * @memberof Collections/ClientOnly
+ * @type {MongoCollection}
  */
 let sellerShops;
 if (Meteor.isClient) {
@@ -164,16 +191,18 @@ if (Meteor.isClient) {
 export const SellerShops = sellerShops;
 
 /**
- * Tags Collection
- * @ignore
+ * @name Tags
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Tags = new Mongo.Collection("Tags");
 
 Tags.attachSchema(Schemas.Tag);
 
 /**
- * Templates Collection
- * @ignore
+ * @name Templates
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Templates = new Mongo.Collection("Templates");
 
@@ -182,16 +211,18 @@ Templates.attachSchema(Schemas.ReactLayout, { selector: { type: "react" } });
 
 
 /**
- * Translations Collection
- * @ignore
+ * @name Translations
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Translations = new Mongo.Collection("Translations");
 
 Translations.attachSchema(Schemas.Translation);
 
 /**
- * Notifications Collection
- * @ignore
+ * @name Notifications
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Notifications = new Mongo.Collection("Notifications");
 
@@ -199,8 +230,9 @@ Notifications.attachSchema(Schemas.Notification);
 
 
 /**
- * Sms Collection
- * @ignore
+ * @name Sms
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Sms = new Mongo.Collection("Sms");
 
@@ -208,16 +240,18 @@ Sms.attachSchema(Schemas.Sms);
 
 
 /**
- * Logs Collection
- * @ignore
+ * @name Logs
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const Logs = new Mongo.Collection("Logs");
 
 Logs.attachSchema(Schemas.Logs);
 
 /**
- * MediaRecords Collection
- * @ignore
+ * @name MediaRecords
+ * @memberof Collections
+ * @type {MongoCollection}
  */
 export const MediaRecords = new Mongo.Collection("cfs.Media.filerecord");
 

--- a/lib/collections/schemas/accounts.js
+++ b/lib/collections/schemas/accounts.js
@@ -7,20 +7,8 @@ import { Address } from "./address";
 import { Metafield } from "./metafield";
 
 /**
- * @typedef {SimpleSchema} SimpleSchema
- * @summary SimpleSchema for Collections - Reaction uses {@link https://github.com/aldeed/meteor-simple-schema SimpleSchema} to apply basic content and structure validation to Collections. See {@link https://docs.reactioncommerce.com/reaction-docs/master/simple-schema full documentation}.
- */
-
-/**
- * @file Reaction Core schemas
- * Reaction uses {@link https://github.com/aldeed/meteor-simple-schema SimpleSchema} to apply basic content and structure validation to Collections.
- * See {@link https://docs.reactioncommerce.com/reaction-docs/master/simple-schema full documentation}.
- * @namespace schemas
- */
-
-/**
  * @name TaxSettings
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} exemptionNo optional
  * @property {String} customerUsageType optional
@@ -40,7 +28,7 @@ registerSchema("TaxSettings", TaxSettings);
 
 /**
  * @name Profile
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {Address[]} addressBook optional, array of Addresses
  * @property {Boolean} invited optional
@@ -96,7 +84,7 @@ registerSchema("Profile", Profile);
 
 /**
  * @name Email
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} provides optional
  * @property {String} address required
@@ -123,7 +111,7 @@ registerSchema("Email", Email);
 
 /**
  * @name Accounts
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} userId required
  * @property {String[]} sessions optional, Array of strings

--- a/lib/collections/schemas/address.js
+++ b/lib/collections/schemas/address.js
@@ -15,7 +15,7 @@ const withoutCodeCountries = ["AO", "AG", "AW", "BS", "BZ", "BJ", "BW",
 
 /**
  * @name Address
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id
  * @property {String} fullName required

--- a/lib/collections/schemas/assets.js
+++ b/lib/collections/schemas/assets.js
@@ -5,7 +5,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name Assets
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} type required
  * @property {String} name optional

--- a/lib/collections/schemas/cart.js
+++ b/lib/collections/schemas/cart.js
@@ -11,7 +11,7 @@ import { Metafield } from "./metafield";
 
 /**
  * @name CartItem
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id required
  * @property {String} productId required
@@ -104,7 +104,7 @@ registerSchema("CartItem", CartItem);
 
 /**
  * @name CartItems
- * @memberof schemas
+ * @memberof Schemas
  * @summary Used in check by inventory/addReserve method
  * @type {SimpleSchema}
  * @property {CartItem[]} items an Array of CartItem optional
@@ -123,7 +123,7 @@ registerSchema("CartItems", CartItems);
 
 /**
  * @name Cart
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id required for check of users' carts
  * @property {String} shopId required, Cart ShopId

--- a/lib/collections/schemas/catalog.js
+++ b/lib/collections/schemas/catalog.js
@@ -1,5 +1,10 @@
 import SimpleSchema from "simpl-schema";
 
+/**
+ * @name Catalog
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ */
 export const Catalog = new SimpleSchema({
   contentType: {
     type: String

--- a/lib/collections/schemas/emails.js
+++ b/lib/collections/schemas/emails.js
@@ -6,7 +6,7 @@ import { createdAtAutoValue, updatedAtAutoValue } from "./helpers";
 
 /**
  * @name Emails
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} to required
  * @property {String} from required

--- a/lib/collections/schemas/event.js
+++ b/lib/collections/schemas/event.js
@@ -5,7 +5,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name Event for EventLog
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} title Event title required
  * @property {String} type Event type required

--- a/lib/collections/schemas/groups.js
+++ b/lib/collections/schemas/groups.js
@@ -6,7 +6,7 @@ import { createdAtAutoValue, updatedAtAutoValue } from "./helpers";
 
 /**
  * @name Group
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} name required
  * @property {String} description optional

--- a/lib/collections/schemas/helpers.js
+++ b/lib/collections/schemas/helpers.js
@@ -5,7 +5,7 @@ import { Shops } from "/lib/collections";
 
 /**
  * @name createdAtAutoValue
- * @memberof schemas
+ * @memberof Schemas
  * @method
  * @summary Helper method used for schema injection autoValue
  * @example autoValue: createdAtAutoValue
@@ -23,7 +23,7 @@ export function createdAtAutoValue() {
 
 /**
  * @name updatedAtAutoValue
- * @memberof schemas
+ * @memberof Schemas
  * @method
  * @summary Helper method used for schema injection autoValue
  * @example autoValue: updatedAtAutoValue
@@ -39,7 +39,7 @@ export function updatedAtAutoValue() {
 
 /**
  * @name shopIdAutoValue
- * @memberof schemas
+ * @memberof Schemas
  * @method
  * @summary Helper method used for schema injection autoValue
  * @example autoValue: shopIdAutoValue
@@ -57,7 +57,7 @@ export function shopIdAutoValue() {
 
 /**
  * @name shopIdAutoValueForCart
- * @memberof schemas
+ * @memberof Schemas
  * @method
  * @summary Helper method copy of shopIdAutoValue with modification for Cart
  * @example autoValue: shopIdAutoValue
@@ -81,7 +81,7 @@ export function shopIdAutoValueForCart() {
 
 /**
  * @name schemaIdAutoValue
- * @memberof schemas
+ * @memberof Schemas
  * @method
  * @summary Helper method used for schema injection autoValue
  * @example autoValue: schemaIdAutoValue
@@ -99,7 +99,7 @@ export function schemaIdAutoValue() {
 
 /**
  * @name shopDefaultCountry
- * @memberof schemas
+ * @memberof Schemas
  * @method
  * @summary Helper method used for schema injection autoValue
  * @example autoValue: shopDefaultCountry

--- a/lib/collections/schemas/index.js
+++ b/lib/collections/schemas/index.js
@@ -1,3 +1,17 @@
+/**
+ * Reaction uses {@link https://github.com/aldeed/simple-schema-js SimpleSchema} to apply basic content and structure validation to Collections.
+ * See {@link https://docs.reactioncommerce.com/reaction-docs/master/simple-schema full documentation}.
+ * @typedef {SimpleSchema} SimpleSchema
+ * @summary SimpleSchema for Collections
+ * @namespace Schemas
+ */
+
+/**
+ * Reaction uses {@link https://github.com/aldeed/simple-schema-js SimpleSchema} to apply basic content and structure validation to Collections.
+ * See {@link https://docs.reactioncommerce.com/reaction-docs/master/simple-schema full documentation}.
+ * @namespace Schemas
+ */
+
 export * from "./accounts";
 export * from "./address";
 export * from "./assets";

--- a/lib/collections/schemas/inventory.js
+++ b/lib/collections/schemas/inventory.js
@@ -9,7 +9,7 @@ import { Workflow } from "./workflow";
 
 /**
  * @name Inventory
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id optional, inserted by Mongo, we need it for schema validation
  * @property {String} shopId required, Inventory shopId

--- a/lib/collections/schemas/layouts.js
+++ b/lib/collections/schemas/layouts.js
@@ -5,7 +5,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name LayoutStructure
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary Layout are used by the Shops and Packages schemas.
  * Layouts are used to in two ways: 1) Define the template layout on the site
@@ -67,7 +67,7 @@ registerSchema("LayoutStructure", LayoutStructure);
 
 /**
  * @name Layout
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary Layout are used by the Shops and Packages schemas.
  * Read more about Layouts in {@link https://docs.reactioncommerce.com/reaction-docs/master/layout documentation}

--- a/lib/collections/schemas/logs.js
+++ b/lib/collections/schemas/logs.js
@@ -6,7 +6,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
 /**
  * @name Logs
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} logType required
  * @property {String} shopId required
  * @property {String} level default: `"info"`, allowed: `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`, `"fatal"`

--- a/lib/collections/schemas/metafield.js
+++ b/lib/collections/schemas/metafield.js
@@ -5,7 +5,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name Metafield
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} key optional
  * @property {String} namespace optional

--- a/lib/collections/schemas/notifications.js
+++ b/lib/collections/schemas/notifications.js
@@ -5,7 +5,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name Notification
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary Notification sends messages corresponding to the type:
  * - `orderCanceled`  : "Your order was canceled."

--- a/lib/collections/schemas/orders.js
+++ b/lib/collections/schemas/orders.js
@@ -8,7 +8,7 @@ import { Workflow } from "./workflow";
 
 /**
  * @name Document
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} docId required
  * @property {String} docType optional
@@ -27,7 +27,7 @@ registerSchema("Document", Document);
 
 /**
  * @name History
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} event required
  * @property {String} value required
@@ -53,7 +53,7 @@ registerSchema("History", History);
 
 /**
  * @name ExportHistory
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} required Whether the export attempt succeeded or failed
  * @property {Date} required Date the export was attempted
@@ -84,7 +84,7 @@ registerSchema("ExportHistory", ExportHistory);
 
 /**
  * @name Notes
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} content required
  * @property {String} userId required
@@ -106,7 +106,7 @@ registerSchema("Notes", Notes);
 
 /**
  * @name OrderItem
- * @memberof schemas
+ * @memberof Schemas
  * @summary CartItem + some additional properties
  * @type {SimpleSchema}
  * @property {String} additionalField optional
@@ -144,7 +144,7 @@ registerSchema("OrderItem", OrderItem);
 
 /**
  * @name OrderTransaction Schema
- * @memberof schemas
+ * @memberof Schemas
  * @summary Order transactions tie Shipping, Payment, and Inventory transactions
  * @type {SimpleSchema}
  * @property {String} itemId optional
@@ -180,7 +180,7 @@ registerSchema("OrderTransaction", OrderTransaction);
 
 /**
  * @name Order Schema
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary Order ties a User to a Cart and an array of History, Documents, Notes, Items and OrderTransactions.
  * @property {String} userId required

--- a/lib/collections/schemas/payments.js
+++ b/lib/collections/schemas/payments.js
@@ -11,7 +11,7 @@ import { Workflow } from "./workflow";
  * @summary Schema for items we're inserting into our Payments
  * To keep track of what items were paid for with a given paymentMethod
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} _id optional, Shipment Line Item
  * @property {String} productId required
  * @property {String} shopId optional, Shipment Item ShopId
@@ -50,7 +50,7 @@ registerSchema("PaymentItem", PaymentItem);
 /**
  * @name PaymentMethod
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} processor required
  * @property {String} paymentPackageId required
  * @property {String} paymentSettingsKey required
@@ -171,7 +171,7 @@ export const PaymentMethodArgument = PaymentMethod.clone().extend({
 /**
  * @name Invoice
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} transaction optional
  * @property {Number} shipping optional
  * @property {Number} taxes optional
@@ -209,7 +209,7 @@ registerSchema("Invoice", Invoice);
 /**
  * @name CurrencyExchangeRate
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} userCurrency, default value: `"USD"`
  * @property {Number} exchangeRate optional
  */
@@ -230,7 +230,7 @@ registerSchema("CurrencyExchangeRate", CurrencyExchangeRate);
 /**
  * @name Payment
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} _id required, Payment Id
  * @property {Address} address optional
  * @property {PaymentMethod} paymentMethod optional
@@ -273,7 +273,7 @@ registerSchema("Payment", Payment);
 /**
  * @name Payment
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} type required
  * @property {Number} amount required
  * @property {Number} created required

--- a/lib/collections/schemas/products.js
+++ b/lib/collections/schemas/products.js
@@ -13,7 +13,7 @@ import { Workflow } from "./workflow";
 
 /**
  * @name VariantMedia
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} mediaId optional
  * @property {Number} priority optional
@@ -51,7 +51,7 @@ registerSchema("VariantMedia", VariantMedia);
 
 /**
  * @name ProductPosition
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} tag optional
  * @property {Number} position optional
@@ -88,7 +88,7 @@ registerSchema("ProductPosition", ProductPosition);
 
 /**
  * @name ProductVariant
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id required, Variant ID
  * @property {String[]} ancestors, default value: `[]`
@@ -368,7 +368,7 @@ registerSchema("ProductVariant", ProductVariant);
 /**
  * @name PriceRange
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} range, default value: `"0.00"`
  * @property {Number} min optional, default value: `0`
  * @property {Number} max optional, default value: `0`
@@ -395,7 +395,7 @@ registerSchema("PriceRange", PriceRange);
 /**
  * @name Product
  * @type {SimpleSchema}
- * @memberof schemas
+ * @memberof Schemas
  * @property {String} _id Product ID
  * @property {String[]} ancestors default value: `[]`
  * @property {String} shopId Product ShopID

--- a/lib/collections/schemas/registry.js
+++ b/lib/collections/schemas/registry.js
@@ -6,7 +6,7 @@ import { Layout } from "./layouts";
 
 /**
  * @name Permissions
- * @memberof schemas
+ * @memberof Schemas
  * @summary The Permissions schema is part of the Registry. The Registry Schema allows package settings to be defined.
  * For more, read the in-depth {@link https://blog.reactioncommerce.com/an-intro-to-architecture-the-registry/ Intro to Architecture: The Registry}.
  * @type {SimpleSchema}
@@ -26,7 +26,7 @@ registerSchema("Permissions", Permissions);
 
 /**
  * @name Registry
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary The Registry Schema allows package settings to be defined. For more, read the in-depth {@link https://blog.reactioncommerce.com/an-intro-to-architecture-the-registry/ Intro to Architecture: The Registry}.
  * @property {String[]} provides Legacy `provides` apps use a String rather than an array. These are transformed in loadPackages.
@@ -174,7 +174,7 @@ registerSchema("Registry", Registry);
 
 /**
  * @name PackageConfig
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary The PackageConfig is part of the configuration settings required for packages in the Registry.
  * The Registry Schema allows package settings to be defined. For more, read the in-depth {@link https://blog.reactioncommerce.com/an-intro-to-architecture-the-registry/ Intro to Architecture: The Registry}.
@@ -233,7 +233,7 @@ registerSchema("PackageConfig", PackageConfig);
 
 /**
  * @name CorePackageConfig
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary The Core Package Config is part of the Registry.
  * The Registry Schema allows package settings to be defined. For more, read the in-depth {@link https://blog.reactioncommerce.com/an-intro-to-architecture-the-registry/ Intro to Architecture: The Registry}.

--- a/lib/collections/schemas/revisions.js
+++ b/lib/collections/schemas/revisions.js
@@ -7,7 +7,7 @@ import { Workflow } from "./workflow";
 
 /**
  * @name Revisions
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id Revision Id
  * @property {Workflow} workflow required

--- a/lib/collections/schemas/shipping.js
+++ b/lib/collections/schemas/shipping.js
@@ -10,7 +10,7 @@ import { Workflow } from "./workflow";
 
 /**
  * @name ShippoShippingMethod
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @todo Move Shippo-related schema to Shippo module
  * @summary This will only exist in ShippingMethods Inside Cart/Order.
@@ -33,7 +33,7 @@ registerSchema("ShippoShippingMethod", ShippoShippingMethod);
 
 /**
  * @name ShippingMethod
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id Shipment method Id
  * @property {String} name Method name
@@ -161,7 +161,7 @@ registerSchema("ShippingMethod", ShippingMethod);
 
 /**
  * @name ShipmentQuote
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} carrier Name of carrier
  * @property {ShippingMethod} method ShippingMethod
@@ -188,7 +188,7 @@ registerSchema("ShipmentQuote", ShipmentQuote);
 
 /**
  * @name ShipmentItem
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary Populate with order.items that are added to a shipment
  * @property {String} _id Shipment Line Item optional
@@ -228,7 +228,7 @@ registerSchema("ShipmentItem", ShipmentItem);
 
 /**
  * @name ShippingParcel
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} containers optional
  * @property {Number} length optional
@@ -264,7 +264,7 @@ registerSchema("ShippingParcel", ShippingParcel);
 /**
  * @name ShippoShipment
  * @summary Specific properties of Shipment for use with Shippo. We don't use
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} transactionId optional
  * @property {String} trackingStatusStatus optional Tracking Status's status
@@ -290,7 +290,7 @@ registerSchema("ShippoShipment", ShippoShipment);
 /**
  * @name ShipmentQuotesQueryStatusUsed
  * @todo Should requestStatus be required or not?
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @summary Status of a query/consumption of a shipping provider's API (e.g Shippo) for shipping quotations.
  * @description Shipping quotations are the costs from different shipping methods like Fedex, DHL etc of
@@ -325,7 +325,7 @@ registerSchema("ShipmentQuotesQueryStatus", ShipmentQuotesQueryStatus);
 /**
  * @name Shipment
  * @summary Used for cart/order shipment tracking
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id Shipment ID
  * @property {String} shopId required
@@ -434,7 +434,7 @@ registerSchema("Shipment", Shipment);
  * @summary Specific properties for use with Shippo.
  * @description We don't use ShippingProvider service* fields because
  * Shippo is on level higher service than simple carrier's ,e.g Fedex api.
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} carrierAccountId optional
  */
@@ -449,7 +449,7 @@ registerSchema("ShippoShippingProvider", ShippoShippingProvider);
 
 /**
  * @name ShippingProvider
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id optional
  * @property {String} name optional
@@ -505,7 +505,7 @@ registerSchema("ShippingProvider", ShippingProvider);
 
 /**
  * @name Shipping
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id optional
  * @property {String} shopId required
@@ -557,8 +557,8 @@ export const Shipping = new SimpleSchema({
 registerSchema("Shipping", Shipping);
 
 /**
- * @name ShippingPackage
- * @memberof schemas
+ * @name ShippingPackageConfig
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} settings.name default value: `Flat Rate Service`
  */

--- a/lib/collections/schemas/shops.js
+++ b/lib/collections/schemas/shops.js
@@ -12,7 +12,7 @@ import { Workflow } from "./workflow";
 
 /**
  * @name CustomEmailSettings
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} service optional
  * @property {String} username optional
@@ -47,7 +47,7 @@ registerSchema("CustomEmailSettings", CustomEmailSettings);
 
 /**
  * @name Currency
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} symbol default value: `$`
  * @property {String} format default value: `%s%v`
@@ -90,7 +90,7 @@ registerSchema("Currency", Currency);
 
 /**
  * @name Locale
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {Object} continents blackbox
  * @property {Object} countries blackbox
@@ -110,7 +110,7 @@ registerSchema("Locale", Locale);
 
 /**
  * @name Languages
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} label required
  * @property {String} i18n required
@@ -133,7 +133,7 @@ registerSchema("Languages", Languages);
 
 /**
  * @name ShopTheme
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} themeId required
  * @property {String} styles optional
@@ -152,7 +152,7 @@ registerSchema("ShopTheme", ShopTheme);
 
 /**
  * @name BrandAsset
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} mediaId optional
  * @property {String} type optional
@@ -172,7 +172,7 @@ registerSchema("BrandAsset", BrandAsset);
 
 /**
  * @name MerchantShop
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id Shop label
  * @property {String} slug Shop slug
@@ -197,7 +197,7 @@ registerSchema("MerchantShop", MerchantShop);
 
 /**
  * @name Shop
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id optional
  * @property {String} slug optional, auto-generated

--- a/lib/collections/schemas/sms.js
+++ b/lib/collections/schemas/sms.js
@@ -5,7 +5,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
 
 /**
  * @name Sms
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} apiKey optional
  * @property {String} apiToken optional

--- a/lib/collections/schemas/social.js
+++ b/lib/collections/schemas/social.js
@@ -6,7 +6,7 @@ import { PackageConfig } from "./registry";
 
 /**
  * @name SocialProvider
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} profilePage optional, Profile Page
  * @property {Boolean} enabled optional, default value: `false`
@@ -30,7 +30,7 @@ registerSchema("SocialProvider", SocialProvider);
 
 /**
  * @name SocialPackageConfig
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @extends {PackageConfig}
  * @property {Object} settings.public optional

--- a/lib/collections/schemas/tags.js
+++ b/lib/collections/schemas/tags.js
@@ -7,7 +7,7 @@ import { Metafield } from "./metafield";
 
 /**
  * @name Tag
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id optional
  * @property {String} name required

--- a/lib/collections/schemas/templates.js
+++ b/lib/collections/schemas/templates.js
@@ -4,24 +4,6 @@ import { Tracker } from "meteor/tracker";
 import { registerSchema } from "@reactioncommerce/schemas";
 import { shopIdAutoValue } from "./helpers";
 
-/**
- * @name sharedFields
- * @memberof schemas
- * @type {SimpleSchema}
- * @property {String} shopId Template ShopId
- * @property {String} name required
- * @property {String} title optional
- * @property {Number} priority optional, default value: 1
- * @property {Boolean} enabled default value: true
- * @property {String} route optional
- * @property {String} type default value: `template`
- * @property {String} provides default value: `template`
- * @property {String} block optional
- * @property {Object} defaultData optional, blackbox
- * @property {String} parser required
- * @property {String} language optional, default value: `en`
- * @property {String} source optional
- */
 const sharedFields = {
   shopId: {
     type: String,
@@ -82,10 +64,21 @@ const sharedFields = {
 
 /**
  * @name ReactLayout
- * @memberof schemas
- * @summary Extends fields from sharedFields
+ * @memberof Schemas
  * @type {SimpleSchema}
- * @extends {sharedFields}
+ * @property {String} shopId Template ShopId
+ * @property {String} name required
+ * @property {String} title optional
+ * @property {Number} priority optional, default value: 1
+ * @property {Boolean} enabled default value: true
+ * @property {String} route optional
+ * @property {String} type default value: `template`
+ * @property {String} provides default value: `template`
+ * @property {String} block optional
+ * @property {Object} defaultData optional, blackbox
+ * @property {String} parser required
+ * @property {String} language optional, default value: `en`
+ * @property {String} source optional
  * @property {String[]} templateFor optional
  * @property {Object[]} template optional, blackbox
  */
@@ -109,11 +102,21 @@ export const ReactLayout = new SimpleSchema({
 registerSchema("ReactLayout", ReactLayout);
 
 /**
- * @name Template
- * @memberof schemas
- * @summary Extends fields from sharedFields
+ * @memberof Schemas
  * @type {SimpleSchema}
- * @extends {sharedFields}
+ * @property {String} shopId Template ShopId
+ * @property {String} name required
+ * @property {String} title optional
+ * @property {Number} priority optional, default value: 1
+ * @property {Boolean} enabled default value: true
+ * @property {String} route optional
+ * @property {String} type default value: `template`
+ * @property {String} provides default value: `template`
+ * @property {String} block optional
+ * @property {Object} defaultData optional, blackbox
+ * @property {String} parser required
+ * @property {String} language optional, default value: `en`
+ * @property {String} source optional
  * @property {Object[]} template optional, blackbox
  */
 export const Template = new SimpleSchema({

--- a/lib/collections/schemas/translations.js
+++ b/lib/collections/schemas/translations.js
@@ -6,7 +6,7 @@ import { shopIdAutoValue } from "./helpers";
 
 /**
  * @name Translation
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @todo Mostly just a blackbox for now. Someday we'll validate the entire schema
  * @property {String} shopId, Translation ShopId

--- a/lib/collections/schemas/workflow.js
+++ b/lib/collections/schemas/workflow.js
@@ -7,7 +7,7 @@ import { registerSchema } from "@reactioncommerce/schemas";
  * @name Workflow
  * @summary Control view flow by attaching layout to a collection.
  * Shop defaultWorkflow is defined in Shop.
- * @memberof schemas
+ * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} status, default value: `new`
  * @property {String[]} workflow optional

--- a/lib/collections/search.js
+++ b/lib/collections/search.js
@@ -1,5 +1,22 @@
 import { Mongo } from "meteor/mongo";
 
+/**
+ * @name ProductSearch
+ * @memberof Collections
+ * @type {MongoCollection}
+ */
 export const ProductSearch = new Mongo.Collection("ProductSearch");
+
+/**
+ * @name OrderSearch
+ * @memberof Collections
+ * @type {MongoCollection}
+ */
 export const OrderSearch = new Mongo.Collection("OrderSearch");
+
+/**
+ * @name AccountSearch
+ * @memberof Collections
+ * @type {MongoCollection}
+ */
 export const AccountSearch = new Mongo.Collection("AccountSearch");

--- a/package-lock.json
+++ b/package-lock.json
@@ -2618,8 +2618,7 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "bunyan-format": {
       "version": "0.2.1",
@@ -2713,8 +2712,7 @@
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-      "dev": true
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "caniuse-lite": {
       "version": "1.0.30000813",
@@ -3655,7 +3653,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
@@ -4314,7 +4311,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
@@ -4636,7 +4632,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -4962,7 +4957,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
       "requires": {
         "locate-path": "2.0.0"
       }
@@ -5651,8 +5645,7 @@
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -6169,8 +6162,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -6397,8 +6389,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
       "version": "1.6.0",
@@ -6430,8 +6421,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -6457,7 +6447,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
@@ -6555,8 +6544,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "1.0.0",
@@ -6806,8 +6794,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobj": {
       "version": "1.0.0",
@@ -7806,7 +7793,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -7870,7 +7856,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
@@ -7891,7 +7876,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
@@ -8232,7 +8216,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -8321,7 +8304,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -9064,8 +9046,7 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "mimic-response": {
       "version": "1.0.0",
@@ -10097,7 +10078,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -10143,7 +10123,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -10430,7 +10409,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
       "requires": {
         "execa": "0.7.0",
         "lcid": "1.0.0",
@@ -10507,14 +10485,12 @@
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
         "p-limit": "1.1.0"
       }
@@ -10591,7 +10567,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -10631,8 +10606,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-extra": {
       "version": "1.0.3",
@@ -10654,8 +10628,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -10679,7 +10652,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
       "requires": {
         "pify": "2.3.0"
       }
@@ -10716,8 +10688,7 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -11086,8 +11057,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -11755,7 +11725,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true,
       "requires": {
         "load-json-file": "2.0.0",
         "normalize-package-data": "2.4.0",
@@ -11766,7 +11735,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "read-pkg": "2.0.0"
@@ -12036,14 +12004,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "require-package-name": {
       "version": "2.0.1",
@@ -12373,8 +12339,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -12472,7 +12437,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -12480,8 +12444,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shellwords": {
       "version": "0.1.1",
@@ -13284,7 +13247,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -13292,14 +13254,12 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "split": {
       "version": "0.3.3",
@@ -13514,7 +13474,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
@@ -13537,7 +13496,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "3.0.0"
       },
@@ -13545,22 +13503,19 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         }
       }
     },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -14003,6 +13958,12 @@
           "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
           "dev": true
         }
+      }
+    },
+    "transliteration": {
+      "version": "github:reactioncommerce/transliteration#699d48cc8dd9a64f1a2773e1b36b6faa4bbdca2f",
+      "requires": {
+        "yargs": "8.0.2"
       }
     },
     "trim-right": {
@@ -14482,7 +14443,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -14615,7 +14575,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -14623,8 +14582,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
       "version": "1.1.2",
@@ -14703,7 +14661,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -14713,7 +14670,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -14722,7 +14678,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -14733,7 +14688,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -14829,14 +14783,80 @@
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+      "requires": {
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "requires": {
+        "camelcase": "4.1.0"
+      }
     },
     "zen-observable": {
       "version": "0.7.1",

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -672,6 +672,7 @@ export default {
   /**
    * @name setUserPreferences
    * @method
+   * @memberof Core
    * @summary save user preferences in the Accounts collection
    * @param {String} packageName
    * @param {String} preference
@@ -687,15 +688,16 @@ export default {
     });
     return setPreferenceResult;
   },
+
   /**
-   *  @name insertPackagesForShop
-   *  @method
-   *  @memberof Core
-   *  @summary insert Reaction packages into Packages collection registry for a new shop
-   *  Assigns owner roles for new packages
-   *  Imports layouts from packages
-   *  @param {String} shopId - the shopId to create packages for
-   *  @return {String} returns insert result
+   * @name insertPackagesForShop
+   * @method
+   * @memberof Core
+   * @summary insert Reaction packages into Packages collection registry for a new shop
+   * - Assigns owner roles for new packages
+   * - Imports layouts from packages
+   * @param {String} shopId - the shopId to create packages for
+   * @return {String} returns insert result
    */
   insertPackagesForShop(shopId) {
     const layouts = [];

--- a/server/api/geocoder.js
+++ b/server/api/geocoder.js
@@ -11,10 +11,9 @@ import { Logger, Reaction } from "/server/api";
  * https://github.com/aldeed/meteor-geocoder
  * The MIT License (MIT)
  * Copyright (c) 2014 Eric Dobbertin
+ * @ignore
  */
 
-//
-// init geocoder
 function GeoCoder(options) {
   let extra;
   const self = this;

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -6,6 +6,10 @@ import Router from "./router";
 import GeoCoder from "./geocoder";
 import { MethodHooks } from "./method-hooks";
 
+/**
+ * @namespace EventHooks
+ */
+
 export {
   Reaction,
   Accounts,

--- a/server/api/method-hooks.js
+++ b/server/api/method-hooks.js
@@ -11,7 +11,6 @@ import { Meteor } from "meteor/meteor";
 export const MethodHooks = {};
 
 /**
- * @method afterHooks
  * @summary A collection of after hooks
  * @type {Object}
  * @summary <String, [Hook]> A mapping from method names to arrays of hooks
@@ -28,14 +27,13 @@ MethodHooks._afterHooks = {};
 MethodHooks._beforeHooks = {};
 
 /**
- * @method handlers
  * @summary The method handler definitions appropriate to the environment
+ * @private
  */
 MethodHooks._handlers = Meteor.isClient ? Meteor.connection._methodHandlers :
   Meteor.server.method_handlers;
 
 /**
- * @method _originalMethodHandlers
  * @summary The original method handlers
  * @type {Object}
  * @returns <String, Function> Method handler mapping
@@ -44,7 +42,6 @@ MethodHooks._handlers = Meteor.isClient ? Meteor.connection._methodHandlers :
 MethodHooks._originalMethodHandlers = {};
 
 /**
- * @method Wrappers
  * @type {Object}
  * @summary <String, Function> A mapping from method names to method functions
  * @private
@@ -52,13 +49,12 @@ MethodHooks._originalMethodHandlers = {};
 MethodHooks._wrappers = {};
 
 /**
- * @method initializeHook
  * @summary Initializes a new hook
  * @param {String} mapping - map hook: a is  place to store the mapping
  * @param {String} methodName - The name of the method
  * @param {Function} hookFunction - The hook function
- * @private
  * @return {String} - returns transformed data
+ * @private
  */
 MethodHooks._initializeHook = function (mapping, methodName, hookFunction) {
   mapping[methodName] = mapping[methodName] || [];

--- a/server/imports/fixtures/orders.js
+++ b/server/imports/fixtures/orders.js
@@ -99,6 +99,7 @@ export default function () {
   const shopId = getShopId();
   /**
    * @name order
+   * @memberof Fixtures
    * @summary Create an Order Factory
    * @example order = Factory.create("order")
    * @property {String} additionalField OrderItems - `faker.lorem.sentence()`

--- a/server/methods/accounts/accounts-password.js
+++ b/server/methods/accounts/accounts-password.js
@@ -6,7 +6,7 @@ import { Reaction, Logger } from "/server/api";
 
 /**
  * @name accounts/sendResetPasswordEmail
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @example Meteor.call("accounts/sendResetPasswordEmail", options)
  * @summary Send reset password email

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -14,12 +14,12 @@ import { sendUpdatedVerificationEmail } from "/server/api/core/accounts";
  * @file Extends Meteor's {@link https://github.com/meteor/meteor/tree/master/packages/accounts-base Accounts-Base}
  * with methods for Reaction-specific behavior and user interaction. Run these methods using: `Meteor.call()`
  * @example Meteor.call("accounts/verifyAccount", email, token)
- * @namespace Methods/Accounts
+ * @namespace Accounts/Methods
  */
 
 /**
  * @name accounts/verifyAccount
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Verifies the email address in account document (if user verification in users collection was successful already)
  * @example Meteor.call("accounts/verifyAccount")
@@ -58,7 +58,7 @@ export function verifyAccount() {
 
 /**
  * @name accounts/updateEmailAddress
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Update a user's email address
  * @param {String} email - user email
@@ -76,7 +76,7 @@ export function updateEmailAddress(email) {
 
 /**
  * @name accounts/removeEmailAddress
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Remove a user's email address.
  * @param {String} email - user email.
@@ -101,7 +101,7 @@ export function removeEmailAddress(email) {
 
 /**
  * @name accounts/syncUsersAndAccounts
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Syncs emails associated with a user profile between the Users and Accounts collections.
  * @returns {Boolean} - returns boolean.
@@ -253,7 +253,7 @@ function compareAddress(address, validationAddress) {
 
 /**
  * @name accounts/validateAddress
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Validates an address, and if fails returns details of issues
  * @param {Object} address - The address object to validate
@@ -292,7 +292,9 @@ export function validateAddress(address) {
 }
 
 /**
- * @name currentUserHasPassword
+ * @name accounts/currentUserHasPassword
+ * @method
+ * @memberof Accounts/Methods
  * @summary Check if current user has password
  * @returns {Boolean} True if current user has password
  * @private
@@ -304,7 +306,7 @@ function currentUserHasPassword() {
 
 /**
  * @name accounts/addressBookAdd
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Add new addresses to an account
  * @example Meteor.call("accounts/addressBookAdd", address, callBackFunction(error, result))
@@ -419,7 +421,7 @@ export function addressBookAdd(address, accountUserId) {
 
 /**
  * @name accounts/addressBookUpdate
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Update existing address in user's profile
  * @param {Object} address - address
@@ -561,7 +563,7 @@ export function addressBookUpdate(address, accountUserId, type) {
 
 /**
  * @name accounts/addressBookRemove
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Remove existing address in user's profile
  * @param {String} addressId - address `_id`
@@ -615,7 +617,7 @@ export function addressBookRemove(addressId, accountUserId) {
 /**
  * @name accounts/inviteShopOwner
  * @summary Invite a new user as owner of a new shop
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @param {Object} options -
  * @param {String} options.email - email of invitee
@@ -684,7 +686,7 @@ export function inviteShopOwner(options, shopData) {
  * @name accounts/inviteShopMember
  * @summary Invite new admin users (not consumers) to secure access in the dashboard to permissions
  * as specified in packages/roles
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @param {Object} options -
  * @param {String} options.shopId - shop to invite user
@@ -796,7 +798,7 @@ export function inviteShopMember(options) {
 /**
  * @name accounts/sendWelcomeEmail
  * @summary Send an email to consumers on sign up
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @param {String} shopId - shopId of new User
  * @param {String} userId - new userId to welcome
@@ -886,7 +888,7 @@ export function sendWelcomeEmail(shopId, userId, token) {
 
 /**
  * @name accounts/addUserPermissions
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @param {String} userId - userId
  * @param {Array|String} permissions - Name of role/permission.
@@ -911,7 +913,7 @@ export function addUserPermissions(userId, permissions, group) {
 
 /**
  * @name accounts/removeUserPermissions
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @param {String} userId - userId
  * @param {Array|String} permissions - Name of role/permission.
@@ -937,7 +939,7 @@ export function removeUserPermissions(userId, permissions, group) {
 
 /**
  * @name accounts/setUserPermissions
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @param {String} userId - userId
  * @param {String|Array} permissions - string/array of permissions
@@ -961,8 +963,8 @@ export function setUserPermissions(userId, permissions, group) {
 }
 
 /**
- * @name getCurrentUserName
- * @memberof Methods/Accounts
+ * @name accounts/getCurrentUserName
+ * @memberof Accounts/Methods
  * @method
  * @private
  * @param  {Object} currentUser - User
@@ -988,7 +990,7 @@ function getCurrentUserName(currentUser) {
 
 /**
  * @name getDataForEmail
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @private
  * @param  {Object} options - shop, currentUserName, token, emailLogo, name
@@ -1049,7 +1051,7 @@ function getDataForEmail(options) {
 
 /**
  * @name accounts/createFallbackLoginToken
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @summary Returns a new loginToken for current user, that can be used for special login scenarios
  * e.g. store the newly created token as cookie on the browser, if the client does not offer local storage.
@@ -1066,7 +1068,7 @@ export function createFallbackLoginToken() {
 
 /**
  * @name accounts/setProfileCurrency
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @param {String} currencyName - currency symbol to add to user profile
  * @param {String} [accountId] - accountId of user to set currency of. Defaults to current user ID
@@ -1104,7 +1106,9 @@ export function setProfileCurrency(currencyName, accountId) {
 }
 
 /**
- * @name markAddressValidationBypassed
+ * @name accounts/markAddressValidationBypassed
+ * @memberof Accounts/Methods
+ * @method
  * @summary Write that the customer has bypassed address validation
  * @returns {Number} updateResult - Result of the update
  */
@@ -1116,7 +1120,9 @@ function markAddressValidationBypassed(value = true) {
 }
 
 /**
- * @name markTaxCalculationFailed
+ * @name accounts/markTaxCalculationFailed
+ * @memberof Accounts/Methods
+ * @method
  * @summary Write tax calculation has failed for this customer
  * @returns {Number} updateResult - Result of the update
  */

--- a/server/methods/accounts/serviceConfiguration.js
+++ b/server/methods/accounts/serviceConfiguration.js
@@ -6,7 +6,7 @@ import { Reaction } from "/server/api";
 
 /**
  * @name accounts/updateServiceConfiguration
- * @memberof Methods/Accounts
+ * @memberof Accounts/Methods
  * @method
  * @example Meteor.call("accounts/updateServiceConfiguration", service, fields, (callBackFunction))
  * @summary Update service configuration

--- a/server/methods/catalog.js
+++ b/server/methods/catalog.js
@@ -14,10 +14,10 @@ import { Media } from "/imports/plugins/core/files/server";
 /* eslint quotes: 0 */
 
 /**
- * @file Methods for Products. Run these methods using `Meteor.call()`.
+ * @file Meteor methods for Products. Run these methods using `Meteor.call()`.
  *
  *
- * @namespace Methods/Products
+ * @namespace Products/Methods
 */
 
 /**
@@ -362,16 +362,13 @@ function createProduct(props = null) {
 }
 
 /**
- * @function
- * @name updateCatalogProduct
- * @summary Updates a product's revision and conditionally updates
- * the underlying product.
- *
+ * @summary Updates a product's revision and conditionally updates the underlying product.
  * @param {String} userId - currently logged in user
  * @param {Object} selector - selector for product to update
  * @param {Object} modifier - Object describing what parts of the document to update.
  * @param {Object} validation - simple schema validation options
  * @return {String} _id of updated document
+ * @private
  */
 function updateCatalogProduct(userId, selector, modifier, validation) {
   const product = Products.findOne(selector);
@@ -399,7 +396,7 @@ function updateCatalogProduct(userId, selector, modifier, validation) {
 Meteor.methods({
   /**
    * @name products/cloneVariant
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary clones a product variant into a new variant
    * @description the method copies variants, but will also create and clone
@@ -519,7 +516,7 @@ Meteor.methods({
 
   /**
    * @name products/createVariant
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary initializes empty variant template
    * @param {String} parentId - the product _id or top level variant _id where
@@ -584,7 +581,7 @@ Meteor.methods({
 
   /**
    * @name products/updateVariant
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary update individual variant with new values, merges into original
    * only need to supply updated information. Currently used for a one use case
@@ -639,7 +636,7 @@ Meteor.methods({
 
   /**
    * @name products/deleteVariant
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary delete variant, which should also delete child variants
    * @param {String} variantId - variantId to delete
@@ -693,7 +690,7 @@ Meteor.methods({
 
   /**
    * @name products/cloneProduct
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary clone a whole product, defaulting visibility, etc
    * in the future we are going to do an inheritance product
@@ -829,7 +826,7 @@ Meteor.methods({
 
   /**
    * @name products/createProduct
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary when we create a new product, we create it with an empty variant.
    * all products have a variant with pricing and details
@@ -876,7 +873,7 @@ Meteor.methods({
 
   /**
    * @name products/archiveProduct
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary archive a product and unlink it from all media
    * @param {String} productId - productId to delete
@@ -963,7 +960,7 @@ Meteor.methods({
 
   /**
    * @name products/updateProductField
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary update single product or variant field
    * @param {String} _id - product._id or variant._id to update
@@ -1051,7 +1048,7 @@ Meteor.methods({
 
   /**
    * @name products/updateProductTags
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary method to insert or update tag with hierarchy
    * @param {String} productId - productId
@@ -1134,7 +1131,7 @@ Meteor.methods({
 
   /**
    * @name products/removeProductTag
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary method to remove tag from product
    * @param {String} productId - productId
@@ -1171,7 +1168,7 @@ Meteor.methods({
 
   /**
    * @name products/setHandle
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary copy of "products/setHandleTag", but without tag
    * @param {String} productId - productId
@@ -1205,7 +1202,7 @@ Meteor.methods({
 
   /**
    * @name products/setHandleTag
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary set or toggle product handle
    * @param {String} productId - productId
@@ -1274,7 +1271,7 @@ Meteor.methods({
 
   /**
    * @name products/updateProductPosition
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary update product grid positions
    * @param {String} productId - productId
@@ -1322,7 +1319,7 @@ Meteor.methods({
 
   /**
    * @name products/updateVariantsPosition
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @description updates top level variant position index
    * @param {Array} sortedVariantIds - array of top level variant `_id`s
@@ -1358,7 +1355,7 @@ Meteor.methods({
 
   /**
    * @name products/updateMetaFields
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary update product metafield
    * @param {String} productId - productId
@@ -1431,7 +1428,7 @@ Meteor.methods({
 
   /**
    * @name products/removeMetaFields
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary update product metafield
    * @param {String} productId - productId
@@ -1466,7 +1463,7 @@ Meteor.methods({
 
   /**
    * @name products/publishProduct
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary publish (visibility) of product
    * @todo hook into publishing flow
@@ -1553,7 +1550,7 @@ Meteor.methods({
 
   /**
    * @name products/toggleVisibility
-   * @memberof Methods/Products
+   * @memberof Products/Methods
    * @method
    * @summary publish (visibility) of product
    * @todo hook into publishing flow

--- a/server/methods/core/cart.js
+++ b/server/methods/core/cart.js
@@ -112,7 +112,7 @@ function removeShippingAddresses(cart) {
 /**
  * @file Methods for Cart - Use these methods by running `Meteor.call()`
  * @example Meteor.call("cart/createCart", this.userId, sessionId)
- * @namespace Methods/Cart
+ * @namespace Cart/Methods
  */
 
 Meteor.methods({
@@ -123,7 +123,7 @@ Meteor.methods({
    * When a user logs in that cart now belongs to that user and we use the a single user cart.
    * If they are logged in on more than one devices, regardless of session,the user cart will be used
    * If they had more than one cart, on more than one device,logged in at separate times then merge the carts
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @param {String} cartId - cartId of the cart to merge matching session carts into.
    * @param {String} [currentSessionId] - current client session id
    * @todo I think this method should be moved out from methods to a Function Declaration to keep it more secure
@@ -252,7 +252,7 @@ Meteor.methods({
    * @method cart/createCart
    * @summary create new cart for user,
    * but all checks for current cart's existence should go before this method will be called, to keep it clean
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @param {String} userId - userId to create cart for
    * @param {String} sessionId - current client session id
    * @todo I think this method should be moved out from methods to a Function Declaration to keep it more secure
@@ -328,7 +328,7 @@ Meteor.methods({
    *  we want to break all relationships with the existing item.
    *  We want to fix price, qty, etc into history.
    *  However, we could check reactively for price /qty etc, adjustments on the original and notify them.
-   *  @memberof Methods/Cart
+   *  @memberof Cart/Methods
    *  @param {String} productId - productId to add to Cart
    *  @param {String} variantId - product variant _id
    *  @param {Number} [itemQty] - qty to add to cart
@@ -519,7 +519,7 @@ Meteor.methods({
 
   /**
    * @method cart/removeFromCart
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @summary Removes or adjust quantity of a variant from the cart
    * @param {String} itemId - cart item _id
    * @param {Number} [quantity] - if provided will adjust increment by quantity
@@ -636,7 +636,7 @@ Meteor.methods({
 
   /**
    * @method cart/setShipmentMethod
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @summary Saves method as order default
    * @param {String} cartId - cartId to apply shipmentMethod
    * @param {Object} method - shipmentMethod object
@@ -698,7 +698,7 @@ Meteor.methods({
 
   /**
    * @method cart/setUserCurrency
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @summary Saves user currency in cart, to be paired with order/setCurrencyExhange
    * @param {String} cartId - cartId to apply setUserCurrency
    * @param {String} userCurrency - userCurrency to set to cart
@@ -759,7 +759,7 @@ Meteor.methods({
 
   /**
    * @method cart/resetShipmentMethod
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @summary Removes `shipmentMethod` object from cart
    * @param {String} cartId - cart _id
    * @return {Number} update result
@@ -786,7 +786,7 @@ Meteor.methods({
 
   /**
    * @method cart/setShipmentAddress
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @summary Adds address book to cart shipping
    * @param {String} cartId - cartId to apply shipmentMethod
    * @param {Object} address - addressBook object
@@ -939,7 +939,7 @@ Meteor.methods({
 
   /**
    * @method cart/setPaymentAddress
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @summary Adds addressbook to cart payments
    * @param {String} cartId - cartId to apply payment address
    * @param {Object} address - addressBook object
@@ -1004,7 +1004,7 @@ Meteor.methods({
   /**
    * @method cart/unsetAddresses
    * @summary Removes address from cart.
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @param {String} addressId - address._id
    * @param {String} userId - cart owner _id
    * @param {String} [type] - billing default or shipping default
@@ -1074,7 +1074,7 @@ Meteor.methods({
 
   /**
    * @method cart/submitPayment
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @summary Saves a submitted payment to cart, triggers workflow and adds "paymentSubmitted" to cart workflow
    * Note: this method also has a client stub, that forwards to cartCompleted
    * @param {Object|Array} paymentMethods - an array of paymentMethods or (deprecated) a single paymentMethod object
@@ -1183,7 +1183,7 @@ Meteor.methods({
 
   /**
    * @method cart/setAnonymousUserEmail
-   * @memberof Methods/Cart
+   * @memberof Cart/Methods
    * @summary Assigns email to anonymous user's cart instance
    * @param {Object} userId - current user's Id
    * @param {String} email - email to set for anonymous user's cart instance

--- a/server/methods/core/cartToOrder.js
+++ b/server/methods/core/cartToOrder.js
@@ -9,7 +9,7 @@ import { Hooks, Logger, Reaction } from "/server/api";
 /**
  * @name cart/copyCartToOrder
  * @method
- * @memberof Methods/Cart
+ * @memberof Cart/Methods
  * @summary Transform Cart to Order when a payment is processed.
  * We want to copy the cart over to an order object, and give the user a new empty
  * cart. Reusing the cart schema makes sense, but integrity of the order,

--- a/server/methods/core/groups.js
+++ b/server/methods/core/groups.js
@@ -10,13 +10,13 @@ import { getSlug } from "/lib/api";
  * @file Methods for creating and managing admin user permission groups.
  * Run these methods using `Meteor.call()`.
  * @example Meteor.call("group/createGroup", sampleCustomerGroup, shop._id)
- * @namespace Methods/Group
+ * @namespace Group/Methods
 */
 Meteor.methods({
   /**
    * @name group/createGroup
    * @method
-   * @memberof Methods/Group
+   * @memberof Group/Methods
    * @summary Creates a new permission group for a shop
    * It creates permission group for a given shop with passed in roles
    * @param {Object} groupData - info about group to create
@@ -70,7 +70,7 @@ Meteor.methods({
   /**
    * @name group/updateGroup
    * @method
-   * @memberof Methods/Group
+   * @memberof Group/Methods
    * @summary Updates a permission group for a shop.
    * Change the details of a group (name, desc, permissions etc) to the values passed in.
    * It also goes into affected user data to modify both the groupName (using Accounts schema)
@@ -124,7 +124,7 @@ Meteor.methods({
   /**
    * @name group/addUser
    * @method
-   * @memberof Methods/Group
+   * @memberof Group/Methods
    * @summary Adds a user to a permission group
    * Updates the user's list of permissions/roles with the defined the list defined for the group
    * (NB: At this time, a user only belongs to only one group per shop)
@@ -201,7 +201,7 @@ Meteor.methods({
   /**
    * @name group/removeUser
    * @method
-   * @memberof Methods/Group
+   * @memberof Group/Methods
    * @summary Removes a user from a group for a shop, and adds them to the default customer group.
    * Updates the user's permission list to reflect.
    * (NB: At this time, a user only belongs to only one group per shop)

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -12,11 +12,13 @@ import { publishProductInventoryAdjustments } from "/imports/plugins/core/catalo
 
 /**
  * @name getPrimaryMediaForItem
+ * @method
  * @summary Gets the FileRecord for the primary media item associated with the variant or product
  *   for the given item. This is similar to a function in /lib/api/helpers, but that one uses
  *   Media.findOneLocal, which is only for browser code.
  * @param {Object} item Must have `productId` and/or `variantId` set to get back a result.
  * @return {FileRecord|null}
+ * @ignore
  */
 async function getPrimaryMediaForItem({ productId, variantId } = {}) {
   let result;
@@ -61,13 +63,13 @@ function formatDateForEmail(date) {
  * @file Methods for Orders.
  *
  *
- * @namespace Methods/Orders
+ * @namespace Orders/Methods
 */
 
 /**
  * @name orderCreditMethod
  * @method
- * @memberof Methods/Orders
+ * @memberof Orders/Methods
  * @summary Helper to return the order credit object.
  * Credit paymentMethod on the order as per current active shop
  * @param  {Object} order order object
@@ -82,7 +84,7 @@ export function orderCreditMethod(order) {
 /**
  * @name orderDebitMethod
  * @method
- * @memberof Methods/Orders
+ * @memberof Orders/Methods
  * @summary Helper to return the order debit object
  * @param  {Object} order order object
  * @return {Object} returns entire payment method
@@ -96,7 +98,7 @@ export function orderDebitMethod(order) {
 /**
  * @name ordersInventoryAdjust
  * @method
- * @memberof Methods/Orders
+ * @memberof Orders/Methods
  * @summary Adjust inventory when an order is placed
  * @param {String} orderId - Add tracking to orderId
  * @todo Why are we waiting until someone with orders permissions does something to reduce quantity of
@@ -135,7 +137,7 @@ export function ordersInventoryAdjust(orderId) {
 /**
  * @name ordersInventoryAdjustByShop
  * @method
- * @memberof Methods/Orders
+ * @memberof Orders/Methods
  * @summary Adjust inventory for a particular shop when an order is approved
  * @todo Marketplace: Is there a reason to do this any other way? Can admins reduce for more than one shop?
  * @param {String} orderId - orderId
@@ -177,7 +179,7 @@ export function ordersInventoryAdjustByShop(orderId, shopId) {
 /**
  * @name orderQuantityAdjust
  * @method
- * @memberof Methods/Orders
+ * @memberof Orders/Methods
  * @param  {String} orderId      orderId
  * @param  {Object} refundedItem refunded item
  * @return {null} no return value
@@ -209,7 +211,7 @@ export const methods = {
   /**
    * @name orders/shipmentPicked
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary update picking status
    * @param {Object} order - order object
    * @param {Object} shipment - shipment object
@@ -246,7 +248,7 @@ export const methods = {
   /**
    * @name orders/shipmentPacked
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary update packing status
    * @param {Object} order - order object
    * @param {Object} shipment - shipment object
@@ -285,7 +287,7 @@ export const methods = {
   /**
    * @name orders/shipmentLabeled
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary update labeling status
    * @param {Object} order - order object
    * @param {Object} shipment - shipment object
@@ -322,7 +324,7 @@ export const methods = {
   /**
    * @name orders/makeAdjustmentsToInvoice
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary Update the status of an invoice to allow adjustments to be made
    * @param {Object} order - order object
    * @return {Object} Mongo update
@@ -350,7 +352,7 @@ export const methods = {
   /**
    * @name orders/approvePayment
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary Approve payment and apply any adjustments
    * @param {Object} order - order object
    * @return {Object} return this.processPayment result
@@ -400,7 +402,7 @@ export const methods = {
   /**
    * @name orders/cancelOrder
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary Start the cancel order process
    * @param {Object} order - order object
    * @param {Boolean} returnToStock - condition to return product to stock
@@ -495,7 +497,7 @@ export const methods = {
   /**
    * @name orders/processPayment
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary trigger processPayment and workflow update
    * @param {Object} order - order object
    * @return {Object} return this.processPayment result
@@ -530,7 +532,7 @@ export const methods = {
   /**
    * @name orders/shipmentShipped
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary trigger shipmentShipped status and workflow update
    * @param {Object} order - order object
    * @param {Object} shipment - shipment object
@@ -598,7 +600,7 @@ export const methods = {
   /**
    * @name orders/shipmentDelivered
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary trigger shipmentShipped status and workflow update
    * @param {Object} order - order object
    * @return {Object} return workflow result
@@ -658,7 +660,7 @@ export const methods = {
   /**
    * @name orders/sendNotification
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary send order notification email
    * @param {Object} order - order object
    * @param {Object} action - send notification action
@@ -894,7 +896,7 @@ export const methods = {
    * @summary Adds tracking information to order without workflow update.
    * Call after any tracking code is generated
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @param {Object} order - An Order object
    * @param {Object} shipment - A Shipment object
    * @param {String} tracking - tracking id
@@ -923,7 +925,7 @@ export const methods = {
   /**
    * @name orders/addOrderEmail
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary Adds email to order, used for guest users
    * @param {String} cartId - add tracking to orderId
    * @param {String} email - valid email address
@@ -948,7 +950,7 @@ export const methods = {
   /**
    * @name orders/updateHistory
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary adds order history item for tracking and logging order updates
    * @param {String} orderId - add tracking to orderId
    * @param {String} event - workflow event
@@ -983,7 +985,7 @@ export const methods = {
    * @summary Finalize any payment where mode is "authorize"
    * and status is "approved", reprocess as "capture"
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @param {String} orderId - add tracking to orderId
    * @return {null} no return value
    */
@@ -1075,7 +1077,7 @@ export const methods = {
    * @summary loop through order's payments and find existing refunds.
    * Get a list of refunds for a particular payment method.
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @param {Object} order - order object
    * @return {Array} Array contains refund records
    */
@@ -1099,7 +1101,7 @@ export const methods = {
   /**
    * @name orders/refund/create
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary Apply a refund to an already captured order
    * @param {String} orderId - order object
    * @param {Object} paymentMethod - paymentMethod object
@@ -1186,7 +1188,7 @@ export const methods = {
   /**
    * @name orders/refunds/refundItems
    * @method
-   * @memberof Methods/Orders
+   * @memberof Orders/Methods
    * @summary Apply a refund to line items
    * @param {String} orderId - order object
    * @param {Object} paymentMethod - paymentMethod object

--- a/server/methods/core/packages.js
+++ b/server/methods/core/packages.js
@@ -7,12 +7,12 @@ import { Reaction } from "/server/api";
  * @file Methods for Packages.
  *
  *
- * @namespace Methods/Package
+ * @namespace Package/Methods
 */
 
 /**
  * @method package/update
- * @memberof Methods/Package
+ * @memberof Package/Methods
  * @summary updates the data stored for a certain Package.
  * @param {String} packageName - the name of the Package to update.
  * @param {String} field - the part of the Package's data that is to

--- a/server/methods/core/payments.js
+++ b/server/methods/core/payments.js
@@ -7,14 +7,14 @@ import { Reaction, Hooks } from "/server/api";
  * @file Methods for Payments. Run these methods using `Meteor.call()`.
  *
  *
- * @namespace Methods/Payments
+ * @namespace Payments/Methods
 */
 
 export const methods = {
   /**
    * @name payments/apply
    * @method
-   * @memberof Methods/Payments
+   * @memberof Payments/Methods
    * @example Meteor.call("payments/apply", id, paymentMethod, collection)
    * @summary Adds payment to order
    * @param {String} id - id

--- a/server/methods/core/registry.js
+++ b/server/methods/core/registry.js
@@ -9,14 +9,14 @@ import { mergeDeep } from "/lib/api";
  * @file Methods for Registry
  *
  *
- * @namespace Methods/Registry
+ * @namespace Registry/Methods
 */
 
 export const methods = {
   /**
    * @name registry/update
    * @method
-   * @memberof Methods/Registry
+   * @memberof Registry/Methods
    * @example Meteor.call("registry/update", packageId, settingsKey, fields)
    * @param  {String} packageId id of package
    * @param  {String} name      Name of package

--- a/server/methods/core/shipping.js
+++ b/server/methods/core/shipping.js
@@ -9,7 +9,7 @@ import { Cart as CartSchema } from "/lib/collections/schemas";
  * Run these methods using `Meteor.call()`.
  *
  *
- * @namespace Methods/Shipping
+ * @namespace Shipping/Methods
 */
 
 /**
@@ -297,7 +297,7 @@ export const methods = {
   /**
    * @name shipping/updateShipmentQuotes
    * @method
-   * @memberof Methods/Shipping
+   * @memberof Shipping/Methods
    * @summary Gets shipping rates and updates the users cart methods
    * @todo Add orderId argument/fallback
    * @param {String} cartId - cartId
@@ -325,7 +325,7 @@ export const methods = {
   /**
    * @name shipping/getShippingRates
    * @method
-   * @memberof Methods/Shipping
+   * @memberof Shipping/Methods
    * @summary Just gets rates, without updating anything
    * @param {Object} cart - cart object
    * @return {Array} return updated rates in cart

--- a/server/methods/core/shop.js
+++ b/server/methods/core/shop.js
@@ -17,6 +17,7 @@ import * as Schemas from "/lib/collections/schemas";
  * @param {Object} shop - the shop to clone
  * @param {Object} partialShopData - any properties you'd like to override
  * @return {Object|null} The cloned shop object or null if a shop with that ID can't be found
+ * @private
  */
 function cloneShop(shop, partialShopData = {}) {
   // if a name is not provided, generate a unique name
@@ -59,8 +60,9 @@ function cloneShop(shop, partialShopData = {}) {
  * @param {String} userId - the user id on whose behalf we are performing this
  *                 action (defaults to Meteor.userId())
  * @return {Int} returns update result
+ * @private
  */
-export function updateShopBrandAssets(asset, shopId = Reaction.getShopId(), userId = Meteor.userId()) {
+function updateShopBrandAssets(asset, shopId = Reaction.getShopId(), userId = Meteor.userId()) {
   check(asset, {
     mediaId: String,
     type: String
@@ -110,13 +112,13 @@ export function updateShopBrandAssets(asset, shopId = Reaction.getShopId(), user
  * @file Meteor methods for Shop
  *
  *
- * @namespace Methods/Shop
+ * @namespace Shop/Methods
 */
 Meteor.methods({
   /**
    * @name shop/resetShopId
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary a way for the client to notifiy the server that the shop has
    *          changed. We could has provided #setShopId, however, the server
    *          has all the information it needs to determine this on its own,
@@ -129,7 +131,7 @@ Meteor.methods({
   /**
    * @name shop/createShop
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @param {String} shopAdminUserId - optionally create shop for provided userId
    * @param {Object} partialShopData - optionally provide a subset of shop data
    *                 which will be merged with properties from the primary shop
@@ -256,7 +258,7 @@ Meteor.methods({
   /**
    * @name shop/getLocale
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary determine user's countryCode and return locale object
    * determine local currency and conversion rate from shop currency
    * @return {Object} returns user location and locale
@@ -367,7 +369,7 @@ Meteor.methods({
   /**
    * @name shop/getCurrencyRates
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary It returns the current exchange rate against the shop currency
    * usage: Meteor.call("shop/getCurrencyRates","USD")
    * @param {String} currency code
@@ -391,7 +393,7 @@ Meteor.methods({
   /**
    * @name shop/fetchCurrencyRate
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary fetch the latest currency rates from
    * https://openexchangerates.org
    * usage: Meteor.call("shop/fetchCurrencyRate")
@@ -482,7 +484,7 @@ Meteor.methods({
   /**
    * @name shop/flushCurrencyRate
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @description Method calls by cron job
    * @summary It removes exchange rates that are too old
    * usage: Meteor.call("shop/flushCurrencyRate")
@@ -537,7 +539,7 @@ Meteor.methods({
   /**
    * @name shop/updateShopExternalServices
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @description On submit OpenExchangeRatesForm handler
    * @summary we need to rerun fetch exchange rates job on every form submit,
    * that's why we update autoform type to "method-update"
@@ -588,7 +590,7 @@ Meteor.methods({
   /**
    * @name shop/locateAddress
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary determine user's full location for autopopulating addresses
    * @param {Number} latitude - latitude
    * @param {Number} longitude - longitude
@@ -620,7 +622,7 @@ Meteor.methods({
   /**
    * @name shop/createTag
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary creates new tag
    * @param {String} tagName - new tag name
    * @param {Boolean} isTopLevel - if true -- new tag will be created on top of
@@ -652,7 +654,7 @@ Meteor.methods({
   /**
    * @name shop/updateHeaderTags
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary method to insert or update tag with hierarchy
    * @param {String} tagName will insert, tagName + tagId will update existing
    * @param {String} tagId - tagId to update
@@ -736,7 +738,7 @@ Meteor.methods({
   /**
    * @name shop/removeHeaderTag
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @param {String} tagId - method to remove tag navigation tags
    * @param {String} currentTagId - currentTagId
    * @return {String} returns remove result
@@ -774,7 +776,7 @@ Meteor.methods({
   /**
    * @name shop/hideHeaderTag
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @param {String} tagId - method to remove tag navigation tags
    * @return {String} returns remove result
    */
@@ -798,7 +800,7 @@ Meteor.methods({
   /**
    * @name shop/getWorkflow
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary gets the current shop workflows
    * @param {String} name - workflow name
    * @return {Array} returns workflow array
@@ -823,7 +825,7 @@ Meteor.methods({
   /**
    * @name shop/updateLanguageConfiguration
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary enable / disable a language
    * @param {String} language - language name | "all" to bulk enable / disable
    * @param {Boolean} enabled - true / false
@@ -886,7 +888,7 @@ Meteor.methods({
   /**
    * @name shop/updateCurrencyConfiguration
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary enable / disable a currency
    * @param {String} currency - currency name | "all" to bulk enable / disable
    * @param {Boolean} enabled - true / false
@@ -944,9 +946,9 @@ Meteor.methods({
   },
 
   /**
-   * @name shop/updateBrandAsset
+   * @name shop/updateBrandAssets
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @param {Object} asset - brand asset {mediaId: "", type, ""}
    * @return {Int} returns update result
    */
@@ -964,7 +966,7 @@ Meteor.methods({
   /**
    * @name shop/togglePackage
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary enable/disable Reaction package
    * @param {String} packageId - package _id
    * @param {Boolean} enabled - current package `enabled` state
@@ -987,7 +989,7 @@ Meteor.methods({
   /**
    * @name shop/changeLayout
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary Change the layout for all workflows so you can use a custom one
    * @param {String} shopId - the shop's ID
    * @param {String} newLayout - new layout to use
@@ -1009,7 +1011,7 @@ Meteor.methods({
   /**
    * @name shop/getBaseLanguage
    * @method
-   * @memberof Methods/Shop
+   * @memberof Shop/Methods
    * @summary Return the shop's base language ISO code
    * @return {String} ISO lang code
    */

--- a/server/methods/core/workflows/orders.js
+++ b/server/methods/core/workflows/orders.js
@@ -7,7 +7,7 @@ Meteor.methods({
   /**
    * @name coreOrderWorkflow/coreOrderProcessing
    * @method
-   * @memberof Methods/Workflow
+   * @memberof Workflow/Methods
    * @summary Checks permissions for a given user to allow them to move an order into the processing phase.
    * @description Step 4 of the "workflow/pushOrderWorkflow" flow - called from Orders.before.update hook.
    * @param  {Object} options An object containing arbitary data
@@ -25,7 +25,7 @@ Meteor.methods({
   /**
    * @name coreOrderWorkflow/coreOrderCompleted
    * @method
-   * @memberof Methods/Workflow
+   * @memberof Workflow/Methods
    * @summary Performs various checks to determine if an order may be moved into the completed phase.
    * @description Step 4 of the "workflow/pushOrderWorkflow" flow - called from Orders.before.update hook.
    * @param  {Object} options An object containing arbitary data

--- a/server/methods/email.js
+++ b/server/methods/email.js
@@ -9,14 +9,14 @@ import { Logger, Reaction } from "/server/api";
  * Run these methods using `Meteor.call()`
  *
  * @example Meteor.call("emails/retryFailed", email._id, (err)
- * @namespace Methods/Email
+ * @namespace Email/Methods
 */
 Meteor.methods({
   /**
    * @name email/verifySettings
    * @method
    * @summary Verify the current email configuration
-   * @memberof Methods/Email
+   * @memberof Email/Methods
    * @param {Object} settings - optional settings object (otherwise uses settings in database)
    * @return {Boolean} - returns true if SMTP connection succeeds
    */
@@ -71,7 +71,7 @@ Meteor.methods({
    * @name email/saveSettings
    * @method
    * @summary Save new email configuration
-   * @memberof Methods/Email
+   * @memberof Email/Methods
    * @param {Object} settings - mail provider settings
    * @return {Boolean} - returns true if update succeeds
    */
@@ -106,7 +106,7 @@ Meteor.methods({
    * @name email/retryFailed
    * @method
    * @summary Retry a failed or cancelled email job
-   * @memberof Methods/Email
+   * @memberof Email/Methods
    * @param {String} jobId - a sendEmail job ID
    * @return {Boolean} - returns true if job is successfully restarted
    */

--- a/server/methods/helpers.js
+++ b/server/methods/helpers.js
@@ -4,13 +4,13 @@ import { Meteor } from "meteor/meteor";
  * @file Meteor methods for Reaction
  *
  *
- * @namespace Methods/Reaction
+ * @namespace Reaction/Methods
 */
 Meteor.methods({
   /**
    * @name reaction/getUserId
    * @method
-   * @memberof Methods/Reaction
+   * @memberof Reaction/Methods
    * @summary return server side userId if available
    * @return {String} userId - if available
    */

--- a/server/publications/collections/packages.js
+++ b/server/publications/collections/packages.js
@@ -6,13 +6,6 @@ import { Packages } from "/lib/collections";
 import { Reaction } from "/server/api";
 import { translateRegistry } from "/lib/api";
 
-/**
- * Packages contains user specific configuration
- * @summary  package publication settings, filtered by permissions
- * @param {Object} shopCursor - current shop object
- * @returns {Object} packagesCursor - current packages for shop
- */
-
 // for transforming packages before publication sets some defaults for the client and adds i18n while checking
 // privileged settings for enabled status.
 function transform(doc, userId) {
@@ -69,9 +62,6 @@ function transform(doc, userId) {
   return doc;
 }
 
-//
-//  Packages Publication
-//
 Meteor.publish("Packages", function (shopId) {
   check(shopId, Match.Maybe(String));
 

--- a/server/publications/collections/products.js
+++ b/server/publications/collections/products.js
@@ -75,6 +75,7 @@ registerSchema("filters", filters);
  * Broadens an existing selector to include all variants of the given top-level productIds
  * Additionally considers the tags product filter, if given
  * Can operate on the "Revisions" and the "Products" collection
+ * @memberof Helpers
  * @param collectionName {String} - "Revisions" or "Products"
  * @param selector {object} - the selector that should be extended
  * @param productFilters { object } - the product filter (e.g. orginating from query parameters)

--- a/server/publications/collections/sessions.js
+++ b/server/publications/collections/sessions.js
@@ -4,14 +4,13 @@ import { check, Match } from "meteor/check";
 import { Reaction } from "/server/api";
 
 /**
- * Reaction Server / amplify permanent sessions
- * If no id is passed we create a new session
- * Load the session
- * If no session is loaded, creates a new one
+ * @name ServerSessions
+ * @memberof Collections/ServerOnly
+ * @type {MongoCollection}
  */
-
 export const ServerSessions = new Mongo.Collection("Sessions");
 
+// Reaction Server / amplify permanent sessions
 Meteor.publish("Sessions", (sessionId) => {
   check(sessionId, Match.OneOf(String, null));
   const created = new Date().getTime();

--- a/server/startup/i18n.js
+++ b/server/startup/i18n.js
@@ -60,8 +60,8 @@ export function loadTranslation(source) {
 
 /**
  * @method loadTranslations
- * @summary Load an array of translation objects
- * and import using loadTranslation
+ * @memberof i18n
+ * @summary Load an array of translation objects and import using loadTranslation
  * @param  {Object} sources array of i18next translations
  * @return {Boolean} false if assets weren't loaded
  */
@@ -69,6 +69,12 @@ export function loadTranslations(sources) {
   sources.forEach(loadTranslation);
 }
 
+/**
+ * @method flushTranslationLoad
+ * @memberof i18n
+ * @summary Execute the bulk asset operation
+ * @return {undefined} No return
+ */
 export async function flushTranslationLoad() {
   if (!bulkAssetOp) return Promise.resolve();
 


### PR DESCRIPTION
Impact: **minor**  
Type: **docs**

## Issue
The generated API documentation, particularly newer GraphQL functions, is not well organized.

## Solution
This PR makes changes to the jsdoc comments in many files. Specifically, adding and changing `namespace` and `memberof` values.

The generated API doc tree now follows this general pattern:

- Organized at the top level by broad concepts, which loosely map to plugin and collection names, such as "Accounts", "Shop", "Orders", etc.
- Within that, there are `/GraphQL`, `/Methods`, and `/NoMeteorQueries` subnamespaces, and occasionally some variations within those.

Also:
- there is now a `Collections` namespace with all of the Meteor collections and the `Schemas` namespace has been cleaned up a bit
- the `Components` namespace is now for React components only, and helpers have been moved to `Components/Helpers` namespace

## Breaking changes
None

## Testing

No code changes to test. Only jsdoc comments were changed.

1. Check out this branch, and `meteor npm install` followed by `npm run docs`
2. Go to file:///private/tmp/reaction-docs/index.html in a browser and check out the more organized left-side navigation tree.