### PR TITLE
Hide Action View iff Product Settings

### DIFF
--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -48,8 +48,10 @@ const wrapComponent = (Comp) => (
 
         // if some other action view is open, do not hide it
         if (actionView.template === ACTION_VIEW_TEMPLATE) {
-          return Reaction.hideActionView();
+          Reaction.hideActionView();
         }
+        
+        return;
       }
 
 

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -13,6 +13,8 @@ import Logger from "/client/modules/logger";
 import { ReactionProduct } from "/lib/api";
 import ProductGrid from "../components/productGrid";
 
+const ACTION_VIEW_TEMPLATE = "productSettings";
+
 const wrapComponent = (Comp) => (
   class ProductGridContainer extends Component {
     static propTypes = {
@@ -41,7 +43,13 @@ const wrapComponent = (Comp) => (
 
       if (Array.isArray(selectedProducts) && _.isEmpty(selectedProducts)) {
         Reaction.setUserPreferences("reaction-product-variant", "selectedGridItems", undefined);
-        return Reaction.hideActionView();
+
+        const actionView = Reaction.getActionView();
+
+        // if some other action view is open, do not hide it
+        if (actionView.template === ACTION_VIEW_TEMPLATE) {
+          return Reaction.hideActionView();
+        }
       }
 
 
@@ -54,7 +62,7 @@ const wrapComponent = (Comp) => (
           Reaction.showActionView({
             label: "Grid Settings",
             i18nKeyLabel: "gridSettingsPanel.title",
-            template: "productSettings",
+            template: ACTION_VIEW_TEMPLATE,
             type: "product",
             data: { products: filteredProducts }
           });

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -50,7 +50,7 @@ const wrapComponent = (Comp) => (
         if (actionView.template === ACTION_VIEW_TEMPLATE) {
           Reaction.hideActionView();
         }
-        
+
         return;
       }
 


### PR DESCRIPTION
Resolves #n/a
Impact: **minor**  
Type: **feature|bugfix**

## Issue
I use the `ProductGrid` component (with its container) in a custom layout page (i.e., content at the top, Grid on the bottom).
I find that when my page re-renders -- which happens surprisingly often... not sure whether that is my implementation or all of Reaction, but I digress -- a new `ProductGrid` is mounted. One case when this happens is when you open an Action Panel. Opening an Action Panel causes a re-render of most of the page, causing `ProductGrid#componentWillMount` to execute. In that code is a call to hide the Action Panel. The result is that you open a panel, and it Immediately closes.

## Solution
I added a condition to ensure that only the "Product Settings" Action Panel is hidden.

## Testing
It seems unlikely that this is happening to out-of-the-box implementations, so testing could be strange
1. Create a page with content _and_ a `ProductsGrid`
2. Open an Action Panel
3. Trigger a re-render*
4. Notice the Panel goes away

--
 * - I have not yet sorted out why my page renders as often as it does... I assume it is related to the publications to which I am subscribed, but not totally sure. With that, this issue may not be applicable to many but feels like the right thing to do regardless.