### PR TITLE
(fix) #4023 changing product handle throws 404

### DIFF
--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -1032,7 +1032,7 @@ Meteor.methods({
         denormalize(doc.ancestors[0], field);
       }
     }
-    return result;
+    return update;
   },
 
   /**

--- a/imports/plugins/included/product-admin/client/containers/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/containers/productAdmin.js
@@ -37,10 +37,14 @@ const wrapComponent = (Comp) => (
     }
 
     handleProductFieldSave = (productId, fieldName, value) => {
-      Meteor.call("products/updateProductField", productId, fieldName, value, (error) => {
+      Meteor.call("products/updateProductField", productId, fieldName, value, (error, result) => {
         if (error) {
           Alerts.toast(error.message, "error");
           this.forceUpdate();
+        } else if (result.handle) {
+          Reaction.Router.go("product", {
+            handle: result.handle
+          });
         }
       });
     }


### PR DESCRIPTION
Resolves #4023
Impact: minor
Type: bugfix

## Issue
When product handle is changed, the screen shows that product is not found. Therefore, user will have  to go to the new URL of the product to continue updating the product.

## Solution
Simply change the current URL to the new product handle. This was achieved by returning the updated fields in `products/updateProductField` to the client and if handle happens to be in the updated fields, then the current route should be changed.

## Breaking changes
None

## Testing
1. Edit a product by changing its handle.
2. Verify that the URL is changed and the "active" product in the screen is the same product that you updated.