### PR TITLE
fix: jsdoc promise returns

### DIFF
--- a/imports/plugins/core/accounts/client/containers/addressBookContainer.js
+++ b/imports/plugins/core/accounts/client/containers/addressBookContainer.js
@@ -125,7 +125,7 @@ function callUpdateAddress(address, property) {
  * @private
  * @param {String} addressId - ID of address to remove from cart
  * @param {String} type - "billing" or "shipping"
- * @returns {<Promise>Object} Result
+ * @returns {Promise<Object>} Result
  */
 function callUnsetAddress(addressId, type) {
   return new Promise((resolve, reject) => {
@@ -149,7 +149,7 @@ function callUnsetAddress(addressId, type) {
 /**
  * @summary Update shipping or billing address for cart
  * @param {Object} updatedAddress Address
- * @returns {<Promise>Boolean[]} Resolves with 0 or more results
+ * @returns {Promise<Boolean[]>} Resolves with 0 or more results
  */
 function updateCartAddresses(updatedAddress) {
   const promises = [];


### PR DESCRIPTION
Resolves: issue where master CI builds are failing due to docs existing with non-zero code
Impact: **major**
Type: **docs**

## Issue
The issue is that in some places in our codebase, we had jsdoc that looked like this:
```
@returns {<Promise>Type} ...
```
The `jsdoc` parser cannot handle the `{` curly brace followed by `<` angle bracket and fails to process that line which causes a non-zero exit code. This results in the badge showing a failed CI on our master branch README which is highly undesirable and the reason for this ticket to be marked as impact **major**

## Solution
The solution appears to be using the angle brackets around the type that the Promise resolves to.
```
@returns {Promise<Type>} Returns a promise that resolves to Type
```

This solution was arrived at by consulting the docs http://usejsdoc.org/tags-returns.html and this jsdoc issue comment https://github.com/jsdoc3/jsdoc/issues/1197#issuecomment-312948746




According to this StackOverflow answer, we could potentially go further and define reject types like `{Promise<Object|Error>}`, but I can't find specific documentation supporting that behavior yet.
https://stackoverflow.com/questions/13104411/how-to-specify-resolution-and-rejection-type-of-the-promise-in-jsdoc

## Testing
1. Run our jsdoc command from the root of the project, verify that this PR resolves the error.
```
jsdoc . --verbose --configure .reaction/jsdoc/jsdoc.json --readme .reaction/jsdoc/templates/static/README.md
```
