### PR TITLE
Fix #4090: Load more products working now

### DIFF
--- a/imports/plugins/included/product-variant/containers/productsContainerCustomer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainerCustomer.js
@@ -115,7 +115,8 @@ function composer(props, onData) {
 }
 
 registerComponent("ProductsCustomer", ProductGridCustomer, [
-  composeWithTracker(composer)
+  composeWithTracker(composer),
+  wrapComponent
 ]);
 
 export default compose(


### PR DESCRIPTION
Resolves #4090  
Impact: **critical**  
Type: **bugfix**

## Issue
The component that was being exported was not the wrapped Component instead the raw Component was exported with composer. Hence the method(`loadProducts`) that was part of the wrapper component was not available in the exported component.

## Solution
The component exported is now wrapped with wrapper component.

## Breaking changes
None

## Testing
1. Add more than 24 products.
2. Access the Reaction Store anonymously.
3. Scroll down to the end.
4. See more products load.