### PR TITLE
fix: added event param to onBlur method in numericInput component

### DIFF
--- a/imports/plugins/core/ui/client/components/numericInput/numericInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numericInput.js
@@ -70,7 +70,7 @@ class NumericInput extends Component {
    * @param  {Event} event Event object
    * @return {void}
    */
-  onBlur = () => {
+  onBlur = (event) => {
     let { value } = this.state;
     if (value > this.props.maxValue) {
       value = this.props.maxValue;


### PR DESCRIPTION
Resolves #4223   
Impact: **critical**  
Type: **bugfix**

## Issue
In the numericInput component's `onBlur` method an `event` variable was being passed to a prop callback but was not defining the `event` as the methods param. This would cause an error in the browser's console and not update the Product's option price.

## Solution
Just added `event` as a param to the `onBlur` method.

## Breaking changes
N/A

## Testing
1. Spin up a fresh RC shop and login as an admin.
2. Select a product from the grid and update one of the options price.
3. The price should update, the variants price range should update and the options should have a yellow dot showing unpublished changes.
4. also no console error. 