### PR TITLE
feat 4571 Replace all Meteor.userId() with util function

### DIFF
--- a/client/modules/core/helpers/apps.js
+++ b/client/modules/core/helpers/apps.js
@@ -1,6 +1,5 @@
 import _ from "lodash";
 import { Template } from "meteor/templating";
-import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { Reaction } from "/client/api";
 import { Packages, Shops } from "/lib/collections";
@@ -21,6 +20,7 @@ import { Packages, Shops } from "/lib/collections";
  * @return {Object[]} returns an array of filtered, structure reactionApps
  */
 export function Apps(optionHash) {
+  const { getUserId } = Reaction;
   const filter = {};
   const registryFilter = {};
   let key;
@@ -94,7 +94,7 @@ export function Apps(optionHash) {
           // This checks that the registry item contains a permissions matches with the user's permission for the shop
           const hasPermissionToRegistryItem = item.permissions.indexOf(permission) > -1;
           // This checks that the user's permission set have the right value that is on the registry item
-          const hasRoleAccessForShop = Roles.userIsInRole(Meteor.userId(), permission, Reaction.getShopId());
+          const hasRoleAccessForShop = Roles.userIsInRole(getUserId(), permission, Reaction.getShopId());
 
           // both checks must pass for access to be granted
           if (hasPermissionToRegistryItem && hasRoleAccessForShop) {

--- a/client/modules/core/helpers/globals.js
+++ b/client/modules/core/helpers/globals.js
@@ -1,10 +1,5 @@
 import _ from "lodash";
 import { Session } from "meteor/session";
-import { Meteor } from "meteor/meteor";
-import { Roles } from "meteor/alanning:roles";
-
-/* eslint "no-extend-native": [2, {"exceptions": ["String"]}] */
-/* eslint "no-alert": 0 */
 
 /**
  * @name toggleSession
@@ -55,29 +50,4 @@ export function getCardType(cardNumber) {
     return "discover";
   }
   return "";
-}
-
-/**
- * @name getGuestLoginState
- * @method
- * @memberof Helpers
- * @todo These should all be removed. PR's happily accepted.
- * @summary Determines if a guest checkout is enabled and the login state for users
- * @return {Boolean} true if authenticated user
- */
-export function getGuestLoginState() {
-  if (Meteor.userId() === "string" && this.getShopId() && this.allowGuestCheckout()) {
-    const isGuestFlow = Session.equals("guestCheckoutFlow", true);
-    const isGuest = Roles.userIsInRole(Meteor.userId(), "guest", this.getShopId());
-    const isAnonymous = Roles.userIsInRole(Meteor.userId(), "anonymous", this.getShopId());
-    if (!isGuestFlow && !isGuest && isAnonymous) {
-      return false;
-    } else if (!isGuestFlow && isGuest && !isAnonymous) {
-      return true;
-    }
-  } else if (Session.equals("guestCheckoutFlow", true) && _.pluck(Meteor.user()
-    .emails, "address")) {
-    return true;
-  }
-  return false;
 }

--- a/client/modules/core/helpers/permissions.js
+++ b/client/modules/core/helpers/permissions.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Reaction } from "/client/api";
 
@@ -12,8 +11,7 @@ import { Reaction } from "/client/api";
  * @return {Boolean}
  */
 Template.registerHelper("hasPermission", (permissions, options) => {
-  // default to checking this.userId
-  const loggedInUser = Meteor.userId();
+  const loggedInUser = Reaction.getUserId();
   const shopId = Reaction.getShopId();
   // we don't necessarily need to check here
   // as these same checks and defaults are

--- a/client/modules/core/helpers/permissions.js
+++ b/client/modules/core/helpers/permissions.js
@@ -7,7 +7,7 @@ import { Reaction } from "/client/api";
  * @summary check current user hasPermission, uses [alanning:meteor-roles](http://alanning.github.io/meteor-roles/classes/Roles.html)
  * @example {{hasPermission admin userId}}
  * @param  {String|Array} "permissions"
- * @param  {String} checkUserId - optional Meteor.userId, default to current
+ * @param  {String} options - object
  * @return {Boolean}
  */
 Template.registerHelper("hasPermission", (permissions, options) => {

--- a/client/modules/core/helpers/utils.js
+++ b/client/modules/core/helpers/utils.js
@@ -1,4 +1,5 @@
 import { latinLangs, getShopLang } from "/lib/api/helpers";
+import { Meteor } from "meteor/meteor";
 
 // dynamic import of slugiy/transliteration.slugify
 let slugify;
@@ -44,4 +45,13 @@ export function getSlug(slugString) {
     slug = "";
   }
   return slug;
+}
+
+/**
+ * @method getUserId
+ * @summary returns the userId of logged in user (e.g Meteor.userId())
+ * @return {String} String
+ */
+export function getUserId() {
+  return Meteor.userId();
 }

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -14,6 +14,7 @@ import { localeDep } from "/client/modules/i18n";
 import { Packages, Shops, Accounts } from "/lib/collections";
 import { Router } from "/client/modules/router";
 import { DomainsMixin } from "./domains";
+import { getUserId } from "./helpers/utils";
 
 /**
  * Reaction core namespace for client code
@@ -200,7 +201,7 @@ export default {
    * @method
    * @memberof Core/Client
    * @param {String | Array} checkPermissions -String or Array of permissions if empty, defaults to "admin, owner"
-   * @param {String} checkUserId - userId, defaults to Meteor.userId()
+   * @param {String} checkUserId - userId, defaults to logged in user ID
    * @param {String} checkGroup group - default to shopId
    * @return {Boolean} Boolean - true if has permission
    */
@@ -215,7 +216,7 @@ export default {
 
     let permissions = ["owner"];
     let id = "";
-    const userId = checkUserId || Meteor.userId();
+    const userId = checkUserId || getUserId();
     //
     // local roleCheck function
     // is the bulk of the logic
@@ -271,7 +272,7 @@ export default {
     // in line 156 setTimeout
     //
     function validateUserId() {
-      if (Meteor.userId()) {
+      if (getUserId()) {
         Meteor.clearTimeout(id);
         Router.reload();
         return roleCheck();
@@ -368,7 +369,7 @@ export default {
   hasAdminAccess(shopId) {
     const adminPermissions = ["owner", "admin"];
     if (shopId) {
-      return this.hasPermission(adminPermissions, Meteor.userId(), shopId);
+      return this.hasPermission(adminPermissions, getUserId(), shopId);
     }
     return this.hasPermission(adminPermissions);
   },
@@ -397,7 +398,7 @@ export default {
    * @method
    * @memberof Core/Client
    */
-  getSellerShopId(userId = Meteor.userId(), noFallback = false) {
+  getSellerShopId(userId = getUserId(), noFallback = false) {
     if (userId) {
       const group = Roles.getGroupsForUser(userId, "admin")[0];
       if (group) {
@@ -444,7 +445,7 @@ export default {
       // the Accounts collection.
       const syncedPackages = ["reaction"];
       if (syncedPackages.indexOf(packageName) > -1) {
-        Accounts.update(Meteor.userId(), {
+        Accounts.update(getUserId(), {
           $set: {
             [`profile.preferences.${packageName}.${preference}`]: value
           }
@@ -721,7 +722,7 @@ export default {
     const groupPermissions = group.permissions;
 
     // granting invitation right for user with `owner` role in a shop
-    if (this.hasPermission(["owner"], Meteor.userId(), group.shopId)) {
+    if (this.hasPermission(["owner"], getUserId(), group.shopId)) {
       return true;
     }
 

--- a/client/modules/core/startup.js
+++ b/client/modules/core/startup.js
@@ -7,6 +7,7 @@ import { Accounts } from "meteor/accounts-base";
 
 import { Reaction, Logger } from "/client/api";
 import { userPrefs } from "./main";
+import { getUserId } from "./helpers/utils";
 
 /**
  *  Startup Reaction
@@ -18,7 +19,7 @@ Meteor.startup(() => {
 
 // Log in anonymous guest users
 Tracker.autorun(() => {
-  const userId = Meteor.userId();
+  const userId = getUserId();
   if (userId) return; // This autorun is only for when we DO NOT have a user
 
   const loggingIn = Tracker.nonreactive(() => Accounts.loggingIn());
@@ -42,7 +43,7 @@ Tracker.autorun(() => {
 });
 
 Tracker.autorun(() => {
-  const userId = Meteor.userId(); // The only reactive thing in this autorun. Reruns on login/logout only.
+  const userId = getUserId(); // The only reactive thing in this autorun. Reruns on login/logout only.
   if (!userId) return;
 
   // Load data from Accounts collection into the localStorage
@@ -72,7 +73,7 @@ Tracker.autorun(() => {
 
 // Fine-grained reactivity on only the user preferences
 Tracker.autorun(() => {
-  const userId = Meteor.userId();
+  const userId = getUserId();
   if (!userId) return;
 
   const user = Meteor.users.findOne(userId, { fields: { profile: 1 } });

--- a/client/modules/core/subscriptions.js
+++ b/client/modules/core/subscriptions.js
@@ -6,6 +6,7 @@ import { SubsManager } from "meteor/meteorhacks:subs-manager";
 import { Roles } from "meteor/alanning:roles";
 import { Accounts } from "/lib/collections";
 import Reaction from "./main";
+import { getUserId } from "./helpers/utils";
 import { getAnonymousCartsReactive, unstoreAnonymousCart } from "/imports/plugins/core/cart/client/util/anonymousCarts";
 
 export const Subscriptions = {};
@@ -19,7 +20,7 @@ Subscriptions.Manager = new SubsManager();
  */
 
 Tracker.autorun(() => {
-  const userId = Meteor.userId();
+  const userId = getUserId();
   Subscriptions.Account = Subscriptions.Manager.subscribe("Accounts");
   Subscriptions.UserProfile = Meteor.subscribe("UserProfile", userId);
 });
@@ -47,7 +48,7 @@ Subscriptions.BrandAssets = Subscriptions.Manager.subscribe("BrandAssets");
 
 const cartSubCreated = new ReactiveVar(false);
 Tracker.autorun(() => {
-  const userId = Meteor.userId();
+  const userId = getUserId();
   if (!userId) return;
 
   const account = Accounts.findOne({ userId });
@@ -79,7 +80,7 @@ function mergeCart(_id, token) {
 // call the mergeCart function to merge it into an account cart and destroy
 let isMerging = false;
 Tracker.autorun(() => {
-  const userId = Meteor.userId();
+  const userId = getUserId();
   if (!userId) return;
 
   const shopId = Reaction.getCartShopId();

--- a/client/modules/i18n/currency.js
+++ b/client/modules/i18n/currency.js
@@ -1,5 +1,4 @@
 import accounting from "accounting-js";
-import { Meteor } from "meteor/meteor";
 import { Reaction, Logger } from "/client/api";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Shops, Accounts } from "/lib/collections";
@@ -23,7 +22,7 @@ export function findCurrency(defaultCurrency, useDefaultShopCurrency) {
 
   const shopCurrency = (shop && shop.currency) || "USD";
   const user = Accounts.findOne({
-    _id: Meteor.userId()
+    _id: Reaction.getUserId()
   });
   const profileCurrency = user && user.profile && user.profile.currency;
   if (typeof shop === "object" && shop.currencies && profileCurrency) {

--- a/client/modules/i18n/helpers.js
+++ b/client/modules/i18n/helpers.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { check, Match } from "meteor/check";
 import { Reaction, Logger, i18next } from "/client/api";
@@ -41,7 +40,7 @@ Template.registerHelper("i18n", (i18nKey, i18nMessage) => {
 Template.registerHelper("currencySymbol", () => {
   const locale = Reaction.Locale.get();
   const user = Accounts.findOne({
-    _id: Meteor.userId()
+    _id: Reaction.getUserId()
   });
   const profileCurrency = user.profile && user.profile.currency;
   if (profileCurrency) {

--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -91,7 +91,7 @@ Meteor.startup(() => {
   // We need to ensure fine-grained reactivity on only the profile.lang because
   // user.profile changed frequently and causes excessive reruns
   Tracker.autorun(() => {
-    const userId = Meteor.userId();
+    const userId = Reaction.getUserId();
     const user = userId && Meteor.users.findOne(userId, { fields: { profile: 1 } });
     userProfileLanguage.set((user && user.profile && user.profile.lang) || null);
   });

--- a/imports/plugins/core/accounts/client/components/groupsTableCell.js
+++ b/imports/plugins/core/accounts/client/components/groupsTableCell.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import React from "react";
 import _ from "lodash";
 import PropTypes from "prop-types";
@@ -54,7 +53,7 @@ const GroupsTableCell = (props) => {
   if (columnName === "dropdown") {
     const groupName = <span className="group-dropdown">{_.startCase(groups[0].name)}</span>;
     const ownerGroup = groups.find((grp) => grp.slug === "owner") || {};
-    const hasOwnerAccess = Reaction.hasPermission("owner", Meteor.userId(), Reaction.getShopId());
+    const hasOwnerAccess = Reaction.hasPermission("owner", Reaction.getUserId(), Reaction.getShopId());
 
     if (groups.length === 1) {
       return groupName;

--- a/imports/plugins/core/accounts/client/containers/addressBookContainer.js
+++ b/imports/plugins/core/accounts/client/containers/addressBookContainer.js
@@ -2,7 +2,7 @@ import { compose, withProps } from "recompose";
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
-import { i18next, Logger } from "/client/api";
+import { i18next, Logger, Reaction } from "/client/api";
 import { Countries } from "/client/collections";
 import * as Collections from "/lib/collections";
 import getCart from "/imports/plugins/core/cart/client/util/getCart";
@@ -286,7 +286,7 @@ const handlers = {
  * @returns {undefined}
  */
 function composer(props, onData) {
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const account = Collections.Accounts.findOne({ userId });
   if (!account) {
     // Subscription not ready

--- a/imports/plugins/core/accounts/client/containers/mainDropdown.js
+++ b/imports/plugins/core/accounts/client/containers/mainDropdown.js
@@ -37,7 +37,7 @@ function displayName(displayUser) {
 
 function getAdminShortcutIcons() {
   // get shortcuts with audience permissions based on user roles
-  const roles = Roles.getRolesForUser(Meteor.userId(), Reaction.getShopId());
+  const roles = Roles.getRolesForUser(Reaction.getUserId(), Reaction.getShopId());
 
   return {
     provides: "shortcut",

--- a/imports/plugins/core/accounts/client/containers/updateEmail.js
+++ b/imports/plugins/core/accounts/client/containers/updateEmail.js
@@ -1,7 +1,7 @@
 import { compose, withProps } from "recompose";
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Meteor } from "meteor/meteor";
-import { i18next } from "/client/api";
+import { i18next, Reaction } from "/client/api";
 import { Accounts } from "/lib/collections";
 import UpdateEmail from "../components/updateEmail";
 
@@ -30,7 +30,7 @@ const handlers = {
 };
 
 const composer = (props, onData) => {
-  const user = Accounts.findOne(Meteor.userId());
+  const user = Accounts.findOne(Reaction.getUserId());
   const email = user.emails.length > 0 ? user.emails[0].address : "";
   onData(null, { email });
 };

--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import _ from "lodash";
 import { Reaction } from "/client/api";
 import * as Collections from "/lib/collections";
@@ -62,7 +61,7 @@ export function getInvitableGroups(groups) {
  */
 export function getDefaultUserInviteGroup(groups) {
   let result;
-  const user = Collections.Accounts.findOne({ userId: Meteor.userId() });
+  const user = Collections.Accounts.findOne({ userId: Reaction.getUserId() });
   result = groups.find((grp) => user && user.groups.indexOf(grp._id) > -1);
 
   if (result && result.slug === "owner") {

--- a/imports/plugins/core/accounts/client/helpers/templates.js
+++ b/imports/plugins/core/accounts/client/helpers/templates.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Roles } from "meteor/alanning:roles";
 import { Reaction, i18next, i18nextDep } from "/client/api";
@@ -13,7 +12,7 @@ import * as Collections from "/lib/collections";
 Template.registerHelper("displayName", (displayUser) => {
   i18nextDep.depend();
 
-  const user = displayUser || Collections.Accounts.findOne(Meteor.userId());
+  const user = displayUser || Collections.Accounts.findOne(Reaction.getUserId());
   if (user) {
     if (user.name) {
       return user.name;

--- a/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
+++ b/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
@@ -90,7 +90,7 @@ Template.accountsDashboard.helpers({
 });
 
 Template.accountsSettings.onCreated(function () {
-  this.subscribe("ServiceConfiguration", Meteor.userId());
+  this.subscribe("ServiceConfiguration", Reaction.getUserId());
 });
 
 Template.accountsSettings.helpers({

--- a/imports/plugins/core/accounts/client/templates/members/member.js
+++ b/imports/plugins/core/accounts/client/templates/members/member.js
@@ -38,14 +38,14 @@ Template.member.events({
 
 Template.memberSettings.helpers({
   isOwnerDisabled() {
-    if (Meteor.userId() === this.userId) {
+    if (Reaction.getUserId() === this.userId) {
       if (Roles.userIsInRole(this.userId, "owner", this.shopId)) {
         return true;
       }
     }
   },
   userId() {
-    return Meteor.userId();
+    return Reaction.getUserId();
   },
   hasPermissionChecked(permission, userId) {
     if (userId && Roles.userIsInRole(userId, permission, this.shopId || Roles.userIsInRole(

--- a/imports/plugins/core/accounts/client/templates/profile/profile.js
+++ b/imports/plugins/core/accounts/client/templates/profile/profile.js
@@ -16,7 +16,7 @@ import { Components } from "@reactioncommerce/reaction-components";
  */
 function isOwnerOfProfile() {
   const targetUserId = Reaction.Router.getQueryParam("userId");
-  const loggedInUserId = Meteor.userId();
+  const loggedInUserId = Reaction.getUserId();
   return targetUserId === undefined || targetUserId === loggedInUserId;
 }
 
@@ -28,7 +28,7 @@ function isOwnerOfProfile() {
  * @return {Object} - the account of the identified user.
  */
 function getTargetAccount() {
-  const targetUserId = Reaction.Router.getQueryParam("userId") || Meteor.userId();
+  const targetUserId = Reaction.Router.getQueryParam("userId") || Reaction.getUserId();
   const account = Collections.Accounts.findOne(targetUserId);
 
   return account;
@@ -98,7 +98,7 @@ Template.accountProfile.helpers({
    * @ignore
    */
   ReactionAvatar() {
-    const account = Collections.Accounts.findOne({ _id: Meteor.userId() });
+    const account = Collections.Accounts.findOne({ _id: Reaction.getUserId() });
     if (account && account.profile && account.profile.picture) {
       const { picture } = account.profile;
       return {
@@ -145,7 +145,7 @@ Template.accountProfile.helpers({
    * @ignore
    */
   userOrders() {
-    const targetUserId = Reaction.Router.getQueryParam("userId") || Meteor.userId();
+    const targetUserId = Reaction.Router.getQueryParam("userId") || Reaction.getUserId();
     const account = Collections.Accounts.findOne({ userId: targetUserId });
     const accountId = (account && account._id) || targetUserId;
     const orderSub = Meteor.subscribe("AccountOrders", accountId);
@@ -216,7 +216,7 @@ Template.accountProfile.helpers({
    */
   showMerchantSignup() {
     if (Reaction.Subscriptions && Reaction.Subscriptions.Account && Reaction.Subscriptions.Account.ready()) {
-      const account = Collections.Accounts.findOne({ _id: Meteor.userId() });
+      const account = Collections.Accounts.findOne({ _id: Reaction.getUserId() });
       const marketplaceEnabled = Reaction.marketplace && Reaction.marketplace.enabled === true;
       const allowMerchantSignup = Reaction.marketplace && Reaction.marketplace.allowMerchantSignup === true;
       // A user has the primaryShopId until a shop is created for them.

--- a/imports/plugins/core/accounts/server/methods/addUserPermissions.js
+++ b/imports/plugins/core/accounts/server/methods/addUserPermissions.js
@@ -1,5 +1,4 @@
 import Logger from "@reactioncommerce/logger";
-import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
@@ -16,7 +15,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @returns {Boolean} success/failure
  */
 export default function addUserPermissions(userId, permissions, group) {
-  if (!Reaction.hasPermission("reaction-accounts", Meteor.userId(), group)) {
+  if (!Reaction.hasPermission("reaction-accounts", Reaction.getUserId(), group)) {
     throw new ReactionError("access-denied", "Access denied");
   }
   check(userId, Match.OneOf(String, Array));

--- a/imports/plugins/core/accounts/server/methods/addressBookAdd.js
+++ b/imports/plugins/core/accounts/server/methods/addressBookAdd.js
@@ -1,8 +1,8 @@
-import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import * as Schemas from "/lib/collections/schemas";
 import addressBookAddMutation from "../no-meteor/mutations/addressBookAdd";
 import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
  * @name accounts/addressBookAdd
@@ -22,6 +22,6 @@ export default function addressBookAdd(address, accountUserId, cartId) {
 
   this.unblock();
 
-  const context = Promise.await(getGraphQLContextInMeteorMethod(Meteor.userId()));
+  const context = Promise.await(getGraphQLContextInMeteorMethod(Reaction.getUserId()));
   return addressBookAddMutation(context, address, accountUserId);
 }

--- a/imports/plugins/core/accounts/server/methods/addressBookUpdate.js
+++ b/imports/plugins/core/accounts/server/methods/addressBookUpdate.js
@@ -22,18 +22,16 @@ export default function addressBookUpdate(address, accountUserId, type) {
   check(accountUserId, Match.Maybe(String));
   check(type, Match.Maybe(String));
 
-  // security, check for admin access. We don't need to check every user call
-  // here because we are calling `Meteor.userId` from within this Method.
-  if (typeof accountUserId === "string") { // if this will not be a String -
-    // `check` will not pass it.
-    if (Meteor.userId() !== accountUserId && !Reaction.hasPermission("reaction-accounts")) {
+  // security check for admin access
+  if (typeof accountUserId === "string") {
+    if (Reaction.getUserId() !== accountUserId && !Reaction.hasPermission("reaction-accounts")) {
       throw new ReactionError("access-denied", "Access denied");
     }
   }
   this.unblock();
 
   // If no userId is provided, use the current user
-  const userId = accountUserId || Meteor.userId();
+  const userId = accountUserId || Reaction.getUserId();
   // Find old state of isShippingDefault & isBillingDefault to compare and reflect in cart
   const account = Accounts.findOne({ userId });
   const oldAddress = (account.profile.addressBook || []).find((addr) => addr._id === address._id);
@@ -92,7 +90,7 @@ export default function addressBookUpdate(address, accountUserId, type) {
   });
 
   // Run afterAccountsUpdate hook to update Accounts Search
-  Hooks.Events.run("afterAccountsUpdate", Meteor.userId(), {
+  Hooks.Events.run("afterAccountsUpdate", userId, {
     accountId: account._id,
     updatedFields
   });

--- a/imports/plugins/core/accounts/server/methods/currentUserHasPassword.js
+++ b/imports/plugins/core/accounts/server/methods/currentUserHasPassword.js
@@ -1,4 +1,5 @@
 import { Meteor } from "meteor/meteor";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
  * @name accounts/currentUserHasPassword
@@ -9,6 +10,6 @@ import { Meteor } from "meteor/meteor";
  * @private
  */
 export default function currentUserHasPassword() {
-  const user = Meteor.users.findOne(Meteor.userId());
+  const user = Meteor.users.findOne(Reaction.getUserId());
   return !!user.services.password;
 }

--- a/imports/plugins/core/accounts/server/methods/getUserId.js
+++ b/imports/plugins/core/accounts/server/methods/getUserId.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 
 /**
+ * @deprecated Use Reaction.getUserId instead
  * @name reaction/getUserId
  * @method
  * @memberof Reaction/Methods

--- a/imports/plugins/core/accounts/server/methods/group/addUser.js
+++ b/imports/plugins/core/accounts/server/methods/group/addUser.js
@@ -21,7 +21,7 @@ function changeMarketplaceOwner({ userId, permissions }) {
   // give global marketplace role to new owner
   Roles.setUserRoles(userId, permissions, Roles.GLOBAL_GROUP);
   // remove global from previous owner
-  Meteor.users.update({ _id: Meteor.userId() }, { $unset: { [`roles.${Roles.GLOBAL_GROUP}`]: "" } });
+  Meteor.users.update({ _id: Reaction.getUserId() }, { $unset: { [`roles.${Roles.GLOBAL_GROUP}`]: "" } });
 }
 
 /**
@@ -40,7 +40,7 @@ export default function addUser(userId, groupId) {
   check(groupId, String);
   const group = Groups.findOne({ _id: groupId }) || {};
   const { permissions, shopId, slug } = group;
-  const loggedInUserId = Meteor.userId();
+  const loggedInUserId = Reaction.getUserId();
   const canInvite = Reaction.canInviteToGroup({ group });
 
   // we are limiting group method actions to only users with admin roles
@@ -58,7 +58,7 @@ export default function addUser(userId, groupId) {
 
   if (slug === "owner") {
     // if adding a user to the owner group, check that the request is done by current owner
-    if (!Reaction.hasPermission("owner", Meteor.userId(), shopId)) {
+    if (!Reaction.hasPermission("owner", Reaction.getUserId(), shopId)) {
       throw new ReactionError("access-denied", "Access Denied");
     }
   }
@@ -90,7 +90,7 @@ export default function addUser(userId, groupId) {
         changeMarketplaceOwner({ userId, permissions });
       }
       // remove current shop owner after setting another admin as the new owner
-      Meteor.call("group/addUser", Meteor.userId(), currentUserGrpInShop);
+      Meteor.call("group/addUser", Reaction.getUserId(), currentUserGrpInShop);
     }
 
     // Return the group the account as added to

--- a/imports/plugins/core/accounts/server/methods/group/createGroup.js
+++ b/imports/plugins/core/accounts/server/methods/group/createGroup.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import Logger from "@reactioncommerce/logger";
 import { check, Match } from "meteor/check";
-import { Meteor } from "meteor/meteor";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Groups } from "/lib/collections";
@@ -30,7 +29,7 @@ export default function createGroup(groupData, shopId) {
 
   // we are limiting group method actions to only users with admin roles
   // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
-  if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
+  if (!Reaction.hasPermission("admin", Reaction.getUserId(), shopId)) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 

--- a/imports/plugins/core/accounts/server/methods/group/removeUser.js
+++ b/imports/plugins/core/accounts/server/methods/group/removeUser.js
@@ -1,7 +1,6 @@
 import Hooks from "@reactioncommerce/hooks";
 import Logger from "@reactioncommerce/logger";
 import { check } from "meteor/check";
-import { Meteor } from "meteor/meteor";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Accounts, Groups } from "/lib/collections";
@@ -28,7 +27,7 @@ export default function removeUser(userId, groupId) {
 
   // we are limiting group method actions to only users with admin roles
   // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
-  if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
+  if (!Reaction.hasPermission("admin", Reaction.getUserId(), shopId)) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 
@@ -39,7 +38,7 @@ export default function removeUser(userId, groupId) {
   try {
     setUserPermissions(user, defaultCustomerGroupForShop.permissions, shopId);
     Accounts.update({ _id: userId, groups: groupId }, { $set: { "groups.$": defaultCustomerGroupForShop._id } }); // replace the old id with new id
-    Hooks.Events.run("afterAccountsUpdate", Meteor.userId(), {
+    Hooks.Events.run("afterAccountsUpdate", Reaction.getUserId(), {
       accountId: userId,
       updatedFields: ["groups"]
     });

--- a/imports/plugins/core/accounts/server/methods/group/updateGroup.js
+++ b/imports/plugins/core/accounts/server/methods/group/updateGroup.js
@@ -1,6 +1,5 @@
 import Logger from "@reactioncommerce/logger";
 import { check } from "meteor/check";
-import { Meteor } from "meteor/meteor";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Accounts, Groups } from "/lib/collections";
@@ -27,7 +26,7 @@ export default function updateGroup(groupId, newGroupData, shopId) {
 
   // we are limiting group method actions to only users with admin roles
   // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
-  if (!Reaction.hasPermission("admin", Meteor.userId(), shopId)) {
+  if (!Reaction.hasPermission("admin", Reaction.getUserId(), shopId)) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 

--- a/imports/plugins/core/accounts/server/methods/markAddressValidationBypassed.js
+++ b/imports/plugins/core/accounts/server/methods/markAddressValidationBypassed.js
@@ -1,7 +1,7 @@
-import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Accounts, Cart } from "/lib/collections";
 import appEvents from "/imports/plugins/core/core/server/appEvents";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
  * @name accounts/markAddressValidationBypassed
@@ -13,7 +13,7 @@ import appEvents from "/imports/plugins/core/core/server/appEvents";
  */
 export default function markAddressValidationBypassed(value = true) {
   check(value, Boolean);
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const account = Accounts.findOne({ userId }, { fields: { _id: 1 } });
   const updateResult = Cart.update({ accountId: account._id }, { $set: { bypassAddressValidation: value } });
 

--- a/imports/plugins/core/accounts/server/methods/markTaxCalculationFailed.js
+++ b/imports/plugins/core/accounts/server/methods/markTaxCalculationFailed.js
@@ -1,7 +1,7 @@
-import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Accounts, Cart } from "/lib/collections";
 import appEvents from "/imports/plugins/core/core/server/appEvents";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
  * @name accounts/markTaxCalculationFailed
@@ -13,7 +13,7 @@ import appEvents from "/imports/plugins/core/core/server/appEvents";
  */
 export default function markTaxCalculationFailed(value = true) {
   check(value, Boolean);
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const account = Accounts.findOne({ userId }, { fields: { _id: 1 } });
   const updateResult = Cart.update({ accountId: account._id }, { $set: { taxCalculationFailed: value } });
 

--- a/imports/plugins/core/accounts/server/methods/removeUserPermissions.js
+++ b/imports/plugins/core/accounts/server/methods/removeUserPermissions.js
@@ -1,5 +1,4 @@
 import Logger from "@reactioncommerce/logger";
-import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
@@ -16,7 +15,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @returns {Boolean} success/failure
  */
 export default function removeUserPermissions(userId, permissions, group) {
-  if (!Reaction.hasPermission("reaction-accounts", Meteor.userId(), group)) {
+  if (!Reaction.hasPermission("reaction-accounts", Reaction.getUserId(), group)) {
     throw new ReactionError("access-denied", "Access denied");
   }
   check(userId, String);

--- a/imports/plugins/core/accounts/server/methods/setUserPermissions.js
+++ b/imports/plugins/core/accounts/server/methods/setUserPermissions.js
@@ -1,5 +1,4 @@
 import Logger from "@reactioncommerce/logger";
-import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
@@ -15,7 +14,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @returns {Boolean} returns Roles.setUserRoles result
  */
 export default function setUserPermissions(userId, permissions, group) {
-  if (!Reaction.hasPermission("reaction-accounts", Meteor.userId(), group)) {
+  if (!Reaction.hasPermission("reaction-accounts", Reaction.getUserId(), group)) {
     throw new ReactionError("access-denied", "Access denied");
   }
   check(userId, String);

--- a/imports/plugins/core/accounts/server/no-meteor/mutations/addressBookAdd.js
+++ b/imports/plugins/core/accounts/server/no-meteor/mutations/addressBookAdd.js
@@ -22,8 +22,7 @@ export default async function addressBookAdd(context, address, accountUserId) {
 
   if (!account) throw new ReactionError("not-found", "No account found");
 
-  // security, check for admin access. We don't need to check every user call
-  // here because we are calling `Meteor.userId` from within this Method.
+  // Security check for admin access
   if (typeof accountUserId === "string" && userIdFromContext !== accountUserId) {
     if (!userHasPermission(["reaction-accounts"], account.shopId)) throw new ReactionError("access-denied", "Access denied");
   }

--- a/imports/plugins/core/cart/client/util/getCart.js
+++ b/imports/plugins/core/cart/client/util/getCart.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import { Reaction } from "/client/api";
 import { Accounts, Cart } from "/lib/collections";
 import { getAnonymousCartsReactive } from "./anonymousCarts";
@@ -8,7 +7,7 @@ import { getAnonymousCartsReactive } from "./anonymousCarts";
  * @returns {Object|null} The cart document or null
  */
 export default function getCart() {
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const account = (userId && Accounts.findOne({ userId })) || null;
 
   const shopId = Reaction.getCartShopId();

--- a/imports/plugins/core/cart/server/methods/addToCart.js
+++ b/imports/plugins/core/cart/server/methods/addToCart.js
@@ -31,7 +31,7 @@ export default function addToCart(cartId, token, items) {
   // In Meteor app we always have a user, but it may have "anonymous" role, meaning
   // it was auto-created as a kind of session. If so, we fool the createCart mutation
   // into thinking there is no user so that it will create an anonymous cart.
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
   const userIdForContext = anonymousUser ? null : userId;
 

--- a/imports/plugins/core/cart/server/methods/createCart.js
+++ b/imports/plugins/core/cart/server/methods/createCart.js
@@ -24,7 +24,7 @@ export default function createCartMethod(items) {
   // In Meteor app we always have a user, but it may have "anonymous" role, meaning
   // it was auto-created as a kind of session. If so, we fool the createCart mutation
   // into thinking there is no user so that it will create an anonymous cart.
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
   const userIdForContext = anonymousUser ? null : userId;
 

--- a/imports/plugins/core/cart/server/methods/mergeCart.js
+++ b/imports/plugins/core/cart/server/methods/mergeCart.js
@@ -2,6 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
 import reconcileCarts from "../no-meteor/mutations/reconcileCarts";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
  * @method cart/mergeCart
@@ -20,7 +21,7 @@ export default function mergeCart(anonymousCartId, anonymousCartToken) {
   check(anonymousCartToken, String);
 
   // Pass through to the new mutation function at this point
-  const context = Promise.await(getGraphQLContextInMeteorMethod(Meteor.userId()));
+  const context = Promise.await(getGraphQLContextInMeteorMethod(Reaction.getUserId()));
   const { cart } = Promise.await(reconcileCarts(context, {
     anonymousCartId,
     anonymousCartToken,

--- a/imports/plugins/core/cart/server/methods/setShipmentAddress.js
+++ b/imports/plugins/core/cart/server/methods/setShipmentAddress.js
@@ -29,7 +29,7 @@ export default function setShipmentAddress(cartId, cartToken, address) {
 
   // In Meteor app we always have a user, but it may have "anonymous" role, meaning
   // it was auto-created as a kind of session.
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
   const userIdForContext = anonymousUser ? null : userId;
 

--- a/imports/plugins/core/cart/server/methods/setShipmentMethod.js
+++ b/imports/plugins/core/cart/server/methods/setShipmentMethod.js
@@ -37,7 +37,7 @@ export default function setShipmentMethod(cartId, cartToken, methodId) {
 
   // In Meteor app we always have a user, but it may have "anonymous" role, meaning
   // it was auto-created as a kind of session.
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
   const userIdForContext = anonymousUser ? null : userId;
 

--- a/imports/plugins/core/cart/server/util/getCart.js
+++ b/imports/plugins/core/cart/server/util/getCart.js
@@ -6,7 +6,7 @@ import Reaction from "/imports/plugins/core/core/server/Reaction";
 import hashLoginToken from "/imports/plugins/core/accounts/server/no-meteor/util/hashLoginToken";
 
 /**
- * @summary Gets the current cart. Assumes a calling context where Meteor.userId() works. It works
+ * @summary Gets the current cart. Assumes a calling context where logged in userID can be retrieved. It works
  *   in all client code, in server methods, and in server publications.
  * @param {String} [cartId] Limit the search by this cart ID if provided.
  * @param {Object} [options] Options
@@ -21,7 +21,7 @@ export default function getCart(cartId, { cartToken, throwIfNotFound = false } =
     throw new Meteor.Error("not-found", "Cart not found");
   }
 
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   let account = null;
   const selector = { shopId };
   if (cartId) {

--- a/imports/plugins/core/core/server/Reaction/accountUtils.js
+++ b/imports/plugins/core/core/server/Reaction/accountUtils.js
@@ -1,0 +1,10 @@
+import { Meteor } from "meteor/meteor";
+
+/**
+ * @method getUserId
+ * @summary returns the userId of logged in user (e.g Meteor.userId())
+ * @return {String} String
+ */
+export function getUserId() {
+  return Meteor.userId();
+}

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -15,6 +15,7 @@ import processJobs from "./processJobs";
 import sendVerificationEmail from "./sendVerificationEmail";
 import { registerTemplate } from "./templates";
 import { AbsoluteUrlMixin } from "./absoluteUrl";
+import { getUserId } from "./accountUtils";
 
 /**
  * @file Server core methods
@@ -99,7 +100,7 @@ export default {
     const groupPermissions = group.permissions;
 
     // granting invitation right for user with `owner` role in a shop
-    if (this.hasPermission(["owner"], Meteor.userId(), group.shopId)) {
+    if (this.hasPermission(["owner"], getUserId(), group.shopId)) {
       return true;
     }
 
@@ -123,11 +124,11 @@ export default {
    * @memberof Core
    * @summary server permissions checks hasPermission exists on both the server and the client.
    * @param {String | Array} checkPermissions -String or Array of permissions if empty, defaults to "admin, owner"
-   * @param {String} userId - userId, defaults to Meteor.userId()
+   * @param {String} userId - userId, defaults to logged in userId
    * @param {String} checkGroup group - default to shopId
    * @return {Boolean} Boolean - true if has permission
    */
-  hasPermission(checkPermissions, userId = Meteor.userId(), checkGroup = this.getShopId()) {
+  hasPermission(checkPermissions, userId = getUserId(), checkGroup = this.getShopId()) {
     // check(checkPermissions, Match.OneOf(String, Array)); check(userId, String); check(checkGroup,
     // Match.Optional(String));
     let permissions;
@@ -192,11 +193,11 @@ export default {
    * @method
    * @memberof Core
    * @param  {array} roles an array of roles to check. Will return a shopId if the user has _any_ of the roles
-   * @param  {string} [userId=Meteor.userId()] Optional userId, defaults to Meteor.userId()
+   * @param  {string} userId Optional userId, defaults to logged in userId
    *                                           Must pass this.userId from publications to avoid error!
    * @return {array} Array of shopIds that the user has at least one of the given set of roles for
    */
-  getShopsWithRoles(roles, userId = Meteor.userId()) {
+  getShopsWithRoles(roles, userId = getUserId()) {
     // Owner permission for a shop superceeds grantable permissions, so we always check for owner permissions as well
     roles.push("owner");
 
@@ -373,9 +374,9 @@ export default {
 
     try {
       // otherwise, find the shop by user settings
-      shopId = this.getUserShopId(Meteor.userId());
+      shopId = this.getUserShopId(getUserId());
     } catch (_e) {
-      // `Meteor.userId` will raise an error when invoked outside of a method
+      // an error when invoked outside of a method
       // call or publication, i.e., at startup. That's ok here.
     }
 
@@ -448,7 +449,7 @@ export default {
    * @memberof Core
    * @summary Get a user's shop ID, as stored in preferences
    * @todo This should intelligently find the correct default shop Probably whatever the main shop is or marketplace
-   * @param {String} userId (probably Meteor.userId())
+   * @param {String} userId (probably logged in userId)
    * @return {StringId} active shop ID
    */
   getUserShopId(userId) {

--- a/imports/plugins/core/core/server/Reaction/index.js
+++ b/imports/plugins/core/core/server/Reaction/index.js
@@ -12,9 +12,11 @@ import setDomain from "./setDomain";
 import setShopName from "./setShopName";
 import * as Collections from "/lib/collections";
 import * as Schemas from "/lib/collections/schemas";
+import * as accountUtils from "./accountUtils";
 
 export default {
   ...Core,
+  ...accountUtils,
   addRolesToGroups,
   assignOwnerRoles,
   Collections,

--- a/imports/plugins/core/core/server/methods/shop/createShop.js
+++ b/imports/plugins/core/core/server/methods/shop/createShop.js
@@ -73,9 +73,10 @@ export default function createShop(shopAdminUserId, partialShopData) {
 
   // Get the current marketplace settings
   const marketplace = Reaction.getMarketplaceSettings();
+  const userId = Reaction.getUserId();
 
   // check to see if the current user has owner permissions for the primary shop
-  const hasPrimaryShopOwnerPermission = Reaction.hasPermission("owner", Meteor.userId(), Reaction.getPrimaryShopId());
+  const hasPrimaryShopOwnerPermission = Reaction.hasPermission("owner", userId, Reaction.getPrimaryShopId());
 
   // only permit merchant signup if marketplace is enabled and allowMerchantSignup is enabled
   let allowMerchantShopCreation = false;
@@ -89,13 +90,13 @@ export default function createShop(shopAdminUserId, partialShopData) {
   }
 
   // Non-admin users may only create shops for themselves
-  if (!hasPrimaryShopOwnerPermission && shopAdminUserId !== Meteor.userId()) {
+  if (!hasPrimaryShopOwnerPermission && shopAdminUserId !== userId) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 
   // Anonymous users should never be permitted to create a shop
   if (!hasPrimaryShopOwnerPermission &&
-      Reaction.hasPermission("anonymous", Meteor.userId(), Reaction.getPrimaryShopId())) {
+      Reaction.hasPermission("anonymous", userId, Reaction.getPrimaryShopId())) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 

--- a/imports/plugins/core/core/server/methods/shop/getLocale.js
+++ b/imports/plugins/core/core/server/methods/shop/getLocale.js
@@ -95,7 +95,7 @@ export default function getLocale() {
   });
 
   // adjust user currency
-  const account = Accounts.findOne({ userId: Meteor.userId() });
+  const account = Accounts.findOne({ userId: Reaction.getUserId() });
   let profileCurrency = account && account.profile && account.profile.currency;
   if (account && !profileCurrency) {
     [localeCurrency] = localeCurrency;

--- a/imports/plugins/core/core/server/methods/shop/updateBrandAssets.js
+++ b/imports/plugins/core/core/server/methods/shop/updateBrandAssets.js
@@ -1,5 +1,4 @@
 import { check } from "meteor/check";
-import { Meteor } from "meteor/meteor";
 import { Reaction } from "/lib/api";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Shops } from "/lib/collections";

--- a/imports/plugins/core/core/server/methods/shop/updateBrandAssets.js
+++ b/imports/plugins/core/core/server/methods/shop/updateBrandAssets.js
@@ -10,11 +10,11 @@ import { Shops } from "/lib/collections";
  * @param {String} shopId - the shop id corresponding to the shop for which
  *                 the asset should be applied (defaults to Reaction.getShopId())
  * @param {String} userId - the user id on whose behalf we are performing this
- *                 action (defaults to Meteor.userId())
+ *                 action (defaults to logged in user ID)
  * @return {Int} returns update result
  * @private
  */
-function updateShopBrandAssets(asset, shopId = Reaction.getShopId(), userId = Meteor.userId()) {
+function updateShopBrandAssets(asset, shopId = Reaction.getShopId(), userId = Reaction.getUserId) {
   check(asset, {
     mediaId: String,
     type: String

--- a/imports/plugins/core/core/server/methods/updatePackage.js
+++ b/imports/plugins/core/core/server/methods/updatePackage.js
@@ -20,7 +20,7 @@ export default function updatePackage(packageName, field, value) {
   check(field, String);
   check(value, Object);
 
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const shopId = Reaction.getShopId();
   if (!Reaction.hasPermission([packageName], userId, shopId)) {
     throw new ReactionError("access-denied", `Access Denied. You don't have permissions for the ${packageName} package.`);

--- a/imports/plugins/core/core/server/methods/updatePackage.js
+++ b/imports/plugins/core/core/server/methods/updatePackage.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import { Packages } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";

--- a/imports/plugins/core/core/server/publications/collections/accounts.js
+++ b/imports/plugins/core/core/server/publications/collections/accounts.js
@@ -9,7 +9,7 @@ import Reaction from "/imports/plugins/core/core/server/Reaction";
  */
 
 Meteor.publish("Accounts", function () {
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
 
   if (!userId) {
     return this.ready();

--- a/imports/plugins/core/core/server/publications/collections/cart.js
+++ b/imports/plugins/core/core/server/publications/collections/cart.js
@@ -2,13 +2,14 @@ import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Accounts, Cart, MediaRecords } from "/lib/collections";
 import hashLoginToken from "/imports/plugins/core/accounts/server/no-meteor/util/hashLoginToken";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 Meteor.publish("Cart", function (accountId, anonymousCarts, shopId) {
   check(accountId, Match.Maybe(String));
   check(anonymousCarts, Match.Maybe([Object]));
   check(shopId, Match.Maybe(String));
 
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   let account;
   if (userId) {
     account = Accounts.findOne({ userId }, { fields: { _id: 1 } });

--- a/imports/plugins/core/core/server/publications/collections/orders.js
+++ b/imports/plugins/core/core/server/publications/collections/orders.js
@@ -138,7 +138,7 @@ Meteor.publish("AccountOrders", function (accountId) {
 
   const account = this.userId ? Accounts.findOne({ userId: this.userId }) : null;
   const contextAccountId = account && account._id;
-  if (accountId !== contextAccountId && !Reaction.hasPermission("orders", Meteor.userId(), shopId)) {
+  if (accountId !== contextAccountId && !Reaction.hasPermission("orders", Reaction.getUserId(), shopId)) {
     return this.ready();
   }
 
@@ -159,7 +159,7 @@ Meteor.publish("AccountOrders", function (accountId) {
 Meteor.publish("CompletedCartOrder", (cartId) => {
   check(cartId, String);
 
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const account = userId ? Accounts.findOne({ userId }) : null;
   const accountId = account && account._id;
 

--- a/imports/plugins/core/core/server/startup/collection-security.js
+++ b/imports/plugins/core/core/server/startup/collection-security.js
@@ -46,7 +46,7 @@ export default function () {
       if (!arg) throw new Error("ifHasRole security rule method requires an argument");
       if (arg.role) {
         // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
-        // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
+        // if not passed, getShopId can default to primaryShopId if userId is not available in the context the code is run
         const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
         return Roles.userIsInRole(userId, arg.role, shopId);
@@ -61,7 +61,7 @@ export default function () {
     fetch: [],
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
-      // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
+      // if not passed, getShopId can default to primaryShopId if userId is not available in the context the code is run
       const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc.shopId !== shopId;
@@ -73,7 +73,7 @@ export default function () {
     fetch: [],
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
-      // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
+      // if not passed, getShopId can default to primaryShopId if userId is not available in the context the code is run
       const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc._id !== shopId;
@@ -84,7 +84,7 @@ export default function () {
     fetch: [],
     deny(type, arg, userId, doc) {
       // Note: userId is passed to getShopId to ensure that it returns the correct shop based on the User Preference
-      // if not passed, getShopId can default to primaryShopId if Meteor.userId is not available in the context the code is run
+      // if not passed, getShopId can default to primaryShopId if userId is not available in the context the code is run
       const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
       return doc.metadata.shopId !== shopId;

--- a/imports/plugins/core/core/server/util/connectionDataStore.js
+++ b/imports/plugins/core/core/server/util/connectionDataStore.js
@@ -4,7 +4,6 @@ const inMemoryCache = {};
 const connectionKey = "connection-data";
 
 function connectionData() {
-  // similar to Meteor.userId()
   const invocation =
     DDP._CurrentMethodInvocation.get() ||
     DDP._CurrentPublicationInvocation.get();

--- a/imports/plugins/core/dashboard/client/containers/packageListContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/packageListContainer.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { composeWithTracker } from "@reactioncommerce/reaction-components";
-import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { Roles } from "meteor/alanning:roles";
 import { Reaction } from "/client/api";
@@ -43,7 +42,7 @@ function handleOpenShortcut(event, app) {
 }
 
 function composer(props, onData) {
-  const audience = Roles.getRolesForUser(Meteor.userId(), Reaction.getShopId());
+  const audience = Roles.getRolesForUser(Reaction.getUserId(), Reaction.getShopId());
   const settings = Reaction.Apps({ provides: "settings", enabled: true, audience }) || [];
 
   const dashboard = Reaction.Apps({ provides: "dashboard", enabled: true, audience })

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -59,7 +59,7 @@ function composer(props, onData) {
     const registryItems = Reaction.Apps({ provides: "settings", container: "dashboard" });
 
     for (const item of registryItems) {
-      if (Reaction.hasPermission(item.route, Meteor.userId())) {
+      if (Reaction.hasPermission(item.route, Reaction.getUserId())) {
         let { icon } = item;
         if (!item.icon && item.provides && item.provides.includes("settings")) {
           icon = "gear";
@@ -84,7 +84,7 @@ function composer(props, onData) {
     isPreview: Reaction.isPreview(),
     isActionViewAtRootView: Reaction.isActionViewAtRootView(),
     actionViewIsOpen: Reaction.isActionViewOpen(),
-    hasCreateProductAccess: Reaction.hasPermission("createProduct", Meteor.userId(), Reaction.getShopId()),
+    hasCreateProductAccess: Reaction.hasPermission("createProduct", Reaction.getUserId(), Reaction.getShopId()),
     shopId: Reaction.getShopId(),
     shops,
 

--- a/imports/plugins/core/dashboard/client/templates/import/import.js
+++ b/imports/plugins/core/dashboard/client/templates/import/import.js
@@ -6,7 +6,7 @@ import { Media } from "/imports/plugins/core/files/client";
 
 function uploadHandler(event) {
   const shopId = Reaction.getShopId();
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const { files } = event.target.files;
 
   for (let i = 0; i < files.length; i += 1) {

--- a/imports/plugins/core/dashboard/client/templates/import/import.js
+++ b/imports/plugins/core/dashboard/client/templates/import/import.js
@@ -1,5 +1,4 @@
 import { Template } from "meteor/templating";
-import { Meteor } from "meteor/meteor";
 import { FileRecord } from "@reactioncommerce/file-collections";
 import { Logger, Reaction } from "/client/api";
 import { Products } from "/lib/collections";

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -38,7 +38,7 @@ Template.shopSettings.helpers({
       selectedMediaId = shop.brandAssets[0].mediaId;
     }
 
-    const userId = Meteor.userId();
+    const userId = Reaction.getUserId();
     const metadata = { type: "brandAsset", ownerId: userId, shopId };
 
     const brandMediaList = Media.findLocal({

--- a/imports/plugins/core/discounts/server/methods/methods.js
+++ b/imports/plugins/core/discounts/server/methods/methods.js
@@ -90,7 +90,7 @@ export const methods = {
 
     const transaction = {
       cartId,
-      userId: Meteor.userId(),
+      userId: Reaction.getUserId(),
       appliedAt: new Date()
     };
     // double duty validation, plus we need the method

--- a/imports/plugins/core/i18n/client/containers/currencyDropdown.js
+++ b/imports/plugins/core/i18n/client/containers/currencyDropdown.js
@@ -44,7 +44,7 @@ const composer = (props, onData) => {
     });
 
     const user = Accounts.findOne({
-      _id: Meteor.userId()
+      _id: Reaction.getUserId()
     });
     const profileCurrency = user && user.profile && user.profile.currency;
 

--- a/imports/plugins/core/i18n/client/containers/languageDropdown.js
+++ b/imports/plugins/core/i18n/client/containers/languageDropdown.js
@@ -7,7 +7,7 @@ import LanguageDropdown from "../components/languageDropdown";
 
 const handlers = {
   handleChange(value) {
-    Meteor.users.update(Meteor.userId(), { $set: { "profile.lang": value } });
+    Meteor.users.update(Reaction.getUserId(), { $set: { "profile.lang": value } });
   }
 };
 

--- a/imports/plugins/core/i18n/server/methods/flushAllTranslations.js
+++ b/imports/plugins/core/i18n/server/methods/flushAllTranslations.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { reloadAllTranslations } from "/imports/plugins/core/core/server/startup/i18n";
@@ -12,7 +11,7 @@ import { reloadAllTranslations } from "/imports/plugins/core/core/server/startup
  * @return {undefined}
  */
 export default function flushAllTranslations() {
-  if (!Reaction.hasPermission("admin", Meteor.userId(), Reaction.getPrimaryShopId())) {
+  if (!Reaction.hasPermission("admin", Reaction.getUserId(), Reaction.getPrimaryShopId())) {
     throw new ReactionError("access-denied", "Access Denied");
   }
 

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -343,7 +343,7 @@ class LineItems extends Component {
         ))}
 
         {
-          Roles.userIsInRole(Meteor.userId(), ["orders", "dashboard/orders"], Reaction.getShopId()) &&
+          Roles.userIsInRole(Reaction.getUserId(), ["orders", "dashboard/orders"], Reaction.getShopId()) &&
           this.renderPopOver()
         }
       </Components.Button>

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { isEmpty } from "lodash";
 import classnames from "classnames";
-import { Meteor } from "meteor/meteor";
 import { Roles } from "meteor/alanning:roles";
 import { formatPriceString, Reaction } from "/client/api";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";

--- a/imports/plugins/core/orders/server/methods/addOrderEmail.js
+++ b/imports/plugins/core/orders/server/methods/addOrderEmail.js
@@ -1,7 +1,7 @@
-import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Orders } from "/lib/collections";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
  * @name orders/addOrderEmail
@@ -21,7 +21,7 @@ export default function addOrderEmail(cartId, email) {
     *provided for tracking order progress.
     */
 
-  if (!Meteor.userId()) {
+  if (!Reaction.getUserId()) {
     throw new ReactionError("access-denied", "Access Denied. You are not connected.");
   }
 

--- a/imports/plugins/core/orders/server/methods/cancelOrder.js
+++ b/imports/plugins/core/orders/server/methods/cancelOrder.js
@@ -36,7 +36,7 @@ export default function cancelOrder(order, returnToStock) {
     // Run this Product update inline instead of using ordersInventoryAdjust because the collection hooks fail
     // in some instances which causes the order not to cancel
     order.items.forEach((item) => {
-      if (Reaction.hasPermission("orders", Meteor.userId(), item.shopId)) {
+      if (Reaction.hasPermission("orders", Reaction.getUserId(), item.shopId)) {
         Products.update(
           {
             _id: item.variantId,

--- a/imports/plugins/core/orders/server/methods/updateHistory.js
+++ b/imports/plugins/core/orders/server/methods/updateHistory.js
@@ -1,4 +1,3 @@
-import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import { Orders } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";

--- a/imports/plugins/core/orders/server/methods/updateHistory.js
+++ b/imports/plugins/core/orders/server/methods/updateHistory.js
@@ -29,7 +29,7 @@ export default function updateHistory(orderId, event, value) {
       history: {
         event,
         value,
-        userId: Meteor.userId(),
+        userId: Reaction.getUserId(),
         updatedAt: new Date()
       }
     }

--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -14,6 +14,7 @@ import { Tracker } from "meteor/tracker";
 import { Packages, Shops } from "/lib/collections";
 import { getComponent } from "@reactioncommerce/reaction-components/components";
 import Hooks from "./hooks";
+import { Reaction } from "/lib/api";
 
 // Using a ternary operator here to avoid a mutable export - open to suggestions for a better way to do this
 export const history = Meteor.isClient ? createBrowserHistory() : createMemoryHistory();
@@ -348,7 +349,7 @@ function hasRoutePermission(route) {
 
   return routeName === "index" ||
     routeName === "not-found" ||
-    Router.Reaction.hasPermission(route.permissions, Meteor.userId());
+    Router.Reaction.hasPermission(route.permissions, Reaction.getUserId());
 }
 
 
@@ -515,7 +516,7 @@ function ReactionLayout(options = {}) {
       // If the current route is unauthorized, and is not the "not-found" route,
       // then override the template to use the default unauthorized template
       if (hasRoutePermission({ ...route, permissions }) === false && route.name !== "not-found" && !Meteor.user()) {
-        if (!Router.Reaction.hasPermission(route.permissions, Meteor.userId())) {
+        if (!Router.Reaction.hasPermission(route.permissions, Reaction.getUserId())) {
           structure.template = "unauthorized";
         }
         return false;

--- a/imports/plugins/core/shipping/server/methods/updateShipmentQuotes.js
+++ b/imports/plugins/core/shipping/server/methods/updateShipmentQuotes.js
@@ -1,6 +1,6 @@
-import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
 import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
  * @name shipping/updateShipmentQuotes
@@ -18,7 +18,7 @@ export default function updateShipmentQuotesMethod(cartId, fulfillmentGroupId, c
   check(cartToken, Match.Maybe(String));
   this.unblock();
 
-  const context = Promise.await(getGraphQLContextInMeteorMethod(Meteor.userId()));
+  const context = Promise.await(getGraphQLContextInMeteorMethod(Reaction.getUserId()));
   return context.mutations.fulfillment.updateFulfillmentOptionsForGroup(context, {
     cartId,
     cartToken,

--- a/imports/plugins/core/templates/server/methods.js
+++ b/imports/plugins/core/templates/server/methods.js
@@ -27,7 +27,7 @@ export const methods = {
     check(doc, Object);
 
     const shopId = Reaction.getShopId();
-    const userId = Meteor.userId();
+    const userId = Reaction.getUserId();
 
     // Check that this user has permission to update templates for the active shop
     if (!Reaction.hasPermission("reaction-templates", userId, shopId)) {

--- a/imports/plugins/core/ui/client/containers/avatar.js
+++ b/imports/plugins/core/ui/client/containers/avatar.js
@@ -1,5 +1,4 @@
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
-import { Meteor } from "meteor/meteor";
 import { Accounts } from "/lib/collections";
 import { Reaction } from "/client/api";
 import { ReactionAvatar } from "../components/avatar";

--- a/imports/plugins/core/ui/client/containers/avatar.js
+++ b/imports/plugins/core/ui/client/containers/avatar.js
@@ -15,7 +15,7 @@ const composer = (props, onData) => {
 
   // If there is no email provided, no query param provide, and the avatar is for the current user, find their account
   if (!email && !account && props.currentUser) {
-    account = Accounts.findOne(Meteor.userId());
+    account = Accounts.findOne(Reaction.getUserId());
   }
 
   // If we now have an account, and that account has an email address, return it

--- a/imports/plugins/core/ui/client/containers/mediaGallery.js
+++ b/imports/plugins/core/ui/client/containers/mediaGallery.js
@@ -136,7 +136,7 @@ const wrapComponent = (Comp) => (
       }
       const variantId = variant._id;
       const shopId = ReactionProduct.selectedProduct().shopId || Reaction.getShopId();
-      const userId = Meteor.userId();
+      const userId = Reaction.getUserId();
       let count = Media.findLocal({
         "metadata.variantId": variantId
       }).length;

--- a/imports/plugins/included/discount-codes/server/methods/methods.js
+++ b/imports/plugins/included/discount-codes/server/methods/methods.js
@@ -272,7 +272,7 @@ export const methods = {
         const users = Array.from(discount.transactions, (trans) => trans.userId);
         const transactionCount = new Map([...new Set(users)].map((userX) => [userX, users.filter((userY) => userY === userX).length]));
         const orders = Array.from(discount.transactions, (trans) => trans.cartId);
-        userCount = transactionCount.get(Meteor.userId());
+        userCount = transactionCount.get(Reaction.getUserId());
         orderCount = orders.length;
       }
       // check limits

--- a/imports/plugins/included/marketplace/client/templates/becomeSellerButton/becomeSellerButton.js
+++ b/imports/plugins/included/marketplace/client/templates/becomeSellerButton/becomeSellerButton.js
@@ -4,7 +4,7 @@ import { Reaction, i18next } from "/client/api";
 
 Template.becomeSellerButton.events({
   "click [data-event-action='button-click-become-seller']"() {
-    Meteor.call("shop/createShop", Meteor.userId(), (error, response) => {
+    Meteor.call("shop/createShop", Reaction.getUserId(), (error, response) => {
       if (error) {
         const errorMessage = i18next.t("marketplace.errorCannotCreateShop", { defaultValue: "Could not create shop for current user {{user}}" });
         return Alerts.toast(`${errorMessage} ${error}`, "error");

--- a/imports/plugins/included/notifications/client/containers/notification.js
+++ b/imports/plugins/included/notifications/client/containers/notification.js
@@ -2,10 +2,11 @@ import { compose, withProps } from "recompose";
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Meteor } from "meteor/meteor";
 import { Notifications } from "/lib/collections";
+import { Reaction } from "/client/api";
 import { Notification } from "../components";
 
 function composer(props, onData) {
-  if (Meteor.subscribe("Notification", Meteor.userId()).ready()) {
+  if (Meteor.subscribe("Notification", Reaction.getUserId()).ready()) {
     const notificationList = Notifications.find({}, { sort: { timeSent: -1 }, limit: 5 }).fetch();
     const unread = Notifications.find({ status: "unread" }).count();
 

--- a/imports/plugins/included/notifications/client/containers/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/containers/notificationRoute.js
@@ -2,6 +2,7 @@ import { compose, withProps } from "recompose";
 import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Meteor } from "meteor/meteor";
 import { Notifications } from "/lib/collections";
+import { Reaction } from "/client/api";
 import { NotificationRoute } from "../components";
 
 const handlers = {
@@ -14,7 +15,7 @@ const handlers = {
 };
 
 function composer(props, onData) {
-  if (Meteor.subscribe("Notification", Meteor.userId()).ready()) {
+  if (Meteor.subscribe("Notification", Reaction.getUserId()).ready()) {
     const notificationList = Notifications.find({}, { sort: { timeSent: -1 } }).fetch();
     const unread = Notifications.find({ status: "unread" }).count();
 

--- a/imports/plugins/included/notifications/server/hooks/notification.js
+++ b/imports/plugins/included/notifications/server/hooks/notification.js
@@ -33,7 +33,7 @@ const sendNotificationToAdmin = (adminUserId) => {
 };
 
 MethodHooks.after("cart/copyCartToOrder", (options) => {
-  const userId = Meteor.userId();
+  const userId = Reaction.getUserId();
   const type = "newOrder";
   const prefix = Reaction.getShopPrefix();
   const url = `${prefix}/notifications`;

--- a/imports/plugins/included/payments-stripe/server/methods/stripe-connect.js
+++ b/imports/plugins/included/payments-stripe/server/methods/stripe-connect.js
@@ -13,8 +13,8 @@ export const methods = {
     check(shopId, String);
     check(authCode, String);
 
-    if (!Reaction.hasPermission(["owner", "admin", "reaction-stripe"], Meteor.userId(), shopId)) {
-      Logger.warn(`user: ${Meteor.userId()} attempted to authorize merchant account
+    if (!Reaction.hasPermission(["owner", "admin", "reaction-stripe"], Reaction.getUserId(), shopId)) {
+      Logger.warn(`user: ${Reaction.getUserId()} attempted to authorize merchant account
         for shopId ${shopId} but was denied access due to insufficient privileges.`);
       throw new ReactionError("access-denied", "Access Denied");
     }

--- a/imports/plugins/included/product-variant/containers/productsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productsContainer.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { compose } from "recompose";
 import { registerComponent, composeWithTracker, Components } from "@reactioncommerce/reaction-components";
-import { Meteor } from "meteor/meteor";
 import { Reaction } from "/client/api";
 
 const ProductsContainer = ({ isAdmin }) => {
@@ -17,7 +16,7 @@ ProductsContainer.propTypes = {
 };
 
 function composer(props, onData) {
-  const isAdmin = Reaction.hasPermission("createProduct", Meteor.userId());
+  const isAdmin = Reaction.hasPermission("createProduct", Reaction.getUserId());
 
   onData(null, {
     isAdmin

--- a/lib/api/core.js
+++ b/lib/api/core.js
@@ -111,7 +111,7 @@ function getSellerShop(user, noFallback = false) {
   * @return {Array} - shopIds user has provided permissions for
   * @private
   */
-function getShopsForUser(roles, userId = Meteor.userId()) {
+function getShopsForUser(roles, userId = Reaction.getUserId()) {
   // Get full user object, and get shopIds of all shops they are attached to
   const user = Meteor.user(userId);
   if (!user || !user.roles) {
@@ -148,7 +148,7 @@ function getShopsForUser(roles, userId = Meteor.userId()) {
   * @return {Boolean} - true if the user has permissions for all the shops
   * @private
   */
-function hasPermissionForAll(roles, userId = Meteor.userId(), shopsOfUser) {
+function hasPermissionForAll(roles, userId = Reaction.getUserId(), shopsOfUser) {
   return !isEqual(getShopsForUser(["admin"], userId), shopsOfUser);
 }
 


### PR DESCRIPTION
Resolves #4571  
Impact: **minor**  
Type: **chore**

## Issue
Goal: As a first step towards being able to replace Meteor's Accounts package, we want to wrap all existing calls to Meteor.userId in a function. Thus establishing an 'API' to retrieve logged in user ID that can be customized in the future.

## Work
- Added of a getUserId() function on the client and server exports of `Reaction` namespace. It returns the value of Meteor.userId().

- Replaces all usage of Meteor.userId() with Reaction.getUserId()
- Marked existing `reaction/getUserId` method as deprecated. Reaction.getUserId should be used instead

- Extras
  - Removes an old `getGuestLoginState` function that was marked for removal in [release 1.5.6](https://github.com/reactioncommerce/reaction/pull/3172/commits/7af076b452b38ecb02813291b1032fe405abf836). It was removed here as it uses the Meteor.userId method we're moving from.
 

## Breaking changes
Core functionality of the app is untouched, but here's a potentially breaking update:
- Removal of the [deprecated](https://github.com/reactioncommerce/reaction/pull/3172/commits/7af076b452b38ecb02813291b1032fe405abf836) `getGuestLoginState`. This *is/was* an internal function, but in case anyone has plugin(s) using it, please update. This logic in this function can be recreated with the `Roles` package if needed.


## Testing
- This does not add any specific feature, so the test here is to confirm that the app still works as usual, no regression!