### PR TITLE
[WIP] React Context Example

### DIFF
--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -164,7 +164,7 @@ class AuthContainer extends Component {
 
   hasPasswordService = () => !!Package["accounts-password"]
 
-  renderAuthView(client) {
+  renderAuthView() {
     if (this.props.currentView === "loginFormSignInView") {
       return (
         <Components.SignIn

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -167,14 +167,23 @@ class AuthContainer extends Component {
   renderAuthView() {
     if (this.props.currentView === "loginFormSignInView") {
       return (
-        <Components.SignIn
-          {...this.props}
-          onFormSubmit={this.handleFormSubmit(client)}
-          messages={this.state.formMessages}
-          onError={this.hasError}
-          loginFormMessages={this.formMessages}
-          isLoading={this.state.isLoading}
-        />
+        <ApolloConsumer>
+          {(client) => {
+            const getViewerQuery = client.query({
+              query: getViewer
+            });
+            return (
+              <Components.SignIn
+                {...this.props}
+                onFormSubmit={this.handleFormSubmit(getViewerQuery)}
+                messages={this.state.formMessages}
+                onError={this.hasError}
+                loginFormMessages={this.formMessages}
+                isLoading={this.state.isLoading}
+              />
+            );
+          }}
+        </ApolloConsumer>
       );
     } else if (this.props.currentView === "loginFormSignUpView") {
       return (
@@ -195,7 +204,6 @@ class AuthContainer extends Component {
               />
             );
           }}
-
         </ApolloConsumer>
       );
     }

--- a/imports/plugins/core/graphql/lib/hocs/withViewer.js
+++ b/imports/plugins/core/graphql/lib/hocs/withViewer.js
@@ -1,0 +1,32 @@
+import React, { Component } from "react";
+import { Query } from "react-apollo";
+import getViewer from "../queries/getViewer";
+
+export default (Comp) => (
+  class Viewer extends Component {
+    render() {
+      return (
+        <Query query={getViewer}>
+          {({ loading, data }) => {
+            const props = {
+              ...this.props,
+              isLoadingViewerId: loading
+            };
+
+            if (loading === false) {
+              const { viewer } = data;
+              const { _id } = viewer || {};
+              if (_id) {
+                props.viewerId = _id;
+              }
+            }
+
+            return (
+              <Comp {...props} />
+            );
+          }}
+        </Query>
+      );
+    }
+  }
+);

--- a/imports/plugins/core/graphql/lib/queries/getViewer.js
+++ b/imports/plugins/core/graphql/lib/queries/getViewer.js
@@ -1,0 +1,9 @@
+import gql from "graphql-tag";
+
+export default gql`
+  query viewerQuery {
+    viewer {
+      _id
+    }
+  }
+`;

--- a/imports/plugins/core/stores/client/contexts/AuthContext.js
+++ b/imports/plugins/core/stores/client/contexts/AuthContext.js
@@ -1,0 +1,36 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+const AuthContext = React.createContext();
+
+export class AuthProvider extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      ctxViewerId: ""
+    };
+  }
+
+  setViewerId = (ctxViewerId) => {
+    this.setState({ ctxViewerId });
+  };
+
+  render() {
+    return (
+      <AuthContext.Provider
+        value={{
+          ...this.state,
+          ctxSetViewerId: this.setViewerId
+        }}
+      >
+        {this.props.children}
+      </AuthContext.Provider>
+    );
+  }
+}
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export const AuthConsumer = AuthContext.Consumer;

--- a/imports/plugins/core/stores/client/hoc/withAuthConsumer.js
+++ b/imports/plugins/core/stores/client/hoc/withAuthConsumer.js
@@ -1,0 +1,11 @@
+import React, { Component } from "react";
+import { AuthConsumer } from "../contexts/AuthContext";
+
+export default (Comp) => {
+  class AuthConsumerWrapper extends Component {
+    render() {
+      return <AuthConsumer>{(values) => <Comp {...this.props} {...values} />}</AuthConsumer>;
+    }
+  }
+  return AuthConsumerWrapper;
+};

--- a/imports/plugins/core/ui-navbar/client/containers/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/containers/navbar.js
@@ -1,9 +1,11 @@
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
+import { compose } from "recompose";
 import { Meteor } from "meteor/meteor";
 import { Reaction } from "/client/api";
 import NavBar from "../components/navbar";
 import { Shops } from "/lib/collections";
 import { Media } from "/imports/plugins/core/files/client";
+import withAuthConsumer from "/imports/plugins/core/stores/client/hoc/withAuthConsumer";
 
 export function composer(props, onData) {
   const shopSub = Meteor.subscribe("MerchantShops", Reaction.getShopsForUser(["admin"]));
@@ -67,6 +69,6 @@ export function composer(props, onData) {
   });
 }
 
-registerComponent("NavBar", NavBar, composeWithTracker(composer));
+registerComponent("NavBar", NavBar, [composeWithTracker(composer), withAuthConsumer]);
 
-export default composeWithTracker(composer)(NavBar);
+export default compose(composeWithTracker(composer), withAuthConsumer)(NavBar);


### PR DESCRIPTION
Impact: **major**  
Type: **refactor**

## Issue
This aims to present how we can make use of react context for client state management.

## Solution

For this example, `ctxViewerId` (encoded auth token that can be queried through graphql) is fetched on mount of `BrowserRouter` and is updated when user logs in, signs up, and logs out. This `ctxViewerId` is then consumed in `navbar` component as an example how to use consume the context.

To accomplish this, I did the following:
1. Create `AuthContext` (done in `imports/plugins/core/stores/client/contexts/AuthContext.js`). See how `AuthContext.Provider` is rendered with `value` containing `ctxVieweId` and handler `ctxSetViewerId` which are essentially the context that can be consumed by components. (See [here](https://github.com/reactioncommerce/reaction/blob/refactor-ajporlante-react-context-example/imports/plugins/core/stores/client/contexts/AuthContext.js))
2. Wrap components with `AuthContext.Provider`. (See [here](https://github.com/reactioncommerce/reaction/blob/61dfe43f53f0532752dc2fd76e65ba6bbcc77aed/imports/plugins/core/router/client/browserRouter.js#L191))
3. Create HOC `withAuthConsumer` for `AuthConsumer`. (See [here](https://github.com/reactioncommerce/reaction/blob/refactor-ajporlante-react-context-example/imports/plugins/core/stores/client/hoc/withAuthConsumer.js))
4. Create HOC `withViewer` for viewer graphql query. (See [here](https://github.com/reactioncommerce/reaction/blob/refactor-ajporlante-react-context-example/imports/plugins/core/graphql/lib/hocs/withViewer.js))
5. Wrap `BrowserRouter` with `withAuthConsumer` and `withViewer`. Set the `ctxViewerId` using `ctxSetViewerId` when `BrowserRouter` has received the `viewerId` from the graphql query. (See [here](https://github.com/reactioncommerce/reaction/blob/61dfe43f53f0532752dc2fd76e65ba6bbcc77aed/imports/plugins/core/router/client/browserRouter.js#L149)) and [here](https://github.com/reactioncommerce/reaction/blob/61dfe43f53f0532752dc2fd76e65ba6bbcc77aed/imports/plugins/core/router/client/browserRouter.js#L46-L51))
6. Trigger querying of `viewerId` and reset `ctxViewerId` when user logs in or signs up using `ctxSetViewerId`. (See [here](https://github.com/reactioncommerce/reaction/blob/61dfe43f53f0532752dc2fd76e65ba6bbcc77aed/imports/plugins/core/accounts/client/containers/auth.js#L81-L82) and [here](https://github.com/reactioncommerce/reaction/blob/61dfe43f53f0532752dc2fd76e65ba6bbcc77aed/imports/plugins/core/accounts/client/containers/auth.js#L101-L102))
7. Wrap `navbar` with `withAuthConsumer`. (See [here](https://github.com/reactioncommerce/reaction/blob/61dfe43f53f0532752dc2fd76e65ba6bbcc77aed/imports/plugins/core/ui-navbar/client/containers/navbar.js#L74))

## Breaking changes
None

## Testing
1. Load any page as an anonymous use.
2. With React Dev Tools, see that `props.ctxViewerId` in `navbar` is set.
3. Log in as a user. See that `props.ctxViewerId` is updated.