### PR TITLE
(refactor) Remove unused discount-rates plugin

### DIFF
--- a/imports/plugins/core/discounts/server/methods/methods.app-test.js
+++ b/imports/plugins/core/discounts/server/methods/methods.app-test.js
@@ -5,11 +5,12 @@ import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";
 import { Discounts } from "/imports/plugins/core/discounts/lib/collections";
 
-const rate = {
+const code = {
   discount: 12,
   label: "Discount 5",
   description: "Discount by 5%",
-  discountMethod: "rate"
+  discountMethod: "code",
+  code: "promocode"
 };
 
 describe("discounts methods", function () {
@@ -24,33 +25,16 @@ describe("discounts methods", function () {
   });
 
   describe("discounts/deleteRate", function () {
-    // it("should not delete rate without permissions", function (done) {
-    //   const roleStub = sandbox.stub(Roles, "userIsInRole", () => true);
-    //   const discountInsertSpy = sandbox.spy(Discounts, "insert");
-    //   const discountId = Meteor.call("discounts/addRate", rate);
-    //   expect(discountInsertSpy).to.have.been.called;
-    //   Meteor._sleepForMs(500);
-    //
-    //   sandbox.stub(Roles, "userIsInRole", () => false);
-    //   Meteor.call("discounts/deleteRate", discountId);
-    //   Meteor._sleepForMs(500);
-    //
-    //   const discountCount = Discounts.find(discountId).count();
-    //   expect(discountCount).to.equal(1);
-    //   return done();
-    // });
-
-    it("should delete rate with discounts permission", function (done) {
+    it("should delete rate with discounts permission", function () {
       this.timeout(15000);
       sandbox.stub(Roles, "userIsInRole", () => true);
       const discountInsertSpy = sandbox.spy(Discounts, "insert");
-      const discountId = Meteor.call("discounts/addRate", rate);
+      const discountId = Meteor.call("discounts/addCode", code);
       expect(discountInsertSpy).to.have.been.called;
 
       Meteor.call("discounts/deleteRate", discountId);
       const discountCount = Discounts.find(discountId).count();
       expect(discountCount).to.equal(0);
-      return done();
     });
   });
 });

--- a/imports/plugins/core/discounts/server/methods/methods.app-test.js
+++ b/imports/plugins/core/discounts/server/methods/methods.app-test.js
@@ -1,0 +1,56 @@
+/* eslint prefer-arrow-callback:0 */
+import { Meteor } from "meteor/meteor";
+import { Roles } from "meteor/alanning:roles";
+import { expect } from "meteor/practicalmeteor:chai";
+import { sinon } from "meteor/practicalmeteor:sinon";
+import { Discounts } from "/imports/plugins/core/discounts/lib/collections";
+
+const rate = {
+  discount: 12,
+  label: "Discount 5",
+  description: "Discount by 5%",
+  discountMethod: "rate"
+};
+
+describe("discounts methods", function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe("discounts/deleteRate", function () {
+    // it("should not delete rate without permissions", function (done) {
+    //   const roleStub = sandbox.stub(Roles, "userIsInRole", () => true);
+    //   const discountInsertSpy = sandbox.spy(Discounts, "insert");
+    //   const discountId = Meteor.call("discounts/addRate", rate);
+    //   expect(discountInsertSpy).to.have.been.called;
+    //   Meteor._sleepForMs(500);
+    //
+    //   sandbox.stub(Roles, "userIsInRole", () => false);
+    //   Meteor.call("discounts/deleteRate", discountId);
+    //   Meteor._sleepForMs(500);
+    //
+    //   const discountCount = Discounts.find(discountId).count();
+    //   expect(discountCount).to.equal(1);
+    //   return done();
+    // });
+
+    it("should delete rate with discounts permission", function (done) {
+      this.timeout(15000);
+      sandbox.stub(Roles, "userIsInRole", () => true);
+      const discountInsertSpy = sandbox.spy(Discounts, "insert");
+      const discountId = Meteor.call("discounts/addRate", rate);
+      expect(discountInsertSpy).to.have.been.called;
+
+      Meteor.call("discounts/deleteRate", discountId);
+      const discountCount = Discounts.find(discountId).count();
+      expect(discountCount).to.equal(0);
+      return done();
+    });
+  });
+});

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -52,26 +52,6 @@ export const methods = {
   },
 
   /**
-   * @name discounts/addRate
-   * @method
-   * @memberof Discounts/Rates/Methods
-   * @param  {Object} doc A Discounts document to be inserted
-   * @param  {String} [docId] DEPRECATED. Existing ID to trigger an update. Use discounts/editCode method instead.
-   * @return {String} Insert result
-   */
-  "discounts/addRate"(doc, docId) {
-    check(doc, Object); // actual schema validation happens during insert below
-
-    // Backward compatibility
-    check(docId, Match.Optional(String));
-    if (docId) return Meteor.call("discounts/editRate", { _id: docId, modifier: doc });
-
-    if (!Reaction.hasPermission("discount-rates")) throw new Meteor.Error("access-denied", "Access Denied");
-    doc.shopId = Reaction.getShopId();
-    return Discounts.insert(doc);
-  },
-
-  /**
    * @name discounts/editRate
    * @method
    * @memberof Discounts/Rates/Methods

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
-import { check } from "meteor/check";
+import { Match, check } from "meteor/check";
+import { Cart } from "/lib/collections";
 import { Discounts } from "../../lib/collections";
 import Reaction from "../api";
 
@@ -9,6 +10,47 @@ import Reaction from "../api";
  */
 
 export const methods = {
+  /**
+   * @name discounts/deleteRate
+   * @method
+   * @memberof Discounts/Methods
+   * @param  {String} discountId discount id to delete
+   * @return {String} returns update/insert result
+   */
+  "discounts/deleteRate"(discountId) {
+    check(discountId, String);
+
+    // check permissions to delete
+    if (!Reaction.hasPermission("discounts")) {
+      throw new Meteor.Error("access-denied", "Access Denied");
+    }
+
+    return Discounts.remove({ _id: discountId });
+  },
+
+  /**
+   * @name discounts/setRate
+   * @method
+   * @memberof Discounts/Methods
+   * @summary Update the cart discounts without hooks
+   * @param  {String} cartId cartId
+   * @param  {Number} discountRate discountRate
+   * @param  {Object} discounts discounts
+   * @return {Number} returns update result
+   */
+  "discounts/setRate"(cartId, discountRate, discounts) {
+    check(cartId, String);
+    check(discountRate, Number);
+    check(discounts, Match.Optional(Array));
+
+    return Cart.update(cartId, {
+      $set: {
+        discounts,
+        discount: discountRate
+      }
+    });
+  },
+
   /**
    * @name discounts/transaction
    * @method

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -52,47 +52,6 @@ export const methods = {
   },
 
   /**
-   * @name discounts/deleteRate
-   * @method
-   * @memberof Discounts/Methods
-   * @param  {String} discountId discount id to delete
-   * @return {String} returns update/insert result
-   */
-  "discounts/deleteRate"(discountId) {
-    check(discountId, String);
-
-    // check permissions to delete
-    if (!Reaction.hasPermission("discounts")) {
-      throw new Meteor.Error("access-denied", "Access Denied");
-    }
-
-    return Discounts.remove({ _id: discountId });
-  },
-
-  /**
-   * @name discounts/setRate
-   * @method
-   * @memberof Discounts/Methods
-   * @summary Update the cart discounts without hooks
-   * @param  {String} cartId cartId
-   * @param  {Number} discountRate discountRate
-   * @param  {Object} discounts discounts
-   * @return {Number} returns update result
-   */
-  "discounts/setRate"(cartId, discountRate, discounts) {
-    check(cartId, String);
-    check(discountRate, Number);
-    check(discounts, Match.Optional(Array));
-
-    return Cart.update(cartId, {
-      $set: {
-        discounts,
-        discount: discountRate
-      }
-    });
-  },
-
-  /**
    * @name discounts/addRate
    * @method
    * @memberof Discounts/Rates/Methods

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -52,6 +52,84 @@ export const methods = {
   },
 
   /**
+   * @name discounts/deleteRate
+   * @method
+   * @memberof Discounts/Methods
+   * @param  {String} discountId discount id to delete
+   * @return {String} returns update/insert result
+   */
+  "discounts/deleteRate"(discountId) {
+    check(discountId, String);
+
+    // check permissions to delete
+    if (!Reaction.hasPermission("discounts")) {
+      throw new Meteor.Error("access-denied", "Access Denied");
+    }
+
+    return Discounts.remove({ _id: discountId });
+  },
+
+  /**
+   * @name discounts/setRate
+   * @method
+   * @memberof Discounts/Methods
+   * @summary Update the cart discounts without hooks
+   * @param  {String} cartId cartId
+   * @param  {Number} discountRate discountRate
+   * @param  {Object} discounts discounts
+   * @return {Number} returns update result
+   */
+  "discounts/setRate"(cartId, discountRate, discounts) {
+    check(cartId, String);
+    check(discountRate, Number);
+    check(discounts, Match.Optional(Array));
+
+    return Cart.update(cartId, {
+      $set: {
+        discounts,
+        discount: discountRate
+      }
+    });
+  },
+
+  /**
+   * @name discounts/addRate
+   * @method
+   * @memberof Discounts/Rates/Methods
+   * @param  {Object} doc A Discounts document to be inserted
+   * @param  {String} [docId] DEPRECATED. Existing ID to trigger an update. Use discounts/editCode method instead.
+   * @return {String} Insert result
+   */
+  "discounts/addRate"(doc, docId) {
+    check(doc, Object); // actual schema validation happens during insert below
+
+    // Backward compatibility
+    check(docId, Match.Optional(String));
+    if (docId) return Meteor.call("discounts/editRate", { _id: docId, modifier: doc });
+
+    if (!Reaction.hasPermission("discount-rates")) throw new Meteor.Error("access-denied", "Access Denied");
+    doc.shopId = Reaction.getShopId();
+    return Discounts.insert(doc);
+  },
+
+  /**
+   * @name discounts/editRate
+   * @method
+   * @memberof Discounts/Rates/Methods
+   * @param  {Object} details An object with _id and modifier props
+   * @return {String} Update result
+   */
+  "discounts/editRate"(details) {
+    check(details, {
+      _id: String,
+      modifier: Object // actual schema validation happens during update below
+    });
+    if (!Reaction.hasPermission("discount-rates")) throw new Meteor.Error("access-denied", "Access Denied");
+    const { _id, modifier } = details;
+    return Discounts.update(_id, modifier);
+  },
+
+  /**
    * @name discounts/transaction
    * @method
    * @memberof Discounts/Methods

--- a/imports/plugins/included/discount-codes/server/i18n/en.json
+++ b/imports/plugins/included/discount-codes/server/i18n/en.json
@@ -24,10 +24,16 @@
         },
         "settings": {
           "codesLabel": "Codes",
-          "noCustomDiscountCodesFound": "No discount codes found."
+          "noCustomDiscountCodesFound": "No discount codes found.",
+          "settingsSaveSuccess": "Settings saved successfully.",
+          "settingsSaveFailure": "Failed to save settings.",
+          "confirmRateDelete": "Confirm discount rate deletion."
         },
         "discountGrid": {
           "code": "Code",
+          "label": "Label",
+          "discountMethod": "Method",
+          "discount": "Discount",
           "calculation": {
             "method": "Calculation"
           },


### PR DESCRIPTION
Resolves #4308  
Impact: **none**  
Type: **refactor**

## Issue
This plugin was never completed and it was disabled so it was never used, but the code was still being shipped by default. Since this was never completed I believe there was never any documentation about it so no doc PR is necessary.

## Solution
Remove the plugin. I am not moving this to `contrib` since afaik it never worked but I did save it off and could be convinced to do so if that's what we want. But I expect we will take a different tact when handling display discounts (as we recently discussed).

## Breaking changes
None

## Testing
1. Add/Edit/Remove discount codes
