### PR TITLE
fix: handle products without positions obj

### DIFF
--- a/imports/plugins/core/versions/server/migrations/25_update_catalog_schema.js
+++ b/imports/plugins/core/versions/server/migrations/25_update_catalog_schema.js
@@ -25,7 +25,7 @@ function getShopsForItems(items) {
 function getTagsForItems(items) {
   const uniquePositionKeys = [];
   items.forEach(({ positions }) => {
-    Object.keys(positions).forEach((key) => {
+    Object.keys(positions || {}).forEach((key) => {
       if (uniquePositionKeys.indexOf(key) === -1) {
         uniquePositionKeys.push(key);
       }

--- a/imports/plugins/core/versions/server/util/convertCatalogItem.js
+++ b/imports/plugins/core/versions/server/util/convertCatalogItem.js
@@ -60,7 +60,7 @@ function xformVariant(variant, variantPriceInfo, shopCurrencyCode, updatedAt) {
  */
 function xformPositions(positions, tags) {
   const newPositions = {};
-  Object.keys(positions).forEach((key) => {
+  Object.keys(positions || {}).forEach((key) => {
     let newKey;
     const positionTag = tags.find((tag) => tag.slug === key || tag._id === key);
     if (positionTag) {


### PR DESCRIPTION
Resolves #4299   
Impact: **minor**  
Type: **bugfix**

## Issue
If any documents in `Catalog` collection do not have a `positions` property, migration fails on startup on first start after migration to v1.12.0. The migration is left locked. The error message is:

```
0|reaction | TypeError: Cannot convert undefined or null to object
0|reaction |     at Function.keys (<anonymous>)
0|reaction |     at items.forEach (imports/plugins/core/versions/server/migrations/25_update_catalog_schema.js:28:12)
```

## Solution
Handle undefined `positions` prop in the migration.

## Breaking changes
NONE

## Testing
1. Start Reaction with v1.11.0 and load data.
1. In Mongo, make sure at least one document in Catalog collection has no `positions` property.
1. Upgrade code to v1.12.0
1. Start Reaction and make sure all migrations run without issue, and the app runs properly afterward.
