### PR TITLE
(fix): change session active product when adding new product

### DIFF
--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -22,6 +22,7 @@ const handleAddProduct = () => {
         if (currentTag) {
           Meteor.call("products/updateProductTags", productId, currentTag.name, currentTagId);
         }
+        Session.set("productGrid/selectedProducts", [productId]);
         // go to new product
         Reaction.Router.go("product", {
           handle: productId


### PR DESCRIPTION
Resolves #3931 and #3933 
Impact: minor
Type: bugfix

## Issue
Props `documentIds` and `documents` of `PublishControls` component do not update when the + (Add Product) button is clicked. This results to:
1. the Archive label being shown upon click of Add Product button when the last active product from the ProductGrid is archived (as explained in #3931)
2. throwing an error when creating a new product and archiving it right after (as explained in #3933)

## Solution
Update the session’s `"productGrid/selectedProducts` when the Add Product button is clicked so that `PublishControls` can pick up the correct product in its props.

## Breaking changes
None


## Testing
1. Click an Archived product from the product grid. Archived label should be displayed at the PublishControls bar
2. Click "+" to add product. The Archived label should disappear.
3. Archive the newly created product. Product should be archived without error.