### PR TITLE
#4504: Fix for date not displaying in printable invoice

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/pdf.js
+++ b/imports/plugins/core/orders/client/templates/list/pdf.js
@@ -1,3 +1,4 @@
+import Logger from "@reactioncommerce/logger";
 import { Template } from "meteor/templating";
 import { Reaction, Router } from "/client/api";
 import { Orders } from "/lib/collections";
@@ -9,7 +10,7 @@ import { ReactiveVar } from "meteor/reactive-var";
 * inheritsHelpersFrom dashboardOrdersList
 * Uses the browser print function.
 */
-Template.completedPDFLayout.onCreated(async function () {
+Template.completedPDFLayout.onCreated(function () {
   this.state = new ReactiveDict();
   this.state.setDefault({
     order: {},
@@ -17,8 +18,15 @@ Template.completedPDFLayout.onCreated(async function () {
   });
 
   this.readyVar = new ReactiveVar(false);
-  this.moment = await import("moment").default;
-  this.readyVar.set(true);
+
+  import("moment")
+    .then((module) => {
+      this.moment = module.default;
+      return this.readyVar.set(true);
+    })
+    .catch((error) => {
+      Logger.error(error, "Unable to load moment");
+    });
 
   const currentRoute = Router.current();
 
@@ -49,9 +57,12 @@ Template.completedPDFLayout.helpers({
   },
   dateFormat(context, block) {
     const { moment } = Template.instance();
-    moment.locale(Reaction.Locale.get().language);
-    const f = block.hash.format || "MMM DD, YYYY hh:mm:ss A";
-    return moment(context).format(f);
+    if (moment) {
+      moment.locale(Reaction.Locale.get().language);
+      const format = block.hash.format || "MMM DD, YYYY hh:mm:ss A";
+      return moment(context).format(format);
+    }
+    return "";
   },
   ready() {
     return Template.instance().readyVar.get();


### PR DESCRIPTION
Resolves #4504 
Impact: **minor**  
Type: **bugfix**

## Issue
The date was no longer displaying on the printable invoices, due to changes importing moment and removing dynamic-imports-node.

## Solution
Instead of having completedPDFLayout.onCreated() be an async/await function, changed it to a normal function and imported moment via `import("moment").then(module...`. Set template.readyVar to true once imported.

## Breaking changes
None


## Testing
1. Complete checkout
2. Dashboard -> Orders -> Order -> approve -> print
3. Confirm date on print screen appears