### PR TITLE
[WIP] feat: Indicator to notify of pending product changes not yet published to catalog

### DIFF
--- a/imports/plugins/core/catalog/client/components/publishControls.js
+++ b/imports/plugins/core/catalog/client/components/publishControls.js
@@ -313,7 +313,7 @@ class PublishControls extends Component {
   }
 
   renderHashCalculation = () => {
-    const productDocument = this.props.documents && this.props.documents[0];
+    const productDocument = this.props && this.props.documents && this.props.documents[0];
 
     if (productDocument) {
       Meteor.call("products/getpublishedProductHash", productDocument._id, (err, result) => {
@@ -326,7 +326,9 @@ class PublishControls extends Component {
   }
 
   renderChangesNotification = () => {
-    const publishedProductHash = (this.props && this.props.documents && this.props.documents[0] && this.props.documents[0].publishedProducthash) || null;
+    const publishedProductHash = (this.props && this.props.documents && this.props.documents[0] && this.props.documents[0].publishedProductHash) || null;
+
+    // Calculate hash to compare
     this.renderHashCalculation();
     const currentProductHash = this.currentProductHash.get();
 

--- a/imports/plugins/core/catalog/client/components/publishControls.js
+++ b/imports/plugins/core/catalog/client/components/publishControls.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { ReactiveVar } from "meteor/reactive-var";
 import { Components } from "@reactioncommerce/reaction-components";
 import {
   Button,
@@ -40,6 +41,8 @@ class PublishControls extends Component {
     this.state = {
       showDiffs: false
     };
+
+    this.currentProductHash = new ReactiveVar([]);
 
     this.handleToggleShowChanges = this.handleToggleShowChanges.bind(this);
     this.handlePublishClick = this.handlePublishClick.bind(this);

--- a/imports/plugins/core/catalog/client/components/publishControls.js
+++ b/imports/plugins/core/catalog/client/components/publishControls.js
@@ -327,6 +327,25 @@ class PublishControls extends Component {
     }
     return;
   }
+
+  renderChangesNotification = () => {
+    const publishedProductHash = (this.props && this.props.documents && this.props.documents[0] && this.props.documents[0].publishedProducthash) || null;
+    const currentProductHash = this.currentProductHash.get();
+
+    if (publishedProductHash !== currentProductHash) {
+      // We don't use the `<Icon>` component here as we do not have layered
+      // icons built in to the existing component
+      return (
+        <span className="fa-stack fa-lg" style={{ fontSize: 12, position: "absolute", top: "2px", right: "8px" }}>
+          <i className="fa fa-circle-o fa-stack-2x" style={{ color: "#ffffff" }} />
+          <i className="fa fa-circle fa-stack-1x fa-inverse" style={{ fontSize: "1.5em", color: "#f4c43c" }} />
+        </span>
+      );
+    }
+
+    return null;
+  }
+
   render() {
     return (
       <Components.ToolbarGroup lastChild={true}>

--- a/imports/plugins/core/catalog/client/components/publishControls.js
+++ b/imports/plugins/core/catalog/client/components/publishControls.js
@@ -49,12 +49,6 @@ class PublishControls extends Component {
     this.handlePublishClick = this.handlePublishClick.bind(this);
   }
 
-  componentDidMount() {
-    // Calculate current product has when component is rendered
-    this.renderHashCalculation();
-  }
-
-
   handleToggleShowChanges() {
     this.setState({
       showDiffs: !this.state.showDiffs
@@ -64,6 +58,9 @@ class PublishControls extends Component {
   handlePublishClick() {
     if (this.props.onPublishClick) {
       this.props.onPublishClick(this.props.revisions);
+
+      // Re-calculate hash after publishing
+      this.renderHashCalculation();
     }
   }
 
@@ -330,6 +327,7 @@ class PublishControls extends Component {
 
   renderChangesNotification = () => {
     const publishedProductHash = (this.props && this.props.documents && this.props.documents[0] && this.props.documents[0].publishedProducthash) || null;
+    this.renderHashCalculation();
     const currentProductHash = this.currentProductHash.get();
 
     if (publishedProductHash !== currentProductHash) {

--- a/imports/plugins/core/catalog/client/components/publishControls.js
+++ b/imports/plugins/core/catalog/client/components/publishControls.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Meteor } from "meteor/meteor";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Components } from "@reactioncommerce/reaction-components";
 import {
@@ -47,6 +48,12 @@ class PublishControls extends Component {
     this.handleToggleShowChanges = this.handleToggleShowChanges.bind(this);
     this.handlePublishClick = this.handlePublishClick.bind(this);
   }
+
+  componentDidMount() {
+    // Calculate current product has when component is rendered
+    this.renderHashCalculation();
+  }
+
 
   handleToggleShowChanges() {
     this.setState({
@@ -203,6 +210,7 @@ class PublishControls extends Component {
 
     return (
       <div className="hidden-xs">
+        {this.renderChangesNotification()}
         <Button
           bezelStyle="outline"
           disabled={isDisabled}
@@ -307,6 +315,18 @@ class PublishControls extends Component {
     );
   }
 
+  renderHashCalculation = () => {
+    const productDocument = this.props.documents && this.props.documents[0];
+
+    if (productDocument) {
+      Meteor.call("products/getpublishedProductHash", productDocument._id, (err, result) => {
+        if (result) {
+          this.currentProductHash.set(result);
+        }
+      });
+    }
+    return;
+  }
   render() {
     return (
       <Components.ToolbarGroup lastChild={true}>

--- a/imports/plugins/core/catalog/server/i18n/en.json
+++ b/imports/plugins/core/catalog/server/i18n/en.json
@@ -5,6 +5,7 @@
     "reaction-catalog": {
       "admin": {
         "catalogProductPublishSuccess": "Product published to catalog",
+        "catalogCalculateHashError": "There was an error trying to calculate this products hash.",
         "shortcut": {
           "catalogLabel": "Catalog",
           "catalogTitle": "Catalog"

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -8,6 +8,7 @@ import { Hooks, Logger, Reaction } from "/server/api";
 import { MediaRecords, Products, Tags } from "/lib/collections";
 import { Media } from "/imports/plugins/core/files/server";
 import rawCollections from "/imports/collections/rawCollections";
+import { createProductHash } from "../no-meteor/mutations/hashProduct";
 import getProductPriceRange from "../no-meteor/utils/getProductPriceRange";
 import getVariants from "../no-meteor/utils/getVariants";
 import hasChildVariant from "../no-meteor/utils/hasChildVariant";
@@ -1576,5 +1577,23 @@ Meteor.methods({
 
     // if collection updated we return new `isVisible` state
     return res === 1 && !product.isVisible;
+  },
+
+  /**
+   * @name products/getpublishedProductHash
+   * @memberof Methods/Products
+   * @method
+   * @summary hashes product information for comparison purposes
+   * @param {String} productId - the product _id of the product to hash
+   * @return {String} hash of product
+   */
+  "products/getpublishedProductHash"(productId) {
+    check(productId, String);
+
+    const product = Products.findOne({ _id: productId });
+
+    const productHash = createProductHash(product, rawCollections);
+
+    return productHash;
   }
 });

--- a/imports/plugins/core/catalog/server/no-meteor/mutations/hashProduct.js
+++ b/imports/plugins/core/catalog/server/no-meteor/mutations/hashProduct.js
@@ -9,7 +9,7 @@ import createCatalogProduct from "../utils/createCatalogProduct";
  * @param {Object} collections - Raw mongo collections
  * @return {String} product hash
  */
-async function createProductHash(productToConvert, collections) {
+export async function createProductHash(productToConvert, collections) {
   const product = await createCatalogProduct(productToConvert, collections);
 
   const hashableFields = {


### PR DESCRIPTION
Resolves #4281 
Impact: **minor**  
Type: **feature**

## Issue
With the removal of revisions, we no long have a way to know if product data has been published to the `Catalog`, or if the `Product` collection contains updated data that has not been published.

## Solution
On the PDP, we create a hash of the current data on the page, using the same functions created in #4264. We then compare this new hash to the hash saved on the product object (also created in #4262). If the hashes match, the data is consistent between the two collections. If the hashes do not match, it means there are changes waiting to be published, and we display an indicator on the Publish button.

![ticket_to_anywhere_t-shirtss](https://user-images.githubusercontent.com/4482263/42051899-29af8f7a-7ac2-11e8-8e69-e2e6737ed057.png)

## Breaking changes
None.

## Testing
1. Create a new product
1. Publish this product to the catalog
1. Update the title (or any field that is published to the catalog)
1. See the indicator appear on the `Publish` button
1. Press the publish button
1. See the indicator go away