### PR TITLE
Added production bundle size check to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,31 @@ jobs:
       - run:
           name: Meteor NPM Install
           command: meteor npm install
+      - run:
+          name: Build dist bundle
+          command: meteor build --directory ../build/
+      - run:
+          name: Check .js size
+          command: |
+            maxSize=1468006
+            size=$( wc -c ../build/bundle/programs/web.browser/*.js | awk '{$1=$1};1' | cut -d " " -f 1 )
+            if [[ $size -gt $maxSize ]]; then
+              echo "The production js file has size" $size "which exceeds limit of" $maxSize 1>&2
+              exit 3
+            else
+              echo "Reduce the js file limit to" $size
+            fi
+      - run:
+          name: Check .css size
+          command: |
+            maxSize=64208
+            size=$( wc -c ../build/bundle/programs/web.browser/*.css | awk '{$1=$1};1' | cut -d " " -f 1 )
+            if [[ $size -gt $maxSize ]]; then
+              echo "The production js file has size" $size "which exceeds limit of" $maxSize 1>&2
+              exit 3
+            else
+              echo "Reduce the css file limit to" $size
+            fi
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.
       - save_cache:
@@ -58,6 +83,7 @@ jobs:
           key: mongodb-memory-server
           paths:
             - ~/.mongodb-binaries
+      
 
   docker-build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Check .js size
           command: |
-            maxSize=1468006
+            maxSize=2964687
             size=$( wc -c ../build/bundle/programs/web.browser/*.js | awk '{$1=$1};1' | cut -d " " -f 1 )
             if [[ $size -gt $maxSize ]]; then
               echo "The production js file has size" $size "which exceeds limit of" $maxSize 1>&2
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Check .css size
           command: |
-            maxSize=64208
+            maxSize=199588
             size=$( wc -c ../build/bundle/programs/web.browser/*.css | awk '{$1=$1};1' | cut -d " " -f 1 )
             if [[ $size -gt $maxSize ]]; then
               echo "The production js file has size" $size "which exceeds limit of" $maxSize 1>&2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Build dist bundle
           command: meteor build --directory ../build/
       - run:
-          name: Check .js size
+          name: Check .js file size
           command: |
             maxSize=2964687
             size=$( wc -c ../build/bundle/programs/web.browser/*.js | awk '{$1=$1};1' | cut -d " " -f 1 )
@@ -56,7 +56,7 @@ jobs:
               echo "The js file size is" $size
             fi
       - run:
-          name: Check .css size
+          name: Check .css file size
           command: |
             maxSize=24888
             size=$( wc -c ../build/bundle/programs/web.browser/*.css | awk '{$1=$1};1' | cut -d " " -f 1 )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,18 +53,18 @@ jobs:
               echo "The production js file has size" $size "which exceeds limit of" $maxSize 1>&2
               exit 3
             else
-              echo "Reduce the js file limit to" $size
+              echo "The js file size is" $size
             fi
       - run:
           name: Check .css size
           command: |
-            maxSize=199588
+            maxSize=24888
             size=$( wc -c ../build/bundle/programs/web.browser/*.css | awk '{$1=$1};1' | cut -d " " -f 1 )
             if [[ $size -gt $maxSize ]]; then
               echo "The production js file has size" $size "which exceeds limit of" $maxSize 1>&2
               exit 3
             else
-              echo "Reduce the css file limit to" $size
+              echo "The css file size is" $size
             fi
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
Currently there is no way to limit the size of the production bundle that is pushed to the client. It is very easy for a developer to push code that increases the bundle by a significant amount.

## Solution
This PR adds a check to CircleCI, to check the bundle size. The `build` will fail if the bundle size is increased.

## Testing
1. Create a PR, click on the Circle CI `build` logs. You can see the logs of `Check .js file size` and `Check .css file size`.
2. Add a client library to reaction and push to the PR. Notice that it will fail and in the logs of `build` the developer can see the actual file size and expected file size.