### PR TITLE
(fix) add getAutoValues: false to discounts/codes/remove

### DIFF
--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -181,7 +181,7 @@ export const methods = {
     const result = Collection.update(
       { _id: id },
       { $set: { discount: currentDiscount }, $pull: { billing: { _id: codeId } } },
-      { multi: true }
+      { multi: true, getAutoValues: false } // See https://github.com/aldeed/meteor-collection2/issues/245 
     );
 
     // calculate discounts

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -178,6 +178,9 @@ export const methods = {
       Collection.update(selector, update);
     }
     // TODO: update a history record of transaction
+    // The Payment schema's currency defaultValue is adding {} to the $pull condition.
+    // If this issue is eventually fixed, autoValues can be re-enabled here
+    // See https://github.com/aldeed/simple-schema-js/issues/272
     const result = Collection.update(
       { _id: id },
       { $set: { discount: currentDiscount }, $pull: { billing: { _id: codeId } } },

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -181,7 +181,7 @@ export const methods = {
     const result = Collection.update(
       { _id: id },
       { $set: { discount: currentDiscount }, $pull: { billing: { _id: codeId } } },
-      { multi: true, getAutoValues: false } // See https://github.com/aldeed/meteor-collection2/issues/245 
+      { multi: true, getAutoValues: false }
     );
 
     // calculate discounts


### PR DESCRIPTION
Resolves #4081 
Impact: **major**  
Type: **bugfix**

## Issue
When there is an applied discount to a cart, clicking the button to remove the discount does not work.

The `Payment` schema has two autovalues: `_id` and `currency` which defaults to `{}`. Because of this, when cart is being updated through `$pull` of the discount payment, SimpleSchema modifies the selector `{ _id: codeId }` to `{ _id: codeId, currency: {} }` which does not match the discount payment that needs to be removed.

## Solution
Add `getAutoValues:false` to the options when updating the cart to avoid the selector for the $pull to be modified.

## Breaking changes
None

## Testing
1. Set up a discount code.
2. Create an order and apply the discount code on checkout.
3. Click the "X' button to remove the discount code.