### PR TITLE
[4092] Bug Fix: Product Visibility for Marketplace Shops

### DIFF
--- a/imports/plugins/included/product-variant/containers/productsContainerCustomer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainerCustomer.js
@@ -84,16 +84,8 @@ function composer(props, onData) {
     window.prerenderReady = true;
   }
 
-  const activeShopsIds = Shops.find({
-    $or: [
-      { "workflow.status": "active" },
-      { _id: Reaction.getPrimaryShopId() }
-    ]
-  }).map((activeShop) => activeShop._id);
-
   const catalogCursor = Catalog.find({
-    "product.type": "product-simple",
-    "shopId": { $in: activeShopsIds }
+    "product.type": "product-simple"
   }, {
     $sort: {
       [`product.positions.${tagIdForPosition}.position`]: 1,

--- a/server/publications/collections/orders-publications.app-test.js
+++ b/server/publications/collections/orders-publications.app-test.js
@@ -47,8 +47,7 @@ describe("Order Publication", function () {
         expect(collections.Orders.length).to.equal(1);
         const shopOrder = collections.Orders[0];
         expect(shopOrder.shopId).to.equal(order.shopId);
-        done();
-      });
+      }).then(() => done(/* empty */)).catch(done);
     });
 
     it("should not return shop orders for a non-admin", function (done) {
@@ -65,8 +64,7 @@ describe("Order Publication", function () {
       const collector = new PublicationCollector({ userId: Random.id() });
       collector.collect("Orders", (collections) => {
         expect(collections.Orders.length).to.equal(0);
-        done();
-      });
+      }).then(() => done(/* empty */)).catch(done);
     });
   });
 });


### PR DESCRIPTION
Resolves #4092  
Impact: **major**  
Type: **bugfix**

## Issue
Marketplace Shops see Products from all shops.

## Solution
Limit the products that a Marketplace Shop sees to those which are created specifically for it.
One catch is that the Primary Shop should see all products from all shops.

*please note*: this PR is against a branch other than `master`, rather a [PR](#4256) which laid some groundwork for this one.

In addition to this fix, I believe I found a bug when filtering Products for a set of Shop Ids. The test for this behavior was (again, IMO) yielding a false positive. Please see my notes inline.

## Testing
1. Please see issue #4092 for repro steps.
