### PR TITLE
Fix hadolint image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
   dockerfile-lint:
     <<: *defaults
     docker:
-      - image: hadolint/hadolint
+      - image: hadolint/hadolint:v1.6.6-6-g254b4ff
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Type: **chore|ci**

## Issue
Hadolint's latest image came with breaking changes causing CI failures.
https://hub.docker.com/r/hadolint/hadolint/tags/

## Solution
Fix hadolint image version to the last compatible version v1.6.6-6-g254b4ff

## Testing
The Dockerfile lint CI step should pass
