### PR TITLE
Supported methods is optional

### DIFF
--- a/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
+++ b/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
@@ -23,7 +23,8 @@ export const PaypalPackageConfig = PackageConfig.clone().extend({
   },
   "settings.express.support": {
     type: Array,
-    label: "Payment provider supported methods"
+    label: "Payment provider supported methods",
+    optional: true
   },
   "settings.express.support.$": {
     type: String,
@@ -35,7 +36,8 @@ export const PaypalPackageConfig = PackageConfig.clone().extend({
   },
   "settings.payflow.support": {
     type: Array,
-    label: "Payment provider supported methods"
+    label: "Payment provider supported methods",
+    optional: true
   },
   "settings.payflow.support.$": {
     type: String,

--- a/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
+++ b/imports/plugins/included/payments-paypal/lib/collections/schemas/paypal.js
@@ -24,7 +24,7 @@ export const PaypalPackageConfig = PackageConfig.clone().extend({
   "settings.express.support": {
     type: Array,
     label: "Payment provider supported methods",
-    optional: true
+    defaultValue: ["Authorize", "Capture", "Refund"]
   },
   "settings.express.support.$": {
     type: String,
@@ -37,7 +37,7 @@ export const PaypalPackageConfig = PackageConfig.clone().extend({
   "settings.payflow.support": {
     type: Array,
     label: "Payment provider supported methods",
-    optional: true
+    defaultValue: ["Authorize", "Capture", "Refund"]
   },
   "settings.payflow.support.$": {
     type: String,


### PR DESCRIPTION
Resolves #4234   
Impact: **critical**  
Type: **bugfix**

## Issue
This error is happening because Reaction uses Autoform for rendering the form. But only a part of the schema is used to render the form(the other part is used for payflow.)
So when trying to save, Autoform detects that the document it got from the form is missing a "required" field(the supported field of PayFlow) and hence is throwing a error.

## Solution
I have made the `supported` array optional. So now when the form is saved for Express and the document without `supported` array for PayFlow is saved, there is no validation error.

## Breaking changes
None

## Testing
1. Login as admin
1. Enable PayPal Express
1. Fill the form, try to save it.
1. Observe no error.