### PR TITLE
Fix 4326 mikemurray import me not

### DIFF
--- a/server/api/core/importer.js
+++ b/server/api/core/importer.js
@@ -120,6 +120,11 @@ Importer.commit = function (collection) {
   // Only commit if the buffer isn't empty (otherwise it'll throw).
   if (this._count[name]) {
     this.buffer(collection).execute((error, result) => {
+      if (error) {
+        Logger.error(error);
+        return;
+      }
+
       // Inserted document counts don't affect the modified document count, so we
       // throw everything together.
       const nImported = result.nModified + result.nInserted + result.nUpserted;

--- a/server/startup/load-data.js
+++ b/server/startup/load-data.js
@@ -1,8 +1,13 @@
 import { Meteor } from "meteor/meteor";
-import { Shops } from "/lib/collections";
+import { Products, Shipping, Tags, Shops } from "/lib/collections";
 import { Logger, Reaction } from "/server/api";
 import { Fixture } from "/server/api/core/importer";
 
+/**
+ * Load fixture data into various collections if those collections are blank
+ * @name loadData
+ * @returns {undefined} No return value
+ */
 export default function loadData() {
   if (!process.env.SKIP_FIXTURES) {
     /**
@@ -31,25 +36,34 @@ export default function loadData() {
       }
     }
 
-    try {
-      Logger.debug("Loading Shipping Data");
-      Fixture.process(Assets.getText("data/Shipping.json"), ["name"], Reaction.Importer.shipping, [shopId]);
-    } catch (error) {
-      Logger.error(error, "Bypassing loading Shipping default data.");
+    // Import Shipping data
+    if (Shipping.find().count() === 0) {
+      try {
+        Logger.debug("Loading Shipping Data");
+        Fixture.process(Assets.getText("data/Shipping.json"), ["name"], Reaction.Importer.shipping, [shopId]);
+      } catch (error) {
+        Logger.error(error, "Bypassing loading Shipping default data.");
+      }
     }
 
-    try {
-      Logger.debug("Loading Product Data");
-      Fixture.process(Assets.getText("data/Products.json"), ["title"], Reaction.Importer.product, [shopId]);
-    } catch (error) {
-      Logger.error(error, "Bypassing loading Products default data.");
+    // Import Product data
+    if (Products.find().count() === 0) {
+      try {
+        Logger.debug("Loading Product Data");
+        Fixture.process(Assets.getText("data/Products.json"), ["title"], Reaction.Importer.product, [shopId]);
+      } catch (error) {
+        Logger.error(error, "Bypassing loading Products default data.");
+      }
     }
 
-    try {
-      Logger.debug("Loading Tag Data");
-      Fixture.process(Assets.getText("data/Tags.json"), ["name"], Reaction.Importer.tag, [shopId]);
-    } catch (error) {
-      Logger.error(error, "Bypassing loading Tags default data.");
+    // Import Tag data
+    if (Tags.find().count() === 0) {
+      try {
+        Logger.debug("Loading Tag Data");
+        Fixture.process(Assets.getText("data/Tags.json"), ["name"], Reaction.Importer.tag, [shopId]);
+      } catch (error) {
+        Logger.error(error, "Bypassing loading Tags default data.");
+      }
     }
     //
     // these will flush and import with the rest of the imports from core init.


### PR DESCRIPTION
Resolves #4326   
Impact: **breaking**  
Type: **bugfix**

## Issue

The Reaction importer tries to import data into various collections, even if data already exists. It tries to be smart about merging, but sometimes that results in unpredictable behavior. This will prevent the app from starting and is not easily recovered from.

## Solution

- `Collection.find().count() === 0` to wrap import statements in /server/startup/load-data.js
- Guard against errors in /server/api/core/importer.js in Importer.commit. 

## Breaking changes

- The Products, Shipping, and Tags collections will no longer have fixture data imported into if they have documents. 
- Modifying `Product.json`, `Shpping.json` or `Tags.json` will have no effect after the first import. Data will need to be imported using the Reaction importer directly.

## Testing

1. With a fresh app go to the PDP page as an admin
1. Change the product title on the PDP page. I did `Basic Reaction Product--`
1. Restart the app either with a code change or, stop/start
1. The app should start with no errors, and the `Basic Reaction Product` should not be modified.
1. Modify `/private/data/Products.json` and save.
1. Wait for the app to refresh
1. Observe that your changes have **not** been imported
