### PR TITLE
#4454 Dynamically import Moment locales to reduce client bundle size

### DIFF
--- a/client/modules/core/helpers/templates.js
+++ b/client/modules/core/helpers/templates.js
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import "moment/min/locales.min.js";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Accounts } from "meteor/accounts-base";
@@ -21,6 +20,8 @@ import { toCamelCase } from "/lib/api";
 const monthOptionsVar = new ReactiveVar([]);
 async function lazyLoadMonths() {
   if (monthOptionsVar.get().length) return;
+
+  await import("moment/min/locales.min.js");
   const { locale, months } = await import("moment-timezone");
 
   let lang = i18next.language;


### PR DESCRIPTION
Resolves #4454   
Impact: **minor**  
Type: **performance**

## Issue
When I ran Meteor's bundle visualizer RC, I noticed that MomentJS (257kb) was included in the initial client bundle, even though some work had previously been done to have it dynamically imported via a Reaction High Order Component.

## Solution
There was 1 import in /client/modules/core/helpers/templates.js that was loading moment's locales. Moving that line to a dynamic import in `lazyLoadMonths()` a few lines below, fixed the issue. RC's bundle is now 257kb lighter.

## Breaking changes
None


## Testing
1. Startup the visualizer with `export TOOL_NODE_FLAGS='--max-old-space-size=4096' && METEOR_DISABLE_OPTIMISTIC_CACHING=1 meteor run --production --extra-packages bundle-visualizer`
2. Confirm you don't see moment in the visualizer. It previously was right after meteor-node-stubs