### PR TITLE
fix(readme): fix README image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [Reaction](http://reactioncommerce.com) is an event-driven, real-time reactive commerce platform built with JavaScript (ES6). It plays nicely with npm, Docker, and React.
 
-![Reaction v.1.x](https://raw.githubusercontent.com/reactioncommerce/reaction-docs/master/assets/Reaction-Commerce-Illustration-BG-800px.png)
+![Reaction v.1.x](https://raw.githubusercontent.com/reactioncommerce/reaction-docs/v1.7.0/assets/Reaction-Commerce-Illustration-BG-800px.png)
 
 ## Features
 


### PR DESCRIPTION
Resolves #4483
Impact: **minor**  
Type: **docs**

## Issue
- README image is a dead link

## Solution
- Use correct link from here: https://github.com/reactioncommerce/reaction-docs/blob/v1.7.0/assets/Reaction-Commerce-Illustration-BG-800px.png

## Breaking changes
None

## Testing
1. View https://github.com/reactioncommerce/reaction/blob/c12c6df176cce59c69e944910f7f1506daeeb706/README.md