### PR TITLE
chore: update version of velocity-react to 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3043,7 +3043,8 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-equal": {
       "version": "1.0.0",
@@ -3228,11 +3229,6 @@
           "dev": true
         }
       }
-    },
-    "chain-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
-      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
     },
     "chalk": {
       "version": "2.3.1",
@@ -4272,11 +4268,6 @@
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
       "dev": true
     },
-    "dateformat": {
-      "version": "1.0.1-1.2.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.1-1.2.3.tgz",
-      "integrity": "sha1-Ll0DA57KifnYeX+ZOJ3l+w9Kovw="
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4284,12 +4275,6 @@
       "requires": {
         "ms": "2.0.0"
       }
-    },
-    "debuglog": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-0.0.2.tgz",
-      "integrity": "sha1-bA3PB+LD90UkYpt0Fmi9RsezYus=",
-      "optional": true
     },
     "decamelize": {
       "version": "1.2.0",
@@ -4642,9 +4627,9 @@
       }
     },
     "dom-helpers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
-      "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -12188,6 +12173,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",
       "integrity": "sha512-xpb0PpALlFWNw/q13A+1aHeyJyLYCg0/cCHPUA43zYluZuIPHaHL3k8OBsTgQtxqW0FhyDEMvi8fZ/+7+r4OSQ=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-loadable": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/react-loadable/-/react-loadable-5.3.1.tgz",
@@ -12364,15 +12354,25 @@
       }
     },
     "react-transition-group": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
+      "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
       "requires": {
-        "chain-function": "1.0.0",
-        "dom-helpers": "3.2.1",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
+        "dom-helpers": "^3.3.1",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-with-direction": {
@@ -14712,6 +14712,7 @@
     },
     "transliteration": {
       "version": "github:reactioncommerce/transliteration#699d48cc8dd9a64f1a2773e1b36b6faa4bbdca2f",
+      "from": "github:reactioncommerce/transliteration",
       "requires": {
         "yargs": "8.0.2"
       }
@@ -15230,21 +15231,14 @@
       "integrity": "sha512-VJ3csMz5zP1ifkbBlsNYpxnoWkPHfVRQ8tUongS78W5DxSGHB68pjYHDTgUYBkVM7P/HpYdVukgVUFcxjr1gGg=="
     },
     "velocity-react": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.3.3.tgz",
-      "integrity": "sha1-1tRyds/Ivip1Yjh5sgFArFjBuCs=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.4.1.tgz",
+      "integrity": "sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==",
       "requires": {
-        "lodash": "3.10.1",
-        "prop-types": "15.6.0",
-        "react-transition-group": "1.2.1",
-        "velocity-animate": "1.5.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
+        "lodash": "^4.17.5",
+        "prop-types": "^15.5.8",
+        "react-transition-group": "^2.0.0",
+        "velocity-animate": "^1.4.0"
       }
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "twilio": "^3.11.3",
     "url": "^0.11.0",
     "velocity-animate": "^1.5.1",
-    "velocity-react": "^1.3.3"
+    "velocity-react": "^1.4.1"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0-beta.49",


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
The version of `velocity-react` we've been using is out of date and depends on an old version of `lodash` which has a snyk reported medium severity vulnerability.

## Solution
This bumps the version of `velocity-react` to the latest version which includes updating the lodash dependency

## Breaking changes
none

## Notes
There are only 6 places in the app that we use Velocity and it's a heavier package. It would be ideal to eliminate the dependency on this package entirely and animate using CSS transitions where possible or eliminate complex animations requiring a package like this from core. That task has been created as a ticket here: https://github.com/reactioncommerce/reaction/issues/4441

## Testing
The animations using velocity are contained in one of 6 files
- containers/cartIconContainer.js
- components/metadata/metafield.js
- components/tagItem.js
- components/productAdmin.js
- components/productField.js
- components/variantForm.js
