### PR TITLE
Add anonymousCartByCartId GraphQL query

### DIFF
--- a/imports/plugins/core/cart/server/no-meteor/queries/anonymousCartByCartId.js
+++ b/imports/plugins/core/cart/server/no-meteor/queries/anonymousCartByCartId.js
@@ -1,0 +1,29 @@
+import { Meteor } from "meteor/meteor";
+
+/**
+ * @name anoynymousCartbyCartId
+ * @method
+ * @memberof Cart/NoMeteorQueries
+ * @summary Query the Cart collection for a cart with the provided cartId
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} params - request parameters
+ * @param {String} [params.cartId] - Cart id to include
+ * @param {String} [params.token] - Anonymous cart token
+ * @return {Object} - An anonymous cart.
+ */
+export default async function anonymousCartByCartId(context, { cartId, token } = {}) {
+  const { collections } = context;
+  const { Cart } = collections;
+
+  if (!cartId) {
+    throw new Meteor.Error("invalid-param", "You must provide a cartId");
+  }
+
+  // TODO: Use token
+
+  const query = {
+    _id: cartId
+  };
+
+  return Cart.findOne(query);
+}

--- a/imports/plugins/core/cart/server/no-meteor/queries/anonymousCartByCartId.js
+++ b/imports/plugins/core/cart/server/no-meteor/queries/anonymousCartByCartId.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 
 /**
- * @name anoynymousCartbyCartId
+ * @name anonymousCartByCartId
  * @method
  * @memberof Cart/NoMeteorQueries
  * @summary Query the Cart collection for a cart with the provided cartId
@@ -11,7 +11,7 @@ import { Meteor } from "meteor/meteor";
  * @param {String} [params.token] - Anonymous cart token
  * @return {Object} - An anonymous cart.
  */
-export default async function anonymousCartByCartId(context, { cartId, token } = {}) {
+export default async function anonymousCartByCartId(context, { cartId } = {}) {
   const { collections } = context;
   const { Cart } = collections;
 

--- a/imports/plugins/core/cart/server/no-meteor/queries/index.js
+++ b/imports/plugins/core/cart/server/no-meteor/queries/index.js
@@ -1,0 +1,5 @@
+import anonymousCartByCartId from "./anonymousCartByCartId";
+
+export default {
+  anonymousCartByCartId
+};

--- a/imports/plugins/core/graphql/server/no-meteor/buildContext.test.js
+++ b/imports/plugins/core/graphql/server/no-meteor/buildContext.test.js
@@ -34,6 +34,9 @@ test("properly mutates the context object without user", async () => {
         tags: jasmine.any(Function),
         tagsByIds: jasmine.any(Function)
       },
+      cart: {
+        anonymousCartByCartId: jasmine.any(Function)
+      },
       shops: {
         shopById: jasmine.any(Function)
       }
@@ -73,6 +76,9 @@ test("properly mutates the context object with user", async () => {
         tag: jasmine.any(Function),
         tags: jasmine.any(Function),
         tagsByIds: jasmine.any(Function)
+      },
+      cart: {
+        anonymousCartByCartId: jasmine.any(Function)
       },
       shops: {
         shopById: jasmine.any(Function)

--- a/imports/plugins/core/graphql/server/no-meteor/queries.js
+++ b/imports/plugins/core/graphql/server/no-meteor/queries.js
@@ -1,9 +1,11 @@
 import accounts from "/imports/plugins/core/accounts/server/no-meteor/queries";
 import catalog from "/imports/plugins/core/catalog/server/no-meteor/queries";
+import cart from "/imports/plugins/core/cart/server/no-meteor/queries";
 
 export default {
   accounts,
   catalog,
+  cart,
   shops: {
     shopById: (context, _id) => context.collections.Shops.findOne({ _id })
   }

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Query/anonymousCartByCartId.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Query/anonymousCartByCartId.js
@@ -5,14 +5,14 @@ import { decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/ca
  * @method
  * @memberof Cart/GraphQL
  * @summary Get an anonymous cart by Id.
- * @param {Object} _ - unused
+ * @param {Object} parentResult - unused
  * @param {ConnectionArgs} args - An object of all arguments that were sent by the client
  * @param {String} args.cartId - Id of the anonymous cart
  * @param {String} args.token - An anonymous cart token
  * @param {Object} context - An object containing the per-request state
  * @return {Promise<Object>} An AnonymousCart object
  */
-export default async function anonymousCartByCartId(_, args, context) {
+export default async function anonymousCartByCartId(parentResult, args, context) {
   const { cartId, token } = args;
 
   return context.queries.cart.anonymousCartByCartId(context, {

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Query/anonymousCartByCartId.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Query/anonymousCartByCartId.js
@@ -1,0 +1,22 @@
+import { decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
+
+/**
+ * @name Query.anonymousCartByCartId
+ * @method
+ * @memberof Cart/GraphQL
+ * @summary Get an anonymous cart by Id.
+ * @param {Object} _ - unused
+ * @param {ConnectionArgs} args - An object of all arguments that were sent by the client
+ * @param {String} args.cartId - Id of the anonymous cart
+ * @param {String} args.token - An anonymous cart token
+ * @param {Object} context - An object containing the per-request state
+ * @return {Promise<Object>} An AnonymousCart object
+ */
+export default async function anonymousCartByCartId(_, args, context) {
+  const { cartId, token } = args;
+
+  return context.queries.cart.anonymousCartByCartId(context, {
+    cartId: decodeCartOpaqueId(cartId),
+    token
+  });
+}

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Query/index.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Query/index.js
@@ -1,0 +1,5 @@
+import anonymousCartByCartId from "./anonymousCartByCartId";
+
+export default {
+  anonymousCartByCartId
+};

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/index.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/index.js
@@ -1,0 +1,10 @@
+import Query from "./Query";
+
+/**
+ * Cart related GraphQL resolvers
+ * @namespace Cart/GraphQL
+ */
+
+export default {
+  Query
+};

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/catalog/Query/catalogItemProduct.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/catalog/Query/catalogItemProduct.js
@@ -1,7 +1,7 @@
 import { decodeCatalogItemOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/catalogItem";
 
 /**
- * @name "Query.catalogItemProduct"
+ * @name Query.catalogItemProduct
  * @method
  * @memberof Catalog/GraphQL
  * @summary Get a CatalogItemProduct from the Catalog

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/index.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/index.js
@@ -1,13 +1,14 @@
 import { merge } from "lodash";
 import account from "./account";
 import catalog from "./catalog";
+import cart from "./cart";
 import core from "./core";
 import ping from "./ping";
 import scalar from "./scalar";
 import shop from "./shop";
 import tag from "./tag";
 
-export default merge({}, account, catalog, core, scalar, ping, shop, tag);
+export default merge({}, account, catalog, cart, core, scalar, ping, shop, tag);
 
 /**
  * Arguments passed by the client for a query

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/util/namespaces.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/util/namespaces.js
@@ -4,6 +4,7 @@ export default {
   CatalogItem: "reaction/catalogItem",
   CatalogProduct: "reaction/catalogProduct",
   CatalogProductVariant: "reaction/catalogProductVariant",
+  Cart: "reaction/cart",
   Currency: "reaction/currency",
   Group: "reaction/group",
   Product: "reaction/product",

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/xforms/cart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/xforms/cart.js
@@ -1,0 +1,7 @@
+import { namespaces } from "@reactioncommerce/reaction-graphql-utils";
+import { assocInternalId, assocOpaqueId, decodeOpaqueIdForNamespace, encodeOpaqueId } from "./id";
+
+export const assocCartInternalId = assocInternalId(namespaces.Cart);
+export const assocCartOpaqueId = assocOpaqueId(namespaces.Cart);
+export const decodeCartOpaqueId = decodeOpaqueIdForNamespace(namespaces.Cart);
+export const encodeCartOpaqueId = encodeOpaqueId(namespaces.Cart);


### PR DESCRIPTION
Resolves: #4361 
Impact: minor
Type: feature

## Feature
Adds a GraphQL query to retrieve an anonymous cart by cart id, and token. This implementation only uses `cartId`, because the new cart supporting a `token` has not been built yet. `TODO` comments are in place for token functionality to be added in the future.


## Breaking changes
N/A

## Testing
Base64 encode _id of existing cart and use as argument for cartId param.

```
{
  anonymousCartByCartId(cartId: "BASE64_ENCODED_EXISTING_CART_ID", token:"") {
    _id
  }
}
```

The query should return the `_id` of the anonymous cart.
