### PR TITLE
Fix GraphQL pagination

### DIFF
--- a/imports/plugins/core/graphql/server/resolvers/util/applyBeforeAfterToFilter.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyBeforeAfterToFilter.test.js
@@ -12,7 +12,7 @@ test("throws an error if both before and after are set", () =>
 describe("after", () => {
   test("alters filter correctly when sorting by _id ascending (default)", async () => {
     const baseFilter = { _id: { $in: ["abc"] } };
-    const result = await applyBeforeAfterToFilter({ after: "cmVhY3Rpb24vc2hvcDoxMjM=", baseFilter });
+    const result = await applyBeforeAfterToFilter({ after: "123", baseFilter });
 
     expect(result).toEqual({
       $and: [
@@ -24,7 +24,7 @@ describe("after", () => {
 
   test("alters filter correctly when sorting by _id descending", async () => {
     const baseFilter = { _id: { $in: ["abc"] } };
-    const result = await applyBeforeAfterToFilter({ after: "cmVhY3Rpb24vc2hvcDoxMjM=", baseFilter, sortOrder: "desc" });
+    const result = await applyBeforeAfterToFilter({ after: "123", baseFilter, sortOrder: "desc" });
 
     expect(result).toEqual({
       $and: [
@@ -38,7 +38,7 @@ describe("after", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
     const name = "Some Name";
     const result = await applyBeforeAfterToFilter({
-      after: "cmVhY3Rpb24vc2hvcDoxMjM=",
+      after: "123",
       baseFilter,
       collection: {
         findOne: () => ({ name })
@@ -63,7 +63,7 @@ describe("after", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
     const name = "Some Name";
     const result = await applyBeforeAfterToFilter({
-      after: "cmVhY3Rpb24vc2hvcDoxMjM=",
+      after: "123",
       baseFilter,
       collection: {
         findOne: () => ({ name })
@@ -89,7 +89,7 @@ describe("after", () => {
 describe("before", () => {
   test("alters filter correctly when sorting by _id ascending (default)", async () => {
     const baseFilter = { _id: { $in: ["abc"] } };
-    const result = await applyBeforeAfterToFilter({ before: "cmVhY3Rpb24vc2hvcDoxMjM=", baseFilter });
+    const result = await applyBeforeAfterToFilter({ before: "123", baseFilter });
 
     expect(result).toEqual({
       $and: [
@@ -101,7 +101,7 @@ describe("before", () => {
 
   test("alters filter correctly when sorting by _id descending", async () => {
     const baseFilter = { _id: { $in: ["abc"] } };
-    const result = await applyBeforeAfterToFilter({ before: "cmVhY3Rpb24vc2hvcDoxMjM=", baseFilter, sortOrder: "desc" });
+    const result = await applyBeforeAfterToFilter({ before: "123", baseFilter, sortOrder: "desc" });
 
     expect(result).toEqual({
       $and: [
@@ -115,7 +115,7 @@ describe("before", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
     const name = "Some Name";
     const result = await applyBeforeAfterToFilter({
-      before: "cmVhY3Rpb24vc2hvcDoxMjM=",
+      before: "123",
       baseFilter,
       collection: {
         findOne: () => ({ name })
@@ -140,7 +140,7 @@ describe("before", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
     const name = "Some Name";
     const result = await applyBeforeAfterToFilter({
-      before: "cmVhY3Rpb24vc2hvcDoxMjM=",
+      before: "123",
       baseFilter,
       collection: {
         findOne: () => ({ name })

--- a/imports/plugins/core/graphql/server/resolvers/util/getMongoSort.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getMongoSort.js
@@ -4,18 +4,20 @@ const sortOrderEnumToMongo = {
 };
 
 /**
+ * Note that this uses the object format rather than the array format because our in-memory db
+ * for tests, `nedb`, expects object format. The Node `mongodb` package allows either.
+ * Technically an array would be better because JS does not guarantee preservation of object key
+ * order, but this seems to work fine.
+ *
  * @name getMongoSort
  * @method
  * @memberof GraphQL/ResolverUtilities
- * @summary Converts GraphQL `sortBy` and `sortOrder` params to the sort array format
+ * @summary Converts GraphQL `sortBy` and `sortOrder` params to the sort object format
  *   that MongoDB uses.
- * @return {Array[]} Sort array
+ * @return {Object} Sort object
  */
 export default function getMongoSort({ sortBy, sortOrder } = {}) {
-  const mongoSort = sortOrderEnumToMongo[sortOrder || "asc"];
-  const sortList = [["_id", mongoSort]];
-  if (sortBy && sortBy !== "_id") {
-    sortList.unshift([sortBy, mongoSort]);
-  }
-  return sortList;
+  const mongoSortDirection = sortOrderEnumToMongo[sortOrder || "asc"];
+  if (sortBy && sortBy !== "_id") return { [sortBy]: mongoSortDirection, _id: mongoSortDirection };
+  return { _id: mongoSortDirection };
 }

--- a/imports/plugins/core/graphql/server/resolvers/util/getMongoSort.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getMongoSort.test.js
@@ -1,21 +1,21 @@
 import getMongoSort from "./getMongoSort";
 
 test("default sort is by _id, ascending", () => {
-  expect(getMongoSort()).toEqual([["_id", 1]]);
+  expect(getMongoSort()).toEqual({ _id: 1 });
 });
 
 test("by _id, ascending", () => {
-  expect(getMongoSort({ sortBy: "_id", sortOrder: "asc" })).toEqual([["_id", 1]]);
+  expect(getMongoSort({ sortBy: "_id", sortOrder: "asc" })).toEqual({ _id: 1 });
 });
 
 test("by _id, descending", () => {
-  expect(getMongoSort({ sortBy: "_id", sortOrder: "desc" })).toEqual([["_id", -1]]);
+  expect(getMongoSort({ sortBy: "_id", sortOrder: "desc" })).toEqual({ _id: -1 });
 });
 
 test("by name then _id, ascending", () => {
-  expect(getMongoSort({ sortBy: "name", sortOrder: "asc" })).toEqual([["name", 1], ["_id", 1]]);
+  expect(getMongoSort({ sortBy: "name", sortOrder: "asc" })).toEqual({ name: 1, _id: 1 });
 });
 
 test("by name then _id, descending", () => {
-  expect(getMongoSort({ sortBy: "name", sortOrder: "desc" })).toEqual([["name", -1], ["_id", -1]]);
+  expect(getMongoSort({ sortBy: "name", sortOrder: "desc" })).toEqual({ name: -1, _id: -1 });
 });

--- a/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
@@ -24,7 +24,9 @@ async function getPaginatedResponse(query, args) {
 
   query.filter(updatedFilter).sort(sort);
 
-  const { pageInfo } = await applyPaginationToMongoCursor(query, args, totalCount);
+  const totalCountAfterOrBefore = await query.clone().count();
+
+  const { pageInfo } = await applyPaginationToMongoCursor(query, args, totalCountAfterOrBefore);
   const nodes = await query.toArray();
   const count = nodes.length;
 

--- a/tests/tag/tags.test.js
+++ b/tests/tag/tags.test.js
@@ -11,8 +11,8 @@ for (let i = 100; i < 155; i += 1) {
   tags.push({ _id: tagId, name: tagName, shopId: internalShopId, position: tagPosition });
 }
 
-const tagsQuery = `($shopId: ID!, $after: ConnectionCursor) {
-  tags(shopId: $shopId, after: $after) {
+const tagsQuery = `($shopId: ID!, $after: ConnectionCursor, $before: ConnectionCursor, $first: ConnectionLimitInt, $last: ConnectionLimitInt) {
+  tags(shopId: $shopId, after: $after, before: $before, first: $first, last: $last) {
     totalCount
     pageInfo {
       hasNextPage
@@ -33,14 +33,14 @@ beforeAll(async () => {
   tester = new GraphTester();
   await tester.startServer();
   query = tester.query(tagsQuery);
+
+  await tester.collections.Shops.insert({ _id: internalShopId, name: shopName });
+  await Promise.all(tags.map((tag) => tester.collections.Tags.insert(tag)));
 });
 
 afterAll(() => tester.stopServer());
 
 test("get the first 50 tags when neither first or last is in query", async () => {
-  await tester.collections.Shops.insert({ _id: internalShopId, name: shopName });
-  await Promise.all(tags.map((tag) => tester.collections.Tags.insert(tag)));
-
   let result;
   try {
     result = await query({ shopId: opaqueShopId });
@@ -63,4 +63,18 @@ test("get the first 50 tags when neither first or last is in query", async () =>
   expect(result.tags.nodes.length).toBe(5);
   expect(result.tags.totalCount).toBe(55);
   expect(result.tags.pageInfo).toEqual({ endCursor: "MTU0", hasNextPage: false, hasPreviousPage: false, startCursor: "MTUw" });
+});
+
+test("get the last 10 tags when last is in query and before last item in list", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, last: 10, before: "MTU0" });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tags.nodes.length).toBe(10);
+  expect(result.tags.totalCount).toBe(55);
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTUz", hasNextPage: false, hasPreviousPage: true, startCursor: "MTQ0" });
 });


### PR DESCRIPTION
Resolves #4227   
Impact: **minor**  
Type: **bugfix**

## Issue
Incorrect GraphQL pagination

## Solution
- Fixed `getPaginatedResponse` to use the count after before/after is added to the filter, when providing count to the skip/limit function.
- Also switched to using object format for MongoDB `sort` rather than array because `nedb` is expecting object format. This way our integration tests are actually accurate when it comes to testing anything sort-related.

## Breaking changes
None

## Testing
Page forward and backward through `catalogItems` and `tags` GraphQL queries and verify that the results are what you expect.