### PR TITLE
devserver improvements

### DIFF
--- a/.reaction/devserver/index.js
+++ b/.reaction/devserver/index.js
@@ -1,3 +1,4 @@
+import express from "express";
 import mongodb, { MongoClient } from "mongodb";
 import createApolloServer from "../../imports/plugins/core/graphql/server/createApolloServer";
 import defineCollections from "../../imports/plugins/core/graphql/server/defineCollections";
@@ -56,6 +57,8 @@ MongoClient.connect(dbUrl, (error, client) => {
   });
 
   app.use("/assets/files", downloadManager.connectHandler);
+
+  app.use(express.static('public'))
 
   app.listen(PORT, () => {
     console.info(`GraphQL listening at http://localhost:${PORT}/graphql-alpha`);

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     }
   },
   "scripts": {
-    "devserver": "NODE_ENV=devserver nodemon .reaction/devserver/index.js --exec babel-node",
+    "devserver": "NODE_ENV=devserver nodemon .reaction/devserver/index.js",
     "lint": "eslint .",
     "test": "npm run test:unit && npm run test:app",
     "test:app": "meteor test --once --full-app --driver-package meteortesting:mocha",
@@ -321,6 +321,17 @@
     },
     "plugins": [
       "jest"
+    ]
+  },
+  "nodemonConfig": {
+    "delay": "2000",
+    "execMap": {
+      "js": "babel-node"
+    },
+    "ext": "js,json,graphql",
+    "watch": [
+      "imports",
+      ".reaction"
     ]
   }
 }


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Changes
- The `devserver`, when running, now watches only /imports and /.reaction, and watches the .graphql files (i.e., will restart if you edit a graphql schema only)
- The `devserver` now hosts the /public folder statically.

## Breaking changes
None

## Testing
With devserver running:

1. Make sure it restarts when you edit a GraphQL schema file.
2. Make sure it does not restart when you edit a file somewhere in, for example, /lib.
3. Make sure you can access http://localhost:3030/resources/placeholder.gif (or any other static file in /public)
