### PR TITLE
fix: fix client errors related to domain lookup changes

### DIFF
--- a/client/modules/core/domains.js
+++ b/client/modules/core/domains.js
@@ -3,7 +3,8 @@ import { composeUrl } from "/lib/core/url-common";
 
 export const DomainsMixin = {
   shopDomain() {
-    return document.location.hostname;
+    // We must use host rather than hostname in order to get the port, too, if present
+    return document.location.host;
   },
 
   /**

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -90,8 +90,7 @@ export default {
         });
 
         if (shop) {
-          this.primaryShopId = shop._id;
-          this.primaryShopName = shop.name;
+          this._primaryShopId.set(shop._id);
 
           // We'll initialize locale and currency for the primary shop unless
           // marketplace settings exist and merchantLocale is set to true
@@ -481,22 +480,12 @@ export default {
   },
 
   /**
-   * primaryShopId is the first created shop. In a marketplace setting it's
-   * the shop that controls the marketplace and can see all other shops.
-   * @name primaryShopId
-   * @memberof Core/Client
-   */
-  set primaryShopId(shopId) {
-    this._primaryShopId.set(shopId);
-  },
-
-  /**
    * @name getPrimaryShopId
    * @method
    * @memberof Core/Client
    */
   getPrimaryShopId() {
-    return this.primaryShopId;
+    return this._primaryShopId.get();
   },
 
   /**

--- a/imports/plugins/core/files/client/index.js
+++ b/imports/plugins/core/files/client/index.js
@@ -1,11 +1,11 @@
 import { Meteor } from "meteor/meteor";
-import { Reaction } from "/client/api";
+import { DomainsMixin } from "/client/modules/core/domains";
 import { MeteorFileCollection, FileRecord } from "@reactioncommerce/file-collections";
 import { MediaRecords } from "/lib/collections";
 
 FileRecord.downloadEndpointPrefix = "/assets/files";
 FileRecord.uploadEndpoint = "/assets/uploads";
-FileRecord.absoluteUrlPrefix = Reaction.absoluteUrl();
+FileRecord.absoluteUrlPrefix = DomainsMixin.absoluteUrl();
 
 export const Media = new MeteorFileCollection("Media", {
   // The backing Meteor Mongo collection, which you must make sure is published to clients as necessary

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
@@ -304,7 +304,7 @@ function composer(props, onData) {
   if (productId) {
     productSub = Meteor.subscribe("Product", productId, shopIdOrSlug);
   }
-  if (productSub && productSub.ready() && tagSub.ready() && Reaction.Subscriptions.Cart.ready()) {
+  if (productSub && productSub.ready() && tagSub.ready() && Reaction.Subscriptions.Cart && Reaction.Subscriptions.Cart.ready()) {
     const product = ReactionProduct.setProduct(productId, variantId);
     if (Reaction.hasPermission("createProduct")) {
       if (!Reaction.getActionView() && Reaction.isActionViewOpen() === true) {


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
When https://github.com/reactioncommerce/reaction/pull/3332 was merged into 1.14.0, it caused some client errors.

## Solution
These are mainly due to the horrible circular dependencies of the Reaction object. Also fixed, `shopDomain` function to return `.host` rather than `.hostname` to match the behavior of `Meteor.absoluteUrl`

## Breaking changes
None

## Testing
Verify that the app starts and you can navigate a few of the main routes.
