### PR TITLE
(fix) #4396 Unable to save custom tax rate

### DIFF
--- a/imports/plugins/core/taxes/client/settings/custom.html
+++ b/imports/plugins/core/taxes/client/settings/custom.html
@@ -49,7 +49,7 @@
         resetOnSuccess=true
       }}
         <div>
-          {{>afFieldInput name="shopId" value=shopId type="hidden"}}
+          {{> afFieldInput name='shopId' value=shopId type='hidden' }}
           {{> afQuickField name='country' options=countryOptions class='form-control'}}
 
           <label class="control-label">{{afFieldLabelText name='region'}}</label>

--- a/imports/plugins/core/taxes/client/settings/custom.html
+++ b/imports/plugins/core/taxes/client/settings/custom.html
@@ -49,6 +49,7 @@
         resetOnSuccess=true
       }}
         <div>
+          {{>afFieldInput name="shopId" value=shopId type="hidden"}}
           {{> afQuickField name='country' options=countryOptions class='form-control'}}
 
           <label class="control-label">{{afFieldLabelText name='region'}}</label>

--- a/imports/plugins/core/taxes/client/settings/custom.js
+++ b/imports/plugins/core/taxes/client/settings/custom.js
@@ -158,6 +158,9 @@ Template.customTaxRates.helpers({
         tax.country = shop.addressBook[0].country;
       }
     }
+    if (!tax.shopId) {
+      tax.shopId = shop._id;
+    }
     return tax;
   },
   taxCodes() {

--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -54,7 +54,7 @@ class VariantForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     const nextVariant = nextProps.variant || {};
-    const currentVariant = this.props.variant || {};
+    const currentVariant = this.state.variant || {};
 
     if (_.isEqual(nextVariant, currentVariant) === false) {
       for (const fieldName of fieldNames) {

--- a/imports/plugins/included/product-variant/components/variantForm.js
+++ b/imports/plugins/included/product-variant/components/variantForm.js
@@ -54,7 +54,7 @@ class VariantForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     const nextVariant = nextProps.variant || {};
-    const currentVariant = this.state.variant || {};
+    const currentVariant = this.props.variant || {};
 
     if (_.isEqual(nextVariant, currentVariant) === false) {
       for (const fieldName of fieldNames) {


### PR DESCRIPTION
Resolves #4396 
Impact: major  
Type: bugfix

## Issue
Tax rates can't be saved because `shopId` is required but is not provided in the form nor it has autoValues.

## Solution
Pass current shopId to the tax rate form as a hidden input value.

## Breaking changes
None

## Testing
1. Go to Taxes in the dashboard, toggle switch for Custom Tax Rates.
2. Add some tax rates and check that all are saved. Edit saved tax rates and check that they are getting updated.
3. Enable the marketplace. Add a new shop by inviting a shop owner.
4. As a shop owner, enable custom tax rates. Check that you are able to save and edit tax rates.