### PR TITLE
Fix migration error preventing app startup

### DIFF
--- a/imports/plugins/core/versions/server/startup.js
+++ b/imports/plugins/core/versions/server/startup.js
@@ -21,7 +21,7 @@ Hooks.Events.add("afterCoreInit", () => {
   const highestAvailableVersion = Migrations._list[Migrations._list.length - 1].version;
 
   if (currentMigrationVersion > highestAvailableVersion) {
-    Logger.warn(`You are running a Reaction version with migration version (${highestAvailableVersion}) below your currrent DB migration state (${currentMigrationVersion})`);
+    Logger.warn(`You are running a Reaction install with migration version (${highestAvailableVersion}) below your current DB migration state (${currentMigrationVersion})`);
     Migrations._setControl({ locked: false, version: highestAvailableVersion });
   } else if (!Meteor.isTest) {
     Migrations.migrateTo("latest");

--- a/imports/plugins/core/versions/server/startup.js
+++ b/imports/plugins/core/versions/server/startup.js
@@ -23,7 +23,7 @@ Hooks.Events.add("afterCoreInit", () => {
   if (currentMigrationVersion > highestAvailableVersion) {
     Logger.warn(`You are running a Reaction version with migration version (${highestAvailableVersion}) below your currrent DB migration state (${currentMigrationVersion})`);
     Migrations._setControl({ locked: false, version: highestAvailableVersion });
-  } else {
+  } else if (!Meteor.isTest) {
     Migrations.migrateTo("latest");
   }
 });

--- a/imports/plugins/core/versions/server/startup.js
+++ b/imports/plugins/core/versions/server/startup.js
@@ -1,3 +1,4 @@
+import { Meteor } from "meteor/meteor";
 import Hooks from "@reactioncommerce/hooks";
 import Logger from "@reactioncommerce/logger";
 import { Migrations } from "meteor/percolate:migrations";
@@ -16,5 +17,13 @@ Migrations.config({
 });
 
 Hooks.Events.add("afterCoreInit", () => {
-  Migrations.migrateTo("latest");
+  const currentMigrationVersion = Migrations._getControl().version;
+  const highestAvailableVersion = Migrations._list[Migrations._list.length - 1].version;
+
+  if (currentMigrationVersion > highestAvailableVersion) {
+    Logger.warn(`You are running a Reaction version with migration version (${highestAvailableVersion}) below your currrent DB migration state (${currentMigrationVersion})`);
+    Migrations._setControl({ locked: false, version: highestAvailableVersion });
+  } else {
+    Migrations.migrateTo("latest");
+  }
 });

--- a/imports/plugins/core/versions/server/startup.js
+++ b/imports/plugins/core/versions/server/startup.js
@@ -20,9 +20,13 @@ Hooks.Events.add("afterCoreInit", () => {
   const currentMigrationVersion = Migrations._getControl().version;
   const highestAvailableVersion = Migrations._list[Migrations._list.length - 1].version;
 
+  // Checks to ensure the app is running against a DB at the right migration state. Running the app
+  // with a wrong DB state will cause the app to malfunction
   if (currentMigrationVersion > highestAvailableVersion) {
-    Logger.warn(`You are running a Reaction install with migration version (${highestAvailableVersion}) below your current DB migration state (${currentMigrationVersion})`);
-    Migrations._setControl({ locked: false, version: highestAvailableVersion });
+    Logger.fatal(`You are running a Reaction install with migration version (${highestAvailableVersion}) below your current DB migration state (${currentMigrationVersion})`);
+    Logger.fatal(`Upgrade to a version of Reaction containing migration ${currentMigrationVersion} or higher.`);
+    Logger.fatal("If you really want to downgrade to this version, you should restore your DB to a previous state from your backup.");
+    process.exit(0);
   } else if (!Meteor.isTest) {
     Migrations.migrateTo("latest");
   }


### PR DESCRIPTION
Resolves #4362   
Impact: **major**  
Type: **fix**

## Issue
If you move to the current version and then decide you need to roll back for any reason, and that newer version contained a migration, the app will not start, and you get an error similar to:
```
web_1  | /app/programs/server/node_modules/fibers/future.js:280
web_1  | 						throw(ex);
web_1  | 						^
web_1  | Error: [Can't find migration version 26]
```
## Solution
- Added a check to to compare the existing migration version with available code migration before running migrations. So, we only call `migrateTo("latest")` when it's actually possible to migrate higher. (as [suggested on issue ](https://github.com/reactioncommerce/reaction/issues/4362#issuecomment-403872554))
- Also added a log.warn with text: `You are running a Reaction version with migration version (${highestAvailableVersion}) below your current DB migration state (${currentMigrationVersion})`

## Breaking changes
None that I'm aware of.

## Testing
- Create a dummy migration after pulling this branch
- Start the app and ensure the app is migrated up to the dummy migration created
- Then, remove that dummy migration 

Alternative way to test:
- Start the app on this branch.
- Connect to your DB, and increment the version number of the only Migration collection document. 
- After incrementing, restart the app
- Confirm that there are no migration errors, and there's a Log warn message about migration version