### PR TITLE
#4545: Fix for sidebar unable to be opened (edge condition)

### DIFF
--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -39,14 +39,15 @@ const wrapComponent = (Comp) => (
       const selectedProducts = Reaction.getUserPreferences("reaction-product-variant", "selectedGridItems");
       const { products } = this;
 
-      if (_.isEmpty(selectedProducts)) {
+      if (Array.isArray(selectedProducts) && _.isEmpty(selectedProducts)) {
+        Reaction.setUserPreferences("reaction-product-variant", "selectedGridItems", undefined);
         return Reaction.hideActionView();
       }
 
-      // Save the selected items to the Session
-      Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
 
-      if (products) {
+      if (products && selectedProducts) {
+        // Save the selected items to the Session
+        Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
         const filteredProducts = products.filter((product) => selectedProducts.includes(product._id));
 
         if (Reaction.isPreview() === false) {
@@ -80,12 +81,11 @@ const wrapComponent = (Comp) => (
 
       Reaction.setUserPreferences("reaction-product-variant", "selectedGridItems", selectedProducts);
 
-      // Save the selected items to the Session
-      Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
-
       const { products } = this;
 
-      if (products) {
+      if (products && selectedProducts) {
+        // Save the selected items to the Session
+        Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
         const filteredProducts = products.filter((product) => selectedProducts.includes(product._id));
 
         Reaction.showActionView({


### PR DESCRIPTION
Resolves #4545  
Impact: **minor**  
Type: **bugfix**

## Issue
After performing a specific set of steps in the UI (see issue), the admin sidebar becomes unusable.

## Solution
There was a piece of logic in `productGridContainer.js` that automatically closed the sidebar if the admin didn't have any products selected in the grid. It was checking whether the user's `selectedGridItems` preference was empty (empty array or undefined). After performing the reproduction steps, that preference is set to an empty array.

To prevent the auto-close logic from re-runing, I set `selectedGridItems` to undefined when auto-closing the sidebar, and updated the logic to only run if `selectedGridItems` is an empty array.


## Breaking changes
None

## Testing
1. Perform the steps in the referenced issue and confirm you can open the sidebar as the last step
2. Select a product in grid. Click it again to de-select. Confirm sidebar still auto-closes
