### PR TITLE
(fix): #4005 missing styles on refund popover

### DIFF
--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -253,7 +253,7 @@ class LineItems extends Component {
         constraints={[
           {
             to: "scrollParent",
-            pin: true
+            pin: ["top", "bottom"]
           },
           {
             to: "window",

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -261,6 +261,7 @@ class LineItems extends Component {
           }
         ]}
         showDropdownButton={false}
+        showShadow
       >
         {this.popOverContent()}
       </Components.Popover>

--- a/imports/plugins/core/ui/client/components/popover/popover.js
+++ b/imports/plugins/core/ui/client/components/popover/popover.js
@@ -103,7 +103,8 @@ class Popover extends Component {
       <TetherComponent
         style={{
           maxHeight: "100vh",
-          overflowY: "auto"
+          overflowY: "auto",
+          boxShadow: this.props.showShadow ? "0 0 4px 2px rgba(0, 0, 0, 0.16)" : "none"
         }}
         attachment={this.attachment}
         classPrefix="popover"
@@ -138,6 +139,7 @@ Popover.propTypes = {
   onRequestOpen: PropTypes.func,
   showArrow: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   showDropdownButton: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  showShadow: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   targetAttachment: PropTypes.string,
   tooltipContent: PropTypes.node
 };

--- a/imports/plugins/included/default-theme/client/styles/dashboard/orders.less
+++ b/imports/plugins/included/default-theme/client/styles/dashboard/orders.less
@@ -154,19 +154,6 @@
   cursor: pointer;
 }
 
-.invoice-popover {
-  width: 416px;
-  height: auto;
-  margin-left: -10px;
-  padding-top: 0px;
-  padding: 10px;
-  padding-bottom: 30px;
-  border-radius: 4px;
-  background-color: @white;
-  box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.16);
-  border: solid 1px #7894a4;
-}
-
 .invoice-popover-controls {
   margin-top: 10px;
   margin-bottom: 10px;

--- a/imports/plugins/included/default-theme/client/styles/dashboard/orders.less
+++ b/imports/plugins/included/default-theme/client/styles/dashboard/orders.less
@@ -543,15 +543,14 @@
 // Invoice Styling
 
 .invoice-popover {
-  width: 416px;
+  width: 408px;
   max-height: 600px;
   overflow-y: scroll;
-  margin-left: -10px;
   padding-top: 0px;
   padding: 10px;
   padding-bottom: 30px;
   border-radius: 4px;
-  background-color: #ffffff;
+  background-color: @white;
   box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.16);
   border: solid 1px #7894a4;
 }

--- a/imports/plugins/included/default-theme/client/styles/dashboard/orders.less
+++ b/imports/plugins/included/default-theme/client/styles/dashboard/orders.less
@@ -551,7 +551,6 @@
   padding-bottom: 30px;
   border-radius: 4px;
   background-color: @white;
-  box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.16);
   border: solid 1px #7894a4;
 }
 


### PR DESCRIPTION
Resolves #4005 
Impact: minor
Type: bugfix

## Issue
Refund popover is missing styles. Box shadow, left border, and alignment are problematic. In particular, the current styling is not working properly well with `tether`.

## Solution
I noticed that `.invoice-popover` has duplicated styling in the same file so I have removed the duplicate. Being pinned to `scrollParent` in all directions cause the popover to misalign a bit from the center so I changed the `pin` parameter to only `top` and `bottom`. The `box-shadow` style should be placed in the top popover div instead of the popover content div for it to take effect. To accomplish this, I updated the `Popover` component to accept `showShadow` props.

Before the fix:
![before](https://user-images.githubusercontent.com/10388757/40956389-2ee98d3e-68ba-11e8-96ef-2e1c2bb5cf74.png)

With some fix but with `constraints` set to `{to: "scrollParent", pin: true}`. Notice that alignment to center is a bit off.

<img width="427" alt="screen shot 2561-06-05 at 12 19 48" src="https://user-images.githubusercontent.com/10388757/40956587-54878b30-68bb-11e8-8e12-c00166b3cf61.png">

`constraints` set to `{to: "scrollParent", pin: ["top", "bottom"]}`. Notice that alignment to center is better.
<img width="432" alt="screen shot 2561-06-05 at 12 22 39" src="https://user-images.githubusercontent.com/10388757/40956591-56b65cec-68bb-11e8-8df8-3e89a6304f89.png">


## Breaking changes
None

## Testing
1. Place an order
2. Refund the order by capturing it and clicking the line item
3. See that popover now have corrected styling
