### PR TITLE
[#4470] Do Not Use Reaction.absoulteUrl at Initialization Time

### DIFF
--- a/imports/plugins/core/files/client/index.js
+++ b/imports/plugins/core/files/client/index.js
@@ -1,11 +1,11 @@
 import { Meteor } from "meteor/meteor";
-import { Reaction } from "/client/api";
+import { DomainsMixin } from "/client/modules/core/domains";
 import { MeteorFileCollection, FileRecord } from "@reactioncommerce/file-collections";
 import { MediaRecords } from "/lib/collections";
 
 FileRecord.downloadEndpointPrefix = "/assets/files";
 FileRecord.uploadEndpoint = "/assets/uploads";
-FileRecord.absoluteUrlPrefix = Reaction.absoluteUrl();
+FileRecord.absoluteUrlPrefix = DomainsMixin.absoluteUrl();
 
 export const Media = new MeteorFileCollection("Media", {
   // The backing Meteor Mongo collection, which you must make sure is published to clients as necessary


### PR DESCRIPTION
Resolves #4470  
Impact: **release blocker**  
Type: **bugfix**

## Issue
When using `absoluteUrl` at initialization time, you must use the method as it is defined in DomainsMixin (client-side) or AbsoluteUrlMixin (server-side) to avoid circular dependency issues.

## Solution
s/`Reaction.absoluteUrl()`/`DomainsMixin.absoluteUrl()`

## Testing
1. Check out `release-1.14.0` locally
2. Open developer tools and see the error `Cannot read property 'absoluteUrl' of undefined`
