### PR TITLE
(fix) #4401 Tax and inventory toggle switches do not work

### DIFF
--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -54,7 +54,7 @@ class VariantForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     const nextVariant = nextProps.variant || {};
-    const currentVariant = this.state.variant || {};
+    const currentVariant = this.props.variant || {};
 
     if (_.isEqual(nextVariant, currentVariant) === false) {
       for (const fieldName of fieldNames) {


### PR DESCRIPTION
Resolves #4401 
Impact: minor
Type: bugfix

## Issue
Toggle switches for both inventory tracking and taxable fields don't work. The switches are rendered using `taxable` and `inventoryManagement` values from `VariantForm` component's `state` (see [here](https://github.com/reactioncommerce/reaction/blob/d15854a90336aa1f08537ac27ec17f267c8f87dd/imports/plugins/included/product-variant/components/variantForm.js#L517) and [here](https://github.com/reactioncommerce/reaction/blob/d15854a90336aa1f08537ac27ec17f267c8f87dd/imports/plugins/included/product-variant/components/variantForm.js#L544)).

These values are updated through `componentWillReceiveProps` method (see [here](https://github.com/reactioncommerce/reaction/blob/d15854a90336aa1f08537ac27ec17f267c8f87dd/imports/plugins/included/product-variant/components/variantForm.js#L55-L80)). The problem is that it compares `variant` object from `nextProps` and current `state` to check if there had been changes but these 2 will always be equal because `state.variant` is already updated [here](https://github.com/reactioncommerce/reaction/blob/d15854a90336aa1f08537ac27ec17f267c8f87dd/imports/plugins/included/product-variant/components/variantForm.js#L152-L161) before`componentWillReceiveProps`.

## Solution
Compare `nextProps` to the variant object in current `props` instead of `state` in the `componentWillReceiveProps` method in the `VariantForm` component.

## Breaking changes
None

## Testing
1. Edit a product.
2. Toggle the switches for inventory tracking and taxable fields. They should work correctly. Update other fields too.
3. Refresh the page to check that data persist.