### PR TITLE
chore: update default GraphQL query limit values

### DIFF
--- a/imports/plugins/core/graphql/server/resolvers/scalar/ConnectionLimitInt.js
+++ b/imports/plugins/core/graphql/server/resolvers/scalar/ConnectionLimitInt.js
@@ -1,7 +1,7 @@
 import { GraphQLScalarType } from "graphql";
 import { Kind } from "graphql/language";
 
-const MAX_LIMIT = 50;
+const MAX_LIMIT = 200;
 
 /**
  * Adjusts value to be between 1 and MAX_LIMIT, inclusive

--- a/imports/plugins/core/graphql/server/resolvers/scalar/ConnectionLimitInt.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/scalar/ConnectionLimitInt.test.js
@@ -11,22 +11,24 @@ describe("serialization", () => {
     expect(ConnectionLimitInt.serialize(null)).toBe(null);
     expect(ConnectionLimitInt.serialize(1)).toBe(1);
     expect(ConnectionLimitInt.serialize(100)).toBe(100);
+    expect(ConnectionLimitInt.serialize(200)).toBe(200);
   });
 });
 
 describe("value parsing", () => {
-  test("returns what is given if it's a number between 1 and 50, inclusive, or undefined", () => {
+  test("returns what is given if it's a number between 1 and 200, inclusive, or undefined", () => {
     expect(ConnectionLimitInt.parseValue(1)).toBe(1);
     expect(ConnectionLimitInt.parseValue(2)).toBe(2);
     expect(ConnectionLimitInt.parseValue(10)).toBe(10);
     expect(ConnectionLimitInt.parseValue(50)).toBe(50);
+    expect(ConnectionLimitInt.parseValue(200)).toBe(200);
     expect(ConnectionLimitInt.parseValue(undefined)).toBe(undefined);
   });
 
-  test("returns 50 if over 50", () => {
-    expect(ConnectionLimitInt.parseValue(null)).toBe(50);
-    expect(ConnectionLimitInt.parseValue(51)).toBe(50);
-    expect(ConnectionLimitInt.parseValue(100)).toBe(50);
+  test("returns 200 if over 200", () => {
+    expect(ConnectionLimitInt.parseValue(null)).toBe(200);
+    expect(ConnectionLimitInt.parseValue(201)).toBe(200);
+    expect(ConnectionLimitInt.parseValue(500)).toBe(200);
   });
 
   test("returns 1 if under 1", () => {
@@ -42,16 +44,17 @@ describe("value parsing", () => {
 const getLiteralForInt = (value) => ({ kind: Kind.INT, value });
 
 describe("literal parsing", () => {
-  test("returns what is given if it's a number between 1 and 50, inclusive", () => {
+  test("returns what is given if it's a number between 1 and 200, inclusive", () => {
     expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(1))).toBe(1);
     expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(2))).toBe(2);
     expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(10))).toBe(10);
     expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(50))).toBe(50);
+    expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(200))).toBe(200);
   });
 
-  test("returns 50 if over 50", () => {
-    expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(51))).toBe(50);
-    expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(100))).toBe(50);
+  test("returns 200 if over 200", () => {
+    expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(201))).toBe(200);
+    expect(ConnectionLimitInt.parseLiteral(getLiteralForInt(500))).toBe(200);
   });
 
   test("returns 1 if under 1", () => {

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
@@ -1,3 +1,5 @@
+const DEFAULT_LIMIT = 20;
+
 /**
  * Inspired by https://www.reindex.io/blog/relay-graphql-pagination-with-mongodb/
  * @name applyPaginationToMongoCursor
@@ -13,8 +15,8 @@
 export default async function applyPaginationToMongoCursor(cursor, { first, last } = {}, totalCount) {
   if (first && last) throw new Error("Request either `first` or `last` but not both");
 
-  // Enforce a `first: 20` limit if no user-supplied limit
-  const limit = first || last || 20;
+  // Enforce a `first: 20` limit if no user-supplied limit, using the DEFAULT_LIMIT
+  const limit = first || last || DEFAULT_LIMIT;
 
   let skip = 0;
   if (last && totalCount > last) skip = totalCount - last;

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.js
@@ -13,8 +13,8 @@
 export default async function applyPaginationToMongoCursor(cursor, { first, last } = {}, totalCount) {
   if (first && last) throw new Error("Request either `first` or `last` but not both");
 
-  // Enforce a `first: 50` limit if no user-supplied limit
-  const limit = first || last || 50;
+  // Enforce a `first: 20` limit if no user-supplied limit
+  const limit = first || last || 20;
 
   let skip = 0;
   if (last && totalCount > last) skip = totalCount - last;

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.test.js
@@ -6,7 +6,7 @@ beforeEach(() => {
   mockCursor = getFakeMongoCursor("Test", new Array(100));
 });
 
-test("with neither first nor last limits to first 50", async () => {
+test("with neither first nor last limits to first 20", async () => {
   mockCursor.count.mockReturnValueOnce(Promise.resolve(21));
   const result = await applyPaginationToMongoCursor(mockCursor, undefined, 100);
   expect(result).toEqual({

--- a/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.test.js
+++ b/imports/plugins/core/graphql/server/resolvers/util/applyPaginationToMongoCursor.test.js
@@ -7,13 +7,13 @@ beforeEach(() => {
 });
 
 test("with neither first nor last limits to first 50", async () => {
-  mockCursor.count.mockReturnValueOnce(Promise.resolve(51));
+  mockCursor.count.mockReturnValueOnce(Promise.resolve(21));
   const result = await applyPaginationToMongoCursor(mockCursor, undefined, 100);
   expect(result).toEqual({
     hasNextPage: true,
     hasPreviousPage: null
   });
-  expect(mockCursor.limit.mock.calls).toEqual([[51], [50]]);
+  expect(mockCursor.limit.mock.calls).toEqual([[21], [20]]);
   expect(mockCursor.skip).not.toHaveBeenCalled();
 });
 


### PR DESCRIPTION
Resolves #4278   
Impact: **minor**  
Type: **chore**

## Issue
The query limits are not optimized on our GraphQL queries

## Solution
Change default first value (when neither first nor last are provided by the client) to 20, to have a default that minimizes DB and server load
Change the max first and last values to 200

## Breaking changes
none.

## Testing
Test on at least one query that has > 205 items. For example, import > 205 tags or catalog items.

- Using GraphQL client, query with no first or last param and make sure you get the first 20 back
- Using GraphQL client, query with first=60 and make sure you get the first 60 back.
- Using GraphQL client, query with first=201 and make sure you get the first 200 back.
- Using GraphQL client, query with last=60 and make sure you get the last 60 back.
- Using GraphQL client, query with last=201 and make sure you get the last 200 back.
- Using the [Reaction NextJS Starter Kit](https://github.com/reactioncommerce/reaction-next-starterkit), connected to devserver, make sure the page size selector above the grid works correctly for all size options.
