### PR TITLE
Spencer update npm deps

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -22,3 +22,7 @@ ignore:
     - '*':
       reason: "extend and request have updated, waiting on twillio and a few other packages to update to the latest requestpackage"
       expires: '2018-08-26T20:23:03.274Z'
+  'npm:chownr:20180731':
+    - '*':
+      reason: "Known bug https://github.com/isaacs/chownr/issues/14, unknown time to patch"
+      expires: '2018-08-30T20:23:03.274Z'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12637,9 +12637,9 @@
       }
     },
     "react": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
-      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
+      "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2718,15 +2718,6 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "babel-plugin-dynamic-import-node": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.2.0.tgz",
-      "integrity": "sha512-yeDwKaLgGdTpXL7RgGt5r6T4LmnTza/hUn5Ul8uZSGGMtEjYo13Nxai7SQaGCTEzUtg9Zq9qJn0EjEr7SeSlTQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0"
-      }
-    },
     "babel-plugin-emotion": {
       "version": "9.2.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.6.tgz",
@@ -2881,12 +2872,6 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
-      "dev": true
-    },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
       "dev": true
     },
     "babel-plugin-syntax-jsx": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14002,9 +14002,9 @@
       }
     },
     "slugify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.0.tgz",
-      "integrity": "sha512-vvz+9ANt7CtdTHwJpfrsHOnGkgxky+CUPnvtzDZBZYFo/H/CdZkd5lJL7z7RqtH/x9QW/ItYYfHlcGf38CBK1w=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.1.tgz",
+      "integrity": "sha512-6BwyhjF5tG5P8s+0DPNyJmBSBePG6iMyhjvIW5zGdA3tFik9PtK+yNkZgTeiroCRGZYgkHftFA62tGVK1EI9Kw=="
     },
     "smart-buffer": {
       "version": "1.1.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12765,9 +12765,9 @@
       }
     },
     "react-dom": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
-      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
+      "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "query-parse": "^2.0.0",
     "radium": "^0.22.0",
     "ramda": "^0.25.0",
-    "react": "16.4.1",
+    "react": "16.4.2",
     "react-autosuggest": "^9.3.3",
     "react-avatar": "^2.5.1",
     "react-color": "^2.13.8",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "react-dates": "17.1.0",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
-    "react-dom": "16.4.1",
+    "react-dom": "16.4.2",
     "react-dropzone": "^4.2.7",
     "react-helmet": "^5.2.0",
     "react-image-magnify": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "shallowequal": "^1.0.2",
     "sharp": "0.20.5",
     "simpl-schema": "1.5.0",
-    "slugify": "^1.2.9",
+    "slugify": "1.3.1",
     "sortablejs": "^1.7.0",
     "store": "^2.0.12",
     "stripe": "^5.4.0",


### PR DESCRIPTION
This PR updates a few dependencies to satisfy the snyk vulnerability scan.

**fix: remove unused babel dynamic dev deps**
Removes babel-plugin-syntax-dynamic-import @6.18.0
and babel-plugin-dynamic-import-node @1.2.0 from package-lock.json
Both were removed automatically when running `meteor npm install`

**fix: update slugify and pin to 1.3.1**
Updates slugify version from 1.3.0 (^1.2.9) to 1.3.1 and pins to 1.3.1

**fix: update react to 16.4.2**
Updates our pinned version of react from 16.4.1 to 16.4.2

**fix: update react-dom to 16.4.2**
Fixes a snyk reported vulnerability on react-dom by
bumping our pinned version from 16.4.1 to 16.4.2

**fix: adds chownr to snyk ignore file**
Chownr has a recently reported issue to snyk, though the issue itself
has been known for over a year. isaacs/chownr#14
This issue has been introduced via sharp via tar and tar-fs npm packages

We'll continue to follow this issue on the chownr repo. And I've added
a comment to the issue thread. https://github.com/isaacs/chownr/issues/14#issuecomment-410554921