### PR TITLE
[WIP] bug - fix hasNextPage being false, even with a known next page

### DIFF
--- a/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/getPaginatedResponse.js
@@ -1,6 +1,5 @@
 import applyBeforeAfterToFilter from "./applyBeforeAfterToFilter";
 import applyPaginationToMongoCursor from "./applyPaginationToMongoCursor";
-import checkHasMoreInOppositeDirection from "./checkHasMoreInOppositeDirection";
 import getCollectionFromCursor from "./getCollectionFromCursor";
 import getMongoSort from "./getMongoSort";
 
@@ -30,6 +29,7 @@ async function getPaginatedResponse(mongoCursor, args) {
   // Find the document for the before/after ID
   const collection = getCollectionFromCursor(mongoCursor);
   let { after, before } = args;
+  let hasMore = false;
   if (after || before) {
     const doc = await collection.findOne({
       _id: before || after
@@ -41,17 +41,8 @@ async function getPaginatedResponse(mongoCursor, args) {
 
     if (after) after = doc;
     if (before) before = doc;
+    hasMore = true;
   }
-
-  const hasMore = await checkHasMoreInOppositeDirection({
-    after,
-    baseFilter,
-    before,
-    mongoCursor,
-    sort,
-    sortBy,
-    sortOrder
-  });
 
   // Get an updated filter, with before/after added
   const updatedFilter = applyBeforeAfterToFilter({

--- a/tests/tag/tags.test.js
+++ b/tests/tag/tags.test.js
@@ -88,7 +88,7 @@ test("get the last 10 tags when last is in query and before last item in list", 
 
   expect(result.tags.nodes.length).toBe(10);
   expect(result.tags.totalCount).toBe(55);
-  expect(result.tags.pageInfo).toEqual({ endCursor: "MTUz", hasNextPage: false, hasPreviousPage: true, startCursor: "MTQ0" });
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTUz", hasNextPage: true, hasPreviousPage: true, startCursor: "MTQ0" });
 
   try {
     result = await query({ shopId: opaqueShopId, last: 10, before: result.tags.pageInfo.startCursor });


### PR DESCRIPTION
Resolves #4248
Impact: **minor**  
Type: **bugfix**

## Issue

Fix an issue with pagination with GraphQL that causes `hasNextPage` to be `false` if there is exactly one item on the next page and `last: <number>, before: <string_cursor>` are passed as arguments to the query.

## Solution

- Set `hasMore` to `true` when `before` or `after` is provided in getPaginatedResponse.js.
- Update tests to reflect this

## Breaking changes

None.

## Testing
1. With 3 items published to the catalog
2. Run the query

```graphql
{
  catalogItems(shopIds: ["cmVhY3Rpb24vc2hvcDpKOEJocTN1VHRkZ3daeDNyeg=="]) {
    totalCount
    pageInfo {
      endCursor
      startCursor
      hasNextPage
      hasPreviousPage
    }
    edges {
      cursor
      node {
        _id
        ... on CatalogItemProduct {
          product {
            _id
            title
        }
      }
    }
  }
}
```

3. Get the last cursor from the returned list

4. Run the following query, replacing `<cursor>` with your copied value

```graphql
{
  catalogItems(shopIds: ["cmVhY3Rpb24vc2hvcDpKOEJocTN1VHRkZ3daeDNyeg=="], last: 2, before: <cursor>) {
    totalCount
    pageInfo {
      endCursor
      startCursor
      hasNextPage
      hasPreviousPage
    }
    edges {
      cursor
      node {
        _id
        ... on CatalogItemProduct {
          product {
            _id
            title
        }
      }
    }
  }
}
```

5. verify that hasNextPage is true