### PR TITLE
Fix mislabeled schema

### DIFF
--- a/imports/collections/schemas/accounts.js
+++ b/imports/collections/schemas/accounts.js
@@ -132,7 +132,7 @@ export const Accounts = new SimpleSchema({
     type: String,
     regEx: SimpleSchema.RegEx.Id,
     index: 1,
-    label: "Accounts ShopId"
+    label: "Accounts userId"
   },
   "sessions": {
     type: Array,


### PR DESCRIPTION
Resolves #N/A
Impact: **minor**  
Type: **bugfix**

## Issue
The field for `userId` in the Accounts schema is mislabeled as "Account ShopId". So you spend a lot of time trying to figure out why the ShopId is not getting written and not why the `userId` is not correct.

## Solution
Correct the label

## Breaking changes
None

## Testing
1. Try to create an Account with a missing or malformed `userId` and notice that the error message matches the actual error
```
Accounts.insert({
  "emails": [
    {
      "address": "user-2-1@reactioncommerce.com",
      "verified": false,
      "provides": "default"
    }
  ],
  "profile": {
    "invited": false,
    "currency": "USD",
    "addressBook": [
      {
        "country": "US",
        "fullName": "user-2-1",
        "address1": "123 Main St.",
        "address2": "",
        "postal": "90406",
        "city": "Santa Monica",
        "region": "California",
        "phone": "3238675309",
        "isShippingDefault": true,
        "isBillingDefault": true,
        "isCommercial": false,
        "_id": "yE4U7D7AZ4w1Bd9glSLy",
        "failedValidation": false
      }
    ]
  },
  "groups": [
    "Ft83kJfbzsdKNHE9C"
  ],
  "userId": "99KAoLzBTgln",
  "shopId": "J8Bhq3uTtdgwZx3rz",
  "state": "new",
  "acceptsMarketing": false,
  "name": "user-2-1"
});
