### PR TITLE
fix: show `.00` cents for whole-dollar amounts in price range

### DIFF
--- a/imports/plugins/core/revisions/server/hooks.js
+++ b/imports/plugins/core/revisions/server/hooks.js
@@ -36,10 +36,10 @@ export const ProductRevision = {
       });
       const priceMin = _.min(variantPrices);
       const priceMax = _.max(variantPrices);
-      let priceRange = `${priceMin} - ${priceMax}`;
+      let priceRange = `${priceMin.toFixed(2)} - ${priceMax.toFixed(2)}`;
       // if we don't have a range
       if (priceMin === priceMax) {
-        priceRange = priceMin.toString();
+        priceRange = priceMin.toFixed(2);
       }
       const priceObject = {
         range: priceRange,

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -75,10 +75,10 @@ export default {
       });
       const priceMin = _.min(variantPrices);
       const priceMax = _.max(variantPrices);
-      let priceRange = `${priceMin} - ${priceMax}`;
+      let priceRange = `${priceMin.toFixed(2)} - ${priceMax.toFixed(2)}`;
       // if we don't have a range
       if (priceMin === priceMax) {
-        priceRange = priceMin.toString();
+        priceRange = priceMin.toFixed(2);
       }
       return {
         range: priceRange,


### PR DESCRIPTION
Resolves #4221   
Impact: **minor**  
Type: **bugfix**

## Issue
`product.price.range` (and also in the catalog) should be in the format "N.NN - N.NN" even when min or max are whole dollar amounts. When there is only a single price, it should be "N.NN" even for a whole dollar amount. Currently a price of exactly $9 for example will be "9" rather than "9.00"

See related reactioncommerce/reaction-next-starterkit#68

## Solution
Updated the code that calculates the range string

## Breaking changes
Not really, but products with whole-dollar prices will start showing the ".00" part after the next time they are published (or immediately for admin users)

## Testing
1. Find a product with a single variant and change it's price to a whole dollar amount. Publish it. Make sure it shows on grid and PDP with ".00"
1. Find a product with multiple variants and/or options. Change the prices such that the highest and lowest prices are both whole dollar amounts. Publish it. Make sure it shows on grid and PDP with ".00" for both the min price and the max price.
1. Any other combinations of the above two steps to be sure there are no issues.
