### PR TITLE
feat: Add resolver for Cart.totalItemQuantity

### DIFF
--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Cart/index.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Cart/index.js
@@ -2,11 +2,13 @@ import { encodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/ca
 import { resolveAccountFromAccountId, resolveShopFromShopId } from "@reactioncommerce/reaction-graphql-utils";
 import checkout from "./checkout";
 import items from "./items";
+import totalItemQuantity from "./totalItemQuantity";
 
 export default {
   _id: (node) => encodeCartOpaqueId(node._id),
   account: resolveAccountFromAccountId,
   checkout,
   items,
-  shop: resolveShopFromShopId
+  shop: resolveShopFromShopId,
+  totalItemQuantity
 };

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Cart/totalItemQuantity.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Cart/totalItemQuantity.js
@@ -1,0 +1,17 @@
+import { xformTotalItemQuantity } from "@reactioncommerce/reaction-graphql-xforms/cart";
+
+/**
+ * @name "Cart.totalItemQuantity"
+ * @method
+ * @memberof Cart/GraphQL
+ * @summary Calculates the total quantity of items in the cart and returns a number
+ * @param {Object} cart - Result of the parent resolver, which is a Cart object in GraphQL schema format
+ * @param {Object} connectionArgs - Connection args. (not used for this resolver)
+ * @param {Object} context - An object containing the per-request state
+ * @return {Promise<Number>} A promise that resolves to the number of the total item quantity
+ */
+export default async function totalItemQuantity(cart, connectionArgs, context) {
+  if (!Array.isArray(cart.items)) return 0;
+
+  return xformTotalItemQuantity(context.collections, cart.items);
+}

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/xforms/cart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/xforms/cart.js
@@ -323,3 +323,13 @@ export async function xformCartCheckout(collections, cart) {
     }
   };
 }
+
+/**
+ * @param {Object} collections Map of Mongo collections
+ * @param {Object} items Cart items
+ * @returns {Number} Total quantity of all items in the cart
+ */
+export async function xformTotalItemQuantity(collections, items) {
+  // Total item quantity comes from the sum of the quantities of each item
+  return (items || []).reduce((sum, item) => (sum + item.quantity), 0);
+}

--- a/imports/plugins/core/graphql/server/no-meteor/schemas/cart.graphql
+++ b/imports/plugins/core/graphql/server/no-meteor/schemas/cart.graphql
@@ -19,6 +19,9 @@ type Cart implements Node {
   "The shop that owns the cart."
   shop: Shop!
 
+  "Total quantity of all items in the cart"
+  totalItemQuantity: Int
+
   "The date and time at which this cart was last updated."
   updatedAt: DateTime!
 

--- a/imports/plugins/core/graphql/server/no-meteor/schemas/cart.graphql
+++ b/imports/plugins/core/graphql/server/no-meteor/schemas/cart.graphql
@@ -20,7 +20,7 @@ type Cart implements Node {
   shop: Shop!
 
   "Total quantity of all items in the cart"
-  totalItemQuantity: Int
+  totalItemQuantity: Int!
 
   "The date and time at which this cart was last updated."
   updatedAt: DateTime!


### PR DESCRIPTION
Resolves #4527  
Impact: **minor**  
Type: **feature**

## Issue

Need a resolver for `Cart.totalItemQuantity` to be able to display the total number of items in the cart in checkout summaries.

## Solution

Add a resolver for `totalItemQuantity` that uses `Array.prototype.reduce` to calculate the sum of the quantities of all the cart items in a given array.

## Testing

1. With the devserver and reaction running
2. Sign into reaction as admin or a customer
3. Add items to the cart
4. With GraphiQL (desktop) pointed to http://localhost:3030/graphql-alpha and
4.1 ...and `meteor-login-token` set in the headers of the GraphiQL app
5. Run a viewer query to get your `accountId` and `shopId`

```
  viewer {
    _id
    shop {
      _id
    }
  }
```

6: Use the `accountId` and `shopId` for the the `accountCartByAccountId` query

```
accountCartByAccountId(accountId: <accountId>, shopId: <shopId>) {
  totalItemQuantity
  items: {
    edges {
        node {
          quantity
       }
    }
  }
}
```

7. See the`totalItemQuantity` is correct in relation to the quantities of all items in the cart

