### PR TITLE
(chore) Remove shippo lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "recompose": "^0.26.0",
     "shallowequal": "^1.0.2",
     "sharp": "0.20.5",
-    "shippo": "^1.3.1",
     "simpl-schema": "1.5.0",
     "slugify": "^1.2.9",
     "sortablejs": "^1.7.0",


### PR DESCRIPTION
Resolves #4308   
Impact: **minor**  
Type: **chore**

## Issue
Even though the Shippo plugin has been migrated to contrib, this library somehow still remains

## Solution
Remove the library


## Breaking changes
None


## Testing
Removing this unused library should have no affect.