### PR TITLE
fix(GraphQL): improve hasNext/hasPrevious

### DIFF
--- a/imports/plugins/core/graphql/server/resolvers/util/__snapshots__/applyBeforeAfterToFilter.test.js.snap
+++ b/imports/plugins/core/graphql/server/resolvers/util/__snapshots__/applyBeforeAfterToFilter.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`throws an error if both before and after are set 1`] = `[Error: Including both 'after' and 'before' params is not allowed]`;
+exports[`throws an error if both before and after are set 1`] = `"Including both 'after' and 'before' params is not allowed"`;
 
-exports[`throws an error if sortBy is missing 1`] = `[Error: sortBy is required]`;
+exports[`throws an error if sortBy is missing 1`] = `"sortBy is required"`;
 
-exports[`throws an error if sortOrder is missing 1`] = `[Error: sortOrder is required]`;
+exports[`throws an error if sortOrder is missing 1`] = `"sortOrder is required"`;

--- a/imports/plugins/core/graphql/server/resolvers/util/__snapshots__/applyPaginationToMongoCursor.test.js.snap
+++ b/imports/plugins/core/graphql/server/resolvers/util/__snapshots__/applyPaginationToMongoCursor.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`with both first and last, throws error 1`] = `"Request either \`first\` or \`last\` but not both"`;

--- a/imports/plugins/core/graphql/server/resolvers/util/applyBeforeAfterToFilter.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyBeforeAfterToFilter.js
@@ -3,13 +3,18 @@
  * @method
  * @memberof GraphQL/ResolverUtilities
  * @summary Adjusts a MongoDB filter based on GraphQL `before` and `after` params
- * @return {Promise<Object>} The potentially-modified filter object
+ * @param {Object} args
+ * @param {Object} [args.after] A document that all results should be filtered to be after.
+ * @param {Object} [args.baseFilter] The MongoDB filter object to extend.
+ * @param {Object} [args.before] A document that all results should be filtered to be before.
+ * @param {String} [args.sortBy] The name of the field we are sorting by. Default _id
+ * @param {String} [args.sortOrder] The sort order, "asc" or "desc". Default "asc"
+ * @return {Object} The potentially-modified filter object
  */
-export default async function applyBeforeAfterToFilter({
+export default function applyBeforeAfterToFilter({
   after,
   baseFilter = {},
   before,
-  collection,
   sortBy: sortByField = "_id",
   sortOrder = "asc"
 }) {
@@ -25,18 +30,19 @@ export default async function applyBeforeAfterToFilter({
 
   if (!after && !before) return filter;
 
-  let internalId;
+  let doc;
   let op;
   if (before) {
-    internalId = before;
+    doc = before;
     op = (sortOrder === "desc" ? "$gt" : "$lt");
   } else {
-    internalId = after;
+    doc = after;
     op = (sortOrder === "desc" ? "$lt" : "$gt");
   }
 
+  const internalId = doc._id;
+
   if (sortByField === "_id") {
-    // We already have _id. Skip the lookup
     if (baseFilterIsEmpty) {
       filter = { _id: { [op]: internalId } };
     } else {
@@ -48,45 +54,35 @@ export default async function applyBeforeAfterToFilter({
       };
     }
   } else {
-    const doc = await collection.findOne({
-      _id: internalId
-    }, {
-      fields: {
-        [sortByField]: 1
-      }
+    limits[op] = doc[sortByField];
+    ors.push({
+      [sortByField]: doc[sortByField],
+      _id: { [op]: internalId }
     });
 
-    if (doc) {
-      limits[op] = doc[sortByField];
-      ors.push({
-        [sortByField]: doc[sortByField],
-        _id: { [op]: internalId }
-      });
-
-      if (baseFilterIsEmpty) {
-        filter = {
-          $or: [
-            {
-              [sortByField]: limits
-            },
-            ...ors
-          ]
-        };
-      } else {
-        filter = {
-          $and: [
-            { ...filter },
-            {
-              $or: [
-                {
-                  [sortByField]: limits
-                },
-                ...ors
-              ]
-            }
-          ]
-        };
-      }
+    if (baseFilterIsEmpty) {
+      filter = {
+        $or: [
+          {
+            [sortByField]: limits
+          },
+          ...ors
+        ]
+      };
+    } else {
+      filter = {
+        $and: [
+          { ...filter },
+          {
+            $or: [
+              {
+                [sortByField]: limits
+              },
+              ...ors
+            ]
+          }
+        ]
+      };
     }
   }
 

--- a/imports/plugins/core/graphql/server/resolvers/util/applyBeforeAfterToFilter.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyBeforeAfterToFilter.test.js
@@ -1,18 +1,18 @@
 import applyBeforeAfterToFilter from "./applyBeforeAfterToFilter";
 
 test("throws an error if sortBy is missing", () =>
-  expect(applyBeforeAfterToFilter({ sortBy: null })).rejects.toMatchSnapshot());
+  expect(() => applyBeforeAfterToFilter({ sortBy: null })).toThrowErrorMatchingSnapshot());
 
 test("throws an error if sortOrder is missing", () =>
-  expect(applyBeforeAfterToFilter({ sortOrder: null })).rejects.toMatchSnapshot());
+  expect(() => applyBeforeAfterToFilter({ sortOrder: null })).toThrowErrorMatchingSnapshot());
 
 test("throws an error if both before and after are set", () =>
-  expect(applyBeforeAfterToFilter({ after: "123", before: "123" })).rejects.toMatchSnapshot());
+  expect(() => applyBeforeAfterToFilter({ after: { _id: "123" }, before: { _id: "123" } })).toThrowErrorMatchingSnapshot());
 
 describe("after", () => {
-  test("alters filter correctly when sorting by _id ascending (default)", async () => {
+  test("alters filter correctly when sorting by _id ascending (default)", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
-    const result = await applyBeforeAfterToFilter({ after: "123", baseFilter });
+    const result = applyBeforeAfterToFilter({ after: { _id: "123" }, baseFilter });
 
     expect(result).toEqual({
       $and: [
@@ -22,9 +22,9 @@ describe("after", () => {
     });
   });
 
-  test("alters filter correctly when sorting by _id descending", async () => {
+  test("alters filter correctly when sorting by _id descending", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
-    const result = await applyBeforeAfterToFilter({ after: "123", baseFilter, sortOrder: "desc" });
+    const result = applyBeforeAfterToFilter({ after: { _id: "123" }, baseFilter, sortOrder: "desc" });
 
     expect(result).toEqual({
       $and: [
@@ -34,15 +34,12 @@ describe("after", () => {
     });
   });
 
-  test("alters filter correctly when sorting by a non-_id field ascending", async () => {
+  test("alters filter correctly when sorting by a non-_id field ascending", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
     const name = "Some Name";
-    const result = await applyBeforeAfterToFilter({
-      after: "123",
+    const result = applyBeforeAfterToFilter({
+      after: { _id: "123", name },
       baseFilter,
-      collection: {
-        findOne: () => ({ name })
-      },
       sortBy: "name"
     });
 
@@ -59,15 +56,12 @@ describe("after", () => {
     });
   });
 
-  test("alters filter correctly when sorting by a non-_id field descending", async () => {
+  test("alters filter correctly when sorting by a non-_id field descending", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
     const name = "Some Name";
-    const result = await applyBeforeAfterToFilter({
-      after: "123",
+    const result = applyBeforeAfterToFilter({
+      after: { _id: "123", name },
       baseFilter,
-      collection: {
-        findOne: () => ({ name })
-      },
       sortBy: "name",
       sortOrder: "desc"
     });
@@ -87,9 +81,9 @@ describe("after", () => {
 });
 
 describe("before", () => {
-  test("alters filter correctly when sorting by _id ascending (default)", async () => {
+  test("alters filter correctly when sorting by _id ascending (default)", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
-    const result = await applyBeforeAfterToFilter({ before: "123", baseFilter });
+    const result = applyBeforeAfterToFilter({ before: { _id: "123" }, baseFilter });
 
     expect(result).toEqual({
       $and: [
@@ -99,9 +93,9 @@ describe("before", () => {
     });
   });
 
-  test("alters filter correctly when sorting by _id descending", async () => {
+  test("alters filter correctly when sorting by _id descending", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
-    const result = await applyBeforeAfterToFilter({ before: "123", baseFilter, sortOrder: "desc" });
+    const result = applyBeforeAfterToFilter({ before: { _id: "123" }, baseFilter, sortOrder: "desc" });
 
     expect(result).toEqual({
       $and: [
@@ -111,15 +105,12 @@ describe("before", () => {
     });
   });
 
-  test("alters filter correctly when sorting by a non-_id field ascending", async () => {
+  test("alters filter correctly when sorting by a non-_id field ascending", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
     const name = "Some Name";
-    const result = await applyBeforeAfterToFilter({
-      before: "123",
+    const result = applyBeforeAfterToFilter({
+      before: { _id: "123", name },
       baseFilter,
-      collection: {
-        findOne: () => ({ name })
-      },
       sortBy: "name"
     });
 
@@ -136,15 +127,12 @@ describe("before", () => {
     });
   });
 
-  test("alters filter correctly when sorting by a non-_id field descending", async () => {
+  test("alters filter correctly when sorting by a non-_id field descending", () => {
     const baseFilter = { _id: { $in: ["abc"] } };
     const name = "Some Name";
-    const result = await applyBeforeAfterToFilter({
-      before: "123",
+    const result = applyBeforeAfterToFilter({
+      before: { _id: "123", name },
       baseFilter,
-      collection: {
-        findOne: () => ({ name })
-      },
       sortBy: "name",
       sortOrder: "desc"
     });

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
@@ -10,44 +10,48 @@
  * @param {Number} totalCount Total count of docs that match the query, after applying the before/after filter
  * @return {Promise<Object>} `{ pageInfo }`
  */
-export default async function applyPaginationToMongoCursor(cursor, { first: requestedFirst, last } = {}, totalCount) {
-  let limit;
-  let skip;
+export default async function applyPaginationToMongoCursor(cursor, { first, last } = {}, totalCount) {
+  if (first && last) throw new Error("Request either `first` or `last` but not both");
 
-  let first;
-  if (!requestedFirst && !last) {
-    first = 50;
-  } else {
-    first = requestedFirst;
-  }
+  // Enforce a `first: 50` limit if no user-supplied limit
+  const limit = first || last || 50;
 
-  if (first && totalCount > first) {
-    limit = first;
-  }
+  let skip = 0;
+  if (last && totalCount > last) skip = totalCount - last;
 
+  let hasNextPage = null;
+  let hasPreviousPage = null;
   if (last) {
-    if (limit && limit > last) {
-      skip = limit - last;
-      limit -= skip;
-    } else if (!limit && totalCount > last) {
-      skip = totalCount - last;
+    if (skip === 0) {
+      hasPreviousPage = false;
+    } else {
+      // For backward pagination, we can find out whether there is a previous page here, but we can't
+      // find out whether there's a next page because the cursor has already had "before" filtering
+      // added. Code external to this function will need to determine whether there are any documents
+      // after that "before" ID.
+      const prevCursor = cursor.clone();
+      prevCursor.limit(limit + 1);
+      prevCursor.skip(skip - 1);
+      const prevCursorCount = await prevCursor.count();
+      hasPreviousPage = prevCursorCount > limit;
     }
+  } else {
+    // For forward pagination, we can find out whether there is a next page here, but we can't
+    // find out whether there's a previous page because the cursor has already had "after" filtering
+    // added. Code external to this function will need to determine whether there are any documents
+    // before that "after" ID.
+    const nextCursor = cursor.clone();
+    nextCursor.limit(limit + 1);
+    const nextCursorCount = await nextCursor.count();
+    hasNextPage = nextCursorCount > limit;
   }
 
-  if (skip) {
-    cursor.skip(skip);
-  }
-
-  if (limit) {
-    cursor.limit(limit);
-  }
-
-  const resultCount = await cursor.clone().count();
+  // Now apply actual limit + skip to the provided cursor
+  cursor.limit(limit);
+  if (skip) cursor.skip(skip);
 
   return {
-    pageInfo: {
-      hasNextPage: !!first && resultCount >= first,
-      hasPreviousPage: !!last && resultCount >= last
-    }
+    hasNextPage,
+    hasPreviousPage
   };
 }

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.test.js
@@ -1,74 +1,66 @@
 import applyPaginationToMongoCursor from "./applyPaginationToMongoCursor";
 import getFakeMongoCursor from "/imports/test-utils/helpers/getFakeMongoCursor";
 
-const mockCursor = getFakeMongoCursor("Test", new Array(100));
+let mockCursor;
+beforeEach(() => {
+  mockCursor = getFakeMongoCursor("Test", new Array(100));
+});
 
-test("with neither first nor last limits to 50", () => {
+test("with neither first nor last limits to first 50", async () => {
+  mockCursor.count.mockReturnValueOnce(Promise.resolve(51));
+  const result = await applyPaginationToMongoCursor(mockCursor, undefined, 100);
+  expect(result).toEqual({
+    hasNextPage: true,
+    hasPreviousPage: null
+  });
+  expect(mockCursor.limit.mock.calls).toEqual([[51], [50]]);
+  expect(mockCursor.skip).not.toHaveBeenCalled();
+});
+
+test("with both first and last, throws error", () => {
+  expect(applyPaginationToMongoCursor(mockCursor, { first: 1, last: 1 }, 100)).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("with first and more, returns hasNextPage true", async () => {
+  mockCursor.count.mockReturnValueOnce(Promise.resolve(51));
+  const result = await applyPaginationToMongoCursor(mockCursor, { first: 50 }, 100);
+  expect(result).toEqual({
+    hasNextPage: true,
+    hasPreviousPage: null
+  });
+  expect(mockCursor.limit.mock.calls).toEqual([[51], [50]]);
+  expect(mockCursor.skip).not.toHaveBeenCalled();
+});
+
+test("with first and no more, returns hasNextPage false", async () => {
   mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, undefined, 100)).resolves.toEqual({
-    pageInfo: {
-      hasNextPage: true,
-      hasPreviousPage: false
-    }
+  const result = await applyPaginationToMongoCursor(mockCursor, { first: 50 }, 100);
+  expect(result).toEqual({
+    hasNextPage: false,
+    hasPreviousPage: null
   });
+  expect(mockCursor.limit.mock.calls).toEqual([[51], [50]]);
+  expect(mockCursor.skip).not.toHaveBeenCalled();
 });
 
-test("with first and maybe more, returns hasNextPage true", () => {
+test("with last and more, returns hasPreviousPage true", async () => {
+  mockCursor.count.mockReturnValueOnce(Promise.resolve(51));
+  const result = await applyPaginationToMongoCursor(mockCursor, { last: 50 }, 80);
+  expect(result).toEqual({
+    hasNextPage: null,
+    hasPreviousPage: true
+  });
+  expect(mockCursor.limit.mock.calls).toEqual([[51], [50]]);
+  expect(mockCursor.skip.mock.calls).toEqual([[29], [30]]);
+});
+
+test("with last and no more, returns hasPreviousPage false", async () => {
   mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 }, 100)).resolves.toEqual({
-    pageInfo: {
-      hasNextPage: true,
-      hasPreviousPage: false
-    }
+  const result = await applyPaginationToMongoCursor(mockCursor, { last: 50 }, 80);
+  expect(result).toEqual({
+    hasNextPage: null,
+    hasPreviousPage: false
   });
-});
-
-test("with first and definitely more, returns hasNextPage true", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 }, 100)).resolves.toEqual({
-    pageInfo: {
-      hasNextPage: true,
-      hasPreviousPage: false
-    }
-  });
-});
-
-test("with first and no more, returns hasNextPage false", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(40));
-  expect(applyPaginationToMongoCursor(mockCursor, { first: 50 }, 100)).resolves.toEqual({
-    pageInfo: {
-      hasNextPage: false,
-      hasPreviousPage: false
-    }
-  });
-});
-
-test("with last and maybe more, returns hasPreviousPage true", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 }, 100)).resolves.toEqual({
-    pageInfo: {
-      hasNextPage: false,
-      hasPreviousPage: true
-    }
-  });
-});
-
-test("with last and definitely more, returns hasPreviousPage true", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(50));
-  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 }, 100)).resolves.toEqual({
-    pageInfo: {
-      hasNextPage: false,
-      hasPreviousPage: true
-    }
-  });
-});
-
-test("with last and no more, returns hasPreviousPage false", () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(40));
-  expect(applyPaginationToMongoCursor(mockCursor, { last: 50 }, 100)).resolves.toEqual({
-    pageInfo: {
-      hasNextPage: false,
-      hasPreviousPage: false
-    }
-  });
+  expect(mockCursor.limit.mock.calls).toEqual([[51], [50]]);
+  expect(mockCursor.skip.mock.calls).toEqual([[29], [30]]);
 });

--- a/imports/plugins/core/graphql/server/resolvers/util/checkHasMoreInOppositeDirection.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/checkHasMoreInOppositeDirection.js
@@ -1,0 +1,58 @@
+import applyBeforeAfterToFilter from "./applyBeforeAfterToFilter";
+
+/**
+ * @name checkHasMoreInOppositeDirection
+ * @method
+ * @summary Checks whether there are more documents before an "after" doc or after a "before" doc
+ * @param {Object} args
+ * @returns {Boolean} Are there more? Always returns `false` if both `before` and `after` are falsy
+ */
+export default async function checkHasMoreInOppositeDirection({
+  after,
+  baseFilter,
+  before,
+  mongoCursor,
+  sort,
+  sortBy,
+  sortOrder
+}) {
+  let moreItems = [];
+
+  // For forward pagination, this is the best place to query and find out if there is at least one
+  // document immediately before the "after" document.
+  if (after) {
+    const previousFilter = applyBeforeAfterToFilter({
+      baseFilter,
+      before: after, // We're swapping these to determine if there's a previous page
+      sortBy,
+      sortOrder
+    });
+
+    moreItems = await mongoCursor
+      .clone()
+      .filter(previousFilter)
+      .sort(sort)
+      .limit(1)
+      .toArray();
+  }
+
+  // For backward pagination, this is the best place to query and find out if there is at least one
+  // document immediately after the "before" document.
+  if (before) {
+    const nextFilter = applyBeforeAfterToFilter({
+      baseFilter,
+      after: before, // We're swapping these to determine if there's a next page
+      sortBy,
+      sortOrder
+    });
+
+    moreItems = await mongoCursor
+      .clone()
+      .filter(nextFilter)
+      .sort(sort)
+      .limit(1)
+      .toArray();
+  }
+
+  return (moreItems.length) === 1;
+}

--- a/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
@@ -1,5 +1,6 @@
 import applyBeforeAfterToFilter from "./applyBeforeAfterToFilter";
 import applyPaginationToMongoCursor from "./applyPaginationToMongoCursor";
+import checkHasMoreInOppositeDirection from "./checkHasMoreInOppositeDirection";
 import getCollectionFromCursor from "./getCollectionFromCursor";
 import getMongoSort from "./getMongoSort";
 
@@ -12,24 +13,71 @@ import getMongoSort from "./getMongoSort";
  * @memberof GraphQL/ResolverUtilities
  * @summary Given a MongoDB cursor, adds skip, limit, sort, and other filters as necessary
  *   based on GraphQL resolver arguments.
+ * @param {Cursor} mongoCursor Node MongoDB Cursor instance. Will be mutated.
+ * @param {Object} args Connection arguments from GraphQL query
  * @return {Promise<Object>} `{ nodes, pageInfo, totalCount }`
  */
-async function getPaginatedResponse(query, args) {
-  const totalCount = await query.clone().count();
-  const collection = getCollectionFromCursor(query);
+async function getPaginatedResponse(mongoCursor, args) {
+  const { sortBy, sortOrder } = args;
+  const baseFilter = mongoCursor.cmd.query;
 
-  const baseFilter = query.cmd.query;
-  const updatedFilter = await applyBeforeAfterToFilter({ collection, baseFilter, ...args });
-  const sort = getMongoSort(args);
+  // Get the total count, prior to adding before/after filtering
+  const totalCount = await mongoCursor.clone().count();
 
-  query.filter(updatedFilter).sort(sort);
+  // Get a MongoDB sort object
+  const sort = getMongoSort({ sortBy, sortOrder });
 
-  const totalCountAfterOrBefore = await query.clone().count();
+  // Find the document for the before/after ID
+  const collection = getCollectionFromCursor(mongoCursor);
+  let { after, before } = args;
+  if (after || before) {
+    const doc = await collection.findOne({
+      _id: before || after
+    }, {
+      fields: {
+        [sortBy]: 1
+      }
+    });
 
-  const { pageInfo } = await applyPaginationToMongoCursor(query, args, totalCountAfterOrBefore);
-  const nodes = await query.toArray();
+    if (after) after = doc;
+    if (before) before = doc;
+  }
+
+  const hasMore = await checkHasMoreInOppositeDirection({
+    after,
+    baseFilter,
+    before,
+    mongoCursor,
+    sort,
+    sortBy,
+    sortOrder
+  });
+
+  // Get an updated filter, with before/after added
+  const updatedFilter = applyBeforeAfterToFilter({
+    baseFilter,
+    after,
+    before,
+    sortBy,
+    sortOrder
+  });
+
+  // Apply these to the cursor
+  mongoCursor.filter(updatedFilter).sort(sort);
+
+  // Get the new count after applying before/after
+  const totalCountAfterOrBefore = await mongoCursor.clone().count();
+
+  const { hasPreviousPage, hasNextPage } = await applyPaginationToMongoCursor(mongoCursor, args, totalCountAfterOrBefore);
+
+  // Figure out proper hasNext/hasPrevious
+  const pageInfo = {
+    hasPreviousPage: hasPreviousPage === null ? hasMore : hasPreviousPage,
+    hasNextPage: hasNextPage === null ? hasMore : hasNextPage
+  };
+
+  const nodes = await mongoCursor.toArray();
   const count = nodes.length;
-
   if (count) {
     pageInfo.startCursor = nodes[0]._id;
     pageInfo.endCursor = nodes[count - 1]._id;

--- a/tests/GraphTester.js
+++ b/tests/GraphTester.js
@@ -27,11 +27,11 @@ Object.assign(Cursor.prototype, {
     return util.promisify(this.exec.bind(this))();
   },
   clone() {
-    const clonedCursor = new Cursor(this.db, this.query, this.execFn);
+    const clonedCursor = new Cursor(this.db, merge({}, this.query), this.execFn);
     clonedCursor._limit = this._limit;
     clonedCursor._skip = this._skip;
-    clonedCursor._sort = this._sort;
-    clonedCursor._projection = this._projection;
+    clonedCursor._sort = this._sort ? merge({}, this._sort) : this._sort;
+    clonedCursor._projection = this._projection ? merge({}, this._projection) : this._projection;
     return clonedCursor;
   },
   async count() {

--- a/tests/tag/tags.test.js
+++ b/tests/tag/tags.test.js
@@ -62,7 +62,19 @@ test("get the first 50 tags when neither first or last is in query", async () =>
 
   expect(result.tags.nodes.length).toBe(5);
   expect(result.tags.totalCount).toBe(55);
-  expect(result.tags.pageInfo).toEqual({ endCursor: "MTU0", hasNextPage: false, hasPreviousPage: false, startCursor: "MTUw" });
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTU0", hasNextPage: false, hasPreviousPage: true, startCursor: "MTUw" });
+
+  // Ensure it's also correct when we pass `first: 5` explicitly
+  try {
+    result = await query({ shopId: opaqueShopId, after: "MTQ5", first: 5 });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tags.nodes.length).toBe(5);
+  expect(result.tags.totalCount).toBe(55);
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTU0", hasNextPage: false, hasPreviousPage: true, startCursor: "MTUw" });
 });
 
 test("get the last 10 tags when last is in query and before last item in list", async () => {
@@ -77,4 +89,40 @@ test("get the last 10 tags when last is in query and before last item in list", 
   expect(result.tags.nodes.length).toBe(10);
   expect(result.tags.totalCount).toBe(55);
   expect(result.tags.pageInfo).toEqual({ endCursor: "MTUz", hasNextPage: false, hasPreviousPage: true, startCursor: "MTQ0" });
+
+  try {
+    result = await query({ shopId: opaqueShopId, last: 10, before: result.tags.pageInfo.startCursor });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tags.nodes.length).toBe(10);
+  expect(result.tags.totalCount).toBe(55);
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTQz", hasNextPage: true, hasPreviousPage: true, startCursor: "MTM0" });
+
+  try {
+    result = await query({ shopId: opaqueShopId, last: 34, before: result.tags.pageInfo.startCursor });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tags.nodes.length).toBe(34);
+  expect(result.tags.totalCount).toBe(55);
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTMz", hasNextPage: true, hasPreviousPage: false, startCursor: "MTAw" });
+});
+
+test("works correctly when last goes before start", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, last: 5, before: "MTAw" });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tags.nodes.length).toBe(0);
+  expect(result.tags.totalCount).toBe(55);
+  expect(result.tags.pageInfo).toEqual({ endCursor: null, hasNextPage: true, hasPreviousPage: false, startCursor: null });
 });


### PR DESCRIPTION
Resolves #4230   
Impact: **minor**  
Type: **bugfix**

## Issue
The current implementation of `hasNextPage` and `hasPreviousPage` for GraphQL connections has two limitations:
- When forward paginating, `hasPreviousPage` is always `false`, and when backward paginating, `hasNextPage` is always `false`
- When the response contains exactly as many items as you request, we set `hasNextPage` or `hasPreviousPage` to `true` without checking for sure to see if it's true.

## Changes

`hasPreviousPage` and `hasNextPage` should always be correct now. It does extra database queries to set correct values.

## Breaking changes
None

## Testing
Do `catalogItems` or `tags` queries with various `before`, `after`, `first`, and `last` values.
Ensure that if `hasPreviousPage` is `true`, there really is a previous page of results. Ensure that if `hasNextPage` is `true`, there really is a next page of results.