### PR TITLE
feat: Add `resolveAccountFromAccountId` resolver

### DIFF
--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Cart/index.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Cart/index.js
@@ -1,9 +1,10 @@
 import { encodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
-import { resolveShopFromShopId } from "@reactioncommerce/reaction-graphql-utils";
+import { resolveAccountFromAccountId, resolveShopFromShopId } from "@reactioncommerce/reaction-graphql-utils";
 import items from "./items";
 
 export default {
   _id: (node) => encodeCartOpaqueId(node._id),
   items,
+  account: resolveAccountFromAccountId,
   shop: resolveShopFromShopId
 };

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/util/index.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/util/index.js
@@ -8,4 +8,5 @@ export { default as getConnectionTypeResolvers } from "./getConnectionTypeResolv
 export { default as getPaginatedResponse } from "./getPaginatedResponse";
 export { default as namespaces } from "./namespaces";
 export { default as optimizeIdOnly } from "./optimizeIdOnly";
+export { default as resolveAccountFromAccountId } from "./resolveAccountFromAccountId";
 export { default as resolveShopFromShopId } from "./resolveShopFromShopId";

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/util/resolveAccountFromAccountId.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/util/resolveAccountFromAccountId.js
@@ -1,0 +1,16 @@
+/**
+ * @name resolveAccountFromAccountId
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary A generic resolver that gets the account object for the provided parent result, assuming it has a `accountId` property
+ * @param {Object} parent - result of the parent resolver
+ * @param {Object} _ - unused param
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} The account having ID parent.accountId, in GraphQL schema format
+ */
+export default async function resolveAccountFromAccountId(parent, _, context) {
+  const { accountId } = parent;
+  if (!accountId) return null;
+
+  return context.queries.accounts.userAccount(context, accountId);
+}

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/util/resolveAccountFromAccountId.test.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/util/resolveAccountFromAccountId.test.js
@@ -1,0 +1,22 @@
+import resolveAccountFromAccountId from "./resolveAccountFromAccountId";
+
+const fakeAccount = {
+  _id: "123",
+  name: "Bob Builder"
+};
+
+const fakeCart = {
+  _id: "reaction/cart:1234",
+  accountId: fakeAccount._id
+};
+
+test("calls queries.accounts.userAccount and returns the requested account", async () => {
+  const userAccount = jest.fn().mockName("queries.accounts.userAccount").mockReturnValueOnce(Promise.resolve(fakeAccount));
+
+  const accountObject = await resolveAccountFromAccountId(fakeCart, {}, { queries: { accounts: { userAccount } } });
+
+  expect(accountObject).toEqual(fakeAccount);
+
+  expect(userAccount).toHaveBeenCalled();
+  expect(userAccount.mock.calls[0][1]).toBe(fakeCart.accountId);
+});


### PR DESCRIPTION
Resolves #issueNumber  
Impact: **minor**  
Type: **feature**

## Issue

Requesting the `account` field in the `accountCartByAccountId` query always retuns `null`, when it should be defined.

## Solution

- Add a new resolver to resolve a provided account id and return an account object
- Using `resolveShopFromShopId` as a template, I created a new resolver called `resolveAccountFromAccountId`.
- Used existing `queries.accounts.userAccount` query for the resolver
- Attached resolver to the Cart resolver on the `account` field

## Breaking changes

none

## Testing

1. As an authenticated user
2. Add an item to your cart, just the be sure a cart has been created
3. Run the `viewer` query in GraphiQL to get your `accountId (_id)` and `shopId`
```graphql
{
  viewer {
    _id
    shop {
      _id
    }
  }
}
```

4. Use the `accountId` and `shopId` to fetch your account cart, and ensure that `account` is not null
```graphql
{
  accountCartByAccountId(accountId: <accountId>, shopId: <shopId>) {
  	_id
    account {
      _id
      name
    }
    shop {
      _id
      name
      currency {
        scale
        decimal
        thousand
        rate
      }
    }
    expiresAt
    createdAt
    updatedAt
    items {
      edges {
        node {
          currentQuantity
          optionTitle
          productSlug
          productType
          productVendor
          variantTitle
          quantity
        }
      }
    }
  }
}
```