### PR TITLE
Fix #4374: not publishing customer accounts

### DIFF
--- a/imports/plugins/core/core/server/publications/collections/accounts.js
+++ b/imports/plugins/core/core/server/publications/collections/accounts.js
@@ -22,7 +22,7 @@ Meteor.publish("Accounts", function (userId) {
   }
 
   const nonAdminGroups = Collections.Groups.find({
-    name: { $in: ["guest"] },
+    name: { $in: ["guest", "customer"] },
     shopId
   }, {
     fields: { _id: 1 }


### PR DESCRIPTION
Resolves #4374   
Impact: **minor**  
Type: **performance**

## Issue
All the customer accounts were being published to the client when logged in as Admin. As the customer can be large, this was making the browser unresponsive.

## Solution
Removed the all "customer" accounts from getting published. 
I couldn't see any place where the customer accounts were used.

## Testing
1. Run reaction.
1. Register a account.
1. Log out
1. Sign-in as admin.
1. Check the minimongo database, in which the Accounts collection will **not** have the account of the customer created in step 2.
