### PR TITLE
#4514: Dynamically import Swiper to reduce client bundle size

### DIFF
--- a/imports/plugins/core/checkout/client/templates/cartDrawer/cartDrawer.js
+++ b/imports/plugins/core/checkout/client/templates/cartDrawer/cartDrawer.js
@@ -1,5 +1,5 @@
-import Swiper from "swiper";
 import { Components } from "@reactioncommerce/reaction-components";
+import Logger from "@reactioncommerce/logger";
 import { $ } from "meteor/jquery";
 import { Session } from "meteor/session";
 import { Template } from "meteor/templating";
@@ -48,18 +48,26 @@ Template.openCartDrawer.onRendered(() => {
 
   $("#cart-drawer-container").fadeIn(() => {
     if (!swiper) {
-      swiper = new Swiper(".cart-drawer-swiper-container", {
-        direction: "horizontal",
-        setWrapperSize: true,
-        loop: false,
-        grabCursor: true,
-        slidesPerView: "auto",
-        wrapperClass: "cart-drawer-swiper-wrapper",
-        slideClass: "cart-drawer-swiper-slide",
-        slideActiveClass: "cart-drawer-swiper-slide-active",
-        pagination: ".cart-drawer-pagination",
-        paginationClickable: true
-      });
+      import("swiper")
+        .then((module) => {
+          const Swiper = module.default;
+          swiper = new Swiper(".cart-drawer-swiper-container", {
+            direction: "horizontal",
+            setWrapperSize: true,
+            loop: false,
+            grabCursor: true,
+            slidesPerView: "auto",
+            wrapperClass: "cart-drawer-swiper-wrapper",
+            slideClass: "cart-drawer-swiper-slide",
+            slideActiveClass: "cart-drawer-swiper-slide-active",
+            pagination: ".cart-drawer-pagination",
+            paginationClickable: true
+          });
+          return swiper;
+        })
+        .catch((error) => {
+          Logger.error(error.message, "Unable to load Swiper module");
+        });
     }
   });
 });


### PR DESCRIPTION
Resolves #4514 
Impact: **minor**  
Type: **performance**

## Issue
The Swiper NPM module (126 kb) is included in the initial client bundle. It's only used in one place - the cart drawer.

## Solution
Move the loading of the module to a dynamic import.

## Breaking changes
None.


## Testing
1. Add items to cart
2. Confirm swiper still works (you can drag the items left/right while cart is expanded)
3. Confirm swiper is no longer in bundle. Run Reaction with `export TOOL_NODE_FLAGS='--max-old-space-size=4096' && METEOR_DISABLE_OPTIMISTIC_CACHING=1 meteor run --production --extra-packages bundle-visualizer`

## Before
![swiper-before](https://user-images.githubusercontent.com/849570/43792490-c6d55142-9a46-11e8-88f6-f6a6e9c5e0e2.jpg)

## After
![swiper-after](https://user-images.githubusercontent.com/849570/43792500-cc31756c-9a46-11e8-8399-76462e0d55be.jpg)

