### PR TITLE
bugfix: Archived products not being removed from Catalog

### DIFF
--- a/imports/plugins/core/catalog/server/hooks/hooks.js
+++ b/imports/plugins/core/catalog/server/hooks/hooks.js
@@ -1,0 +1,25 @@
+import { Catalog } from "/lib/collections";
+import { Hooks } from "/server/api";
+
+/**
+ * @summary archives product in the Catalog collection when it is archived in Products collection
+ * @param {String} userId - userId of user making the call
+ * @param {Object} doc - product document
+ * @return {undefined}
+ * @private
+ */
+Hooks.Events.add("afterRemoveCatalogProduct", (userId, doc) => {
+  // If this is a parent product, update the `Catalog` collection
+  // to set `isDeleted` to true
+  if (doc.type === "simple") {
+    Catalog.update({
+      "product.productId": doc._id
+    }, {
+      $set: {
+        "product.isDeleted": true
+      }
+    });
+  }
+
+  return doc;
+});

--- a/imports/plugins/core/catalog/server/hooks/hooks.js
+++ b/imports/plugins/core/catalog/server/hooks/hooks.js
@@ -9,7 +9,7 @@ import { Hooks } from "/server/api";
  * @private
  */
 Hooks.Events.add("afterRemoveCatalogProduct", (userId, doc) => {
-  // If this is a parent product, update the `Catalog` collection
+  // If this is a top level product, update the `Catalog` collection
   // to set `isDeleted` to true
   if (doc.type === "simple") {
     Catalog.update({

--- a/imports/plugins/core/catalog/server/index.js
+++ b/imports/plugins/core/catalog/server/index.js
@@ -1,6 +1,7 @@
 import "./i18n";
 import "./methods/catalog";
 import "./methods/publishProducts";
+import "./hooks/hooks";
 
 /**
  * Query functions that do not import or use any Meteor packages or globals. These can be used both

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -937,6 +937,9 @@ Meteor.methods({
       return numFlaggedAsDeleted;
     }
 
+    // We need this hook here, in addition to the similar hook inside the `productsWithVariants.forEach` loop.
+    // The previous hook updates the data of a `variant` product (i.e. `type: variant`) only.
+    // This hook here updates the data of a parent product (i.e. `type: simple`).
     Hooks.Events.run("afterRemoveCatalogProduct", this.userId, product);
 
     Logger.debug(`${numFlaggedAsDeleted} products have been flagged as deleted`);

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -937,6 +937,8 @@ Meteor.methods({
       return numFlaggedAsDeleted;
     }
 
+    Hooks.Events.run("afterRemoveCatalogProduct", this.userId, product);
+
     Logger.debug(`${numFlaggedAsDeleted} products have been flagged as deleted`);
   },
 

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -937,11 +937,6 @@ Meteor.methods({
       return numFlaggedAsDeleted;
     }
 
-    // We need this hook here, in addition to the similar hook inside the `productsWithVariants.forEach` loop.
-    // The previous hook updates the data of a `variant` product (i.e. `type: variant`) only.
-    // This hook here updates the data of a parent product (i.e. `type: simple`).
-    Hooks.Events.run("afterRemoveCatalogProduct", this.userId, product);
-
     Logger.debug(`${numFlaggedAsDeleted} products have been flagged as deleted`);
   },
 

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -626,7 +626,7 @@ Meteor.methods({
     const selector = {
       // Don't "archive" variants that are already marked deleted.
       isDeleted: {
-        $in: [false, undefined]
+        $ne: true
       },
       $or: [
         {
@@ -874,7 +874,7 @@ Meteor.methods({
     const productsWithVariants = Products.find({
       // Don't "archive" products that are already marked deleted.
       isDeleted: {
-        $in: [false, undefined]
+        $ne: true
       },
       $or: [
         {


### PR DESCRIPTION
Resolves #4347   
Impact: **major**  
Type: **bugfix**

## Issue
Products that have been archived sometimes still appear in the catalog that customers see.

When a product is archived, the first thing that happens is it is updated in the `Products` collection to be `isDeleted: true`.

If you are on the PDP, you are immediately re-routed to the Product grid after archiving, so you don't have a chance to "Publish" the product to the `Catalog` collection, so the product in the `Catalog` collection never gets that updated `isDeleted` value - it still has the state of the product from before the archive / the last publication.

Even when you "Publish All", from the Product grid, you're only publishing the products that are available inside the `Products` publication, since the Admin gets the `Products` publication, while a non-admin gets the `Catalog` publication. Since the `isDeleted: true` is updated in the `Products` collection correctly, it's no longer on the grid, and therefore isn't published to the `Catalog` when you `Publish All`.

If you archive a product from the Product Grid, you will most likely not notice this error if you press "publish" at any time before navigating off the grid. This is because the Product Grid is not reactive, so even after you archive a product, the product is still visible on the Grid until you navigate away from the grid and refresh the publication.

## Solution

Add a `Hook` to the `products/archiveProduct` method that always archives the `Catalog` version of the product along with the `Products` version when it is archived.

## Breaking changes
None.


## Testing
1. Open a few browsers sessions, one as an admin, one as a logged out user (incognito probably), and one that is using the Starterkit (to make sure the GraphQL data is being updated).
1. Create a few different products
1. See that all the products show on all your sessions
1. Archive a product from the Product grid
1. See that the product is archived over all your sessions (you may need to refresh on the starterkit)
1. Archive a product from the PDP
1. See that the product is archived over all your sessions (you may need to refresh on the starterkit)
