### PR TITLE
refactor: create connection/edge resolver helper

### DIFF
--- a/imports/plugins/core/graphql/server/resolvers/account/AccountConnection.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/AccountConnection.js
@@ -1,3 +1,0 @@
-export default {
-  edges: ({ nodes }) => nodes
-};

--- a/imports/plugins/core/graphql/server/resolvers/account/AccountEdge.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/AccountEdge.js
@@ -1,4 +1,0 @@
-export default {
-  cursor: (account) => account._id,
-  node: (account) => account
-};

--- a/imports/plugins/core/graphql/server/resolvers/account/AddressEdge.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/AddressEdge.js
@@ -1,4 +1,0 @@
-export default {
-  cursor: (address) => address._id,
-  node: (address) => address
-};

--- a/imports/plugins/core/graphql/server/resolvers/account/GroupConnection.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/GroupConnection.js
@@ -1,3 +1,0 @@
-export default {
-  edges: ({ nodes }) => nodes
-};

--- a/imports/plugins/core/graphql/server/resolvers/account/GroupEdge.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/GroupEdge.js
@@ -1,4 +1,0 @@
-export default {
-  cursor: (group) => group._id,
-  node: (group) => group
-};

--- a/imports/plugins/core/graphql/server/resolvers/account/RoleConnection.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/RoleConnection.js
@@ -1,3 +1,0 @@
-export default {
-  edges: ({ nodes }) => nodes
-};

--- a/imports/plugins/core/graphql/server/resolvers/account/RoleEdge.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/RoleEdge.js
@@ -1,4 +1,0 @@
-export default {
-  cursor: (role) => role._id,
-  node: (role) => role
-};

--- a/imports/plugins/core/graphql/server/resolvers/account/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/account/index.js
@@ -1,14 +1,9 @@
+import { getConnectionTypeResolvers } from "@reactioncommerce/reaction-graphql-utils";
 import Account from "./Account";
-import AccountConnection from "./AccountConnection";
-import AccountEdge from "./AccountEdge";
 import AddAccountAddressBookEntryPayload from "./AddAccountAddressBookEntryPayload";
 import Group from "./Group";
-import GroupConnection from "./GroupConnection";
-import GroupEdge from "./GroupEdge";
 import Mutation from "./Mutation";
 import Query from "./Query";
-import RoleConnection from "./RoleConnection";
-import RoleEdge from "./RoleEdge";
 
 /**
  * Account-related GraphQL resolvers
@@ -17,14 +12,11 @@ import RoleEdge from "./RoleEdge";
 
 export default {
   Account,
-  AccountConnection,
-  AccountEdge,
   AddAccountAddressBookEntryPayload,
   Group,
-  GroupConnection,
-  GroupEdge,
   Mutation,
   Query,
-  RoleConnection,
-  RoleEdge
+  ...getConnectionTypeResolvers("Account"),
+  ...getConnectionTypeResolvers("Group"),
+  ...getConnectionTypeResolvers("Role")
 };

--- a/imports/plugins/core/graphql/server/resolvers/catalog/CatalogItemConnection.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/CatalogItemConnection.js
@@ -1,3 +1,0 @@
-export default {
-  edges: ({ nodes }) => nodes
-};

--- a/imports/plugins/core/graphql/server/resolvers/catalog/CatalogItemEdge.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/CatalogItemEdge.js
@@ -1,4 +1,0 @@
-export default {
-  cursor: (item) => item._id,
-  node: (item) => item
-};

--- a/imports/plugins/core/graphql/server/resolvers/catalog/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/catalog/index.js
@@ -1,6 +1,5 @@
 import { encodeCatalogItemOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/catalogItem";
-import CatalogItemConnection from "./CatalogItemConnection";
-import CatalogItemEdge from "./CatalogItemEdge";
+import { getConnectionTypeResolvers } from "@reactioncommerce/reaction-graphql-utils";
 import CatalogItemProduct from "./CatalogItemProduct";
 import CatalogProduct from "./CatalogProduct";
 import CatalogProductVariant from "./CatalogProductVariant";
@@ -21,10 +20,9 @@ export default {
   CatalogItemContent: {
     _id: (item) => encodeCatalogItemOpaqueId(item._id)
   },
-  CatalogItemConnection,
-  CatalogItemEdge,
   CatalogItemProduct,
   CatalogProduct,
   CatalogProductVariant,
-  Query
+  Query,
+  ...getConnectionTypeResolvers("CatalogItem")
 };

--- a/imports/plugins/core/graphql/server/resolvers/core/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/core/index.js
@@ -1,7 +1,9 @@
+import { getConnectionTypeResolvers } from "@reactioncommerce/reaction-graphql-utils";
 import Address from "./Address";
 import Currency from "./Currency";
 
 export default {
   Address,
-  Currency
+  Currency,
+  ...getConnectionTypeResolvers("Address")
 };

--- a/imports/plugins/core/graphql/server/resolvers/tag/TagConnection.js
+++ b/imports/plugins/core/graphql/server/resolvers/tag/TagConnection.js
@@ -1,3 +1,0 @@
-export default {
-  edges: ({ nodes }) => nodes
-};

--- a/imports/plugins/core/graphql/server/resolvers/tag/TagEdge.js
+++ b/imports/plugins/core/graphql/server/resolvers/tag/TagEdge.js
@@ -1,4 +1,0 @@
-export default {
-  cursor: (tag) => tag._id,
-  node: (tag) => tag
-};

--- a/imports/plugins/core/graphql/server/resolvers/tag/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/tag/index.js
@@ -1,7 +1,6 @@
+import { getConnectionTypeResolvers } from "@reactioncommerce/reaction-graphql-utils";
 import Query from "./Query";
 import Tag from "./Tag";
-import TagConnection from "./TagConnection";
-import TagEdge from "./TagEdge";
 
 /**
  * Tag-related GraphQL resolvers
@@ -11,6 +10,5 @@ import TagEdge from "./TagEdge";
 export default {
   Query,
   Tag,
-  TagConnection,
-  TagEdge
+  ...getConnectionTypeResolvers("Tag")
 };

--- a/imports/plugins/core/graphql/server/resolvers/util/getConnectionTypeResolvers.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getConnectionTypeResolvers.js
@@ -1,0 +1,20 @@
+/**
+ * @name getConnectionTypeResolvers
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Makes resolvers for connection and edge types, based on the parent resolver returning an object
+ *   that has a `nodes` property that is an array of the items.
+ * @return {Object} An object with `${name}Connection` and `${name}Edge` properties, to be included in
+ *   the resolvers object.
+ */
+export default function getConnectionTypeResolvers(name) {
+  return {
+    [`${name}Connection`]: {
+      edges: ({ nodes }) => nodes
+    },
+    [`${name}Edge`]: {
+      cursor: (item) => item._id,
+      node: (item) => item
+    }
+  };
+}

--- a/imports/plugins/core/graphql/server/resolvers/util/index.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/index.js
@@ -4,6 +4,7 @@
  */
 
 export { default as applyPaginationToMongoCursor } from "./applyPaginationToMongoCursor";
+export { default as getConnectionTypeResolvers } from "./getConnectionTypeResolvers";
 export { default as getPaginatedResponse } from "./getPaginatedResponse";
 export { default as namespaces } from "./namespaces";
 export { default as optimizeIdOnly } from "./optimizeIdOnly";


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

## Changes
There are no longer separate files for each of the `<Name>Connection` and `<Name>Edge` GraphQL resolvers. Instead they are created by a call to `getConnectionTypeResolvers(name)`.

## Breaking changes
None

## Testing
By running GraphQL queries that return them, verify that `AccountConnection`, `GroupConnection`, `RoleConnection`, `CatalogItemConnection`, and `TagConnection` still resolve correctly.
