### PR TITLE
Implement setShippingAddressOnCart mutation

### DIFF
--- a/imports/collections/schemas/address.js
+++ b/imports/collections/schemas/address.js
@@ -93,12 +93,14 @@ export const Address = new SimpleSchema({
   "isBillingDefault": {
     label: "Make this your default billing address?",
     type: Boolean,
-    defaultValue: false
+    defaultValue: false,
+    optional: true
   },
   "isShippingDefault": {
     label: "Make this your default shipping address?",
     type: Boolean,
-    defaultValue: false
+    defaultValue: false,
+    optional: true
   },
   "failedValidation": {
     label: "Failed validation",

--- a/imports/collections/schemas/address.js
+++ b/imports/collections/schemas/address.js
@@ -87,15 +87,18 @@ export const Address = new SimpleSchema({
   },
   "isCommercial": {
     label: "This is a commercial address.",
-    type: Boolean
+    type: Boolean,
+    defaultValue: false
   },
   "isBillingDefault": {
     label: "Make this your default billing address?",
-    type: Boolean
+    type: Boolean,
+    defaultValue: false
   },
   "isShippingDefault": {
     label: "Make this your default shipping address?",
-    type: Boolean
+    type: Boolean,
+    defaultValue: false
   },
   "failedValidation": {
     label: "Failed validation",

--- a/imports/plugins/core/cart/server/methods/setShipmentAddress.js
+++ b/imports/plugins/core/cart/server/methods/setShipmentAddress.js
@@ -1,11 +1,14 @@
+import Hooks from "@reactioncommerce/hooks";
 import Logger from "@reactioncommerce/logger";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Cart } from "/lib/collections";
+import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
+import { Address as AddressSchema } from "/imports/collections/schemas";
 import ReactionError from "@reactioncommerce/reaction-error";
-import getCart from "/imports/plugins/core/cart/server/util/getCart";
-import appEvents from "/imports/plugins/core/core/server/appEvents";
+import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
+import setShippingAddressOnCart from "../no-meteor/mutations/setShippingAddressOnCart";
+
 
 /**
  * @method cart/setShipmentAddress
@@ -19,110 +22,37 @@ import appEvents from "/imports/plugins/core/core/server/appEvents";
 export default function setShipmentAddress(cartId, cartToken, address) {
   check(cartId, String);
   check(cartToken, Match.Maybe(String));
-  Reaction.Schemas.Address.validate(address);
+  AddressSchema.validate(address);
 
-  const { cart } = getCart(cartId, { cartToken, throwIfNotFound: true });
-
-  let selector;
-  let update;
-  let updated = false; // if we update inline set to true, otherwise fault to update at the end
-  // We have two behaviors depending on if we have existing shipping records and if we
-  // have items in the cart.
-  if (cart.shipping && cart.shipping.length > 0 && cart.items && cart.items.length > 0) {
-    // if we have shipping records and cart.items, update each one by shop
-    const shopIds = Object.keys(cart.getItemsByShop());
-    shopIds.forEach((shopId) => {
-      selector = {
-        "_id": cartId,
-        "shipping.shopId": shopId
-      };
-
-      update = {
-        $set: {
-          "shipping.$.address": address
-        }
-      };
-      try {
-        Cart.update(selector, update);
-        updated = true;
-      } catch (error) {
-        Logger.error(error, "An error occurred adding the address");
-        throw new ReactionError(error, "An error occurred adding the address");
-      }
-    });
-  } else if (!cart.items || cart.items.length === 0) {
-    // if no items in cart just add or modify one record for the carts shop
-    // add a shipping record if it doesn't exist
-    if (!cart.shipping) {
-      selector = {
-        _id: cartId
-      };
-      update = {
-        $push: {
-          shipping: {
-            address,
-            shopId: cart.shopId
-          }
-        }
-      };
-
-      try {
-        Cart.update(selector, update);
-        updated = true;
-      } catch (error) {
-        Logger.error(error);
-        throw new ReactionError("server-error", "An error occurred adding the address");
-      }
-    } else {
-      // modify an existing record if we have one already
-      selector = {
-        "_id": cartId,
-        "shipping.shopId": cart.shopId
-      };
-
-      update = {
-        $set: {
-          "shipping.$.address": address
-        }
-      };
-    }
-  } else {
-    // if we have items in the cart but we didn't have existing shipping records
-    // add a record for each shop that's represented in the items
-    const shopIds = Object.keys(cart.getItemsByShop());
-    shopIds.forEach((shopId) => {
-      selector = {
-        _id: cartId
-      };
-      update = {
-        $addToSet: {
-          shipping: {
-            address,
-            shopId
-          }
-        }
-      };
-    });
-  }
-  if (!updated) {
-    // if we didn't do one of the inline updates, then run the update here
-    try {
-      Cart.update(selector, update);
-    } catch (error) {
-      Logger.error(error);
-      throw new ReactionError("server-error", "An error occurred adding the address");
-    }
+  const shopId = Reaction.getCartShopId();
+  if (!shopId) {
+    throw new ReactionError("invalid-param", "No shop ID found");
   }
 
+  // In Meteor app we always have a user, but it may have "anonymous" role, meaning
+  // it was auto-created as a kind of session.
+  const userId = Meteor.userId();
+  const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
+  const userIdForContext = anonymousUser ? null : userId;
+
+  const context = Promise.await(getGraphQLContextInMeteorMethod(userIdForContext));
+  const result = Promise.await(setShippingAddressOnCart(context, {
+    address,
+    cartId,
+    cartToken
+  }));
+
+  const { cart } = result;
+
+  // We now ask clients to call this when necessary to avoid calling it when not needed, but the Meteor
+  // client still relies on it being called here, and on the workflow updates below this.
   try {
     Meteor.call("shipping/updateShipmentQuotes", cartId);
   } catch (error) {
     Logger.error(`Error calling shipping/updateShipmentQuotes method in setShipmentAddress method for cart with ID ${cartId}`, error);
   }
 
-  const updatedCart = Cart.findOne({ _id: cartId });
-
-  Promise.await(appEvents.emit("afterCartUpdate", cartId, updatedCart));
+  Hooks.Events.run("afterCartUpdateCalculateDiscount", cartId);
 
   if (typeof cart.workflow !== "object") {
     throw new ReactionError(
@@ -137,7 +67,7 @@ export default function setShipmentAddress(cartId, cartToken, address) {
     cart.workflow.workflow.length < 2) {
     Meteor.call(
       "workflow/pushCartWorkflow", "coreCartWorkflow",
-      "coreCheckoutShipping", cart._id
+      "coreCheckoutShipping", cartId
     );
   }
 
@@ -146,8 +76,8 @@ export default function setShipmentAddress(cartId, cartToken, address) {
   if (typeof cart.workflow.workflow === "object" &&
     cart.workflow.workflow.length > 2) { // "2" index of
     // `coreCheckoutShipping`
-    Meteor.call("workflow/revertCartWorkflow", "coreCheckoutShipping", cart._id);
+    Meteor.call("workflow/revertCartWorkflow", "coreCheckoutShipping", cartId);
   }
 
-  return true;
+  return result;
 }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.js
@@ -1,12 +1,64 @@
-import Logger from "@reactioncommerce/logger";
+import SimpleSchema from "simpl-schema";
+import ReactionError from "@reactioncommerce/reaction-error";
+import { Address as AddressSchema } from "/imports/collections/schemas";
+import getCartById from "../util/getCartById";
+
+const inputSchema = new SimpleSchema({
+  address: AddressSchema,
+  addressId: {
+    type: String,
+    optional: true
+  },
+  cartId: String,
+  cartToken: {
+    type: String,
+    optional: true
+  }
+});
 
 /**
  * @method setShippingAddressOnCart
- * @summary TODO
- * @param {Object} context -  an object containing the per-request state
- * @return {Promise<Object>} TODO
+ * @summary Sets the shippingAddress data for all fulfillment groups on a cart that have
+ *   a type of "shipping"
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} input - Input (see SimpleSchema)
+ * @return {Promise<Object>} An object with a `cart` property containing the updated cart
  */
-export default async function setShippingAddressOnCart() {
-  Logger.info("setShippingAddressOnCart mutation is not yet implemented");
-  return null;
+export default async function setShippingAddressOnCart(context, input) {
+  const cleanedInput = inputSchema.clean(input); // add default values and such
+  inputSchema.validate(cleanedInput);
+
+  const { address, addressId, cartId, cartToken } = cleanedInput;
+  if (addressId) {
+    address._id = addressId;
+  }
+
+  const cart = await getCartById(context, cartId, { cartToken, throwIfNotFound: true });
+
+  let didModify = false;
+  const updatedFulfillmentGroups = (cart.shipping || []).map((group) => {
+    if (group.type === "shipping") {
+      didModify = true;
+      return { ...group, address };
+    }
+    return group;
+  });
+
+  if (!didModify) return { cart };
+
+  const { collections } = context;
+  const { Cart } = collections;
+
+  const updatedAt = new Date();
+  const { modifiedCount } = await Cart.updateOne({ _id: cartId }, {
+    $set: {
+      shipping: updatedFulfillmentGroups,
+      updatedAt
+    }
+  });
+  if (modifiedCount === 0) throw new ReactionError("server-error", "Failed to update cart");
+
+  const updatedCart = { ...cart, shipping: updatedFulfillmentGroups, updatedAt };
+
+  return { cart: updatedCart };
 }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.js
@@ -1,4 +1,5 @@
 import SimpleSchema from "simpl-schema";
+import Random from "@reactioncommerce/random";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Address as AddressSchema } from "/imports/collections/schemas";
 import getCartById from "../util/getCartById";
@@ -29,9 +30,7 @@ export default async function setShippingAddressOnCart(context, input) {
   inputSchema.validate(cleanedInput);
 
   const { address, addressId, cartId, cartToken } = cleanedInput;
-  if (addressId) {
-    address._id = addressId;
-  }
+  address._id = addressId || Random.id();
 
   const cart = await getCartById(context, cartId, { cartToken, throwIfNotFound: true });
 

--- a/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.test.js
@@ -11,7 +11,7 @@ jest.mock("../util/getCartById", () => jest.fn().mockImplementation(() => Promis
   }]
 })));
 
-const address = Factory.Address.makeOne();
+const address = Factory.Address.makeOne({ _id: undefined });
 
 test("expect to return a cart that has address added to all shipping fulfillment groups", async () => {
   const result = await setShippingAddressOnCart(mockContext, {
@@ -23,7 +23,10 @@ test("expect to return a cart that has address added to all shipping fulfillment
       _id: "cartId",
       shipping: [{
         _id: "group1",
-        address,
+        address: {
+          ...address,
+          _id: jasmine.any(String)
+        },
         itemIds: ["123"],
         type: "shipping"
       }],

--- a/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/setShippingAddressOnCart.test.js
@@ -1,7 +1,58 @@
+import Factory from "/imports/test-utils/helpers/factory";
 import mockContext from "/imports/test-utils/helpers/mockContext";
 import setShippingAddressOnCart from "./setShippingAddressOnCart";
 
-test("expect to return a Promise that resolves to TODO", async () => {
-  const result = await setShippingAddressOnCart(mockContext);
-  expect(result).toEqual(null);
+jest.mock("../util/getCartById", () => jest.fn().mockImplementation(() => Promise.resolve({
+  _id: "cartId",
+  shipping: [{
+    _id: "group1",
+    itemIds: ["123"],
+    type: "shipping"
+  }]
+})));
+
+const address = Factory.Address.makeOne();
+
+test("expect to return a cart that has address added to all shipping fulfillment groups", async () => {
+  const result = await setShippingAddressOnCart(mockContext, {
+    address,
+    cartId: "cartId"
+  });
+  expect(result).toEqual({
+    cart: {
+      _id: "cartId",
+      shipping: [{
+        _id: "group1",
+        address,
+        itemIds: ["123"],
+        type: "shipping"
+      }],
+      updatedAt: jasmine.any(Date)
+    }
+  });
+});
+
+const addressId = "ADDRESS_ID";
+
+test("if addressId is provided, sets the address._id to that", async () => {
+  const result = await setShippingAddressOnCart(mockContext, {
+    address,
+    addressId,
+    cartId: "cartId"
+  });
+  expect(result).toEqual({
+    cart: {
+      _id: "cartId",
+      shipping: [{
+        _id: "group1",
+        address: {
+          ...address,
+          _id: addressId
+        },
+        itemIds: ["123"],
+        type: "shipping"
+      }],
+      updatedAt: jasmine.any(Date)
+    }
+  });
 });

--- a/imports/plugins/core/cart/server/no-meteor/util/getCartById.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/getCartById.js
@@ -1,0 +1,34 @@
+import ReactionError from "@reactioncommerce/reaction-error";
+import hashLoginToken from "/imports/plugins/core/accounts/server/no-meteor/util/hashLoginToken";
+
+/**
+ * @summary Gets a cart from the db by ID. If there is an account for the request, verifies that the
+ *   account has permission to access the cart. Optionally throws an error if not found.
+ * @param {Object} context Object defining the request state
+ * @param {String} cartId The cart ID
+ * @param {Object} [options] Options
+ * @param {String} [options.cartToken] Cart token, required if it's an anonymous cart
+ * @param {Boolean} [options.throwIfNotFound] Default false. Throw a not-found error rather than return null `cart`
+ * @returns {Object|null} The cart document, or null if not found and `throwIfNotFound` was false
+ */
+export default async function getCartById(context, cartId, { cartToken, throwIfNotFound = false } = {}) {
+  const { accountId, collections } = context;
+  const { Cart } = collections;
+
+  const selector = { _id: cartId };
+
+  if (cartToken) {
+    selector.anonymousAccessToken = hashLoginToken(cartToken);
+  }
+
+  const cart = await Cart.findOne(selector);
+  if (!cart && throwIfNotFound) {
+    throw new ReactionError("not-found", "Cart not found");
+  }
+
+  if (cart && cart.accountId && cart.accountId !== accountId) {
+    throw new ReactionError("access-denied", "Access Denied");
+  }
+
+  return cart || null;
+}

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Mutation/setShippingAddressOnCart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Mutation/setShippingAddressOnCart.js
@@ -1,3 +1,6 @@
+import { decodeAddressOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/address";
+import { decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
+
 /**
  * @name "Mutation.setShippingAddressOnCart"
  * @method
@@ -5,16 +8,29 @@
  * @summary resolver for the setShippingAddressOnCart GraphQL mutation
  * @param {Object} parentResult - unused
  * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {Object} args.input.address - The shipping address
+ * @param {String} [args.input.addressId] - If set, this will be saved as the Address._id. Otherwise an ID will be generated.
+ * @param {String} args.input.cartId - The cart to set shipping address on
+ * @param {String} [args.input.cartToken] - The token for the cart, required if it is an anonymous cart
  * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<Object>} SetShippingAddressOnCartPayload
  */
 export default async function setShippingAddressOnCart(parentResult, { input }, context) {
-  const { clientMutationId = null } = input;
-  // TODO: decode incoming IDs here
-  const renameMe = await context.mutations.cart.setShippingAddressOnCart(context);
+  const { address, addressId: opaqueAddressId, cartId: opaqueCartId, cartToken, clientMutationId = null } = input;
+
+  const addressId = decodeAddressOpaqueId(opaqueAddressId);
+  const cartId = decodeCartOpaqueId(opaqueCartId);
+
+  const { cart } = await context.mutations.cart.setShippingAddressOnCart(context, {
+    address,
+    addressId,
+    cartId,
+    cartToken
+  });
+
   return {
-    renameMe,
+    cart,
     clientMutationId
   };
 }

--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Mutation/setShippingAddressOnCart.test.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Mutation/setShippingAddressOnCart.test.js
@@ -1,7 +1,15 @@
 import setShippingAddressOnCart from "./setShippingAddressOnCart";
 
+const internalAddressId = "999";
+const opaqueAddressId = "cmVhY3Rpb24vYWRkcmVzczo5OTk=";
+const internalCartId = "555";
+const opaqueCartId = "cmVhY3Rpb24vY2FydDo1NTU=";
+const cartToken = "TOKEN";
+
 test("correctly passes through to mutations.cart.setShippingAddressOnCart", async () => {
-  const fakeResult = { /* TODO */ };
+  const fakeResult = {
+    cart: { _id: "123" }
+  };
 
   const mockMutation = jest.fn().mockName("mutations.cart.setShippingAddressOnCart");
   mockMutation.mockReturnValueOnce(Promise.resolve(fakeResult));
@@ -15,13 +23,23 @@ test("correctly passes through to mutations.cart.setShippingAddressOnCart", asyn
 
   const result = await setShippingAddressOnCart(null, {
     input: {
-      /* TODO */
+      address: { foo: "bar" },
+      addressId: opaqueAddressId,
+      cartId: opaqueCartId,
+      cartToken,
       clientMutationId: "clientMutationId"
     }
   }, context);
 
   expect(result).toEqual({
-    renameMe: fakeResult,
+    ...fakeResult,
     clientMutationId: "clientMutationId"
+  });
+
+  expect(mockMutation).toHaveBeenCalledWith(context, {
+    address: { foo: "bar" },
+    addressId: internalAddressId,
+    cartId: internalCartId,
+    cartToken
   });
 });

--- a/imports/plugins/core/graphql/server/no-meteor/schemas/address.graphql
+++ b/imports/plugins/core/graphql/server/no-meteor/schemas/address.graphql
@@ -28,13 +28,13 @@ input AddressInput {
   fullName: String!
 
   "Is this the default address for billing purposes?"
-  isBillingDefault: Boolean!
+  isBillingDefault: Boolean
 
   "Is this a commercial address?"
-  isCommercial: Boolean!
+  isCommercial: Boolean
 
   "Is this the default address to use when selecting a shipping address at checkout?"
-  isShippingDefault: Boolean!
+  isShippingDefault: Boolean
 
   "Arbitrary additional metadata about this address"
   metafields: [MetafieldInput]


### PR DESCRIPTION
Resolves #4497 
Impact: **minor**  
Type: **feature**

Note: Need to merge #4535 before this one.

## Changes
The `setShippingAddressOnCart` mutation now works. It sets the provided shipping address on all fulfillment groups that have a `type` of `"shipping"`.

## Breaking changes
None

## Testing
1. Using GraphQL or Reaction app, create a cart and add some items to it.
1. Call the `setShippingAddressOnCart` mutation for that cart with a valid address.
1. Query for the `cart` using GraphQL and verify that the address you set is there.
    - Note that the address will not be shown in current Reaction checkout properly. This is a UI issue that will be addressed in the future, but make sure that checkout otherwise continues to work.
1. Try to set it on an account cart other than your own, or on an anonymous cart with the wrong token, and verify that you can't.

```graphql
mutation {
  setShippingAddressOnCart(input: {cartId: "cmVhY3Rpb24vY2FydDpicnlrcjRwdzNCQTNNdHpyYQ==", cartToken: "6WN6BsR7g7SS2bQa16K_utAqb2yDaJY7R9W7c6OwJ9d", address: {fullName: "Full Name", address1: "address1", address2: "address2", city: "City", region: "WI", country: "US", phone: "15556789999", postal: "53073", isCommercial: false}}) {
    cart {
      checkout {
        fulfillmentGroups {
          _id
          data {
            shippingAddress {
              _id
              fullName
              address1
              address2
              city
              region
              country
              phone
              postal
              isCommercial
            }
          }
        }
      }
    }
  }
}
```