### PR TITLE
Refactor cart / fulfillment hooks

### DIFF
--- a/.reaction/devserver/index.js
+++ b/.reaction/devserver/index.js
@@ -1,5 +1,6 @@
 import express from "express";
 import mongodb, { MongoClient } from "mongodb";
+import appEvents from "../../imports/plugins/core/core/server/appEvents";
 import createApolloServer from "../../imports/plugins/core/graphql/server/no-meteor/createApolloServer";
 import defineCollections from "../../imports/collections/defineCollections";
 import setUpFileCollections from "../../imports/plugins/core/files/server/no-meteor/setUpFileCollections";
@@ -48,7 +49,7 @@ MongoClient.connect(dbUrl, (error, client) => {
         return null;
       };
     },
-    context: { collections },
+    context: { appEvents, collections },
     debug: true,
     graphiql: true
   });

--- a/imports/plugins/core/accounts/server/methods/markAddressValidationBypassed.js
+++ b/imports/plugins/core/accounts/server/methods/markAddressValidationBypassed.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Accounts, Cart } from "/lib/collections";
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 
 /**
  * @name accounts/markAddressValidationBypassed
@@ -15,5 +16,11 @@ export default function markAddressValidationBypassed(value = true) {
   const userId = Meteor.userId();
   const account = Accounts.findOne({ userId }, { fields: { _id: 1 } });
   const updateResult = Cart.update({ accountId: account._id }, { $set: { bypassAddressValidation: value } });
+
+  const updatedCart = Cart.findOne({ accountId: account._id });
+  if (updatedCart) {
+    Promise.await(appEvents.emit("afterCartUpdate", updatedCart._id, updatedCart));
+  }
+
   return updateResult;
 }

--- a/imports/plugins/core/accounts/server/methods/markTaxCalculationFailed.js
+++ b/imports/plugins/core/accounts/server/methods/markTaxCalculationFailed.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Accounts, Cart } from "/lib/collections";
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 
 /**
  * @name accounts/markTaxCalculationFailed
@@ -15,5 +16,11 @@ export default function markTaxCalculationFailed(value = true) {
   const userId = Meteor.userId();
   const account = Accounts.findOne({ userId }, { fields: { _id: 1 } });
   const updateResult = Cart.update({ accountId: account._id }, { $set: { taxCalculationFailed: value } });
+
+  const updatedCart = Cart.findOne({ accountId: account._id });
+  if (updatedCart) {
+    Promise.await(appEvents.emit("afterCartUpdate", updatedCart._id, updatedCart));
+  }
+
   return updateResult;
 }

--- a/imports/plugins/core/cart/server/methods/mergeCart.js
+++ b/imports/plugins/core/cart/server/methods/mergeCart.js
@@ -1,4 +1,3 @@
-import Hooks from "@reactioncommerce/hooks";
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
@@ -29,9 +28,6 @@ export default function mergeCart(anonymousCartId, anonymousCartToken) {
   }));
 
   const cartId = cart._id;
-
-  // Calculate discounts
-  Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
 
   const accountCartWorkflow = cart.workflow;
   if (accountCartWorkflow && accountCartWorkflow.workflow) {

--- a/imports/plugins/core/cart/server/methods/setPaymentAddress.js
+++ b/imports/plugins/core/cart/server/methods/setPaymentAddress.js
@@ -1,8 +1,8 @@
-import Hooks from "@reactioncommerce/hooks";
 import { check, Match } from "meteor/check";
-import * as Collections from "/lib/collections";
+import { Cart } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import getCart from "/imports/plugins/core/cart/server/util/getCart";
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 
 /**
  * @method cart/setPaymentAddress
@@ -48,10 +48,11 @@ export default function setPaymentAddress(cartId, cartToken, address) {
     };
   }
 
-  const result = Collections.Cart.update(selector, update);
+  const result = Cart.update(selector, update);
 
-  // Calculate discounts
-  Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
+  const updatedCart = Cart.findOne({ _id: cartId });
+
+  Promise.await(appEvents.emit("afterCartUpdate", updatedCart._id, updatedCart));
 
   return result;
 }

--- a/imports/plugins/core/cart/server/methods/setShipmentAddress.js
+++ b/imports/plugins/core/cart/server/methods/setShipmentAddress.js
@@ -1,4 +1,3 @@
-import Hooks from "@reactioncommerce/hooks";
 import Logger from "@reactioncommerce/logger";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
@@ -6,7 +5,7 @@ import { Cart } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import getCart from "/imports/plugins/core/cart/server/util/getCart";
-
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 
 /**
  * @method cart/setShipmentAddress
@@ -121,7 +120,9 @@ export default function setShipmentAddress(cartId, cartToken, address) {
     Logger.error(`Error calling shipping/updateShipmentQuotes method in setShipmentAddress method for cart with ID ${cartId}`, error);
   }
 
-  Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
+  const updatedCart = Cart.findOne({ _id: cartId });
+
+  Promise.await(appEvents.emit("afterCartUpdate", cartId, updatedCart));
 
   if (typeof cart.workflow !== "object") {
     throw new ReactionError(

--- a/imports/plugins/core/cart/server/methods/setUserCurrency.js
+++ b/imports/plugins/core/cart/server/methods/setUserCurrency.js
@@ -1,9 +1,9 @@
-import Hooks from "@reactioncommerce/hooks";
 import Logger from "@reactioncommerce/logger";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { check, Match } from "meteor/check";
-import * as Collections from "/lib/collections";
+import { Cart } from "/lib/collections";
 import getCart from "/imports/plugins/core/cart/server/util/getCart";
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 
 /**
  * @method cart/setUserCurrency
@@ -53,14 +53,15 @@ export default function setUserCurrency(cartId, cartToken, userCurrency) {
 
   // add / or set the shipping address
   try {
-    Collections.Cart.update(selector, update);
+    Cart.update(selector, update);
   } catch (error) {
     Logger.error(error);
     throw new ReactionError("server-error", "An error occurred adding the currency");
   }
 
-  // Calculate discounts
-  Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
+  const updatedCart = Cart.findOne({ _id: cartId });
+
+  Promise.await(appEvents.emit("afterCartUpdate", cartId, updatedCart));
 
   return true;
 }

--- a/imports/plugins/core/cart/server/methods/submitPayment.js
+++ b/imports/plugins/core/cart/server/methods/submitPayment.js
@@ -1,11 +1,11 @@
-import Hooks from "@reactioncommerce/hooks";
 import Logger from "@reactioncommerce/logger";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import * as Collections from "/lib/collections";
+import { Cart } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import getCart from "/imports/plugins/core/cart/server/util/getCart";
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 import { PaymentMethodArgument } from "/lib/collections/schemas";
 
 /**
@@ -102,19 +102,18 @@ export default function submitPayment(cartId, cartToken, paymentMethods) {
   };
 
   try {
-    Collections.Cart.update(selector, update);
+    Cart.update(selector, update);
   } catch (error) {
     Logger.error(error);
     throw new ReactionError("server-error", "An error occurred saving the order");
   }
 
-  // Calculate discounts
-  Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
-
-  const updatedCart = Collections.Cart.findOne(selector);
+  const updatedCart = Cart.findOne({ _id: cartId });
 
   // update workflow
   Meteor.call("workflow/pushCartWorkflow", "coreCartWorkflow", "paymentSubmitted", cartId);
+
+  Promise.await(appEvents.emit("afterCartUpdate", cartId, updatedCart));
 
   // create order
   if (updatedCart && updatedCart.items && updatedCart.billing && updatedCart.billing[0].paymentMethod) {

--- a/imports/plugins/core/cart/server/no-meteor/mutations/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/addCartItems.js
@@ -1,4 +1,3 @@
-import Hooks from "@reactioncommerce/hooks";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Cart as CartSchema } from "/imports/collections/schemas";
 import hashLoginToken from "/imports/plugins/core/accounts/server/no-meteor/util/hashLoginToken";
@@ -19,7 +18,7 @@ import addCartItemsUtil from "../util/addCartItems";
  */
 export default async function addCartItems(context, input, options = {}) {
   const { cartId, items, token } = input;
-  const { collections, accountId = null } = context;
+  const { appEvents, collections, accountId = null } = context;
   const { Cart } = collections;
 
   let selector;
@@ -67,8 +66,7 @@ export default async function addCartItems(context, input, options = {}) {
     items: updatedItemList,
     updatedAt
   };
-  Hooks.Events.run("afterCartUpdate", cart._id, updatedCart);
-  Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
+  await appEvents.emit("afterCartUpdate", cart._id, updatedCart);
 
   return { cart: updatedCart, incorrectPriceFailures, minOrderQuantityFailures };
 }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/convertAnonymousCartToNewAccountCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/convertAnonymousCartToNewAccountCart.js
@@ -1,3 +1,4 @@
+import Hooks from "@reactioncommerce/hooks";
 import Random from "@reactioncommerce/random";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Cart as CartSchema } from "/imports/collections/schemas";
@@ -45,11 +46,13 @@ export default async function convertAnonymousCartToNewAccountCart({
 
   CartSchema.validate(newCart);
 
-  const { ops, result } = await Cart.insertOne(newCart);
+  const { result } = await Cart.insertOne(newCart);
   if (result.ok !== 1) throw new ReactionError("server-error", "Unable to create account cart");
+
+  Hooks.Events.run("afterCartCreate", newCart);
 
   const { deletedCount } = await Cart.deleteOne(anonymousCartSelector);
   if (deletedCount === 0) throw new ReactionError("server-error", "Unable to delete anonymous cart");
 
-  return ops[0];
+  return newCart;
 }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/convertAnonymousCartToNewAccountCart.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/convertAnonymousCartToNewAccountCart.test.js
@@ -2,7 +2,6 @@ import mockContext from "/imports/test-utils/helpers/mockContext";
 import convertAnonymousCartToNewAccountCart from "./convertAnonymousCartToNewAccountCart";
 
 const { Cart } = mockContext.collections;
-const mockCart = { _id: "mockCart" };
 const currencyCode = "GBP";
 const accountId = "accountId";
 const anonymousCartSelector = { _id: "123" };
@@ -27,7 +26,7 @@ const items = [
 ];
 
 test("inserts a cart with the existing cart's items and returns it", async () => {
-  Cart.insertOne.mockReturnValueOnce(Promise.resolve({ ops: [mockCart], result: { ok: 1 } }));
+  Cart.insertOne.mockReturnValueOnce(Promise.resolve({ result: { ok: 1 } }));
 
   const result = await convertAnonymousCartToNewAccountCart({
     accountId,
@@ -40,7 +39,7 @@ test("inserts a cart with the existing cart's items and returns it", async () =>
     shopId
   });
 
-  expect(Cart.insertOne).toHaveBeenCalledWith({
+  const newCart = {
     _id: jasmine.any(String),
     accountId,
     anonymousAccessToken: null,
@@ -60,15 +59,17 @@ test("inserts a cart with the existing cart's items and returns it", async () =>
     workflow: {
       status: "new"
     }
-  });
+  };
+
+  expect(Cart.insertOne).toHaveBeenCalledWith(newCart);
 
   expect(Cart.deleteOne).toHaveBeenCalledWith(anonymousCartSelector);
 
-  expect(result).toEqual(mockCart);
+  expect(result).toEqual(newCart);
 });
 
 test("throws if insertOne fails", async () => {
-  Cart.insertOne.mockReturnValueOnce(Promise.resolve({ ops: [mockCart], result: { ok: 0 } }));
+  Cart.insertOne.mockReturnValueOnce(Promise.resolve({ result: { ok: 0 } }));
 
   const promise = convertAnonymousCartToNewAccountCart({
     accountId,
@@ -85,7 +86,7 @@ test("throws if insertOne fails", async () => {
 });
 
 test("throws if deleteOne fails", async () => {
-  Cart.insertOne.mockReturnValueOnce(Promise.resolve({ ops: [mockCart], result: { ok: 1 } }));
+  Cart.insertOne.mockReturnValueOnce(Promise.resolve({ result: { ok: 1 } }));
   Cart.deleteOne.mockReturnValueOnce(Promise.resolve({ deletedCount: 0 }));
 
   const promise = convertAnonymousCartToNewAccountCart({

--- a/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
@@ -1,3 +1,4 @@
+import Hooks from "@reactioncommerce/hooks";
 import Random from "@reactioncommerce/random";
 import ReactionError from "@reactioncommerce/reaction-error";
 import hashLoginToken from "/imports/plugins/core/accounts/server/no-meteor/util/hashLoginToken";
@@ -82,9 +83,11 @@ export default async function createCart(context, input) {
 
   CartSchema.validate(newCart);
 
-  const { ops, result } = await Cart.insertOne(newCart);
+  const { result } = await Cart.insertOne(newCart);
 
   if (result.ok !== 1) throw new ReactionError("server-error", "Unable to create cart");
 
-  return { cart: ops[0], incorrectPriceFailures, minOrderQuantityFailures, token: anonymousAccessToken };
+  Hooks.Events.run("afterCartCreate", newCart);
+
+  return { cart: newCart, incorrectPriceFailures, minOrderQuantityFailures, token: anonymousAccessToken };
 }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/removeCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/removeCartItems.js
@@ -1,4 +1,3 @@
-import Hooks from "@reactioncommerce/hooks";
 import SimpleSchema from "simpl-schema";
 import ReactionError from "@reactioncommerce/reaction-error";
 import hashLoginToken from "/imports/plugins/core/accounts/server/no-meteor/util/hashLoginToken";
@@ -29,7 +28,7 @@ const inputSchema = new SimpleSchema({
 export default async function removeCartItems(context, input) {
   inputSchema.validate(input || {});
 
-  const { accountId, collections } = context;
+  const { accountId, appEvents, collections } = context;
   const { Cart } = collections;
   const { cartId, cartItemIds, token } = input;
 
@@ -54,8 +53,7 @@ export default async function removeCartItems(context, input) {
   const cart = await Cart.findOne(selector);
   if (!cart) throw new ReactionError("not-found", "Cart not found");
 
-  Hooks.Events.run("afterCartUpdate", cart._id);
-  Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
+  await appEvents.emit("afterCartUpdate", cart._id, cart);
 
   return { cart };
 }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.js
@@ -6,7 +6,7 @@ import Logger from "@reactioncommerce/logger";
  * @param {Object} context -  an object containing the per-request state
  * @return {Promise<Object>} TODO
  */
-export default async function setShippingAddressOnCart(context) {
+export default async function setShippingAddressOnCart() {
   Logger.info("setShippingAddressOnCart mutation is not yet implemented");
   return null;
 }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/updateCartItemsQuantity.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/updateCartItemsQuantity.js
@@ -1,4 +1,3 @@
-import Hooks from "@reactioncommerce/hooks";
 import SimpleSchema from "simpl-schema";
 import ReactionError from "@reactioncommerce/reaction-error";
 import hashLoginToken from "/imports/plugins/core/accounts/server/no-meteor/util/hashLoginToken";
@@ -36,7 +35,7 @@ const inputSchema = new SimpleSchema({
 export default async function updateCartItemsQuantity(context, input) {
   inputSchema.validate(input || {});
 
-  const { accountId, collections } = context;
+  const { accountId, appEvents, collections } = context;
   const { Cart } = collections;
   const { cartId, items, token } = input;
 
@@ -78,8 +77,7 @@ export default async function updateCartItemsQuantity(context, input) {
   const cart = await Cart.findOne(selector);
   if (!cart) throw new ReactionError("not-found", "Cart not found");
 
-  Hooks.Events.run("afterCartUpdate", cart._id);
-  Hooks.Events.run("afterCartUpdateCalculateDiscount", cart._id);
+  await appEvents.emit("afterCartUpdate", cart._id, cart);
 
   return { cart };
 }

--- a/imports/plugins/core/core/server/appEvents.js
+++ b/imports/plugins/core/core/server/appEvents.js
@@ -1,0 +1,43 @@
+/**
+ * This is a temporary events solution on our path to
+ * event streams and services. For now, some code relies
+ * on events happening synchronously and we need it to
+ * work in Fibers when running within Meteor.
+ */
+
+/**
+ * @summary calls each function in an array with args, one at a time
+ * @param {Function[]} funcs List of functions to call
+ * @param {Array} args Arguments to pass to each function
+ * @returns {undefined} Promise that resolves with undefined after all
+ *   functions in the list have been called
+ */
+async function synchronousPromiseLoop(funcs, args) {
+  const func = funcs.shift();
+  await func(...args);
+  if (funcs.length) {
+    await synchronousPromiseLoop(funcs, args);
+  }
+}
+
+class AppEvents {
+  handlers = {};
+
+  async emit(name, ...args) {
+    if (!this.handlers[name]) return;
+
+    // Can't use forEach or map because we want each func to wait
+    // until the previous func promise resolves
+    await synchronousPromiseLoop(this.handlers[name].slice(0), args);
+  }
+
+  on(name, func) {
+    if (!this.handlers[name]) {
+      this.handlers[name] = [];
+    }
+
+    this.handlers[name].push(func);
+  }
+}
+
+export default new AppEvents();

--- a/imports/plugins/core/discounts/server/hooks/cart.js
+++ b/imports/plugins/core/discounts/server/hooks/cart.js
@@ -1,15 +1,26 @@
 import Hooks from "@reactioncommerce/hooks";
 import { Meteor } from "meteor/meteor";
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 import { Cart } from "/lib/collections";
 
-Hooks.Events.add("afterCartUpdateCalculateDiscount", (cartId) => {
-  if (cartId) {
-    const cart = Cart.findOne({ _id: cartId });
-    const discount = Meteor.call("discounts/calculate", cart);
-
-    Cart.update({ _id: cart._id }, { $set: { discount } });
-
-    // Calculate taxes
-    Hooks.Events.run("afterCartUpdateCalculateTaxes", cartId);
+appEvents.on("afterCartUpdate", (cartId, cart) => {
+  if (!cartId) {
+    throw new Error("afterCartUpdate hook run with no cartId argument");
   }
+
+  if (typeof cartId !== "string") {
+    throw new Error("afterCartUpdate hook run with non-string cartId argument");
+  }
+
+  if (!cart) {
+    throw new Error("afterCartUpdate hook run with no cart argument");
+  }
+
+  const discount = Meteor.call("discounts/calculate", cart);
+  if (discount !== cart.discount) {
+    Cart.update({ _id: cart._id }, { $set: { discount } });
+  }
+
+  // Calculate taxes
+  Hooks.Events.run("afterCartUpdateCalculateTaxes", cartId);
 });

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -2,6 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { Match, check } from "meteor/check";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Cart } from "/lib/collections";
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 import { Discounts } from "../../lib/collections";
 import Reaction from "../api";
 
@@ -44,12 +45,17 @@ export const methods = {
     check(discountRate, Number);
     check(discounts, Match.Optional(Array));
 
-    return Cart.update(cartId, {
+    const result = Cart.update({ _id: cartId }, {
       $set: {
         discounts,
         discount: discountRate
       }
     });
+
+    const updatedCart = Cart.findOne({ _id: cartId });
+    Promise.await(appEvents.emit("afterCartUpdate", cartId, updatedCart));
+
+    return result;
   },
 
   /**

--- a/imports/plugins/core/graphql/server/index.js
+++ b/imports/plugins/core/graphql/server/index.js
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { WebApp } from "meteor/webapp";
+import appEvents from "/imports/plugins/core/core/server/appEvents";
 import collections from "/imports/collections/rawCollections";
 import createApolloServer from "./no-meteor/createApolloServer";
 import runMeteorMethodWithContext from "./runMeteorMethodWithContext";
@@ -8,7 +9,7 @@ const server = createApolloServer({
   addCallMeteorMethod(context) {
     context.callMeteorMethod = (name, ...args) => runMeteorMethodWithContext(context, name, args);
   },
-  context: { collections },
+  context: { appEvents, collections },
   // XXX Eventually these should be from individual env variables instead
   debug: Meteor.isDevelopment,
   graphiql: Meteor.isDevelopment

--- a/imports/plugins/core/graphql/server/no-meteor/createApolloServer.js
+++ b/imports/plugins/core/graphql/server/no-meteor/createApolloServer.js
@@ -5,6 +5,7 @@ import { graphqlExpress, graphiqlExpress } from "apollo-server-express";
 import buildContext from "./buildContext";
 import getErrorFormatter from "./getErrorFormatter";
 import meteorTokenMiddleware from "./meteorTokenMiddleware";
+import runPluginStartup from "./runPluginStartup";
 import schema from "./schema";
 
 const defaultServerConfig = {
@@ -78,6 +79,9 @@ export default function createApolloServer(options = {}) {
       })
     );
   }
+
+  // For now this is a convenient place to do this, but move it eventually.
+  runPluginStartup(contextFromOptions);
 
   return expressServer;
 }

--- a/imports/plugins/core/graphql/server/no-meteor/runPluginStartup.js
+++ b/imports/plugins/core/graphql/server/no-meteor/runPluginStartup.js
@@ -1,0 +1,9 @@
+import shippingStartup from "/imports/plugins/core/shipping/server/no-meteor/startup";
+
+/**
+ * @param {Object} context Context object with appEvents and collections
+ * @returns {undefined}
+ */
+export default function runPluginStartup(context) {
+  shippingStartup(context);
+}

--- a/imports/plugins/core/shipping/server/no-meteor/startup.js
+++ b/imports/plugins/core/shipping/server/no-meteor/startup.js
@@ -1,0 +1,80 @@
+import Random from "@reactioncommerce/random";
+import ReactionError from "@reactioncommerce/reaction-error";
+
+/**
+ * @summary Figures out which fulfillment group a cart item should initially be in
+ * @param {Object[]} currentGroups The current cart fulfillment groups array
+ * @param {String[]} supportedFulfillmentTypes Array of fulfillment types supported by the item
+ * @param {String} shopId The ID of the shop that owns the item (product)
+ * @returns {Object|null} The group or null if no viable group
+ */
+function determineInitialGroupForItem(currentGroups, supportedFulfillmentTypes, shopId) {
+  const compatibleGroup = currentGroups.find((group) => supportedFulfillmentTypes.indexOf(group.type) !== -1 &&
+    shopId === group.shopId);
+  return compatibleGroup || null;
+}
+
+/**
+ * @summary Called on startup
+ * @param {Object} context Startup context
+ * @param {Object} context.appEvents App event emitter
+ * @returns {undefined}
+ */
+export default function startup({ appEvents, collections }) {
+  const { Cart } = collections;
+
+  appEvents.on("afterCartUpdate", async (cartId, updatedCart) => {
+    if (!cartId) {
+      throw new Error("afterCartUpdate hook run with no cartId argument");
+    }
+
+    if (typeof cartId !== "string") {
+      throw new Error("afterCartUpdate hook run with non-string cartId argument");
+    }
+
+    if (!updatedCart) {
+      throw new Error("afterCartUpdate hook run with no cart argument");
+    }
+
+    // Every time the cart is updated, create any missing fulfillment groups as necessary.
+    // We need one group per type per shop, containing only the items from that shop.
+    // Also make sure that every item is assigned to a fulfillment group.
+    const currentGroups = updatedCart.shipping || [];
+
+    let didModifyGroups = false;
+    (updatedCart.items || []).forEach((item) => {
+      let { supportedFulfillmentTypes } = item;
+      if (!supportedFulfillmentTypes || supportedFulfillmentTypes.length === 0) {
+        supportedFulfillmentTypes = ["shipping"];
+      }
+
+      const group = determineInitialGroupForItem(currentGroups, supportedFulfillmentTypes, item.shopId);
+      if (!group) {
+        // Add one
+        didModifyGroups = true;
+        currentGroups.push({
+          _id: Random.id(),
+          itemIds: [item._id],
+          shopId: item.shopId,
+          type: supportedFulfillmentTypes[0]
+        });
+      } else if (!group.itemIds) {
+        didModifyGroups = true;
+        group.itemIds = [item._id];
+      } else if (group.itemIds.indexOf(item._id) === -1) {
+        didModifyGroups = true;
+        group.itemIds.push(item._id);
+      }
+    });
+
+    if (!didModifyGroups) return;
+
+    const modifier = { $set: { updatedAt: new Date() } };
+    if (didModifyGroups) {
+      modifier.$set.shipping = currentGroups;
+    }
+
+    const { modifiedCount } = await Cart.updateOne({ _id: cartId }, modifier);
+    if (modifiedCount === 0) throw new ReactionError("server-error", "Failed to update cart");
+  });
+}

--- a/tests/TestApp.js
+++ b/tests/TestApp.js
@@ -3,6 +3,7 @@ import graphql from "graphql.js";
 import findFreePort from "find-free-port";
 import MongoDBMemoryServer from "mongodb-memory-server";
 import Random from "@reactioncommerce/random";
+import appEvents from "../imports/plugins/core/core/server/appEvents";
 import createApolloServer from "../imports/plugins/core/graphql/server/no-meteor/createApolloServer";
 import defineCollections from "../imports/collections/defineCollections";
 import Factory from "/imports/test-utils/helpers/factory";
@@ -22,6 +23,7 @@ class TestApp {
         };
       },
       context: {
+        appEvents,
         collections: this.collections
       },
       debug: true


### PR DESCRIPTION
Impact: **breaking**  
Type: **refactor**

## Changes
These are changes to prepare for implementing GraphQL checkout mutations for fulfillment. The primary goal here is for the fulfillment (shipping) plugin to watch for cart create/update and after each event, ensure that we have every item added to a fitting fulfillment group. This is done in a single file: `imports/plugins/core/shipping/server/no-meteor/startup.js`

This PR adds a new `appEvents` event emitter object to the context, and it can also be imported directly in Meteor code. This object has `on` and `emit` methods that are similar to `Hooks.Events.add` and `Hooks.Events.run`, except for the following differences:
- The hook need not (and should not) return the potentially modified first argument. It should return `undefined` or a Promise that resolves with `undefined`
- Hooks cannot adjust the arguments received by future hooks
- You must `await` (non-Meteor code) or `Promise.await` (Meteor Fibers code) your `appEvents.emit()` call if you want all of the hooks to be done running before the next line runs.

## Breaking changes
- If a plugin adds an "afterCartUpdate" hook, it will no longer be called. Change the plugin code to use `appEvents.on("afterCartUpdate"` instead.
- If a plugin creates or updates a cart, be sure it calls `appEvents.emit("afterCartCreate")` or `appEvents.emit("afterCartUpdate")`, respectively, passing the proper arguments. If you do this within an `appEvents.on` hook for the same event, be sure to wrap the call in conditional logic to avoid an infinite loop.

## Testing
- Test various cart flows (adding, removing, changing quantity, checkout)
- Verify in the database that there is always a `shipping` array on the cart with one group in the array per shop ID of the added items, and that the `itemIds` of each group collectively account for all of the `cart.items`.