### PR TITLE
Bug Fix: Product Visibility for Marketplace Shops 2

### DIFF
--- a/imports/plugins/included/product-variant/containers/productsContainerAdmin.js
+++ b/imports/plugins/included/product-variant/containers/productsContainerAdmin.js
@@ -9,7 +9,7 @@ import { Tracker } from "meteor/tracker";
 import { Reaction } from "/client/api";
 import { ITEMS_INCREMENT } from "/client/config/defaults";
 import { ReactionProduct } from "/lib/api";
-import { Products, Tags, Shops } from "/lib/collections";
+import { Products, Tags } from "/lib/collections";
 import ProductsComponent from "../components/products";
 
 const reactiveProductIds = new ReactiveVar([], (oldVal, newVal) => JSON.stringify(oldVal.sort()) === JSON.stringify(newVal.sort()));
@@ -161,17 +161,9 @@ function composer(props, onData) {
     window.prerenderReady = true;
   }
 
-  const activeShopsIds = Shops.find({
-    $or: [
-      { "workflow.status": "active" },
-      { _id: Reaction.getPrimaryShopId() }
-    ]
-  }).map((activeShop) => activeShop._id);
-
   const productCursor = Products.find({
     ancestors: [],
-    type: { $in: ["simple"] },
-    shopId: { $in: activeShopsIds }
+    type: { $in: ["simple"] }
   });
 
   const products = productCursor.fetch();


### PR DESCRIPTION
Follow up to #4259, but for Marketplace Shop Admins (not sure how did this got missed the first time?!)

Resolves #4092  
Impact: **major**  
Type: **bugfix**

## Issue
When a non-active shop is created and products added to it, the displayed products collection is empty for Admins. The non-Admin version was addressed in #4259. This admin version was overlooked, I guess?

## Solution
Remove the client-side filtering of products, as the same (yet more exhaustive check), is done server-side.

## Testing
1. Create a shop, but do not activate it
2. Add a product to that shop
3. View the Product Grid for that shop and notice that it is empty.
