### PR TITLE
Refactor fulfillment items

### DIFF
--- a/imports/collections/schemas/shipping.js
+++ b/imports/collections/schemas/shipping.js
@@ -293,6 +293,7 @@ registerSchema("ShipmentQuotesQueryStatus", ShipmentQuotesQueryStatus);
  * @property {ShipmentQuote[]} shipmentQuotes optional
  * @property {ShipmentQuotesQueryStatus} shipmentQuotesQueryStatus optional
  * @property {String} tracking optional
+ * @property {String} type The fulfillment type. Currently only "shipping" supported
  * @property {ShippingParcel} parcel optional
  * @property {Workflow} workflow optional
  * @property {Invoice} invoice optional
@@ -341,6 +342,11 @@ export const Shipment = new SimpleSchema({
   "tracking": {
     type: String,
     optional: true
+  },
+  "type": {
+    type: String,
+    allowedValues: ["shipping"],
+    defaultValue: "shipping"
   },
   "parcel": {
     type: ShippingParcel,

--- a/imports/collections/schemas/shipping.js
+++ b/imports/collections/schemas/shipping.js
@@ -185,46 +185,6 @@ export const ShipmentQuote = new SimpleSchema({
 registerSchema("ShipmentQuote", ShipmentQuote);
 
 /**
- * @name ShipmentItem
- * @memberof Schemas
- * @type {SimpleSchema}
- * @summary Populate with order.items that are added to a shipment
- * @property {String} _id Shipment Line Item optional
- * @property {String} productId required
- * @property {String} shopId Shipment Item ShopId optional
- * @property {Number} quantity required
- * @property {String} variantId required
- */
-export const ShipmentItem = new SimpleSchema({
-  _id: {
-    type: String,
-    label: "Shipment Line Item",
-    optional: true,
-    autoValue: schemaIdAutoValue
-  },
-  productId: {
-    type: String,
-    index: 1
-  },
-  shopId: {
-    type: String,
-    index: 1,
-    label: "Shipment Item ShopId",
-    optional: true
-  },
-  quantity: {
-    label: "Quantity",
-    type: SimpleSchema.Integer,
-    min: 0
-  },
-  variantId: {
-    type: String
-  }
-});
-
-registerSchema("ShipmentItem", ShipmentItem);
-
-/**
  * @name ShippingParcel
  * @memberof Schemas
  * @type {SimpleSchema}
@@ -334,7 +294,6 @@ registerSchema("ShipmentQuotesQueryStatus", ShipmentQuotesQueryStatus);
  * @property {ShipmentQuotesQueryStatus} shipmentQuotesQueryStatus optional
  * @property {String} tracking optional
  * @property {ShippingParcel} parcel optional
- * @property {ShipmentItem[]} items optional
  * @property {Workflow} workflow optional
  * @property {Invoice} invoice optional
  * @property {Object[]} transactions optional
@@ -383,14 +342,6 @@ export const Shipment = new SimpleSchema({
   },
   "parcel": {
     type: ShippingParcel,
-    optional: true
-  },
-  "items": {
-    type: Array,
-    optional: true
-  },
-  "items.$": {
-    type: ShipmentItem,
     optional: true
   },
   "workflow": {

--- a/imports/collections/schemas/shipping.js
+++ b/imports/collections/schemas/shipping.js
@@ -251,7 +251,7 @@ registerSchema("ShippoShipment", ShippoShipment);
  * @memberof Schemas
  * @type {SimpleSchema}
  * @summary Status of a query/consumption of a shipping provider's API (e.g Shippo) for shipping quotations.
- * @description Shipping quotations are the costs from different shipping methods like Fedex, DHL etc of
+ * @description Shipping quotations are the costs from different shipping methods like FedEx, DHL etc of
  * shipping one or more items to a particular place in a given amount of time.)
  * @property {String} requestStatus optional, default value: `noRequestsYet`
  * @property {String} shippingProvider optional
@@ -382,7 +382,7 @@ registerSchema("Shipment", Shipment);
  * @name ShippoShippingProvider Schema
  * @summary Specific properties for use with Shippo.
  * @description We don't use ShippingProvider service* fields because
- * Shippo is on level higher service than simple carrier's ,e.g Fedex api.
+ * Shippo is on level higher service than simple carrier's ,e.g FedEx api.
  * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} carrierAccountId optional

--- a/imports/collections/schemas/shipping.js
+++ b/imports/collections/schemas/shipping.js
@@ -296,6 +296,8 @@ registerSchema("ShipmentQuotesQueryStatus", ShipmentQuotesQueryStatus);
  * @property {ShippingParcel} parcel optional
  * @property {Workflow} workflow optional
  * @property {Invoice} invoice optional
+ * @property {String[]} itemIds Required on an order but not on a cart, this is set to a denormalized
+ *   list of item IDs when a cart is converted to an order
  * @property {Object[]} transactions optional
  * @property {String} shippingLabelUrl For printable Shipping label
  * @property {String} customsLabelUrl For customs printable label
@@ -353,6 +355,11 @@ export const Shipment = new SimpleSchema({
     type: Invoice,
     optional: true
   },
+  "itemIds": {
+    type: Array,
+    optional: true
+  },
+  "itemIds.$": String,
   "transactions": {
     type: Array,
     optional: true

--- a/imports/plugins/core/cart/server/methods/copyCartToOrder.js
+++ b/imports/plugins/core/cart/server/methods/copyCartToOrder.js
@@ -98,6 +98,7 @@ export default function copyCartToOrder(cartId, cartToken) {
     const billingRecord = order.billing.find((billing) => billing.shopId === shippingRecord.shopId);
     return {
       ...shippingRecord,
+      itemIds: [],
       paymentId: billingRecord._id,
       workflow: { status: "new", workflow: ["coreOrderWorkflow/notStarted"] }
     };
@@ -136,8 +137,13 @@ export default function copyCartToOrder(cartId, cartToken) {
       variant: chosenVariant
     } = Promise.await(findProductAndVariant(rawCollections, item.productId, item.variantId));
 
+    const fulfillmentGroup = order.shipping.find((group) => group.shopId === item.shopId);
+
+    // This is a convenient place to push into the itemIds array on the fulfillment group
+    fulfillmentGroup.itemIds.push(item._id);
+
     item.product = catalogProduct;
-    item.shippingMethod = order.shipping[order.shipping.length - 1];
+    item.shippingMethod = fulfillmentGroup;
     item.variants = chosenVariant;
     item.workflow = {
       status: "new",

--- a/imports/plugins/core/core/server/fixtures/orders.js
+++ b/imports/plugins/core/core/server/fixtures/orders.js
@@ -138,7 +138,7 @@ export default function defineOrders() {
    * @property {Object} billing.paymentMethod - Billing - Payment Method
    * @property {String} billing.paymentMethod.method - `"credit"`
    * @property {String} billing.paymentMethod.processor - `"Example"`
-   * @property {String} billing.paymentMethod.storedCard - `"Mastercard 2346"`
+   * @property {String} billing.paymentMethod.storedCard - `"MasterCard 2346"`
    * @property {String} billing.paymentMethod.paymentPackageId - `getPkgData("example-paymentmethod")._id`
    * @property {String} paymentSettingsKey - `"example-paymentmethod"`
    * @property {String} mode - `"authorize"`
@@ -228,7 +228,7 @@ export default function defineOrders() {
       paymentMethod: paymentMethod({
         method: "credit",
         processor: "Example",
-        storedCard: "Mastercard 2346",
+        storedCard: "MasterCard 2346",
         paymentPackageId: getPkgData("example-paymentmethod") ? getPkgData("example-paymentmethod")._id : "uiwneiwknekwewe",
         paymentSettingsKey: "example-paymentmethod",
         mode: "authorize",

--- a/imports/plugins/core/core/server/fixtures/orders.js
+++ b/imports/plugins/core/core/server/fixtures/orders.js
@@ -55,7 +55,8 @@ export function randomMode() {
  * @method paymentMethod
  * @memberof Fixtures
  * @summary Create Payment Method object
- * @return {Object}     Payment method object
+ * @param {Object} doc Override props
+ * @return {Object} Payment method object
  * @property {String} processor - `randomProcessor()`
  * @property {String} storedCard - `"4242424242424242"`
  * @property {String} transactionId - `Random.id()`
@@ -95,8 +96,14 @@ export function getShopId() {
   return getShop()._id;
 }
 
-export default function () {
+/**
+ * @method defineOrders
+ * @memberof Fixtures
+ * @return {undefined}
+ */
+export default function defineOrders() {
   const shopId = getShopId();
+
   /**
    * @name order
    * @memberof Fixtures
@@ -124,11 +131,7 @@ export default function () {
    * @property {String} shopId.items.workflow.status Cart - Product - `"new"`
    * @property {Boolean} requiresShipping - `true`
    * @property {Array} shipping - Shipping - `[{}]`
-   * @property {Object} items - Shipping - `Object`
-   * @property {String} item._id - Shipping - `itemIdOne`
-   * @property {String} item.productId - Shipping - `Random.id()`
-   * @property {String} item.variantId - Shipping - `Random.id()`
-   * @property {Boolean} item.packed - Shipping - `false`
+   * @property {String[]} itemIds
    * @property {Array} billing - Billing - `[]`
    * @property {String} billing._id - Billing - `Random.id()`
    * @property {Object} billing.address - Billing - Address object
@@ -216,24 +219,7 @@ export default function () {
     shipping: [{
       shopId,
       address: getAddress({ isShippingDefault: true }),
-      items: [
-        {
-          _id: itemIdOne,
-          productId: Random.id(),
-          quantity: 1,
-          shopId,
-          variantId: Random.id(),
-          packed: false
-        },
-        {
-          _id: itemIdTwo,
-          productId: Random.id(),
-          quantity: 1,
-          shopId,
-          variantId: Random.id(),
-          packed: false
-        }
-      ]
+      itemIds: [itemIdOne, itemIdTwo]
     }], // Shipping Schema
     billing: [{
       _id: Random.id(),

--- a/imports/plugins/core/orders/client/containers/orderSummaryContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderSummaryContainer.js
@@ -49,26 +49,14 @@ class OrderSummaryContainer extends Component {
       };
     }
 
-    const shipped = _.every(shipment.items, (shipmentItem) => {
-      for (const fullItem of order.items) {
-        if (fullItem._id === shipmentItem._id) {
-          if (fullItem.workflow) {
-            if (_.isArray(fullItem.workflow.workflow)) {
-              return _.includes(fullItem.workflow.workflow, "coreOrderItemWorkflow/completed");
-            }
-          }
-        }
+    const shipped = order.items.every((item) => {
+      if (shipment.itemIds.indexOf(item._id) === -1) {
+        // The item is not in this shipment so we don't care
+        return true;
       }
-    });
 
-    const canceled = _.every(shipment.items, (shipmentItem) => {
-      for (const fullItem of order.items) {
-        if (fullItem._id === shipmentItem._id) {
-          if (fullItem.workflow) {
-            return fullItem.workflow.status === "coreOrderItemWorkflow/canceled";
-          }
-        }
-      }
+      return item.workflow && Array.isArray(item.workflow.workflow) &&
+        item.workflow.workflow.indexOf("coreOrderItemWorkflow/shipped") > -1;
     });
 
     if (shipped) {
@@ -79,6 +67,15 @@ class OrderSummaryContainer extends Component {
         label: i18next.t("orderShipping.shipped")
       };
     }
+
+    const canceled = order.items.every((item) => {
+      if (shipment.itemIds.indexOf(item._id) === -1) {
+        // The item is not in this shipment so we don't care
+        return true;
+      }
+
+      return item.workflow && item.workflow.status === "coreOrderItemWorkflow/canceled";
+    });
 
     if (canceled) {
       return {

--- a/imports/plugins/core/orders/client/containers/orderSummaryContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderSummaryContainer.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { composeWithTracker, withMoment } from "@reactioncommerce/reaction-components";
 import { Orders } from "/lib/collections";
@@ -24,8 +23,8 @@ class OrderSummaryContainer extends Component {
 
   dateFormat = (context, block) => {
     const { moment } = this.props;
-    const f = block || "MMM DD, YYYY hh:mm:ss A";
-    return (moment && moment(context).format(f)) || context.toLocaleString();
+    const formatString = block || "MMM DD, YYYY hh:mm:ss A";
+    return (moment && moment(context).format(formatString)) || context.toLocaleString();
   }
 
   tracking = () => {

--- a/imports/plugins/core/orders/client/helpers/index.js
+++ b/imports/plugins/core/orders/client/helpers/index.js
@@ -3,7 +3,7 @@ import { Reaction } from "/client/api";
 /*
  * @method getOrderRiskBadge
  * @private
- * @summary Selects appropriate color badge (e.g  danger, warning) value based on risklevel
+ * @summary Selects appropriate color badge (e.g  danger, warning) value based on risk level
  * @param {string} riskLevel - risk level value on the paymentMethod
  * @return {string} label - style color class based on risk level
  */
@@ -26,9 +26,9 @@ export function getOrderRiskBadge(riskLevel) {
  * @method getOrderRiskStatus
  * @private
  * @summary Gets the risk label on the paymentMethod object for a shop on an order.
- * An empty string is returned if the value is "normal" becuase we don't flag a normal charge
+ * An empty string is returned if the value is "normal" because we don't flag a normal charge
  * @param {object} order - order object
- * @return {string} label - risklevel value (if risklevel is not normal)
+ * @return {string} label - risk level value (if risk level is not normal)
  */
 export function getOrderRiskStatus(order) {
   const billingForShop = order.billing.find((billing) => billing.shopId === Reaction.getShopId());

--- a/imports/plugins/core/orders/client/helpers/index.js
+++ b/imports/plugins/core/orders/client/helpers/index.js
@@ -1,6 +1,6 @@
 import { Reaction } from "/client/api";
 
-/*
+/**
  * @method getOrderRiskBadge
  * @private
  * @summary Selects appropriate color badge (e.g  danger, warning) value based on risk level
@@ -22,7 +22,7 @@ export function getOrderRiskBadge(riskLevel) {
   return label;
 }
 
-/*
+/**
  * @method getOrderRiskStatus
  * @private
  * @summary Gets the risk label on the paymentMethod object for a shop on an order.
@@ -47,7 +47,7 @@ export function getOrderRiskStatus(order) {
   return riskLevel;
 }
 
-/*
+/**
  * @method getTaxRiskStatus
  * @private
  * @summary Gets the tax status of the order.

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -13,6 +13,11 @@ Template.coreOrderShippingTracking.onCreated(() => {
   template.orderDep = new Tracker.Dependency();
   template.showTrackingEditForm = ReactiveVar(false);
 
+  /**
+   * @param {String} orderId Order ID
+   * @param {String} shipmentId Shipment ID
+   * @returns {Object} The order document
+   */
   function getOrder(orderId, shipmentId) {
     template.orderDep.depend();
     return Orders.findOne({

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -118,61 +118,53 @@ Template.coreOrderShippingTracking.helpers({
     return false;
   },
   isShipped() {
-    const currentData = Template.currentData();
+    const { fulfillment } = Template.currentData();
     const { order } = Template.instance();
 
-    const shippedItems = currentData.fulfillment && currentData.fulfillment.items.every((shipmentItem) => {
-      const fullItem = order.items.find((orderItem) => {
-        if (orderItem._id === shipmentItem._id) {
-          return true;
-        }
-        return false;
-      });
+    if (!fulfillment) return false;
 
-      return !fullItem.workflow.workflow.includes("coreOrderItemWorkflow/shipped");
+    return order.items.every((item) => {
+      if (fulfillment.itemIds.indexOf(item._id) === -1) {
+        // The item is not in this shipment so we don't care
+        return true;
+      }
+
+      return item.workflow && Array.isArray(item.workflow.workflow) &&
+        item.workflow.workflow.indexOf("coreOrderItemWorkflow/shipped") > -1;
     });
-
-    return shippedItems;
   },
 
   isNotCanceled() {
-    const currentData = Template.currentData();
+    const { fulfillment } = Template.currentData();
     const { order } = Template.instance();
 
-    const canceledItems = currentData.fulfillment && currentData.fulfillment.items.every((shipmentItem) => {
-      const fullItem = order.items.find((orderItem) => {
-        if (orderItem._id === shipmentItem._id) {
-          return true;
-        }
-        return false;
-      });
+    if (!fulfillment) return false;
 
-      return fullItem.workflow.status !== "coreOrderItemWorkflow/canceled";
+    return order.items.every((item) => {
+      if (fulfillment.itemIds.indexOf(item._id) === -1) {
+        // The item is not in this shipment so we don't care
+        return true;
+      }
+
+      return !item.workflow || item.workflow.status !== "coreOrderItemWorkflow/canceled";
     });
-
-    return canceledItems;
   },
 
   isCompleted() {
-    const currentData = Template.currentData();
+    const { fulfillment } = Template.currentData();
     const { order } = Template.instance();
 
-    const completedItems = currentData.fulfillment && currentData.fulfillment.items.every((shipmentItem) => {
-      const fullItem = order.items.find((orderItem) => {
-        if (orderItem._id === shipmentItem._id) {
-          return true;
-        }
-        return false;
-      });
+    if (!fulfillment) return false;
 
-      if (Array.isArray(fullItem.workflow.workflow)) {
-        return fullItem.workflow.workflow.includes("coreOrderItemWorkflow/completed");
+    return order.items.every((item) => {
+      if (fulfillment.itemIds.indexOf(item._id) === -1) {
+        // The item is not in this shipment so we don't care
+        return true;
       }
 
-      return false;
+      return item.workflow && Array.isArray(item.workflow.workflow) &&
+        item.workflow.workflow.indexOf("coreOrderItemWorkflow/completed") > -1;
     });
-
-    return completedItems;
   },
 
   editTracking() {

--- a/imports/plugins/core/orders/server/methods/cancelOrder.js
+++ b/imports/plugins/core/orders/server/methods/cancelOrder.js
@@ -65,8 +65,7 @@ export default function cancelOrder(order, returnToStock) {
   let { paymentMethod } = orderCreditMethod(order);
   paymentMethod = Object.assign(paymentMethod, { amount: Number(paymentMethod.amount) });
   const invoiceTotal = billingRecord.invoice.total;
-  const shipment = shippingRecord;
-  const itemIds = shipment.items.map((item) => item._id);
+  const { itemIds } = shippingRecord;
 
   // refund payment to customer
   const paymentMethodId = paymentMethod && paymentMethod.paymentPackageId;

--- a/imports/plugins/core/orders/server/methods/capturePayments.js
+++ b/imports/plugins/core/orders/server/methods/capturePayments.js
@@ -24,8 +24,8 @@ export default function capturePayments(orderId) {
   const shopId = Reaction.getShopId(); // the shopId of the current user, i.e. merchant
   const order = Orders.findOne({ _id: orderId });
   // find the appropriate shipping record by shop
-  const shippingRecord = order.shipping.find((sRecord) => sRecord.shopId === shopId);
-  const itemIds = shippingRecord.items.map((item) => item._id);
+  const fulfillmentGroup = order.shipping.find((sRecord) => sRecord.shopId === shopId);
+  const { itemIds } = fulfillmentGroup;
 
   Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/captured", order, itemIds);
 

--- a/imports/plugins/core/orders/server/methods/capturePayments.js
+++ b/imports/plugins/core/orders/server/methods/capturePayments.js
@@ -48,8 +48,8 @@ export default function capturePayments(orderId) {
     let error;
     try {
       result = Meteor.call(`${processor}/payment/capture`, paymentMethod);
-    } catch (e) {
-      error = e;
+    } catch (err) {
+      error = err;
     }
 
     if (result && result.saved === true) {
@@ -102,4 +102,6 @@ export default function capturePayments(orderId) {
 
     return { error: "orders/capturePayments: Failed to capture transaction" };
   }
+
+  return { error: null, result: null };
 }

--- a/imports/plugins/core/orders/server/methods/processPayment.js
+++ b/imports/plugins/core/orders/server/methods/processPayment.js
@@ -26,9 +26,9 @@ export default function processPayment(order) {
     if (result) {
       Meteor.call("workflow/pushOrderWorkflow", "coreOrderWorkflow", "coreProcessPayment", order._id);
 
-      const shippingRecord = order.shipping.find((shipping) => shipping.shopId === Reaction.getShopId());
+      const fulfillmentGroup = order.shipping.find((shipping) => shipping.shopId === Reaction.getShopId());
       // Set the status of the items as shipped
-      const itemIds = shippingRecord.items.map((item) => item._id);
+      const { itemIds } = fulfillmentGroup;
 
       Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/captured", order, itemIds);
 

--- a/imports/plugins/core/orders/server/methods/shipmentDelivered.js
+++ b/imports/plugins/core/orders/server/methods/shipmentDelivered.js
@@ -24,11 +24,11 @@ export default function shipmentDelivered(order) {
 
   this.unblock();
 
-  const shipment = order.shipping.find((shipping) => shipping.shopId === Reaction.getShopId());
+  const fulfillmentGroup = order.shipping.find((shipping) => shipping.shopId === Reaction.getShopId());
 
   sendOrderEmail(order);
 
-  const itemIds = shipment.items.map((item) => item._id);
+  const { itemIds } = fulfillmentGroup;
 
   Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/delivered", order, itemIds);
   Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/completed", order, itemIds);
@@ -38,7 +38,7 @@ export default function shipmentDelivered(order) {
   Orders.update(
     {
       "_id": order._id,
-      "shipping._id": shipment._id
+      "shipping._id": fulfillmentGroup._id
     },
     {
       $set: {

--- a/imports/plugins/core/orders/server/methods/shipmentLabeled.js
+++ b/imports/plugins/core/orders/server/methods/shipmentLabeled.js
@@ -10,26 +10,26 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @memberof Orders/Methods
  * @summary update labeling status
  * @param {Object} order - order object
- * @param {Object} shipment - shipment object
+ * @param {Object} fulfillmentGroup - fulfillmentGroup object
  * @return {Object} return workflow result
  */
-export default function shipmentLabeled(order, shipment) {
+export default function shipmentLabeled(order, fulfillmentGroup) {
   check(order, Object);
-  check(shipment, Object);
+  check(fulfillmentGroup, Object);
 
   if (!Reaction.hasPermission("orders")) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 
   // Set the status of the items as labeled
-  const itemIds = shipment.items.map((item) => item._id);
+  const { itemIds } = fulfillmentGroup;
 
   const result = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/labeled", order, itemIds);
   if (result === 1) {
     return Orders.update(
       {
         "_id": order._id,
-        "shipping._id": shipment._id
+        "shipping._id": fulfillmentGroup._id
       },
       {
         $set: {

--- a/imports/plugins/core/orders/server/methods/shipmentPacked.js
+++ b/imports/plugins/core/orders/server/methods/shipmentPacked.js
@@ -10,12 +10,12 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @memberof Orders/Methods
  * @summary update packing status
  * @param {Object} order - order object
- * @param {Object} shipment - shipment object
+ * @param {Object} fulfillmentGroup - fulfillmentGroup object
  * @return {Object} return workflow result
  */
-export default function shipmentPacked(order, shipment) {
+export default function shipmentPacked(order, fulfillmentGroup) {
   check(order, Object);
-  check(shipment, Object);
+  check(fulfillmentGroup, Object);
 
   // REVIEW: who should have permission to do this in a marketplace setting?
   // Do we need to update the order schema to reflect multiple packers / shipments?
@@ -24,14 +24,14 @@ export default function shipmentPacked(order, shipment) {
   }
 
   // Set the status of the items as packed
-  const itemIds = shipment.items.map((item) => item._id);
+  const { itemIds } = fulfillmentGroup;
 
   const result = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/packed", order, itemIds);
   if (result === 1) {
     return Orders.update(
       {
         "_id": order._id,
-        "shipping._id": shipment._id
+        "shipping._id": fulfillmentGroup._id
       },
       {
         $set: {

--- a/imports/plugins/core/orders/server/methods/shipmentPicked.js
+++ b/imports/plugins/core/orders/server/methods/shipmentPicked.js
@@ -10,26 +10,26 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @memberof Orders/Methods
  * @summary update picking status
  * @param {Object} order - order object
- * @param {Object} shipment - shipment object
+ * @param {Object} fulfillmentGroup - fulfillmentGroup object
  * @return {Object} return workflow result
  */
-export default function shipmentPicked(order, shipment) {
+export default function shipmentPicked(order, fulfillmentGroup) {
   check(order, Object);
-  check(shipment, Object);
+  check(fulfillmentGroup, Object);
 
   if (!Reaction.hasPermission("orders")) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 
   // Set the status of the items as picked
-  const itemIds = shipment.items.map((item) => item._id);
+  const { itemIds } = fulfillmentGroup;
 
   const result = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/picked", order, itemIds);
   if (result === 1) {
     return Orders.update(
       {
         "_id": order._id,
-        "shipping._id": shipment._id
+        "shipping._id": fulfillmentGroup._id
       },
       {
         $set: {

--- a/imports/plugins/core/orders/server/methods/shipmentShipped.js
+++ b/imports/plugins/core/orders/server/methods/shipmentShipped.js
@@ -13,12 +13,12 @@ import sendOrderEmail from "../util/sendOrderEmail";
  * @memberof Orders/Methods
  * @summary trigger shipmentShipped status and workflow update
  * @param {Object} order - order object
- * @param {Object} shipment - shipment object
+ * @param {Object} fulfillmentGroup - fulfillmentGroup object
  * @return {Object} return results of several operations
  */
-export default function shipmentShipped(order, shipment) {
+export default function shipmentShipped(order, fulfillmentGroup) {
   check(order, Object);
-  check(shipment, Object);
+  check(fulfillmentGroup, Object);
 
   // TODO: Who should have access to ship shipments in a marketplace setting
   // Should be anyone who has product in an order.
@@ -32,7 +32,7 @@ export default function shipmentShipped(order, shipment) {
   let completedItemsResult;
   let completedOrderResult;
 
-  const itemIds = shipment.items.map((item) => item._id);
+  const { itemIds } = fulfillmentGroup;
 
   // TODO: In the future, this could be handled by shipping delivery status
   // REVIEW: This hook seems to run before the shipment has been marked as shipped
@@ -59,7 +59,7 @@ export default function shipmentShipped(order, shipment) {
   Orders.update(
     {
       "_id": order._id,
-      "shipping._id": shipment._id
+      "shipping._id": fulfillmentGroup._id
     },
     {
       $set: {

--- a/imports/plugins/core/versions/server/migrations/34_remove_order_shipping_items.js
+++ b/imports/plugins/core/versions/server/migrations/34_remove_order_shipping_items.js
@@ -2,8 +2,8 @@ import { Migrations } from "meteor/percolate:migrations";
 import { Orders } from "/lib/collections";
 
 /**
- * Going up, migrates order.shipping.$.items -> order.shipping.$.itemIds.
- * Going down, migrates order.shipping.$.itemIds -> order.shipping.$.items
+ * Going up, migrates order.shipping.$.items -> order.shipping.$.itemIds and adds type
+ * Going down, migrates order.shipping.$.itemIds -> order.shipping.$.items and adds type
  */
 
 Migrations.add({
@@ -14,7 +14,8 @@ Migrations.add({
         const itemIds = (group.items || []).map((item) => item._id);
         const newGroup = {
           ...group,
-          itemIds
+          itemIds,
+          type: "shipping"
         };
         delete newGroup.items;
         return newGroup;
@@ -45,6 +46,7 @@ Migrations.add({
           items
         };
         delete newGroup.itemIds;
+        delete newGroup.type;
         return newGroup;
       });
 

--- a/imports/plugins/core/versions/server/migrations/34_remove_order_shipping_items.js
+++ b/imports/plugins/core/versions/server/migrations/34_remove_order_shipping_items.js
@@ -1,0 +1,58 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Orders } from "/lib/collections";
+
+/**
+ * Going up, migrates order.shipping.$.items -> order.shipping.$.itemIds.
+ * Going down, migrates order.shipping.$.itemIds -> order.shipping.$.items
+ */
+
+Migrations.add({
+  version: 34,
+  up() {
+    Orders.find({}).forEach((order) => {
+      const shipping = (order.shipping || []).map((group) => {
+        const itemIds = (group.items || []).map((item) => item._id);
+        const newGroup = {
+          ...group,
+          itemIds
+        };
+        delete newGroup.items;
+        return newGroup;
+      });
+
+      Orders.update({ _id: order._id }, {
+        $set: {
+          shipping
+        }
+      }, { bypassCollection2: true });
+    });
+  },
+  down() {
+    Orders.find({}).forEach((order) => {
+      const shipping = (order.shipping || []).map((group) => {
+        const items = (group.itemIds || []).map((itemId) => {
+          const item = order.items.find((orderItem) => orderItem._id === itemId);
+          return {
+            _id: item._id,
+            productId: item.productId,
+            quantity: item.quantity,
+            shopId: item.shopId,
+            variantId: item.variantId
+          };
+        });
+        const newGroup = {
+          ...group,
+          items
+        };
+        delete newGroup.itemIds;
+        return newGroup;
+      });
+
+      Orders.update({ _id: order._id }, {
+        $set: {
+          shipping
+        }
+      }, { bypassCollection2: true });
+    });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -31,3 +31,4 @@ import "./30_cart_schema_changes";
 import "./31_order_schema_changes";
 import "./32_publish_all_existing_visible_products";
 import "./33_change_products_template_name";
+import "./34_remove_order_shipping_items";

--- a/imports/plugins/included/payments-stripe/server/methods/stripe.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripe.js
@@ -21,7 +21,8 @@ function unformatFromStripe(amount) {
 export const utils = {};
 
 utils.getStripeApi = function (paymentPackageId) {
-  const stripePackage = Packages.findOne(paymentPackageId);
+  const stripePackage = Packages.findOne({ _id: paymentPackageId });
+  if (!stripePackage) throw new Error(`No package found with paymentPackageId ${paymentPackageId}`);
   const stripeKey = stripePackage.settings.api_key || stripePackage.settings.connectAuth.access_token;
   return stripeKey;
 };


### PR DESCRIPTION
Impact: **breaking**  
Type: **refactor**

## Changes
This is some refactor work in preparation for #4497. In particular, the `cart.shipping` and `order.shipping` array items no longer have an `items` array on them because this wasn't used much and isn't necessary. The items are already on `cart.items` or `order.items`. It is replaced by an `itemIds` property, with just the IDs, which is only set for orders, not carts.

## Breaking changes
There are migrations that make this non-breaking for core, but it will break any non-core plugins that are expecting the `items` property to be there. Such plugins should be updated to use a combination of `itemIds` and the main `items` list.

## Testing
Verify that you can still successfully add items to a cart, checkout, and fulfill the order through to completion as an admin.