### PR TITLE
Update to our latest eslint config

### DIFF
--- a/client/modules/core/helpers/utils.js
+++ b/client/modules/core/helpers/utils.js
@@ -37,7 +37,7 @@ async function lazyLoadSlugify() {
  */
 export function getSlug(slugString) {
   let slug;
-  Promise.resolve(lazyLoadSlugify());
+  Promise.resolve(lazyLoadSlugify()); // eslint-disable-line promise/catch-or-return
   if (slugString && slugify) {
     slug = slugify(slugString.toLowerCase());
   } else {

--- a/imports/plugins/core/accounts/client/components/addressBook.js
+++ b/imports/plugins/core/accounts/client/components/addressBook.js
@@ -273,6 +273,7 @@ class AddressBook extends Component {
               mode: "grid"
             });
           }
+          return undefined;
         })
         .catch(onError);
     }
@@ -284,6 +285,7 @@ class AddressBook extends Component {
             validationResults: result
           });
         }
+        return undefined;
       })
       .catch(onError);
   }

--- a/imports/plugins/core/accounts/client/components/loginInline.js
+++ b/imports/plugins/core/accounts/client/components/loginInline.js
@@ -21,7 +21,7 @@ class LoginInline extends Component {
   static propTypes = {
     continueAsGuest: PropTypes.func,
     handleEmailSubmit: PropTypes.func.isRequired,
-    renderEmailForm: PropTypes.bool
+    renderEmailForm: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
   };
 
   constructor(props) {

--- a/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
+++ b/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
@@ -17,6 +17,7 @@ const handlers = {
             if (value) {
               return updateMethodCall(groupId);
             }
+            return null;
           })
           .finally(() => {
             if (onMethodDone) { onMethodDone(); }

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -188,17 +188,14 @@ function copyMedia(newId, variantOldId, variantNewId) {
     "metadata.variantId": variantOldId
   })
     .then((fileRecords) => {
-      fileRecords.forEach((fileRecord) => {
-        // Copy File and insert directly, bypasing revision control
-        fileRecord
-          .fullClone({
-            productId: newId,
-            variantId: variantNewId
-          })
-          .catch((error) => {
-            Logger.error(`Error in copyMedia for product ${newId}`, error);
-          });
-      });
+      // Copy File and insert directly, bypassing revision control
+      const promises = fileRecords.map((fileRecord) => (
+        fileRecord.fullClone({
+          productId: newId,
+          variantId: variantNewId
+        })
+      ));
+      return Promise.all(promises);
     })
     .catch((error) => {
       Logger.error(`Error in copyMedia for product ${newId}`, error);

--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -49,6 +49,7 @@ export function withMoment(component) {
           this.setState({
             moment
           });
+          return null;
         })
         .catch((error) => {
           Logger.debug(error, "moment.js async import error");
@@ -74,6 +75,7 @@ export function withMomentTimezone(component) {
           this.setState({
             momentTimezone: moment.tz
           });
+          return null;
         })
         .catch((error) => {
           Logger.debug(error, "moment.js async import error");

--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -147,10 +147,10 @@ const getStyles = (props) => {
 class ActionView extends Component {
   static propTypes = {
     actionView: PropTypes.object,
-    actionViewIsOpen: PropTypes.bool,
+    actionViewIsOpen: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     buttons: PropTypes.array,
     detailView: PropTypes.object,
-    detailViewIsOpen: PropTypes.bool,
+    detailViewIsOpen: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     handleActionViewBack: PropTypes.func,
     handleActionViewClose: PropTypes.func,
     handleActionViewDetailBack: PropTypes.func,

--- a/imports/plugins/core/dashboard/client/components/toolbar.js
+++ b/imports/plugins/core/dashboard/client/components/toolbar.js
@@ -28,7 +28,7 @@ class PublishControls extends Component {
     packageButtons: PropTypes.arrayOf(PropTypes.object),
     shopId: PropTypes.string,
     shops: PropTypes.arrayOf(PropTypes.object),
-    showViewAsControls: PropTypes.bool,
+    showViewAsControls: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     translation: PropTypes.shape({
       lang: PropTypes.string
     })

--- a/imports/plugins/core/discounts/client/components/form.js
+++ b/imports/plugins/core/discounts/client/components/form.js
@@ -163,5 +163,5 @@ DiscountForm.propTypes = {
   collection: PropTypes.string,
   discount: PropTypes.string,
   id: PropTypes.string,
-  validatedInput: PropTypes.bool
+  validatedInput: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
 };

--- a/imports/plugins/core/discounts/client/components/list.js
+++ b/imports/plugins/core/discounts/client/components/list.js
@@ -65,7 +65,7 @@ DiscountList.propTypes = {
   collection: PropTypes.string,
   id: PropTypes.string,
   listItems: PropTypes.array,
-  validatedInput: PropTypes.bool
+  validatedInput: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
 };
 
 function composer(props, onData) {

--- a/imports/plugins/core/graphql/server/resolvers/shop/Shop/groups.js
+++ b/imports/plugins/core/graphql/server/resolvers/shop/Shop/groups.js
@@ -17,5 +17,5 @@ export default async function groups({ _id }, connectionArgs, context) {
   const dbShopId = decodeShopOpaqueId(_id);
   const query = await context.queries.groups(context, dbShopId);
 
-  return await getPaginatedResponse(query, connectionArgs);
+  return getPaginatedResponse(query, connectionArgs);
 }

--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -62,7 +62,7 @@ class CoreLayout extends React.Component {
 }
 
 CoreLayout.propTypes = {
-  actionViewIsOpen: PropTypes.bool,
+  actionViewIsOpen: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   data: PropTypes.object,
   structure: PropTypes.object
 };

--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -80,6 +80,7 @@ Object.assign(Alerts, {
         if (isConfirm === true && typeof messageOrCallback === "function") {
           messageOrCallback(isConfirm, false);
         }
+        return null;
       }, (dismiss) => {
         if (dismiss === "cancel" || dismiss === "esc" || dismiss === "overlay") {
           messageOrCallback(false, dismiss);
@@ -105,6 +106,7 @@ Object.assign(Alerts, {
       if (isConfirm === true && typeof callback === "function") {
         callback(isConfirm);
       }
+      return null;
     }).catch((err) => {
       if (err === "cancel" || err === "overlay" || err === "timer") {
         return undefined; // Silence error

--- a/imports/plugins/core/orders/client/components/invoice.js
+++ b/imports/plugins/core/orders/client/components/invoice.js
@@ -28,14 +28,14 @@ class Invoice extends Component {
     */
   static propTypes = {
     canMakeAdjustments: PropTypes.bool,
-    discounts: PropTypes.bool,
+    discounts: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     displayMedia: PropTypes.func,
     hasRefundingEnabled: PropTypes.bool,
     invoice: PropTypes.object,
     isFetching: PropTypes.bool,
     moment: PropTypes.func,
     order: PropTypes.object,
-    paymentCaptured: PropTypes.bool,
+    paymentCaptured: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     refunds: PropTypes.array
   }
 

--- a/imports/plugins/core/orders/client/components/invoiceActions.js
+++ b/imports/plugins/core/orders/client/components/invoiceActions.js
@@ -42,11 +42,11 @@ class InvoiceActions extends Component {
     invoice: PropTypes.object,
     isCapturing: PropTypes.bool,
     isRefunding: PropTypes.bool,
-    paymentApproved: PropTypes.bool,
-    paymentCaptured: PropTypes.bool,
-    paymentPendingApproval: PropTypes.bool,
+    paymentApproved: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    paymentCaptured: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    paymentPendingApproval: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     printOrder: PropTypes.string,
-    showAfterPaymentCaptured: PropTypes.bool
+    showAfterPaymentCaptured: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
   }
 
   state = {

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -50,8 +50,8 @@ class LineItems extends Component {
     handleSelectAllItems: PropTypes.func,
     isRefunding: PropTypes.bool,
     order: PropTypes.object,
-    popOverIsOpen: PropTypes.bool,
-    selectAllItems: PropTypes.bool,
+    popOverIsOpen: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    selectAllItems: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     selectedItems: PropTypes.array,
     uniqueItems: PropTypes.array
   }

--- a/imports/plugins/core/orders/client/components/orderBulkActionsBar.js
+++ b/imports/plugins/core/orders/client/components/orderBulkActionsBar.js
@@ -6,9 +6,9 @@ class OrderBulkActionsBar extends Component {
   static propTypes = {
     handleBulkPaymentCapture: PropTypes.func,
     isLoading: PropTypes.object,
-    multipleSelect: PropTypes.bool,
+    multipleSelect: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     orders: PropTypes.array,
-    renderFlowList: PropTypes.bool,
+    renderFlowList: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     selectAllOrders: PropTypes.func,
     selectedItems: PropTypes.array,
     setShippingStatus: PropTypes.func,

--- a/imports/plugins/core/orders/client/components/orderDashboard.js
+++ b/imports/plugins/core/orders/client/components/orderDashboard.js
@@ -17,13 +17,13 @@ class OrderDashboard extends Component {
     handleClick: PropTypes.func,
     handleSelect: PropTypes.func,
     isLoading: PropTypes.object,
-    multipleSelect: PropTypes.bool,
+    multipleSelect: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     onPageChange: PropTypes.func,
     onPageSizeChange: PropTypes.func,
     orders: PropTypes.array,
     pages: PropTypes.number,
     query: PropTypes.object,
-    renderFlowList: PropTypes.bool,
+    renderFlowList: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     searchQuery: PropTypes.string,
     selectAllOrders: PropTypes.func,
     selectedItems: PropTypes.array,

--- a/imports/plugins/core/orders/client/components/orderTable.js
+++ b/imports/plugins/core/orders/client/components/orderTable.js
@@ -43,14 +43,14 @@ class OrderTable extends Component {
     isLoading: PropTypes.object,
     isOpen: PropTypes.bool,
     moment: PropTypes.func,
-    multipleSelect: PropTypes.bool,
+    multipleSelect: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     onPageChange: PropTypes.func,
     onPageSizeChange: PropTypes.func,
     orders: PropTypes.array,
     page: PropTypes.number,
     pages: PropTypes.number,
     query: PropTypes.object,
-    renderFlowList: PropTypes.bool,
+    renderFlowList: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     selectAllOrders: PropTypes.func,
     selectedItems: PropTypes.array,
     setShippingStatus: PropTypes.func,

--- a/imports/plugins/core/orders/client/components/productImage.js
+++ b/imports/plugins/core/orders/client/components/productImage.js
@@ -7,7 +7,7 @@ const MEDIA_PLACEHOLDER = "/resources/placeholder.gif";
 
 class ProductImage extends Component {
   static propTypes = {
-    badge: PropTypes.bool,
+    badge: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     displayMedia: PropTypes.func.isRequired,
     item: PropTypes.shape({
       quantity: PropTypes.number,

--- a/imports/plugins/core/orders/client/containers/totalActionsContainer.js
+++ b/imports/plugins/core/orders/client/containers/totalActionsContainer.js
@@ -7,7 +7,7 @@ class TotalActionsContaner extends Component {
   static propTypes = {
     adjustedTotal: PropTypes.number,
     invoice: PropTypes.object,
-    paymentCaptured: PropTypes.bool
+    paymentCaptured: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
   }
 
   constructor(props) {

--- a/imports/plugins/core/revisions/client/components/publishControls.js
+++ b/imports/plugins/core/revisions/client/components/publishControls.js
@@ -29,7 +29,7 @@ class PublishControls extends Component {
     onViewContextChange: PropTypes.func,
     onVisibilityChange: PropTypes.func,
     revisions: PropTypes.arrayOf(PropTypes.object),
-    showViewAsControls: PropTypes.bool,
+    showViewAsControls: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     translation: PropTypes.shape({
       lang: PropTypes.string
     })

--- a/imports/plugins/core/revisions/client/components/settings.js
+++ b/imports/plugins/core/revisions/client/components/settings.js
@@ -36,7 +36,7 @@ class RevisionControlSettings extends Component {
 }
 
 RevisionControlSettings.propTypes = {
-  checked: PropTypes.bool,
+  checked: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   label: PropTypes.string,
   onUpdateSettings: PropTypes.func,
   settings: PropTypes.object

--- a/imports/plugins/core/ui-navbar/client/components/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/components/navbar.js
@@ -6,7 +6,7 @@ class NavBar extends Component {
   static propTypes = {
     brandMedia: PropTypes.object,
     hasProperPermission: PropTypes.bool,
-    searchEnabled: PropTypes.bool,
+    searchEnabled: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     shop: PropTypes.object,
     visibility: PropTypes.object.isRequired
   };

--- a/imports/plugins/core/ui-tagnav/client/components/tagGroup.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagGroup.js
@@ -159,8 +159,8 @@ class TagGroup extends Component {
 }
 
 TagGroup.propTypes = {
-  blank: PropTypes.bool,
-  editable: PropTypes.bool,
+  blank: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   onNewTagSave: PropTypes.func,
   onTagRemove: PropTypes.func,
   tagGroupProps: PropTypes.object

--- a/imports/plugins/core/ui-tagnav/client/components/tagGroupBody.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagGroupBody.js
@@ -159,7 +159,7 @@ class TagGroupBody extends Component {
 }
 
 TagGroupBody.propTypes = {
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   onNewTagSave: PropTypes.func,
   onTagClick: PropTypes.func,
   onTagRemove: PropTypes.func,

--- a/imports/plugins/core/ui-tagnav/client/components/tagGroupHeader.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagGroupHeader.js
@@ -60,7 +60,7 @@ class TagGroupHeader extends Component {
 }
 
 TagGroupHeader.propTypes = {
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   onTagClick: PropTypes.func,
   onTagRemove: PropTypes.func,
   onUpdateTag: PropTypes.func,

--- a/imports/plugins/core/ui-tagnav/client/components/tagNav.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav.js
@@ -138,7 +138,7 @@ TagNav.propTypes = {
   canEdit: PropTypes.bool,
   children: PropTypes.node,
   closeNavbar: PropTypes.func,
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   handleShopSelectChange: PropTypes.func,
   navButtonStyles: PropTypes.object,
   navbarAnchor: PropTypes.string,

--- a/imports/plugins/core/ui-tagnav/client/containers/tagNavContainer.js
+++ b/imports/plugins/core/ui-tagnav/client/containers/tagNavContainer.js
@@ -84,7 +84,7 @@ const wrapComponent = (Comp) => (
     static propTypes = {
       closeNavbar: PropTypes.func,
       editButton: PropTypes.node,
-      editable: PropTypes.bool,
+      editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
       hasEditRights: PropTypes.bool,
       isVisible: PropTypes.bool,
       tagIds: PropTypes.arrayOf(PropTypes.string),

--- a/imports/plugins/core/ui/client/components/avatar/avatar.js
+++ b/imports/plugins/core/ui/client/components/avatar/avatar.js
@@ -40,14 +40,14 @@ ReactionAvatar.propTypes = {
   className: PropTypes.string,
   color: PropTypes.string,
   colors: PropTypes.array,
-  currentUser: PropTypes.bool,
+  currentUser: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   email: PropTypes.string,
   facebookId: PropTypes.string,
   fgColor: PropTypes.string,
   googleId: PropTypes.string,
   md5Email: PropTypes.string,
   name: PropTypes.string,
-  round: PropTypes.bool,
+  round: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   size: PropTypes.number,
   skypeId: PropTypes.string,
   src: PropTypes.string,

--- a/imports/plugins/core/ui/client/components/badge/badge.js
+++ b/imports/plugins/core/ui/client/components/badge/badge.js
@@ -113,7 +113,7 @@ Badge.propTypes = {
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   i18nKeyLabel: PropTypes.string,
   i18nKeyTooltip: PropTypes.string,
-  indicator: PropTypes.bool,
+  indicator: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   label: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   status: PropTypes.string,
   tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.node]),

--- a/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
+++ b/imports/plugins/core/ui/client/components/calendarPicker/calendarPicker.js
@@ -113,8 +113,8 @@ CalendarPicker.defaultProps = {
 };
 
 CalendarPicker.propTypes = {
-  autoFocusEndDate: PropTypes.bool,
-  enableOutsideDays: PropTypes.bool,
+  autoFocusEndDate: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  enableOutsideDays: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   initialEndDate: PropTypes.object,
   initialStartDate: PropTypes.object,
   initialVisibleMonth: PropTypes.func,
@@ -122,7 +122,7 @@ CalendarPicker.propTypes = {
   isDayHighlighted: PropTypes.func,
   isOutsideRange: PropTypes.func,
   isRTL: PropTypes.bool,
-  keepOpenOnDateSelect: PropTypes.bool,
+  keepOpenOnDateSelect: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   minimumNights: PropTypes.number,
   monthFormat: PropTypes.string,
   navNext: PropTypes.node,
@@ -134,7 +134,7 @@ CalendarPicker.propTypes = {
   onPrevMonthClick: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
   renderDayContents: PropTypes.func,
-  withPortal: PropTypes.bool
+  withPortal: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
 };
 
 registerComponent("CalendarPicker", CalendarPicker);

--- a/imports/plugins/core/ui/client/components/cards/card.js
+++ b/imports/plugins/core/ui/client/components/cards/card.js
@@ -79,8 +79,8 @@ Card.defaultProps = {
 Card.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  expandable: PropTypes.bool,
-  expanded: PropTypes.bool,
+  expandable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  expanded: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   name: PropTypes.string,
   onExpand: PropTypes.func,
   style: PropTypes.object

--- a/imports/plugins/core/ui/client/components/cards/cardBody.js
+++ b/imports/plugins/core/ui/client/components/cards/cardBody.js
@@ -19,8 +19,8 @@ class CardBody extends Component {
 
   static propTypes = {
     children: PropTypes.node,
-    expanded: PropTypes.bool,
-    padded: PropTypes.bool
+    expanded: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    padded: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
   };
 
   renderCard() {

--- a/imports/plugins/core/ui/client/components/cards/cardHeader.js
+++ b/imports/plugins/core/ui/client/components/cards/cardHeader.js
@@ -10,19 +10,19 @@ class CardHeader extends Component {
   };
 
   static propTypes = {
-    actAsExpander: PropTypes.bool,
+    actAsExpander: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     children: PropTypes.node,
-    expandOnSwitchOn: PropTypes.bool,
-    expanded: PropTypes.bool,
+    expandOnSwitchOn: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    expanded: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     i18nKeyTitle: PropTypes.string,
     icon: PropTypes.string,
     imageView: PropTypes.node,
     isValid: PropTypes.bool,
     onClick: PropTypes.func,
     onSwitchChange: PropTypes.func,
-    showSwitch: PropTypes.bool,
+    showSwitch: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     switchName: PropTypes.string,
-    switchOn: PropTypes.bool,
+    switchOn: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     title: PropTypes.string
   };
 

--- a/imports/plugins/core/ui/client/components/cards/settingsCard.js
+++ b/imports/plugins/core/ui/client/components/cards/settingsCard.js
@@ -16,18 +16,18 @@ class SettingsCard extends Component {
 
   static propTypes = {
     children: PropTypes.node,
-    enabled: PropTypes.bool,
-    expanded: PropTypes.bool,
+    enabled: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    expanded: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     i18nKeyTitle: PropTypes.string,
     icon: PropTypes.string,
     name: PropTypes.string,
     onExpand: PropTypes.func,
     onSwitchChange: PropTypes.func,
     packageName: PropTypes.string,
-    padded: PropTypes.bool,
+    padded: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     preferences: PropTypes.object,
-    saveOpenStateToPreferences: PropTypes.bool,
-    showSwitch: PropTypes.bool,
+    saveOpenStateToPreferences: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    showSwitch: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     template: PropTypes.any,
     title: PropTypes.string
   }

--- a/imports/plugins/core/ui/client/components/checkbox/checkbox.js
+++ b/imports/plugins/core/ui/client/components/checkbox/checkbox.js
@@ -52,7 +52,7 @@ Checkbox.defaultProps = {
 };
 
 Checkbox.propTypes = {
-  checked: PropTypes.bool,
+  checked: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   className: PropTypes.string,
   i18nKeyLabel: PropTypes.string,
   id: PropTypes.string,

--- a/imports/plugins/core/ui/client/components/checkbox/rolloverCheckbox.js
+++ b/imports/plugins/core/ui/client/components/checkbox/rolloverCheckbox.js
@@ -41,7 +41,7 @@ const RolloverCheckbox = ({ children, checked, checkboxClassName, onChange, name
 
 RolloverCheckbox.propTypes = {
   checkboxClassName: PropTypes.string,
-  checked: PropTypes.bool,
+  checked: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   children: PropTypes.node,
   className: PropTypes.string,
   name: PropTypes.string,

--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -29,7 +29,7 @@ class Form extends Component {
   * @ignore
   */
   static propTypes = {
-    autoSave: PropTypes.bool,
+    autoSave: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     doc: PropTypes.object,
     docPath: PropTypes.string,
     fields: PropTypes.object,
@@ -37,8 +37,8 @@ class Form extends Component {
     hideFields: PropTypes.arrayOf(PropTypes.string),
     name: PropTypes.string,
     onSubmit: PropTypes.func,
-    renderFromFields: PropTypes.bool,
-    schema: PropTypes.object
+    renderFromFields: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    schema: PropTypes.object // eslint-disable-line react/boolean-prop-naming
   }
 
   constructor(props) {

--- a/imports/plugins/core/ui/client/components/list/listItem.js
+++ b/imports/plugins/core/ui/client/components/list/listItem.js
@@ -15,7 +15,7 @@ class ListItem extends Component {
     onClick: PropTypes.func,
     onSwitchChange: PropTypes.func,
     switchName: PropTypes.string,
-    switchOn: PropTypes.bool,
+    switchOn: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     value: PropTypes.any
   }
 

--- a/imports/plugins/core/ui/client/components/media/mediaGallery.js
+++ b/imports/plugins/core/ui/client/components/media/mediaGallery.js
@@ -8,7 +8,7 @@ import { Reaction } from "/client/api";
 
 class MediaGallery extends Component {
   static propTypes = {
-    editable: PropTypes.bool,
+    editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     featuredMedia: PropTypes.object,
     media: PropTypes.arrayOf(PropTypes.object),
     mediaGalleryHeight: PropTypes.number,

--- a/imports/plugins/core/ui/client/components/media/mediaItem.js
+++ b/imports/plugins/core/ui/client/components/media/mediaItem.js
@@ -12,7 +12,7 @@ class MediaItem extends Component {
     connectDragSource: PropTypes.func,
     connectDropTarget: PropTypes.func,
     defaultSource: PropTypes.string,
-    editable: PropTypes.bool,
+    editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     mediaHeight: PropTypes.number,
     mediaWidth: PropTypes.number,
     onClick: PropTypes.func,
@@ -21,7 +21,7 @@ class MediaItem extends Component {
     onRemoveMedia: PropTypes.func,
     size: PropTypes.string,
     source: PropTypes.object,
-    zoomable: PropTypes.bool
+    zoomable: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
   };
 
   static defaultProps = {

--- a/imports/plugins/core/ui/client/components/media/mediaUploader.js
+++ b/imports/plugins/core/ui/client/components/media/mediaUploader.js
@@ -50,10 +50,15 @@ class MediaUploader extends Component {
       promises.push(promise);
     });
 
-    Promise.all(promises).then(() => {
-      if (!this._isMounted) return;
-      this.setState({ isUploading: false });
-    });
+    Promise.all(promises)
+      .then(() => {
+        if (!this._isMounted) return null;
+        this.setState({ isUploading: false });
+        return null;
+      })
+      .catch((error) => {
+        Logger.error(error);
+      });
   };
 
   render() {

--- a/imports/plugins/core/ui/client/components/menu/dropDownMenu.js
+++ b/imports/plugins/core/ui/client/components/menu/dropDownMenu.js
@@ -117,7 +117,7 @@ DropDownMenu.propTypes = {
   buttonElement: PropTypes.node,
   children: PropTypes.node,
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  closeOnClick: PropTypes.bool,
+  closeOnClick: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   constraints: PropTypes.array,
   isClickable: PropTypes.bool,
   isEnabled: PropTypes.bool,

--- a/imports/plugins/core/ui/client/components/menu/menuItem.js
+++ b/imports/plugins/core/ui/client/components/menu/menuItem.js
@@ -57,10 +57,10 @@ class MenuItem extends Component {
 }
 
 MenuItem.propTypes = {
-  active: PropTypes.bool,
+  active: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   children: PropTypes.node,
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   eventAction: PropTypes.string,
   i18nKeyLabel: PropTypes.string,
   i18nKeySelectedLabel: PropTypes.string,

--- a/imports/plugins/core/ui/client/components/metadata/metadata.js
+++ b/imports/plugins/core/ui/client/components/metadata/metadata.js
@@ -110,7 +110,7 @@ Metadata.defaultProps = {
 
 // Prop Types
 Metadata.propTypes = {
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   metafields: PropTypes.arrayOf(PropTypes.object),
   newMetafield: PropTypes.object,
   onMetaChange: PropTypes.func,

--- a/imports/plugins/core/ui/client/components/metadata/metafield.js
+++ b/imports/plugins/core/ui/client/components/metadata/metafield.js
@@ -137,7 +137,7 @@ Metafield.defaultProps = {
 
 // Prop Types
 Metafield.propTypes = {
-  blank: PropTypes.bool,
+  blank: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   detailInfoPlaceholder: PropTypes.func,
   detailNamePlaceholder: PropTypes.func,
   i18nKeyDetailInfo: PropTypes.func,

--- a/imports/plugins/core/ui/client/components/numericInput/numericInput.js
+++ b/imports/plugins/core/ui/client/components/numericInput/numericInput.js
@@ -227,7 +227,7 @@ NumericInput.defaultProps = {
 
 NumericInput.propTypes = {
   classNames: PropTypes.shape({}),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   format: PropTypes.shape({
     decimal: PropTypes.string
   }),

--- a/imports/plugins/core/ui/client/components/popover/popover.js
+++ b/imports/plugins/core/ui/client/components/popover/popover.js
@@ -136,8 +136,8 @@ Popover.propTypes = {
   onClick: PropTypes.func,
   onDisplayButtonClick: PropTypes.func,
   onRequestOpen: PropTypes.func,
-  showArrow: PropTypes.bool,
-  showDropdownButton: PropTypes.bool,
+  showArrow: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  showDropdownButton: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   targetAttachment: PropTypes.string,
   tooltipContent: PropTypes.node
 };

--- a/imports/plugins/core/ui/client/components/switch/switch.js
+++ b/imports/plugins/core/ui/client/components/switch/switch.js
@@ -9,8 +9,8 @@ class Switch extends Component {
   }
 
   static propTypes = {
-    checked: PropTypes.bool,
-    disabled: PropTypes.bool,
+    checked: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+    disabled: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     helpText: PropTypes.string,
     i18nKeyHelpText: PropTypes.string,
     i18nKeyLabel: PropTypes.string,

--- a/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
@@ -162,8 +162,8 @@ SortableTablePagination.propTypes = {
   paginationStyle: PropTypes.object,
   previousText: PropTypes.string,
   rowsText: PropTypes.string,
-  showPageJump: PropTypes.bool,
-  showPageSizeOptions: PropTypes.bool
+  showPageJump: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  showPageSizeOptions: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
 };
 
 export default SortableTablePagination;

--- a/imports/plugins/core/ui/client/components/table/sortableTableComponents/paginationButtons.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTableComponents/paginationButtons.js
@@ -71,7 +71,7 @@ class PaginationButtons extends Component {
 
 PaginationButtons.propTypes = {
   children: PropTypes.string,
-  disabled: PropTypes.bool,
+  disabled: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   onClick: PropTypes.func
 };
 

--- a/imports/plugins/core/ui/client/components/tabs/tabItem.js
+++ b/imports/plugins/core/ui/client/components/tabs/tabItem.js
@@ -5,7 +5,7 @@ import { registerComponent } from "@reactioncommerce/reaction-components";
 
 class TabItem extends Component {
   static propTypes = {
-    active: PropTypes.bool,
+    active: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
     children: PropTypes.node,
     className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     href: PropTypes.string,

--- a/imports/plugins/core/ui/client/components/tags/tagItem.js
+++ b/imports/plugins/core/ui/client/components/tags/tagItem.js
@@ -304,12 +304,12 @@ class TagItem extends Component {
 }
 
 TagItem.propTypes = {
-  blank: PropTypes.bool,
+  blank: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   connectDragSource: PropTypes.func,
   connectDropTarget: PropTypes.func,
-  draggable: PropTypes.bool,
-  editable: PropTypes.bool,
-  fullWidth: PropTypes.bool,
+  draggable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  fullWidth: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   i18nKeyInputPlaceholder: PropTypes.string,
   index: PropTypes.number,
   inputPlaceholder: PropTypes.string,

--- a/imports/plugins/core/ui/client/components/tags/tagList.js
+++ b/imports/plugins/core/ui/client/components/tags/tagList.js
@@ -170,9 +170,9 @@ TagList.defaultProps = {
 
 TagList.propTypes = {
   children: PropTypes.node,
-  draggable: PropTypes.bool,
-  editable: PropTypes.bool,
-  enableNewTagForm: PropTypes.bool,
+  draggable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  enableNewTagForm: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   hasDropdownClassName: PropTypes.func,
   isTagNav: PropTypes.bool,
   navbarSelectedClassName: PropTypes.func,
@@ -190,7 +190,7 @@ TagList.propTypes = {
   onTagSort: PropTypes.func,
   onTagUpdate: PropTypes.func,
   parentTag: ReactionPropTypes.Tag,
-  showBookmark: PropTypes.bool,
+  showBookmark: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   suggestions: PropTypes.arrayOf(PropTypes.object),
   tags: ReactionPropTypes.arrayOfTags
 };

--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -22,7 +22,7 @@ class TextField extends Component {
 
   /**
    * Getter: isValid
-   * @return {Boolean} true/false if field is valid from props.isValid or props.valitation[this.props.name].isValid
+   * @return {Boolean} true/false if field is valid from props.isValid or props.validation[this.props.name].isValid
    */
   get isValid() {
     const { isValid } = this.props;
@@ -276,7 +276,7 @@ class TextField extends Component {
 TextField.propTypes = {
   align: PropTypes.oneOf(["left", "center", "right", "justify"]),
   className: PropTypes.string,
-  disabled: PropTypes.bool,
+  disabled: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   helpText: PropTypes.string,
   i18nKeyHelpText: PropTypes.string,
   i18nKeyLabel: PropTypes.string,
@@ -287,7 +287,7 @@ TextField.propTypes = {
   maxRows: PropTypes.number,
   maxValue: PropTypes.any,
   minValue: PropTypes.number,
-  multiline: PropTypes.bool,
+  multiline: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   name: PropTypes.string,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,

--- a/imports/plugins/core/ui/client/components/toolbar/toolbarGroup.js
+++ b/imports/plugins/core/ui/client/components/toolbar/toolbarGroup.js
@@ -25,9 +25,9 @@ const ToolbarGroup = (props) => {
 ToolbarGroup.propTypes = {
   children: PropTypes.node,
   className: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  firstChild: PropTypes.bool,
-  lastChild: PropTypes.bool,
-  visibleOnMobile: PropTypes.bool
+  firstChild: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  lastChild: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  visibleOnMobile: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
 };
 
 registerComponent("ToolbarGroup", ToolbarGroup);

--- a/imports/plugins/core/ui/client/components/translation/currency.js
+++ b/imports/plugins/core/ui/client/components/translation/currency.js
@@ -9,7 +9,7 @@ const Currency = ({ amount, priceRange, editable }) => (
 
 Currency.propTypes = {
   amount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   priceRange: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 

--- a/imports/plugins/core/ui/client/containers/edit.js
+++ b/imports/plugins/core/ui/client/containers/edit.js
@@ -156,14 +156,14 @@ class EditContainer extends Component {
 }
 
 EditContainer.propTypes = {
-  autoHideEditButton: PropTypes.bool,
+  autoHideEditButton: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   children: PropTypes.node,
   data: PropTypes.object,
   field: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   hasPermission: PropTypes.bool,
   onEditButtonClick: PropTypes.func,
   onVisibilityButtonClick: PropTypes.func,
-  showsVisibilityButton: PropTypes.bool
+  showsVisibilityButton: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
 };
 
 function composer(props, onData) {

--- a/imports/plugins/core/ui/client/containers/mediaGallery.js
+++ b/imports/plugins/core/ui/client/containers/mediaGallery.js
@@ -17,7 +17,7 @@ import { Media } from "/imports/plugins/core/files/client";
 const wrapComponent = (Comp) => (
   class MediaGalleryContainer extends Component {
     static propTypes = {
-      editable: PropTypes.bool,
+      editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
       id: PropTypes.string,
       media: PropTypes.arrayOf(PropTypes.object),
       placement: PropTypes.string
@@ -172,6 +172,7 @@ const wrapComponent = (Comp) => (
               if (error) Alerts.toast(error.reason, "error");
               this.setState({ uploadProgress: null });
             });
+            return null;
           })
           .catch((error) => {
             this.setState({ uploadProgress: null });

--- a/imports/plugins/core/ui/client/containers/tagListContainer.js
+++ b/imports/plugins/core/ui/client/containers/tagListContainer.js
@@ -34,7 +34,7 @@ const wrapComponent = (Comp) => (
   class TagListContainer extends Component {
     static propTypes = {
       children: PropTypes.node,
-      editable: PropTypes.bool,
+      editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
       hasPermission: PropTypes.bool,
       product: PropTypes.object,
       tagIds: PropTypes.arrayOf(PropTypes.string),

--- a/imports/plugins/core/versions/server/migrations/14_rebuild_order_search_collection.js
+++ b/imports/plugins/core/versions/server/migrations/14_rebuild_order_search_collection.js
@@ -17,23 +17,25 @@ async function loadSearchRecordBuilderIfItExists() {
   }
 }
 
-loadSearchRecordBuilderIfItExists().then(() => Migrations.add({
-  // Migrations 12 and 13 introduced changes on Orders, so we need to rebuild the search collection
-  version: 14,
-  up() {
-    OrderSearch.remove({});
+loadSearchRecordBuilderIfItExists()
+  .then(() => Migrations.add({
+    // Migrations 12 and 13 introduced changes on Orders, so we need to rebuild the search collection
+    version: 14,
+    up() {
+      OrderSearch.remove({});
 
-    if (buildOrderSearch) {
-      buildOrderSearch();
-    }
-  },
-  down() {
-    // whether we are going up or down we just want to update the search collections
-    // to match whatever the current code in the build methods are.
-    OrderSearch.remove({});
+      if (buildOrderSearch) {
+        buildOrderSearch();
+      }
+    },
+    down() {
+      // whether we are going up or down we just want to update the search collections
+      // to match whatever the current code in the build methods are.
+      OrderSearch.remove({});
 
-    if (buildOrderSearch) {
-      buildOrderSearch();
+      if (buildOrderSearch) {
+        buildOrderSearch();
+      }
     }
-  }
-}), (err) => Logger.warn(`Failed to run version migration step 14. Received error: ${err}.`));
+  }))
+  .catch((err) => Logger.warn(`Failed to run version migration step 14. Received error: ${err}.`));

--- a/imports/plugins/core/versions/server/migrations/1_rebuild_account_and_order_search_collections.js
+++ b/imports/plugins/core/versions/server/migrations/1_rebuild_account_and_order_search_collections.js
@@ -21,32 +21,34 @@ async function loadSearchRecordBuilderIfItExists() {
   }
 }
 
-loadSearchRecordBuilderIfItExists().then(() => Migrations.add({
-  version: 1,
-  up() {
-    OrderSearch.remove({});
-    AccountSearch.remove({});
+loadSearchRecordBuilderIfItExists()
+  .then(() => Migrations.add({
+    version: 1,
+    up() {
+      OrderSearch.remove({});
+      AccountSearch.remove({});
 
-    if (buildOrderSearch) {
-      buildOrderSearch();
-    }
+      if (buildOrderSearch) {
+        buildOrderSearch();
+      }
 
-    if (buildAccountSearch) {
-      buildAccountSearch();
-    }
-  },
-  down() {
-    // whether we are going up or down we just want to update the search collections
-    // to match whatever the current code in the build methods are.
-    OrderSearch.remove({});
-    AccountSearch.remove({});
+      if (buildAccountSearch) {
+        buildAccountSearch();
+      }
+    },
+    down() {
+      // whether we are going up or down we just want to update the search collections
+      // to match whatever the current code in the build methods are.
+      OrderSearch.remove({});
+      AccountSearch.remove({});
 
-    if (buildOrderSearch) {
-      buildOrderSearch();
-    }
+      if (buildOrderSearch) {
+        buildOrderSearch();
+      }
 
-    if (buildAccountSearch) {
-      buildAccountSearch();
+      if (buildAccountSearch) {
+        buildAccountSearch();
+      }
     }
-  }
-}), (err) => Logger.warn(`Failed to run version migration step 1. Received error: ${err}.`));
+  }))
+  .catch((err) => Logger.warn(`Failed to run version migration step 1. Received error: ${err}.`));

--- a/imports/plugins/included/connectors-shopify/server/jobs/order-export.js
+++ b/imports/plugins/included/connectors-shopify/server/jobs/order-export.js
@@ -36,6 +36,7 @@ export default () => {
       exportToShopify(order)
         .then((exportedOrders) => {
           Logger.debug("exported order(s)", exportedOrders);
+          return null;
         })
         .catch((error) => {
           Logger.error("Encountered error when exporting to shopify", error);

--- a/imports/plugins/included/notifications/client/components/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/components/notificationRoute.js
@@ -101,7 +101,7 @@ NotificationRoute.propTypes = {
   markOneAsRead: PropTypes.func,
   moment: PropTypes.func,
   notificationList: PropTypes.array,
-  showViewAll: PropTypes.bool,
+  showViewAll: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   unread: PropTypes.number
 };
 

--- a/imports/plugins/included/payments-stripe/server/methods/stripe-payment-create-charges.app-test.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripe-payment-create-charges.app-test.js
@@ -291,12 +291,16 @@ describe("stripe/payment/createCharges", function () {
       .post("/v1/charges", `amount=${cart.getTotal() * 100}&capture=false&currency=USD&customer=${stripeCustomerResponse.id}`)
       .reply(200, chargeResult); // .log(console.log);
 
-    methods["stripe/payment/createCharges"]("authorize", cardData, cart._id).then((res) => {
-      const transactionIds = Object.keys(res.transactions);
-      const txId = transactionIds[0];
-      expect(res.success).to.equal(true);
-      expect(res.transactions[txId].amount).to.equal(cart.getTotal() * 100);
-    }).then(() => done(), done);
+    methods["stripe/payment/createCharges"]("authorize", cardData, cart._id)
+      .then((res) => {
+        const transactionIds = Object.keys(res.transactions);
+        const txId = transactionIds[0];
+        expect(res.success).to.equal(true);
+        expect(res.transactions[txId].amount).to.equal(cart.getTotal() * 100);
+        return null;
+      })
+      .then(() => done())
+      .catch(done);
   });
 });
 

--- a/imports/plugins/included/product-admin/client/components/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/components/productAdmin.js
@@ -425,7 +425,7 @@ class ProductAdmin extends Component {
 ProductAdmin.propTypes = {
   countries: PropTypes.arrayOf(PropTypes.object),
   editFocus: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   handleFieldBlur: PropTypes.func,
   handleFieldChange: PropTypes.func,
   handleProductFieldChange: PropTypes.func,

--- a/imports/plugins/included/product-detail-simple/client/components/addToCartButton.js
+++ b/imports/plugins/included/product-detail-simple/client/components/addToCartButton.js
@@ -50,7 +50,7 @@ class AddToCartButton extends Component {
 
 AddToCartButton.propTypes = {
   cartQuantity: PropTypes.number,
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   onAddToCart: PropTypes.func,
   onCartQuantityChange: PropTypes.func,
   onClick: PropTypes.func,

--- a/imports/plugins/included/product-detail-simple/client/components/childVariant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/childVariant.js
@@ -151,7 +151,7 @@ ChildVariant.propTypes = {
   isSelected: PropTypes.bool,
   media: PropTypes.arrayOf(PropTypes.object),
   onClick: PropTypes.func.isRequired,
-  soldOut: PropTypes.bool,
+  soldOut: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   variant: PropTypes.object,
   visibilityButton: PropTypes.node
 };

--- a/imports/plugins/included/product-detail-simple/client/components/metadata.js
+++ b/imports/plugins/included/product-detail-simple/client/components/metadata.js
@@ -58,7 +58,7 @@ class ProductMetadata extends Component {
 
 ProductMetadata.propTypes = {
   editContainerProps: PropTypes.object,
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   metafields: PropTypes.arrayOf(PropTypes.object),
   product: PropTypes.object
 };

--- a/imports/plugins/included/product-detail-simple/client/components/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/components/productDetail.js
@@ -36,7 +36,7 @@ class ProductDetail extends Component {
 
 ProductDetail.propTypes = {
   cartQuantity: PropTypes.number,
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   hasAdminPermission: PropTypes.bool,
   layout: PropTypes.string,
   layoutName: PropTypes.string,

--- a/imports/plugins/included/product-detail-simple/client/components/productField.js
+++ b/imports/plugins/included/product-detail-simple/client/components/productField.js
@@ -154,12 +154,12 @@ class ProductField extends Component {
 
 ProductField.propTypes = {
   editContainerProps: PropTypes.object,
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   element: PropTypes.node,
   fieldName: PropTypes.string,
   fieldTitle: PropTypes.string,
   itemProp: PropTypes.string,
-  multiline: PropTypes.bool,
+  multiline: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   onProductFieldChange: PropTypes.func,
   product: PropTypes.object,
   textFieldProps: PropTypes.object

--- a/imports/plugins/included/product-detail-simple/client/components/tags.js
+++ b/imports/plugins/included/product-detail-simple/client/components/tags.js
@@ -59,7 +59,7 @@ class ProductTags extends Component {
 
 ProductTags.propTypes = {
   editButton: PropTypes.node,
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   product: PropTypes.object,
   tags: PropTypes.arrayOf(PropTypes.object)
 };

--- a/imports/plugins/included/product-detail-simple/client/components/variant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variant.js
@@ -166,10 +166,10 @@ Variant.propTypes = {
   connectDropTarget: PropTypes.func,
   displayPrice: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   editButton: PropTypes.node,
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   isSelected: PropTypes.bool,
   onClick: PropTypes.func,
-  soldOut: PropTypes.bool,
+  soldOut: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   variant: PropTypes.object,
   visibilityButton: PropTypes.node
 };

--- a/imports/plugins/included/product-detail-simple/client/components/variantList.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variantList.js
@@ -181,7 +181,7 @@ VariantList.propTypes = {
   childVariantMedia: PropTypes.arrayOf(PropTypes.any),
   childVariants: PropTypes.arrayOf(PropTypes.object),
   displayPrice: PropTypes.func,
-  editable: PropTypes.bool,
+  editable: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   isSoldOut: PropTypes.func,
   onCreateVariant: PropTypes.func,
   onEditVariant: PropTypes.func,

--- a/imports/plugins/included/product-variant/components/products.js
+++ b/imports/plugins/included/product-variant/components/products.js
@@ -21,7 +21,7 @@ class Products extends Component {
     products: PropTypes.array,
     productsSubscription: PropTypes.object,
     ready: PropTypes.func,
-    showNotFound: PropTypes.bool
+    showNotFound: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
   };
 
   /**

--- a/imports/plugins/included/product-variant/containers/productsContainerAdmin.js
+++ b/imports/plugins/included/product-variant/containers/productsContainerAdmin.js
@@ -55,7 +55,7 @@ const wrapComponent = (Comp) => (
     static propTypes = {
       canLoadMoreProducts: PropTypes.bool,
       productsSubscription: PropTypes.object,
-      showNotFound: PropTypes.bool
+      showNotFound: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
     };
 
     constructor(props) {

--- a/imports/plugins/included/product-variant/containers/productsContainerCustomer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainerCustomer.js
@@ -14,7 +14,7 @@ const wrapComponent = (Comp) => (
     static propTypes = {
       canLoadMoreProducts: PropTypes.bool,
       productsSubscription: PropTypes.object,
-      showNotFound: PropTypes.bool
+      showNotFound: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
     };
 
     constructor(props) {

--- a/imports/plugins/included/social/client/components/facebook.js
+++ b/imports/plugins/included/social/client/components/facebook.js
@@ -109,7 +109,7 @@ FacebookSocialButton.propTypes = {
   altIcon: PropTypes.string,
   media: PropTypes.string,
   settings: PropTypes.object,
-  showText: PropTypes.bool,
+  showText: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   size: PropTypes.string,
   url: PropTypes.string
 };

--- a/imports/plugins/included/social/client/components/googleplus.js
+++ b/imports/plugins/included/social/client/components/googleplus.js
@@ -86,9 +86,9 @@ class GooglePlusSocialButton extends Component {
 }
 
 GooglePlusSocialButton.propTypes = {
-  altIcon: PropTypes.bool,
+  altIcon: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   settings: PropTypes.object,
-  showText: PropTypes.bool,
+  showText: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   size: PropTypes.string,
   url: PropTypes.string
 };

--- a/imports/plugins/included/social/client/components/pinterest.js
+++ b/imports/plugins/included/social/client/components/pinterest.js
@@ -62,9 +62,9 @@ class PinterestSocialButton extends Component {
 }
 
 PinterestSocialButton.propTypes = {
-  altIcon: PropTypes.bool,
+  altIcon: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   settings: PropTypes.object,
-  showText: PropTypes.bool,
+  showText: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   size: PropTypes.string
 };
 

--- a/imports/plugins/included/social/client/components/twitter.js
+++ b/imports/plugins/included/social/client/components/twitter.js
@@ -92,9 +92,9 @@ class TwitterSocialButton extends Component {
 }
 
 TwitterSocialButton.propTypes = {
-  altIcon: PropTypes.bool,
+  altIcon: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   settings: PropTypes.object,
-  showText: PropTypes.bool,
+  showText: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   size: PropTypes.string
 };
 

--- a/imports/plugins/included/ui-search/lib/containers/searchModalContainer.js
+++ b/imports/plugins/included/ui-search/lib/containers/searchModalContainer.js
@@ -32,7 +32,7 @@ const wrapComponent = (Comp) => (
   class SearchModalContainer extends Component {
     static propTypes = {
       onClose: PropTypes.func,
-      open: PropTypes.bool
+      open: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
     }
 
     constructor(props) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1074,9 +1074,9 @@
       }
     },
     "@reactioncommerce/eslint-config": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/eslint-config/-/eslint-config-1.0.1.tgz",
-      "integrity": "sha512-Lpq/k4UzyUDyXeysZT+o+VMNi8BUTVoM+IfdvYL+7mpNiGYhj3BCprapOZget1t7V11TIxbxSL2wTXvRFP5JaQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/eslint-config/-/eslint-config-1.8.0.tgz",
+      "integrity": "sha512-8zVQ00A9uo+GJsCKoSeBKYr2qucoQG9ygIDpvNbLVEWujJubR3gb/RDZvd9QYNzqnA0b0/vB77ehLRdR7WJXTA==",
       "dev": true
     },
     "@reactioncommerce/file-collections": {
@@ -3900,9 +3900,9 @@
       }
     },
     "doctrine": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -4249,15 +4249,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2"
-          }
         }
       }
     },
@@ -4282,9 +4273,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -4292,21 +4283,21 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz",
+      "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.1.1",
+        "eslint-module-utils": "2.2.0",
         "has": "1.0.1",
-        "lodash.cond": "4.5.2",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.7.1"
       },
       "dependencies": {
         "doctrine": {
@@ -4317,6 +4308,15 @@
           "requires": {
             "esutils": "2.0.2",
             "isarray": "1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
           }
         }
       }
@@ -4343,18 +4343,18 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
-      "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
+      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-      "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz",
+      "integrity": "sha512-H3ne8ob4Bn6NXSN9N9twsn7t8dyHT5bF/ibQepxIHi6JiPIdC2gXlfYvZYucbdrWio4FxBq7Z4mSauQP+qmMkQ==",
       "dev": true,
       "requires": {
-        "doctrine": "2.0.2",
+        "doctrine": "2.1.0",
         "has": "1.0.1",
         "jsx-ast-utils": "2.0.1",
         "prop-types": "15.6.0"
@@ -7971,12 +7971,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
-    "lodash.cond": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
     "lodash.curry": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@babel/preset-es2015": "7.0.0-beta.38",
     "@babel/preset-react": "7.0.0-beta.38",
     "@babel/preset-stage-2": "7.0.0-beta.38",
-    "@reactioncommerce/eslint-config": "^1.0.1",
+    "@reactioncommerce/eslint-config": "1.8.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.1",
     "babel-jest": "^22.4.1",
@@ -164,10 +164,11 @@
     "enzyme-to-json": "^3.3.1",
     "eslint": "^4.19.1",
     "eslint-import-resolver-meteor": "^0.4.0",
-    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-import": "2.12.0",
     "eslint-plugin-jest": "^21.14.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-promise": "3.8.0",
+    "eslint-plugin-react": "7.8.2",
     "find-free-port": "^1.2.0",
     "graphql.js": "^0.4.20",
     "jest": "^22.4.2",
@@ -309,19 +310,26 @@
   "eslintConfig": {
     "extends": "@reactioncommerce",
     "globals": {
+      "Alerts": true,
       "Assets": true,
       "jasmine": true,
       "jest/globals": true,
-      "Package": true,
-      "FS": true,
-      "Alerts": true
+      "Package": true
     },
     "settings": {
       "import/resolver": "meteor"
     },
-    "plugins": [
-      "jest"
-    ]
+    "rules": {
+      "valid-jsdoc": [
+        1,
+        {
+          "prefer": {
+            "arg": "param",
+            "argument": "param"
+          }
+        }
+      ]
+    }
   },
   "nodemonConfig": {
     "delay": "2000",


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Changes

- Updated to latest `@reactioncommerce/eslint-config` package, but adjusted the `valid-jsdoc` rule to be a warning because there are too many issues to fix all at once.
- Fixed all other errors, or ignored them line by line. Ignored all of the React bool prop naming errors rather than risk changing those names. They can be changed as we touch each component, and the rule will help ensure new components are correct.
- There are many warnings now, mostly about missing or incorrect jsdoc. We can leave these to be fixed file by file in the future as each file is touched.

## Breaking changes
None

## Testing
Make sure the app still works, all tests still pass, etc.