### PR TITLE
bugfix: Error when starting app / updating productsFix 4434 kieckhafer validation error

### DIFF
--- a/imports/collections/schemas/catalog.js
+++ b/imports/collections/schemas/catalog.js
@@ -605,8 +605,8 @@ export const Catalog = new SimpleSchema({
     label: "Catalog item ID"
   },
   product: {
-    type: Object,
-    label: CatalogProduct
+    type: CatalogProduct,
+    label: "Product object of Catalog product data"
   },
   createdAt: {
     type: Date,


### PR DESCRIPTION
Resolves #4434  
Impact: **minor**  
Type: **bugfix**

## Issue
When starting the app (`release-1.14.0`), the following error appears:
```
06:27:53.974Z ERROR Reaction: [product._id is not allowed by the schema]
  Error: [product._id is not allowed by the schema]
      at Function.SimpleSchema.defineValidationErrorTransform.error [as validationErrorTransform] (imports/plugins/core/core/server/startup/index.js:20:20)
      at /Users/brenthoover/Projects/js/reaction/node_modules/simpl-schema/dist/SimpleSchema.js:757:30
      at Array.forEach (<anonymous>)
      at SimpleSchema.validate (/Users/brenthoover/Projects/js/reaction/node_modules/simpl-schema/dist/SimpleSchema.js:730:15)
      at Promise.asyncApply (imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalog.js:36:21)
      at /Users/brenthoover/.meteor/packages/promise/.0.11.1.tdo4r7.5gbr++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
```

This error was also showing when a product was updated and published to the catalog.

## Solution
The `type` and `label` fields were reversed / wrong in the catalog validation schema, which was causing this error. Fixing these field names seems to fix the issue.

## Breaking changes
None

## Testing
1. Start the app after a reset
1. See no error in the log
1. Update a product and publish to catalog
1. See no error in the log
