### PR TITLE
(fix): Update prerender.js

### DIFF
--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -3,9 +3,12 @@ import { WebApp } from "meteor/webapp";
 import { Logger } from "/server/api";
 
 export default function preRender() {
-  if (process.env.PRERENDER_TOKEN && process.env.PRERENDER_HOST) {
+  if (process.env.PRERENDER_TOKEN && process.env.PRERENDER_SERVICE_URL) {
     prerender.set("prerenderToken", process.env.PRERENDER_TOKEN);
-    prerender.set("host", process.env.PRERENDER_HOST);
+    prerender.set(“prerenderServiceUrl”, process.env.PRERENDER_SERVICE_URL);
+    if (process.env.PRERENDER_HOST) {
+      prerender.set("host", process.env.PRERENDER_HOST);
+    }
     prerender.set("protocol", "https");
     WebApp.rawConnectHandlers.use(prerender);
     Logger.info("Prerender Initialization finished.");

--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -13,8 +13,8 @@ export default function preRender() {
     WebApp.rawConnectHandlers.use(prerender);
     Logger.info("Prerender initialization finished.");
   } else if (process.env.PRERENDER_TOKEN) {
-     Logger.error("Prerender initialization failed. Please set PRERENDER_SERVICE_URL in your environment variables.");
+    Logger.error("Prerender initialization failed. Please set PRERENDER_SERVICE_URL in your environment variables.");
   } else if (process.env.PRERENDER_SERVICE_URL) {
-     Logger.error("Prerender initialization failed. Please set PRERENDER_TOKEN in your environment variables.");
+    Logger.error("Prerender initialization failed. Please set PRERENDER_TOKEN in your environment variables.");
   }
 }

--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -5,7 +5,7 @@ import { Logger } from "/server/api";
 export default function preRender() {
   if (process.env.PRERENDER_TOKEN && process.env.PRERENDER_SERVICE_URL) {
     prerender.set("prerenderToken", process.env.PRERENDER_TOKEN);
-    prerender.set(“prerenderServiceUrl”, process.env.PRERENDER_SERVICE_URL);
+    prerender.set("prerenderServiceUrl", process.env.PRERENDER_SERVICE_URL);
     if (process.env.PRERENDER_HOST) {
       prerender.set("host", process.env.PRERENDER_HOST);
     }

--- a/server/startup/prerender.js
+++ b/server/startup/prerender.js
@@ -11,6 +11,10 @@ export default function preRender() {
     }
     prerender.set("protocol", "https");
     WebApp.rawConnectHandlers.use(prerender);
-    Logger.info("Prerender Initialization finished.");
+    Logger.info("Prerender initialization finished.");
+  } else if (process.env.PRERENDER_TOKEN) {
+     Logger.error("Prerender initialization failed. Please set PRERENDER_SERVICE_URL in your environment variables.");
+  } else if (process.env.PRERENDER_SERVICE_URL) {
+     Logger.error("Prerender initialization failed. Please set PRERENDER_TOKEN in your environment variables.");
   }
 }


### PR DESCRIPTION
Resolves #4330 
Impact: minor
Type: bugfix

## Issue
Current prerender implementation does not have provision to set `PRERENDER_SERVICE_URL` as a parameter which is required if one intends to use [prenrender.io](https://prerender.io) as the prerender server.

## Solution
Update `server/startup/prerender.js` to set `PRERENDER_SERVICE_URL` in the prerender function when present as an environment variable.

## Breaking changes
None

## Testing
1. Sign up/log in to a prerender.io account. Get your token.
2. With that token, add below to your environment variables:
```
PRERENDER_TOKEN=token
PRERENDER_SERVICE_URL=http://service.prerender.io/
```
3. Access a page in your Reaction site and append `?_escaped_fragment_=` to the url.
4. After a couple of minutes, you will see that there is no more error message in your prerender.io dashboard saying "We haven't seen a request with your Prerender token yet."