### PR TITLE
Invalid class name: .variant-list-item-{variant._id}

### DIFF
--- a/imports/plugins/included/product-detail-simple/client/components/variant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variant.js
@@ -122,7 +122,7 @@ class Variant extends Component {
     const variantElement = (
       <li
         className="variant-list-item"
-        id="variant-list-item-{variant._id}"
+        id={`variant-list-item-${variant._id}`}
         key={variant._id}
       >
         <div


### PR DESCRIPTION
~~Resolves #issueNumber~~ 
Impact: **minor**  
Type: **bugfix**

## Issue
`id="variant-list-item-{variant._id}"` didn't interpolate the `variant._id`

## Solution
`id={`variant-list-item-${variant._id}`}` is working fine for me.

## Breaking changes
None


## Testing
1. With current Product-Detail-Simple product page active, inspect the element ID of `variant-list-item-{variant._id}`
2. Then swap in the fix and reload this product page and search again for the `variant-list-item-...`
