### PR TITLE
fix: sync lowInventoryThreshold number between variants and child options

### DIFF
--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -240,6 +240,19 @@ const wrapComponent = (Comp) => (
       }
     }
 
+    updateLowInventoryThresholdIfChildVariants = (variant) => {
+      // Check to see if this variant has options attached to it
+      const variantOptions = ReactionProduct.getVariants(variant._id);
+
+      if (variantOptions && variantOptions.length !== 0) {
+        variantOptions.forEach((option) => Meteor.call("products/updateProductField", option._id, "lowInventoryWarningThreshold", variant.lowInventoryWarningThreshold, (error) => {
+          if (error) {
+            Alerts.toast(error.message, "error");
+          }
+        }));
+      }
+    }
+
     updateQuantityIfChildVariants = (variant) => {
       if (this.hasChildVariants(variant)) {
         const variantQuantity = ReactionProduct.getVariantQuantity(variant);

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -190,6 +190,10 @@ const wrapComponent = (Comp) => (
           if (fieldName === "inventoryPolicy") {
             this.updateInventoryPolicyIfChildVariants(variant);
           }
+
+          if (fieldName === "lowInventoryWarningThreshold") {
+            this.updateLowInventoryThresholdIfChildVariants(variant);
+          }
         });
       }
     }


### PR DESCRIPTION
Resolves #4358   
Impact: **minor**  
Type: **fix**

## Issue
Low inventory threshold numbers are stored only on a product variant, not on it's options. We have login in our code to attach the variants number to each option, however even with this logic, in the database, the `lowInventoryThreshold` is always set to `0` on the the option. 

## Solution
We are keeping the logic the same, and how we read the numbers the same, but we are now syncing the `lowInventoryThreshold` number to each option, when it's changed on it's parent variant. This may create easier use in the future, but should not create any real changes now, as `option.lowInventoryThreshold` isn't used anywhere. The only change seen should be the number inside the database.

## Breaking changes
None

## Testing
1. Add a product with variants and options
1. Add a "warn at" number to the product variant
1. Open `3T` and see the same number is saved as the `lowInventoryThreshold` number on that variant, as well as all the option children of said variant.