### PR TITLE
remove inventoryPolicy check on low inventory

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/utils/isLowQuantity.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/isLowQuantity.js
@@ -11,7 +11,7 @@ export default function isLowQuantity(variants) {
   const threshold = variants && variants.length && variants[0].lowInventoryWarningThreshold;
   const results = variants.map((variant) => {
     const quantity = getProductQuantity(variant, variants);
-    if (variant.inventoryManagement && variant.inventoryPolicy && quantity) {
+    if (variant.inventoryManagement && quantity) {
       return quantity <= threshold;
     }
     return false;


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

## Issue
`Low Inventory` status was not being passed to GraphQL if inventoryPolicy was off.  Inventory Policy is used to determine if products are allowed to be backordered or not, it should not block the low inventory badge from being displayed.

## Solution
Remove inventory policy check on the low inventory status.

Please note this affects nothing on the existing core app, this only affects the way `inventoryPolicy` status is passed to our GraphQL data.

## Breaking changes
None

## Testing
- Open the GraphiQL testing page: http://localhost:3000/graphiql
- Use this query:
```
query {
  catalogItemProduct(slugOrId: "product-a-copy"){ 
  product {
    isLowQuantity
    isSoldOut
    isBackorder
  }
  }
}
```
- Change the inventoryPolicy and inventory amounts on a product, and watch the values change.

`isLowQuantity` should always be true IF quantity is lower than `lowInventoryThresehold`, regardless of `inventoryPolicy` status.
