### PR TITLE
chore: access media through devserver app

### DIFF
--- a/.reaction/devserver/index.js
+++ b/.reaction/devserver/index.js
@@ -1,11 +1,13 @@
-import { MongoClient } from "mongodb";
+import mongodb, { MongoClient } from "mongodb";
 import createApolloServer from "../../imports/plugins/core/graphql/server/createApolloServer";
 import defineCollections from "../../imports/plugins/core/graphql/server/defineCollections";
 import methods from "./methods";
 import queries from "../../imports/plugins/core/graphql/server/queries";
+import setUpFileCollections from "../../imports/plugins/core/files/server/no-meteor/setUpFileCollections";
 
-const { MONGO_URL } = process.env;
+const { MONGO_URL, ROOT_URL } = process.env;
 if (!MONGO_URL) throw new Error("You must set MONGO_URL");
+if (!ROOT_URL) throw new Error("You must set ROOT_URL");
 
 const lastSlash = MONGO_URL.lastIndexOf("/");
 const dbUrl = MONGO_URL.slice(0, lastSlash);
@@ -23,24 +25,40 @@ MongoClient.connect(dbUrl, (error, client) => {
   mongoClient = client;
   db = client.db(dbName);
   defineCollections(db, collections);
-});
 
-/**
- * This is a server for development of the GraphQL API without needing
- * to run Meteor. After finishing development, you should still test
- * the API changes through the Meteor app in case there are any differences.
- */
-const app = createApolloServer({
-  context: {
-    collections,
-    methods,
-    queries
-  },
-  debug: true,
-  graphiql: true
-});
+  const {
+    downloadManager,
+    Media
+  } = setUpFileCollections({
+    absoluteUrlPrefix: ROOT_URL,
+    db,
+    Logger: { info: console.info.bind(console) },
+    MediaRecords: collections.MediaRecords,
+    mongodb
+  });
 
-app.listen(PORT, () => {
-  console.info(`GraphQL listening at http://localhost:${PORT}/graphql-alpha`);
-  console.info(`GraphiQL UI: http://localhost:${PORT}/graphiql`);
+  // Make the Media collection available to resolvers
+  collections.Media = Media;
+
+  /**
+   * This is a server for development of the GraphQL API without needing
+   * to run Meteor. After finishing development, you should still test
+   * the API changes through the Meteor app in case there are any differences.
+   */
+  const app = createApolloServer({
+    context: {
+      collections,
+      methods,
+      queries
+    },
+    debug: true,
+    graphiql: true
+  });
+
+  app.use("/assets/files", downloadManager.connectHandler);
+
+  app.listen(PORT, () => {
+    console.info(`GraphQL listening at http://localhost:${PORT}/graphql-alpha`);
+    console.info(`GraphiQL UI: http://localhost:${PORT}/graphiql`);
+  });
 });

--- a/imports/plugins/core/files/server/fileCollections.js
+++ b/imports/plugins/core/files/server/fileCollections.js
@@ -5,124 +5,30 @@ import { check } from "meteor/check";
 import { Security } from "meteor/ongoworks:security";
 import fetch from "node-fetch";
 import {
-  FileDownloadManager,
-  FileRecord,
   MeteorFileCollection,
   RemoteUrlWorker,
-  TempFileStore,
   TempFileStoreWorker
 } from "@reactioncommerce/file-collections";
-import GridFSStore from "@reactioncommerce/file-collections-sa-gridfs";
 import { Logger } from "/server/api";
 import { MediaRecords } from "/lib/collections";
+import setUpFileCollections from "./no-meteor/setUpFileCollections";
 
-// lazy loading sharp package
-let sharp;
-async function lazyLoadSharp() {
-  if (sharp) return;
-  sharp = await import("sharp");
-}
-
-FileRecord.downloadEndpointPrefix = "/assets/files";
-FileRecord.absoluteUrlPrefix = Meteor.absoluteUrl();
-
-// 1024*1024*2 is the GridFSStore default chunk size, and 256k is default GridFS chunk size, but performs terribly
-const gridFSStoresChunkSize = 1 * 1024 * 1024;
 const mongodb = MongoInternals.NpmModules.mongodb.module;
 const { db } = MongoInternals.defaultRemoteCollectionDriver().mongo;
 
-/**
- * @name imgTransforms
- * @constant {Array}
- * @property {string} name - transform name that will be used as GridFS name
- * @property {object|undefined} transform - object with image transform settings
- * @property {number} size - transform size, only one number needed for both width & height
- * @property {string} mod - transform modifier function call,
- * for example the `large` & `medium` image transforms want to preserve
- * the image's aspect ratio and resize based on the larger width or height
- * so we use the `max` Sharp modifier function.
- * Check out the {@link http://sharp.pixelplumbing.com/en/stable/|Sharp Docs} for more helper functions.
- * {@link http://sharp.pixelplumbing.com/en/stable/api-resize/#max|Sharp max()}
- * {@link http://sharp.pixelplumbing.com/en/stable/api-resize/#crop|Sharp crop()}
- * @property {string} format - output image format
- * @summary Defines all image transforms
- * Image files are resized to 4 different sizes:
- * 1. `large` - 1000px by 1000px - preserves aspect ratio
- * 2. `medium` - 600px by 600px - preserves aspect ratio
- * 3. `small` - 235px by 235px - crops to square - creates png version
- * 4. `thumbnail` - 100px by 100px - crops to square - creates png version
- */
-const imgTransforms = [
-  { name: "image", transform: { size: 1600, mod: "max", format: "jpg", type: "image/jpeg" } },
-  { name: "large", transform: { size: 1000, mod: "max", format: "jpg", type: "image/jpeg" } },
-  { name: "medium", transform: { size: 600, mod: "max", format: "jpg", type: "image/jpeg" } },
-  { name: "small", transform: { size: 235, mod: "crop", format: "png", type: "image/png" } },
-  { name: "thumbnail", transform: { size: 100, mod: "crop", format: "png", type: "image/png" } }
-];
-
-/**
- * @function buildGFS
- * @param {object} imgTransform
- * @summary buildGFS returns a fresh GridFSStore instance from provided image transform settings.
- */
-const buildGFS = ({ name, transform }) => (
-  new GridFSStore({
-    chunkSize: gridFSStoresChunkSize,
-    collectionPrefix: "cfs_gridfs.",
-    db,
-    mongodb,
-    name,
-    async transformWrite(fileRecord) {
-      if (!transform) return;
-
-      try {
-        await lazyLoadSharp();
-      } catch (error) {
-        Logger.warn("Problem lazy loading Sharp lib in image transformWrite", error.message);
-      }
-
-      if (!sharp) {
-        Logger.warn("In transformWrite, sharp does not seem to be available");
-        return;
-      }
-
-      const { size, mod, format, type } = transform;
-      // Need to update the content type and extension of the file info, too.
-      // The new size gets set correctly automatically by FileCollections package.
-      fileRecord.type(type, { store: name });
-      fileRecord.extension(format, { store: name });
-
-      // resizing image, adding mod, setting output format
-      return sharp().resize(size, size)[mod]().toFormat(format);
-    }
-  })
-);
-
-/**
- * @name stores
- * @constant {Array}
- * @summary Defines an array of GridFSStore by mapping the imgTransform settings over the buildGFS function
- */
-const stores = imgTransforms.map(buildGFS);
-
-/**
- * @name tempStore
- * @type TempFileStore
- * @summary Defines the temporary store where chunked uploads from browsers go
- * initially, until the chunks are eventually combined into one complete file
- * which the worker will then store to the permanant stores.
- * @see https://github.com/reactioncommerce/reaction-file-collections
- */
-const tempStore = new TempFileStore({
-  shouldAllowRequest(req) {
-    const { type } = req.uploadMetadata;
-    if (typeof type !== "string" || !type.startsWith("image/")) {
-      Logger.info(`shouldAllowRequest received request to upload file of type "${type}" and denied it`);
-      return false;
-    }
-    return true;
-  }
+const {
+  downloadManager,
+  Media: NoMeteorMedia,
+  stores,
+  tempStore
+} = setUpFileCollections({
+  absoluteUrlPrefix: Meteor.absoluteUrl(),
+  db,
+  Logger,
+  MediaRecords: MediaRecords.rawCollection(),
+  mongodb
 });
+
 WebApp.connectHandlers.use("/assets/uploads", (req, res) => {
   req.baseUrl = "/assets/uploads"; // tus relies on this being set, which is an Express thing
   tempStore.connectHandler(req, res);
@@ -136,7 +42,7 @@ WebApp.connectHandlers.use("/assets/uploads", (req, res) => {
  * {@link http://sharp.pixelplumbing.com/en/stable/|Sharp Docs}
  * @see https://github.com/reactioncommerce/reaction-file-collections
  */
-export const Media = new MeteorFileCollection("Media", {
+const Media = new MeteorFileCollection("Media", {
   allowInsert: (userId, doc) => Security.can(userId).insert(doc).for(MediaRecords).check(),
   allowUpdate: (userId, id, modifier) => Security.can(userId).update(id, modifier).for(MediaRecords).check(),
   allowRemove: (userId, id) => Security.can(userId).remove(id).for(MediaRecords).check(),
@@ -152,20 +58,6 @@ export const Media = new MeteorFileCollection("Media", {
 // reference to the backing MongoDB collection on Media.files property as well.
 Media.files = MediaRecords;
 
-/**
- * @name downloadManager
- * @type FileDownloadManager
- * @summary Set up a URL for downloading the files
- * @see https://github.com/reactioncommerce/reaction-file-collections
- */
-const downloadManager = new FileDownloadManager({
-  collections: [Media],
-  headers: {
-    get: {
-      "Cache-Control": "public, max-age=31536000"
-    }
-  }
-});
 WebApp.connectHandlers.use("/assets/files", downloadManager.connectHandler);
 
 /**
@@ -186,3 +78,8 @@ remoteUrlWorker.start();
  */
 const fileWorker = new TempFileStoreWorker({ fileCollections: [Media] });
 fileWorker.start();
+
+export {
+  Media,
+  NoMeteorMedia
+};

--- a/imports/plugins/core/files/server/index.js
+++ b/imports/plugins/core/files/server/index.js
@@ -1,4 +1,4 @@
-import { Media } from "./fileCollections";
+import { Media, NoMeteorMedia } from "./fileCollections";
 import "./methods";
 
-export { Media };
+export { Media, NoMeteorMedia };

--- a/imports/plugins/core/files/server/no-meteor/setUpFileCollections.js
+++ b/imports/plugins/core/files/server/no-meteor/setUpFileCollections.js
@@ -1,0 +1,144 @@
+import Random from "@reactioncommerce/random";
+import sharp from "sharp";
+import {
+  FileDownloadManager,
+  FileRecord,
+  MongoFileCollection,
+  TempFileStore
+} from "@reactioncommerce/file-collections";
+import GridFSStore from "@reactioncommerce/file-collections-sa-gridfs";
+
+export default function setUpFileCollections({
+  absoluteUrlPrefix,
+  db,
+  Logger,
+  MediaRecords,
+  mongodb
+}) {
+  FileRecord.downloadEndpointPrefix = "/assets/files";
+  FileRecord.absoluteUrlPrefix = absoluteUrlPrefix;
+
+  // 1024*1024*2 is the GridFSStore default chunk size, and 256k is default GridFS chunk size, but performs terribly
+  const gridFSStoresChunkSize = 1 * 1024 * 1024;
+
+  /**
+   * @name imgTransforms
+   * @constant {Array}
+   * @property {string} name - transform name that will be used as GridFS name
+   * @property {object|undefined} transform - object with image transform settings
+   * @property {number} size - transform size, only one number needed for both width & height
+   * @property {string} mod - transform modifier function call,
+   * for example the `large` & `medium` image transforms want to preserve
+   * the image's aspect ratio and resize based on the larger width or height
+   * so we use the `max` Sharp modifier function.
+   * Check out the {@link http://sharp.pixelplumbing.com/en/stable/|Sharp Docs} for more helper functions.
+   * {@link http://sharp.pixelplumbing.com/en/stable/api-resize/#max|Sharp max()}
+   * {@link http://sharp.pixelplumbing.com/en/stable/api-resize/#crop|Sharp crop()}
+   * @property {string} format - output image format
+   * @summary Defines all image transforms
+   * Image files are resized to 4 different sizes:
+   * 1. `large` - 1000px by 1000px - preserves aspect ratio
+   * 2. `medium` - 600px by 600px - preserves aspect ratio
+   * 3. `small` - 235px by 235px - crops to square - creates png version
+   * 4. `thumbnail` - 100px by 100px - crops to square - creates png version
+   */
+  const imgTransforms = [
+    { name: "image", transform: { size: 1600, mod: "max", format: "jpg", type: "image/jpeg" } },
+    { name: "large", transform: { size: 1000, mod: "max", format: "jpg", type: "image/jpeg" } },
+    { name: "medium", transform: { size: 600, mod: "max", format: "jpg", type: "image/jpeg" } },
+    { name: "small", transform: { size: 235, mod: "crop", format: "png", type: "image/png" } },
+    { name: "thumbnail", transform: { size: 100, mod: "crop", format: "png", type: "image/png" } }
+  ];
+
+  /**
+   * @function buildGFS
+   * @param {object} imgTransform
+   * @summary buildGFS returns a fresh GridFSStore instance from provided image transform settings.
+   */
+  const buildGFS = ({ name, transform }) => (
+    new GridFSStore({
+      chunkSize: gridFSStoresChunkSize,
+      collectionPrefix: "cfs_gridfs.",
+      db,
+      mongodb,
+      name,
+      async transformWrite(fileRecord) {
+        if (!transform) return;
+
+        const { size, mod, format, type } = transform;
+
+        // Need to update the content type and extension of the file info, too.
+        // The new size gets set correctly automatically by FileCollections package.
+        fileRecord.type(type, { store: name });
+        fileRecord.extension(format, { store: name });
+
+        // resizing image, adding mod, setting output format
+        return sharp().resize(size, size)[mod]().toFormat(format);
+      }
+    })
+  );
+
+  /**
+   * @name stores
+   * @constant {Array}
+   * @summary Defines an array of GridFSStore by mapping the imgTransform settings over the buildGFS function
+   */
+  const stores = imgTransforms.map(buildGFS);
+
+  /**
+   * @name tempStore
+   * @type TempFileStore
+   * @summary Defines the temporary store where chunked uploads from browsers go
+   * initially, until the chunks are eventually combined into one complete file
+   * which the worker will then store to the permanant stores.
+   * @see https://github.com/reactioncommerce/reaction-file-collections
+   */
+  const tempStore = new TempFileStore({
+    shouldAllowRequest(req) {
+      const { type } = req.uploadMetadata;
+      if (typeof type !== "string" || !type.startsWith("image/")) {
+        Logger.info(`shouldAllowRequest received request to upload file of type "${type}" and denied it`);
+        return false;
+      }
+      return true;
+    }
+  });
+
+  /**
+   * @name Media
+   * @type MongoFileCollection
+   * @summary Defines the Media FileCollection
+   * To learn how to further manipulate images with Sharp, refer to
+   * {@link http://sharp.pixelplumbing.com/en/stable/|Sharp Docs}
+   * @see https://github.com/reactioncommerce/reaction-file-collections
+   */
+  const Media = new MongoFileCollection("Media", {
+    allowGet: () => true, // add more security here if the files should not be public
+    collection: MediaRecords,
+    makeNewStringID: () => Random.id(),
+    stores,
+    tempStore
+  });
+
+  /**
+   * @name downloadManager
+   * @type FileDownloadManager
+   * @summary Set up a URL for downloading the files
+   * @see https://github.com/reactioncommerce/reaction-file-collections
+   */
+  const downloadManager = new FileDownloadManager({
+    collections: [Media],
+    headers: {
+      get: {
+        "Cache-Control": "public, max-age=31536000"
+      }
+    }
+  });
+
+  return {
+    downloadManager,
+    Media,
+    stores,
+    tempStore
+  };
+}

--- a/imports/plugins/core/graphql/server/defineCollections.js
+++ b/imports/plugins/core/graphql/server/defineCollections.js
@@ -12,7 +12,7 @@ export default function defineCollections(db, collections) {
     Groups: db.collection("Groups"),
     Inventory: db.collection("Inventory"),
     Logs: db.collection("Logs"),
-    MediaRecords: db.collection("MediaRecords"),
+    MediaRecords: db.collection("cfs.Media.filerecord"),
     Notifications: db.collection("Notifications"),
     Orders: db.collection("Orders"),
     Packages: db.collection("Packages"),

--- a/imports/plugins/core/graphql/server/index.js
+++ b/imports/plugins/core/graphql/server/index.js
@@ -1,12 +1,13 @@
 import { Meteor } from "meteor/meteor";
 import { MongoInternals } from "meteor/mongo";
 import { WebApp } from "meteor/webapp";
+import { NoMeteorMedia } from "/imports/plugins/core/files/server";
 import createApolloServer from "./createApolloServer";
 import defineCollections from "./defineCollections";
 import methods from "./methods";
 import queries from "./queries";
 
-const collections = {};
+const collections = { Media: NoMeteorMedia };
 
 const { db } = MongoInternals.defaultRemoteCollectionDriver().mongo;
 defineCollections(db, collections);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1032,7 +1032,7 @@
         "request": "2.83.0",
         "retry-request": "3.3.1",
         "split-array-stream": "1.0.3",
-        "stream-events": "1.0.3",
+        "stream-events": "1.0.4",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       },
@@ -1068,7 +1068,7 @@
         "mime-types": "2.1.17",
         "once": "1.4.0",
         "pumpify": "1.4.0",
-        "stream-events": "1.0.3",
+        "stream-events": "1.0.4",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
       }
@@ -1080,14 +1080,14 @@
       "dev": true
     },
     "@reactioncommerce/file-collections": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections/-/file-collections-0.4.5.tgz",
-      "integrity": "sha512-xcjxbTk7cW0YJulo7L9vbzC7lFJbfpFnCxbQX8dv76ZgsLlqPY+Jwckf+7Vhn5Ar0d4ZRmcIGF5vKWxwL1PXfQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections/-/file-collections-0.5.0.tgz",
+      "integrity": "sha512-92983/xIT6xAnHR0+4XKVY9jUp0vpobLhG0wCyegvX/dkSRO5srL4tz1ZN/77pxe7d1MfEEYo6MLQ/YmluIw6A==",
       "requires": {
         "babel-runtime": "6.26.0",
         "content-disposition": "0.5.2",
         "debug": "3.1.0",
-        "path-parser": "3.0.1",
+        "path-parser": "4.0.4",
         "query-string": "5.1.0",
         "tus-js-client": "1.5.1",
         "tus-node-server": "0.2.11"
@@ -1104,9 +1104,9 @@
       }
     },
     "@reactioncommerce/file-collections-sa-base": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections-sa-base/-/file-collections-sa-base-0.0.1.tgz",
-      "integrity": "sha512-vTD97pNCSa7Gh2SNrXl1RjAykc9MT26Wj2Xt27CIkhZIyZbAkBweZPgDOuAuyUL6s2XnOUPkROI7SR64cCUSSg==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections-sa-base/-/file-collections-sa-base-0.0.2.tgz",
+      "integrity": "sha512-yUIot7kvA8qNaowk4FJJMxJ2+lME74zjTBJxGXjauS3USeBw27NjlckpW3F8LwizPzW8L5J3BmYRHGqXIVGykQ==",
       "requires": {
         "babel-runtime": "6.26.0",
         "debug": "3.1.0"
@@ -1123,11 +1123,11 @@
       }
     },
     "@reactioncommerce/file-collections-sa-gridfs": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections-sa-gridfs/-/file-collections-sa-gridfs-0.0.1.tgz",
-      "integrity": "sha512-iZdDjLXyTKGJ0pwGDDV13G9gfheBeO6tQ12hsVT9VsU+Xzi7RqgCcuSWpGxeL1ugyVlz4idkISfvOmZnIoDzfg==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections-sa-gridfs/-/file-collections-sa-gridfs-0.0.2.tgz",
+      "integrity": "sha512-taswRPu3iIq+OsO5Q1Ohn/uealYRHKZSss0/DFdahaWYW7hcZualruvysqbzbtN42VWmZ9Yv+sVCtkVIxiwN2w==",
       "requires": {
-        "@reactioncommerce/file-collections-sa-base": "0.0.1",
+        "@reactioncommerce/file-collections-sa-base": "0.0.2",
         "babel-runtime": "6.26.0",
         "debug": "3.1.0",
         "gridfs-stream": "1.1.1"
@@ -2618,8 +2618,7 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "bunyan-format": {
       "version": "0.2.1",
@@ -2713,8 +2712,7 @@
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-      "dev": true
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "caniuse-lite": {
       "version": "1.0.30000813",
@@ -3655,7 +3653,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
@@ -4314,7 +4311,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
@@ -4636,7 +4632,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -4962,7 +4957,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
       "requires": {
         "locate-path": "2.0.0"
       }
@@ -5434,7 +5428,7 @@
         "google-auto-auth": "0.6.1",
         "pumpify": "1.4.0",
         "request": "2.83.0",
-        "stream-events": "1.0.3",
+        "stream-events": "1.0.4",
         "through2": "2.0.3"
       },
       "dependencies": {
@@ -5651,8 +5645,7 @@
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -6169,8 +6162,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -6397,8 +6389,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
       "version": "1.6.0",
@@ -6430,8 +6421,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -6457,7 +6447,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
@@ -6555,8 +6544,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "1.0.0",
@@ -6806,8 +6794,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobj": {
       "version": "1.0.0",
@@ -7806,7 +7793,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -7870,7 +7856,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
@@ -7891,7 +7876,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
@@ -8232,7 +8216,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -8321,7 +8304,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -9064,8 +9046,7 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "mimic-response": {
       "version": "1.0.0",
@@ -10097,7 +10078,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -10143,7 +10123,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -10430,7 +10409,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
       "requires": {
         "execa": "0.7.0",
         "lcid": "1.0.0",
@@ -10507,14 +10485,12 @@
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
         "p-limit": "1.1.0"
       }
@@ -10591,7 +10567,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -10631,8 +10606,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-extra": {
       "version": "1.0.3",
@@ -10654,8 +10628,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -10663,11 +10636,11 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/path-parser/-/path-parser-3.0.1.tgz",
-      "integrity": "sha512-6MFp3XsoMGN3rvBQ6a/SKy56SVRNn3EVcj79kI1YPKf0UdAwQ/Gbt/Jkr0AD87bQZtM4pMCdDGpo3S6ap61Twg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/path-parser/-/path-parser-4.0.4.tgz",
+      "integrity": "sha512-U71kuqOWLb/syIOvL3PuuoMYy1j9M709F3VfS8MqmSy+gTnIwY5CXuASKlhs+5DDAkmuDIML3vdW7Pna28E/cg==",
       "requires": {
-        "search-params": "1.3.0"
+        "search-params": "2.1.2"
       }
     },
     "path-to-regexp": {
@@ -10679,7 +10652,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
       "requires": {
         "pify": "2.3.0"
       }
@@ -10716,8 +10688,7 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -11086,8 +11057,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -11755,7 +11725,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true,
       "requires": {
         "load-json-file": "2.0.0",
         "normalize-package-data": "2.4.0",
@@ -11766,7 +11735,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "read-pkg": "2.0.0"
@@ -12036,14 +12004,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "require-package-name": {
       "version": "2.0.1",
@@ -12304,9 +12270,9 @@
       "integrity": "sha1-NkjfLXKUZB5/eGc//CloHZutkHM="
     },
     "search-params": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/search-params/-/search-params-1.3.0.tgz",
-      "integrity": "sha1-uh4cAdy9ii5BolI29gLyy/cQ1og="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/search-params/-/search-params-2.1.2.tgz",
+      "integrity": "sha512-RToWw6ftSKU8awWFFXK7CxNblBrwDck800RjXxqcFICg4HP1DAI71f4eJlxUpV4mtuWe0ueAnlHrQX7UtbQVNA=="
     },
     "section-iterator": {
       "version": "2.0.0",
@@ -12373,8 +12339,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -12472,7 +12437,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -12480,8 +12444,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shellwords": {
       "version": "0.1.1",
@@ -13284,7 +13247,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -13292,14 +13254,12 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "split": {
       "version": "0.3.3",
@@ -13473,9 +13433,9 @@
       }
     },
     "stream-events": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.3.tgz",
-      "integrity": "sha512-SvnBCMhEBQSJml4/ImlWkzGWgchjo1tVxnoBUOa1i1g3BsYNWz4W6a9Hc8VhqfmwJiEGu6tLrGdNRm/K/I4YXw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
+      "integrity": "sha512-D243NJaYs/xBN2QnoiMDY7IesJFIK7gEhnvAYqJa5JvDdnh2dC4qDBwlCf0ohPpX2QRlA/4gnbnPd3rs3KxVcA==",
       "requires": {
         "stubs": "3.0.0"
       }
@@ -13514,7 +13474,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
@@ -13537,7 +13496,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "3.0.0"
       },
@@ -13545,22 +13503,19 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         }
       }
     },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -14003,6 +13958,12 @@
           "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
           "dev": true
         }
+      }
+    },
+    "transliteration": {
+      "version": "github:reactioncommerce/transliteration#699d48cc8dd9a64f1a2773e1b36b6faa4bbdca2f",
+      "requires": {
+        "yargs": "8.0.2"
       }
     },
     "trim-right": {
@@ -14482,7 +14443,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -14615,7 +14575,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -14623,8 +14582,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
       "version": "1.1.2",
@@ -14703,7 +14661,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -14713,7 +14670,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -14722,7 +14678,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -14733,7 +14688,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -14829,14 +14783,80 @@
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+      "requires": {
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "requires": {
+        "camelcase": "4.1.0"
+      }
     },
     "zen-observable": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.38",
-    "@reactioncommerce/file-collections": "0.4.5",
-    "@reactioncommerce/file-collections-sa-gridfs": "0.0.1",
+    "@reactioncommerce/file-collections": "0.5.0",
+    "@reactioncommerce/file-collections-sa-gridfs": "0.0.2",
     "@reactioncommerce/hooks": "1.0.2",
     "@reactioncommerce/job-queue": "1.0.4",
     "@reactioncommerce/logger": "1.1.1",


### PR DESCRIPTION
Resolves #4214  
Impact: **minor**  
Type: **chore**

## Changes
When running `devserver` app rather than full Meteor app, images can now be downloaded, and the `collections.Media` on resolver context has the media FileCollection instance.

The path is the same. Only port is different when running locally. For example:

Normal reaction: http://localhost:3000/assets/files/Media/Jtj3k7QWNALNhwo5d/thumbnail/FvpPJZk.png
Devserver: http://localhost:3030/assets/files/Media/Jtj3k7QWNALNhwo5d/thumbnail/FvpPJZk.png

### Technical details

There isn't much new code here. Much of `fileCollections.js` has been moved to `no-meteor/setUpFileCollections.js` and wrapped in a function, so that some dependencies such as the Mongo collection can be passed in one way within the Meteor app and another way in devserver.

There are now two different `Media` file collections when running within Meteor. `Media` is the same as before, while `NoMeteorMedia` export is a `MongoFileCollection`, which is similar but does not set up DDP methods or work in client code.

When running devserver, there is just one `Media` export and that is the `MongoFileCollection`.

Because temp store / upload handling currently relies on Meteor Mongo observes, that part is still only in the Meteor file. We will eventually handle that in a different way, if we need to support browser uploads in the devserver app.

## Breaking changes
None

## Testing
1. Use `docker-compose up -d` to start both apps.
1. Find a product image in normal Reaction app, and get it's URL.
1. Change the port to 3030 and verify that you can see the same image there.
1. Make sure that media in general still works correctly for admins (upload, publish, delete, reorder images)