### PR TITLE
Fix CI step failure to tag Docker image with latest release version 

### DIFF
--- a/.circleci/bin/docker-tags
+++ b/.circleci/bin/docker-tags
@@ -33,6 +33,7 @@ if [[ "$BRANCH" == "master" ]]; then
       | grep "^${SHA1}" \
       | sed -e 's,.* refs/tags/,,' -e 's/\^{}//' \
       | grep "^v[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+$" \
+      | sed 's/v//g' \
       | sort \
   )
 
@@ -40,6 +41,7 @@ if [[ "$BRANCH" == "master" ]]; then
   HIGHEST_TAG=$( \
     git --no-pager tag \
       | grep "^v[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+$" \
+      | sed 's/v//g' \
       | sort -r --version-sort \
       | head -n 1 \
   )

--- a/.circleci/bin/docker-tags
+++ b/.circleci/bin/docker-tags
@@ -37,7 +37,12 @@ if [[ "$BRANCH" == "master" ]]; then
   )
 
   # Find the highest tagged version number
-  HIGHEST_TAG=$(git --no-pager tag | grep "^v[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+$" | sort -r | head -n 1)
+  HIGHEST_TAG=$( \
+    git --no-pager tag \
+      | grep "^v[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+$" \
+      | sort -r --version-sort \
+      | head -n 1 \
+  )
 
   # We tag :latest only if
   # 1. We have a current tag


### PR DESCRIPTION
Resolves #4305  
Impact: **critical**  
Type: **bugfix**

## Issue
CI process fails to push the `:latest` tag to docker since `v1.10.0`. Currently `reactioncommerce/reaction:latest` points to `v1.9.0` image.

This is caused by the `sort` command called on the git tags. The current sort ranks 1.9.0 higher than 1.10.0. So we never get the correct highest tag. 

## Solution
Adding the `--version-sort` flag to the sort command creates the correct tag version hierarchy.
From the man page:

```
-V, --version-sort
Sort version numbers.  The input lines are treated as file names in form PREFIX VERSION SUFFIX, where SUFFIX matches the regu-
lar expression "(.([A-Za-z~][A-Za-z0-9~]*)?)*".  The files are compared by their prefixes and versions (leading zeros are
ignored in version numbers, see example below).  If an input string does not match the pattern, then it is compared using the
byte compare function.  All string comparisons are performed in C locale, the locale environment setting is ignored.

Example:

$ ls sort* | sort -V
sort-1.022.tgz
sort-1.23.tgz
sort-1.23.1.tgz
sort-1.024.tgz
sort-1.024.003.
sort-1.024.003.tgz
sort-1.024.07.tgz
sort-1.024.009.tgz
```

## How To Test
Because the code section affected is in an `if` condition that checks that the merge happened on a master branch, testing this PR is not so direct.

I tested that this worked by using [another branch](https://github.com/reactioncommerce/reaction/blob/confirm-docker-tags/.circleci/bin/docker-tags) with that `if` statement removed. I also had to hard-code a commit SHA that is tied to the latest release in order to confirm that the command getting the CURRENT_RELEASE var works correctly. That way I could see this in the CI logs:

```

mkdir -p docker-cache
.circleci/bin/docker-tags "$CIRCLE_SHA1" "$CIRCLE_BRANCH" | sed 's/\//-/g' \
  > docker-cache/docker-tags.txt
cat docker-cache/docker-tags.txt


confirm-docker-tags
v1.12.1
HIGHEST_TAG: 1.12.1
latest
```



## Breaking changes
None

#### For the failing CI job (Dockerfile lint), see https://github.com/reactioncommerce/reaction/pull/4306