### PR TITLE
[WIP] Feat ajporlante create deploy to heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ docker-compose -f docker-compose-demo.yml up
 
 You can also use this file as starting point for your production docker-compose setup.
 
+## See it in action
+
+You can check our latest release in Heroku by simply clicking the button below.
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ### License
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,31 @@
+{
+  "name": "Reaction Commerce",
+  "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
+  "repository": "https://github.com/reactioncommerce/reaction",
+  "logo": "https://avatars1.githubusercontent.com/u/5605462?s=200&v=4",
+  "website": "https://www.reactioncommerce.com",
+  "keywords": ["reaction", "e-commerce", "meteor"],
+  "buildpacks": [
+    {
+      "url": "https://github.com/Zanobo/reaction-buildpack.git"
+    }
+  ],
+  "addons": [
+    "papertrail",
+    {
+      "plan": "mongolab:sandbox"
+    }
+  ],
+  "env": {
+    "TOOL_NODE_FLAGS": {
+      "required": true,
+      "description": "Set memory limit to a high value",
+      "value": "--max-old-space-size=2048"
+    },
+    "ROOT_URL": {
+      "required": true,
+      "description": "Your app's URL",
+      "value": "https://app-name.herokuapp.com"
+    }
+  }
+}

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -206,8 +206,8 @@ export function getAbsoluteUrl(path) {
  */
 export function getSlug(slugString) {
   let slug;
-  Promise.await(lazyLoadSlugify());
-  if (slugString) {
+  Promise.resolve(lazyLoadSlugify());
+  if (slugString && slugify) {
     slug = slugify(slugString.toLowerCase());
   } else {
     slug = "";


### PR DESCRIPTION
Type: feature

## Issue
This adds a 'Deploy to Heroku' button in our readme.

## Solution
Created `app.json` as required in https://devcenter.heroku.com/articles/heroku-button, then modified our readme. The build fails because of failing to load transliteration package, so I modified `lib/api/helpers.js`.

## Breaking changes
None

## Testing
1. Click 'Deploy to Heroku' button in readme.
2. Fill out information required by Heroku.
3. Wait for some time (roughly 30 mins), the app should successfully build.