### PR TITLE
CircleCI step for deploying to an existing ECS cluster

### DIFF
--- a/.circleci/bin/ecs-deploy.sh
+++ b/.circleci/bin/ecs-deploy.sh
@@ -7,7 +7,15 @@ sudo mv /tmp/yq /usr/local/bin/yq
 sudo chmod +x /usr/local/bin/yq
 
 if [ -z "${AWS_REGION}" ]; then
-		AWS_REGION=us-west-2
+	AWS_REGION=us-west-2
+fi
+
+if [ "${CLOUDFORMATION_AWS_ACCESS_KEY_ID}" ]; then
+	AWS_ACCESS_KEY_ID=${CLOUDFORMATION_AWS_ACCESS_KEY_ID}
+fi
+
+if [ "${CLOUDFORMATION_AWS_SECRET_ACCESS_KEY}" ]; then
+	AWS_SECRET_ACCESS_KEY=${CLOUDFORMATION_AWS_SECRET_ACCESS_KEY}
 fi
 
 aws s3 cp --recursive s3://${S3_ECS_DEPLOY_BUCKET}/devops .

--- a/.circleci/bin/ecs-deploy.sh
+++ b/.circleci/bin/ecs-deploy.sh
@@ -20,5 +20,6 @@ fi
 
 aws s3 cp --recursive s3://${S3_ECS_DEPLOY_BUCKET}/devops .
 
+find aws -name \*sh | xargs chmod +x
 cd aws/app
 ./update-app-stack.sh core-service

--- a/.circleci/bin/ecs-deploy.sh
+++ b/.circleci/bin/ecs-deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+sudo apt-get -y install python3-pip wget
+sudo pip3 install awscli
+wget https://github.com/mikefarah/yq/releases/download/2.0.1/yq_linux_amd64 -O /tmp/yq
+sudo mv /tmp/yq /usr/local/bin/yq
+sudo chmod +x /usr/local/bin/yq
+
+if [ -z "${AWS_REGION}" ]; then
+		AWS_REGION=us-west-2
+fi
+
+aws s3 cp --recursive s3://${S3_ECS_DEPLOY_BUCKET}/devops .
+
+cd devops/aws/app
+./update-app-stack.sh core-service

--- a/.circleci/bin/ecs-deploy.sh
+++ b/.circleci/bin/ecs-deploy.sh
@@ -20,5 +20,5 @@ fi
 
 aws s3 cp --recursive s3://${S3_ECS_DEPLOY_BUCKET}/devops .
 
-cd devops/aws/app
+cd aws/app
 ./update-app-stack.sh core-service

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,6 +299,9 @@ workflows:
       - deploy-to-ecs:
           requires:
             - docker-push
+          filters:
+            branches:
+              only: /^release-1\.14\.\d+$/
       - deploy-docs:
           requires:
             - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,15 @@ jobs:
               echo "No deploy for forks"
             fi
 
+  deploy-to-ecs:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Deploy new task definition and update service in ECS
+          command: |
+            .circleci/bin/ecs-deploy.sh
+
   deploy-docs:
     <<: *defaults
     steps:
@@ -268,9 +277,9 @@ workflows:
     jobs:
       - build
       - dockerfile-lint
-      - test-app:
-          requires:
-            - build
+      #- test-app:
+      #    requires:
+      #      - build
       - test-unit:
           requires:
             - build
@@ -287,10 +296,13 @@ workflows:
           context: reaction-publish-docker
           requires:
             - docker-build
+      - deploy-to-ecs:
+          requires:
+            - docker-push
       - deploy-docs:
           requires:
             - test-unit
-            - test-app
+      #      - test-app
             - docker-build
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,9 +277,9 @@ workflows:
     jobs:
       - build
       - dockerfile-lint
-      #- test-app:
-      #    requires:
-      #      - build
+      - test-app:
+          requires:
+            - build
       - test-unit:
           requires:
             - build
@@ -302,7 +302,7 @@ workflows:
       - deploy-docs:
           requires:
             - test-unit
-      #      - test-app
+            - test-app
             - docker-build
           filters:
             branches:


### PR DESCRIPTION
This change adds a step called deploy-to-ecs to the CircleCi workflow. The step is executed after the docker-push step. It deploys the newly built Docker container by updating a task definition in an already running ECS service in an ECS cluster. To do this, it first downloads a series of scripts and CloudFormation templates from an S3 bucket specified as a CircleCI env var, then it runs one of those scripts.