### PR TITLE
Null Guarding in GroupsTableCell

### DIFF
--- a/imports/plugins/core/accounts/client/components/groupsTableCell.js
+++ b/imports/plugins/core/accounts/client/components/groupsTableCell.js
@@ -17,7 +17,7 @@ const GroupsTableCell = (props) => {
     moment
   } = props;
 
-  const email = _.get(account, "emails[0].address");
+  const email = _.get(account, "emails[0].address", "");
   const groups = adminGroups;
   const userAvatar = getUserAvatar(account);
   const createdAt = (moment && moment(account.createdAt).format("MMM Do")) || account.createdAt.toLocaleString();


### PR DESCRIPTION
Resolves #n/a
Impact: **minor**  
Type: **bugfix**

## Issue
on line 27, there is a line which expects `name` to be a string.