### PR TITLE
(fix): Use Catalog collection for PDP

### DIFF
--- a/imports/plugins/core/ui/client/containers/inventoryBadge.js
+++ b/imports/plugins/core/ui/client/containers/inventoryBadge.js
@@ -1,25 +1,52 @@
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { InventoryBadge } from "../components/badge";
+import { Reaction } from "/client/api";
 import { ReactionProduct } from "/lib/api";
 
 const composer = (props, onData) => {
   const { variant, soldOut } = props;
-  const { inventoryManagement, inventoryPolicy, lowInventoryWarningThreshold } = variant;
-  const inventoryQuantity = ReactionProduct.getVariantQuantity(variant);
+  const {
+    inventoryManagement,
+    inventoryPolicy,
+    lowInventoryWarningThreshold,
+    isSoldOut,
+    isBackorder,
+    isLowQuantity
+  } = variant;
   let label = null;
   let i18nKeyLabel = null;
   let status = null;
-  // TODO: update this to use Catalog API.
-  if (inventoryManagement && !inventoryPolicy && inventoryQuantity === 0) {
-    status = "info";
-    label = "Backorder";
-    i18nKeyLabel = "productDetail.backOrder";
-  } else if (soldOut) {
-    status = "danger";
-    label = "Sold Out!";
-    i18nKeyLabel = "productDetail.soldOut";
-  } else if (inventoryManagement) {
-    if (lowInventoryWarningThreshold >= inventoryQuantity) {
+
+  // Admins pull variants from the Products collection
+  if (Reaction.hasPermission(["createProduct"], Reaction.getShopId())) {
+    const inventoryQuantity = ReactionProduct.getVariantQuantity(variant);
+    // Product collection variant
+    if (inventoryManagement && !inventoryPolicy && inventoryQuantity === 0) {
+      status = "info";
+      label = "Backorder";
+      i18nKeyLabel = "productDetail.backOrder";
+    } else if (soldOut) {
+      status = "danger";
+      label = "Sold Out!";
+      i18nKeyLabel = "productDetail.soldOut";
+    } else if (inventoryManagement) {
+      if (lowInventoryWarningThreshold >= inventoryQuantity) {
+        status = "warning";
+        label = "Limited Supply";
+        i18nKeyLabel = "productDetail.limitedSupply";
+      }
+    }
+  } else if (inventoryManagement) { // Customers pull variants from the Catalog collection
+    // Catalog item variant
+    if (isBackorder) {
+      status = "info";
+      label = "Backorder";
+      i18nKeyLabel = "productDetail.backOrder";
+    } else if (isSoldOut) {
+      status = "danger";
+      label = "Sold Out!";
+      i18nKeyLabel = "productDetail.soldOut";
+    } else if (isLowQuantity) {
       status = "warning";
       label = "Limited Supply";
       i18nKeyLabel = "productDetail.limitedSupply";

--- a/imports/plugins/included/product-detail-simple/client/components/childVariant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/childVariant.js
@@ -17,7 +17,7 @@ class ChildVariant extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.variantValidation();
   }
 
@@ -91,7 +91,9 @@ class ChildVariant extends Component {
   }
 
   renderValidationButton = () => {
-    if (this.state.invalidVariant === true) {
+    if (this.props.isEditable === false) {
+      return null;
+    } else if (this.state.invalidVariant === true) {
       return (
         <Components.Badge
           status="danger"
@@ -102,6 +104,8 @@ class ChildVariant extends Component {
         />
       );
     }
+
+    return null;
   }
 
   // checks whether the product variant is validated
@@ -148,6 +152,7 @@ class ChildVariant extends Component {
 
 ChildVariant.propTypes = {
   editButton: PropTypes.node,
+  isEditable: PropTypes.bool,
   isSelected: PropTypes.bool,
   media: PropTypes.arrayOf(PropTypes.object),
   onClick: PropTypes.func.isRequired,

--- a/imports/plugins/included/product-detail-simple/client/components/variant.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variant.js
@@ -21,7 +21,7 @@ class Variant extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.variantValidation();
   }
 
@@ -56,7 +56,9 @@ class Variant extends Component {
   }
 
   renderValidationButton = () => {
-    if (this.state.selfValidation.isValid === false) {
+    if (this.props.editable === false) {
+      return null;
+    } else if (this.state.selfValidation.isValid === false) {
       return (
         <Components.Badge
           status="danger"
@@ -65,8 +67,7 @@ class Variant extends Component {
           i18nKeyTooltip={"admin.tooltip.validationError"}
         />
       );
-    }
-    if (this.state.invalidVariant.length) {
+    } else if (this.state.invalidVariant.length) {
       return (
         <Components.Badge
           status="danger"
@@ -76,6 +77,8 @@ class Variant extends Component {
         />
       );
     }
+
+    return null;
   }
 
   variantValidation = () => {

--- a/imports/plugins/included/product-detail-simple/client/components/variantList.js
+++ b/imports/plugins/included/product-detail-simple/client/components/variantList.js
@@ -141,6 +141,7 @@ class VariantList extends Component {
             showsVisibilityButton={true}
           >
             <Components.ChildVariant
+              isEditable={this.props.editable}
               isSelected={this.props.variantIsSelected(childVariant._id)}
               media={media}
               onClick={this.handleChildVariantClick}

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -111,6 +111,8 @@ ReactionProduct.setProduct = (currentProductId, currentVariantId) => {
     $or: [
       { handle: productId.toLowerCase() }, // Try the handle (slug) lowercased
       { handle: productId }, // Otherwise try the handle (slug) untouched
+      { slug: productId.toLowerCase() }, // Try the slug lowercased
+      { slug: productId }, // Otherwise try the slug untouched
       { _id: productId }, // try the product id
       { changedHandleWas: productId } // Last attempt: the permalink may have changed.
     ]

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -388,7 +388,6 @@ describe("Publication", function () {
       });
 
       it("should return a product based on an id", function (done) {
-        this.timeout(25000);
         const product = Collections.Products.findOne({
           isVisible: true
         });

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -383,7 +383,7 @@ describe("Publication", function () {
 
     describe("Product", function () {
       it("should return a product based on an id", function (done) {
-        this.timeout(20000);
+        this.timeout(25000);
         const product = Collections.Products.findOne({
           isVisible: true
         });

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -12,6 +12,7 @@ import { Reaction } from "/server/api";
 import * as Collections from "/lib/collections";
 import Fixtures from "/server/imports/fixtures";
 import publishProductsToCatalog from "/imports/plugins/core/catalog/server/no-meteor/utils/publishProductsToCatalog";
+import publishProductToCatalog from "/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalog";
 import collections from "/imports/collections/rawCollections";
 
 Fixtures();
@@ -387,7 +388,7 @@ describe("Publication", function () {
         const product = Collections.Products.findOne({
           isVisible: true
         });
-        Promise.await(publishProductsToCatalog([product._id], collections));
+        Promise.await(publishProductToCatalog(product, collections));
 
         sandbox.stub(Reaction, "getShopId", () => shopId);
 

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -383,6 +383,10 @@ describe("Publication", function () {
     });
 
     describe("Product", function () {
+      beforeEach(function () {
+        Collections.Catalog.remove({});
+      });
+
       it("should return a product based on an id", function (done) {
         this.timeout(25000);
         const product = Collections.Products.findOne({

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -383,6 +383,7 @@ describe("Publication", function () {
 
     describe("Product", function () {
       it("should return a product based on an id", function (done) {
+        this.timeout(10000);
         const product = Collections.Products.findOne({
           isVisible: true
         });

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -383,7 +383,7 @@ describe("Publication", function () {
 
     describe("Product", function () {
       it("should return a product based on an id", function (done) {
-        this.timeout(10000);
+        this.timeout(20000);
         const product = Collections.Products.findOne({
           isVisible: true
         });

--- a/server/publications/collections/product-publications.app-test.js
+++ b/server/publications/collections/product-publications.app-test.js
@@ -386,6 +386,8 @@ describe("Publication", function () {
         const product = Collections.Products.findOne({
           isVisible: true
         });
+        Promise.await(publishProductsToCatalog([product._id], collections));
+
         sandbox.stub(Reaction, "getShopId", () => shopId);
 
         collector.collect("Product", product._id, ({ Products }) => {

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -111,13 +111,11 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
 
   // Product data for customers visiting the PDP page
   const cursor = Catalog.find({
-    "product._id": productIdOrHandle
-    // "$or": [{
-
-    // } , {
-    //   "product.slug": productIdOrHandle
-    // }
-    //           ]
+    "$or": [{
+      "product._id": productIdOrHandle
+    }, {
+      "product.slug": productIdOrHandle
+    }]
     // "product.type": "product-simple",
     // "product.shopId": selector.shopId,
     // "product.isVisible": true,

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -109,6 +109,9 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
     return Products.find(selector);
   }
 
+  if (!selector.shopId) {
+    selector.shopId = product.shopId;
+  }
   // Product data for customers visiting the PDP page
   const cursor = Catalog.find({
     "$or": [{
@@ -117,7 +120,7 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
       "product.slug": productIdOrHandle
     }],
     "product.type": "product-simple",
-    // "product.shopId": selector.shopId
+    "product.shopId": selector.shopId,
     "product.isVisible": true,
     "product.isDeleted": { $in: [null, false] }
   });

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -116,6 +116,7 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
     }, {
       "product.slug": productIdOrHandle
     }],
+    "product.type": "product-simple",
     "product.shopId": selector.shopId,
     "product.isVisible": true,
     "product.isDeleted": { $in: [null, false] }

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -111,15 +111,17 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
 
   // Product data for customers visiting the PDP page
   const cursor = Catalog.find({
-    "$or": [{
-      "product._id": productIdOrHandle
-    }, {
-      "product.slug": productIdOrHandle
-    }],
-    "product.type": "product-simple",
-    "product.shopId": selector.shopId,
-    "product.isVisible": true,
-    "product.isDeleted": { $in: [null, false] }
+    "product._id": productIdOrHandle
+    // "$or": [{
+
+    // } , {
+    //   "product.slug": productIdOrHandle
+    // }
+    //           ]
+    // "product.type": "product-simple",
+    // "product.shopId": selector.shopId,
+    // "product.isVisible": true,
+    // "product.isDeleted": { $in: [null, false] }
   });
 
   const handle = cursor.observeChanges({

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -117,9 +117,9 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
       "product.slug": productIdOrHandle
     }],
     "product.type": "product-simple",
-    "product.shopId": selector.shopId
-    // "product.isVisible": true,
-    // "product.isDeleted": { $in: [null, false] }
+    // "product.shopId": selector.shopId
+    "product.isVisible": true,
+    "product.isDeleted": { $in: [null, false] }
   });
 
   const handle = cursor.observeChanges({

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -116,8 +116,8 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
     }, {
       "product.slug": productIdOrHandle
     }],
-    "product.type": "product-simple"
-    // "product.shopId": selector.shopId,
+    "product.type": "product-simple",
+    "product.shopId": selector.shopId
     // "product.isVisible": true,
     // "product.isDeleted": { $in: [null, false] }
   });

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -115,8 +115,8 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
       "product._id": productIdOrHandle
     }, {
       "product.slug": productIdOrHandle
-    }]
-    // "product.type": "product-simple",
+    }],
+    "product.type": "product-simple"
     // "product.shopId": selector.shopId,
     // "product.isVisible": true,
     // "product.isDeleted": { $in: [null, false] }

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -1,6 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Products, Shops } from "/lib/collections";
+import { Catalog, Products, Shops } from "/lib/collections";
 import { Logger, Reaction } from "/server/api";
 
 /**
@@ -64,7 +64,9 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
     selector.isVisible = {
       $in: [true, false, undefined]
     };
+
+    return Products.find(selector);
   }
 
-  return Products.find(selector);
+  return Catalog.find(selector);
 });

--- a/server/publications/collections/product.js
+++ b/server/publications/collections/product.js
@@ -4,6 +4,47 @@ import { Catalog, Products, Shops } from "/lib/collections";
 import { Logger, Reaction } from "/server/api";
 
 /**
+ * Flatten variant tree from a Catalog Item Product document
+ * @param {Object} product A Catalog Item Product document
+ * @returns {Array} Variant array
+ */
+function flattenCatalogProductVariants(product) {
+  const variants = [];
+
+  // Un-tree the variant tree
+  if (Array.isArray(product.variants)) {
+    // Loop over top-level variants
+    product.variants.forEach((variant) => {
+      if (Array.isArray(variant.options)) {
+        // Loop over variant options
+        variant.options.forEach((option) => {
+          variants.push({
+            ancestors: [
+              product.productId,
+              variant.variantId
+            ],
+            type: "variant",
+            isVisible: true,
+            ...option
+          });
+        });
+      }
+
+      variants.push({
+        ancestors: [
+          product.productId
+        ],
+        type: "variant",
+        isVisible: true,
+        ...variant
+      });
+    });
+  }
+
+  return variants;
+}
+
+/**
  * product detail publication
  * @param {String} productIdOrHandle - productId or handle
  * @return {Object} return product cursor
@@ -68,5 +109,42 @@ Meteor.publish("Product", function (productIdOrHandle, shopIdOrSlug) {
     return Products.find(selector);
   }
 
-  return Catalog.find(selector);
+  // Product data for customers visiting the PDP page
+  const cursor = Catalog.find({
+    "$or": [{
+      "product._id": productIdOrHandle
+    }, {
+      "product.slug": productIdOrHandle
+    }],
+    "product.shopId": selector.shopId,
+    "product.isVisible": true,
+    "product.isDeleted": { $in: [null, false] }
+  });
+
+  const handle = cursor.observeChanges({
+    added: (id, { product: catalogProduct }) => {
+      this.added("Products", catalogProduct.productId, catalogProduct);
+      flattenCatalogProductVariants(catalogProduct).forEach((variant) => {
+        this.added("Products", variant.variantId, variant);
+      });
+    },
+    changed: (id, { product: catalogProduct }) => {
+      this.changed("Products", catalogProduct.productId, catalogProduct);
+      flattenCatalogProductVariants(product).forEach((variant) => {
+        this.changed("Products", variant.variantId, variant);
+      });
+    },
+    removed: (id, { product: catalogProduct }) => {
+      this.removed("Products", catalogProduct.productId, catalogProduct);
+      flattenCatalogProductVariants(product).forEach((variant) => {
+        this.removed("Products", variant.variantId, variant);
+      });
+    }
+  });
+
+  this.onStop(() => {
+    handle.stop();
+  });
+
+  return this.ready();
 });

--- a/tests/tag/tags.test.js
+++ b/tests/tag/tags.test.js
@@ -37,7 +37,7 @@ beforeAll(async () => {
 
 afterAll(() => tester.stop());
 
-test("get the first 50 tags when neither first or last is in query", async () => {
+test("get the first 20 tags when neither first or last is in query", async () => {
   let result;
   try {
     result = await query({ shopId: opaqueShopId });
@@ -46,9 +46,9 @@ test("get the first 50 tags when neither first or last is in query", async () =>
     return;
   }
 
-  expect(result.tags.nodes.length).toBe(50);
+  expect(result.tags.nodes.length).toBe(20);
   expect(result.tags.totalCount).toBe(55);
-  expect(result.tags.pageInfo).toEqual({ endCursor: "MTQ5", hasNextPage: true, hasPreviousPage: false, startCursor: "MTAw" });
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTE5", hasNextPage: true, hasPreviousPage: false, startCursor: "MTAw" });
 
   try {
     result = await query({ shopId: opaqueShopId, after: result.tags.pageInfo.endCursor });
@@ -57,9 +57,20 @@ test("get the first 50 tags when neither first or last is in query", async () =>
     return;
   }
 
-  expect(result.tags.nodes.length).toBe(5);
+  expect(result.tags.nodes.length).toBe(20);
   expect(result.tags.totalCount).toBe(55);
-  expect(result.tags.pageInfo).toEqual({ endCursor: "MTU0", hasNextPage: false, hasPreviousPage: true, startCursor: "MTUw" });
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTM5", hasNextPage: true, hasPreviousPage: true, startCursor: "MTIw" });
+
+  try {
+    result = await query({ shopId: opaqueShopId, after: result.tags.pageInfo.endCursor });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tags.nodes.length).toBe(15);
+  expect(result.tags.totalCount).toBe(55);
+  expect(result.tags.pageInfo).toEqual({ endCursor: "MTU0", hasNextPage: false, hasPreviousPage: true, startCursor: "MTQw" });
 
   // Ensure it's also correct when we pass `first: 5` explicitly
   try {


### PR DESCRIPTION
Resolves #4319   
Impact: **major**  
Type: **feature/bugfix**

## Issue

In a post revision control world, the product detail page receives changes immediately and is out of sync with the product on the product grid.

## Solution

Using `Approach 4`

> Do the heavy lifting in the Product publication, using observables to deconstruct a catalog item product back into multiple documents for the product and variants.

## Breaking changes

PDP page will use the Catalog collection for customers only.

## Testing
1. Edit a product as an admin
2. In another browser or incognito mode, while not signed in, see that no changes have appeared on page
3. Publish changes
4. In the other browser, see changes have been made.

---

1. As a customer add a product to the cart
1. Checkout as normal
1. As an admin fulfil that order
1. Ensure that inventory has be decremented properly


