### PR TITLE
feat: add robots.txt file

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /resources/*
+

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
-Disallow: /resources/*
+Disallow: /resources/
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: resources/*
+

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Disallow: /resources/*
-

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
-Disallow: resources/*
+Disallow: /resources/*
 


### PR DESCRIPTION
Resolves #4370 
Impact: **minor**  
Type: **feature**

## Issue
By default, Reaction does not contain a robots.txt file.  While it can be easily created, as an ecommerce platform it would be ideal to have certain best practices be implemented out of the box. 

## Solution
Create a robots.txt file by default for SEO purposes.  The file has default directives to: 
1. Allow all bots to crawl 
2. Disallow bots from crawling the "resources" folder and its subfolder

## Test Instructions
1. Browse to http://domain.com/robots.txt 
1. Verify file is there and can be viewed