### PR TITLE
Do not publish empty variant to Catalog Customer

### DIFF
--- a/imports/plugins/core/core/server/publications/collections/products.js
+++ b/imports/plugins/core/core/server/publications/collections/products.js
@@ -367,7 +367,7 @@ function filterCatalogItems(catalogFilters) {
   // Init default selector - Everyone can see products that fit this selector
   const baseSelector = {
     "product.isDeleted": { $ne: true }, // by default, we don't publish deleted products
-    "product.isVisible": true // by default, only lookup visible products
+    "product.isVisible": true, // by default, only lookup visible products
     "product.variants": { $ne: [] } // if no variant, then do not publish
   };
 

--- a/imports/plugins/core/core/server/publications/collections/products.js
+++ b/imports/plugins/core/core/server/publications/collections/products.js
@@ -368,6 +368,7 @@ function filterCatalogItems(catalogFilters) {
   const baseSelector = {
     "product.isDeleted": { $ne: true }, // by default, we don't publish deleted products
     "product.isVisible": true // by default, only lookup visible products
+    "product.variants": { $ne: [] } // if no variant, then do not publish
   };
 
   const { shopIdsOrSlugs } = catalogFilters || {};


### PR DESCRIPTION
Resolves #4467 
Impact: **minor**  
Type: **bugfix**

## Issue
When a Product is made visible and published without any Variant,  Catalog customer gets price range as **$NaN.undefined - $-NaN.undefined**

## Solution
Included a condition in Products Publication to base  catalog selector to  not include products with empty variants.  Products without any Variant does not make any sense to end customer till it  is complete.  Let Admin work on the product in meantime and publish as many times as needed, customer will see only when product has at least 1 variant  in Catalog.


## Testing
From this branch start the app, login as admin, create a product by entering title, subtitle, vendor and description only( no variant detail). Make visible and publish.
Logout as admin and see product should not be displayed on homepage.

