### PR TITLE
WIP - Fix 2895 impactmass has permisssion owner fix

### DIFF
--- a/client/modules/core/helpers/apps.js
+++ b/client/modules/core/helpers/apps.js
@@ -1,6 +1,5 @@
 import _ from "lodash";
 import { Template } from "meteor/templating";
-import { Roles } from "meteor/alanning:roles";
 import { Reaction } from "/client/api";
 import { Packages, Shops } from "/lib/collections";
 
@@ -94,7 +93,7 @@ export function Apps(optionHash) {
           // This checks that the registry item contains a permissions matches with the user's permission for the shop
           const hasPermissionToRegistryItem = item.permissions.indexOf(permission) > -1;
           // This checks that the user's permission set have the right value that is on the registry item
-          const hasRoleAccessForShop = Roles.userIsInRole(getUserId(), permission, Reaction.getShopId());
+          const hasRoleAccessForShop = Reaction.hasPermission(permission, getUserId(), Reaction.getShopId());
 
           // both checks must pass for access to be granted
           if (hasPermissionToRegistryItem && hasRoleAccessForShop) {

--- a/client/modules/core/helpers/templates.js
+++ b/client/modules/core/helpers/templates.js
@@ -3,7 +3,6 @@ import { Template } from "meteor/templating";
 import { Accounts } from "meteor/accounts-base";
 import { Spacebars } from "meteor/spacebars";
 import { ReactiveVar } from "meteor/reactive-var";
-import { Roles } from "meteor/alanning:roles";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { i18next, Reaction } from "/client/api";
 import * as Collections from "/lib/collections";
@@ -75,9 +74,9 @@ Template.registerHelper("currentUser", () => {
     const user = Accounts.user();
     if (!shopId || typeof user !== "object") return null;
     // shoppers should always be guests
-    const isGuest = Roles.userIsInRole(user, "guest", shopId);
+    const isGuest = Reaction.hasPermission("guest", user._id, shopId);
     // but if a user has never logged in then they are anonymous
-    const isAnonymous = Roles.userIsInRole(user, "anonymous", shopId);
+    const isAnonymous = Reaction.hasPermission("anonymous", user._id, shopId, { appendOwner: false });
 
     return isGuest && !isAnonymous ? user : null;
   }

--- a/client/modules/core/subscriptions.js
+++ b/client/modules/core/subscriptions.js
@@ -3,7 +3,6 @@ import { Meteor } from "meteor/meteor";
 import { ReactiveVar } from "meteor/reactive-var";
 import { Tracker } from "meteor/tracker";
 import { SubsManager } from "meteor/meteorhacks:subs-manager";
-import { Roles } from "meteor/alanning:roles";
 import { Accounts } from "/lib/collections";
 import Reaction from "./main";
 import { getUserId } from "./helpers/utils";
@@ -20,9 +19,7 @@ Subscriptions.Manager = new SubsManager();
  */
 
 Tracker.autorun(() => {
-  const userId = getUserId();
   Subscriptions.Account = Subscriptions.Manager.subscribe("Accounts");
-  Subscriptions.UserProfile = Meteor.subscribe("UserProfile", userId);
 });
 
 // Primary shop subscription
@@ -86,7 +83,7 @@ Tracker.autorun(() => {
   const shopId = Reaction.getCartShopId();
   if (!shopId) return; // could be waiting for subscription
 
-  const isAnonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
+  const isAnonymousUser = Reaction.hasPermission("anonymous", userId, shopId, { appendOwner: false });
   if (!isAnonymousUser && cartSubCreated.get() && Subscriptions.Cart.ready() && !isMerging) {
     const anonymousCarts = getAnonymousCartsReactive();
 

--- a/imports/plugins/core/accounts/client/containers/mainDropdown.js
+++ b/imports/plugins/core/accounts/client/containers/mainDropdown.js
@@ -14,6 +14,7 @@ function displayName(displayUser) {
   i18nextDep.depend();
 
   const user = displayUser || Accounts.user();
+  const shopId = Reaction.getShopId();
 
   if (user) {
     if (user.name) {
@@ -24,12 +25,7 @@ function displayName(displayUser) {
       return user.profile.name;
     }
 
-    // todo: previous check was user.services !== "anonymous", "resume". Is this
-    // new check covers previous check?
-    if (Roles.userIsInRole(
-      user._id || user.userId, "account/profile",
-      Reaction.getShopId()
-    )) {
+    if (Reaction.hasPermission("account/profile", user._id || user.userId, shopId, { appendOwner: false })) {
       return i18next.t("accountsUI.guest", { defaultValue: "Guest" });
     }
   }

--- a/imports/plugins/core/accounts/client/helpers/templates.js
+++ b/imports/plugins/core/accounts/client/helpers/templates.js
@@ -1,5 +1,4 @@
 import { Template } from "meteor/templating";
-import { Roles } from "meteor/alanning:roles";
 import { Reaction, i18next, i18nextDep } from "/client/api";
 import * as Collections from "/lib/collections";
 
@@ -11,7 +10,7 @@ import * as Collections from "/lib/collections";
  */
 Template.registerHelper("displayName", (displayUser) => {
   i18nextDep.depend();
-
+  const shopId = Reaction.getShopId();
   const user = displayUser || Collections.Accounts.findOne(Reaction.getUserId());
   if (user) {
     if (user.name) {
@@ -20,12 +19,7 @@ Template.registerHelper("displayName", (displayUser) => {
       return user.username;
     }
 
-    // todo: previous check was user.services !== "anonymous", "resume". Is this
-    // new check covers previous check?
-    if (Roles.userIsInRole(
-      user._id || user.userId, "account/profile",
-      Reaction.getShopId()
-    )) {
+    if (Reaction.hasPermission("account/profile", user._id || user.userId, shopId)) {
       return i18next.t("accountsUI.guest", { defaultValue: "Guest" });
     }
   }

--- a/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
+++ b/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
@@ -2,7 +2,6 @@ import _ from "lodash";
 import { Components } from "@reactioncommerce/reaction-components";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
-import { Roles } from "meteor/alanning:roles";
 import { ServiceConfiguration } from "meteor/service-configuration";
 import { Reaction, i18next } from "/client/api";
 import * as Collections from "/lib/collections";
@@ -64,17 +63,17 @@ Template.accountsDashboard.helpers({
           }
           // member.user = user;
           member.username = user.username;
-          member.isAdmin = Roles.userIsInRole(user._id, "admin", shopId);
+          member.isAdmin = Reaction.hasPermission("admin", user._id, shopId);
           member.roles = user.roles;
           member.services = user.services;
 
-          if (Roles.userIsInRole(member.userId, "owner", shopId)) {
+          if (Reaction.hasPermission("owner", member.userId, shopId)) {
             member.role = "owner";
-          } else if (Roles.userIsInRole(member.userId, "admin", shopId)) {
+          } else if (Reaction.hasPermission("admin", member.userId, shopId)) {
             member.role = "admin";
-          } else if (Roles.userIsInRole(member.userId, "dashboard", shopId)) {
+          } else if (Reaction.hasPermission("dashboard", member.userId, shopId)) {
             member.role = "dashboard";
-          } else if (Roles.userIsInRole(member.userId, "guest", shopId)) {
+          } else if (Reaction.hasPermission("guest", member.userId, shopId)) {
             member.role = "guest";
           }
 

--- a/imports/plugins/core/accounts/client/templates/dropdown/helpers/templates.js
+++ b/imports/plugins/core/accounts/client/templates/dropdown/helpers/templates.js
@@ -1,6 +1,5 @@
 import { Template } from "meteor/templating";
 import { Accounts } from "meteor/accounts-base";
-import { Roles } from "meteor/alanning:roles";
 import { Reaction, i18next, i18nextDep } from "/client/api";
 
 /**
@@ -11,7 +10,7 @@ import { Reaction, i18next, i18nextDep } from "/client/api";
  */
 Template.registerHelper("displayName", (displayUser) => {
   i18nextDep.depend();
-
+  const shopId = Reaction.getShopId();
   const user = displayUser || Accounts.user();
   if (user) {
     if (user.profile && user.profile.name) {
@@ -20,9 +19,7 @@ Template.registerHelper("displayName", (displayUser) => {
       return user.username;
     }
 
-    // todo: previous check was user.services !== "anonymous", "resume". Is this
-    // new check covers previous check?
-    if (Roles.userIsInRole(user._id || user.userId, "account/profile", Reaction.getShopId())) {
+    if (Reaction.hasPermission("account/profile", user._id || user.userId, shopId)) {
       return i18next.t("accountsUI.guest", { defaultValue: "Guest" });
     }
   }

--- a/imports/plugins/core/accounts/client/templates/members/member.js
+++ b/imports/plugins/core/accounts/client/templates/members/member.js
@@ -39,7 +39,7 @@ Template.member.events({
 Template.memberSettings.helpers({
   isOwnerDisabled() {
     if (Reaction.getUserId() === this.userId) {
-      if (Roles.userIsInRole(this.userId, "owner", this.shopId)) {
+      if (Reaction.hasPermission("owner", this.userId, this.shopId)) {
         return true;
       }
     }
@@ -48,10 +48,7 @@ Template.memberSettings.helpers({
     return Reaction.getUserId();
   },
   hasPermissionChecked(permission, userId) {
-    if (userId && Roles.userIsInRole(userId, permission, this.shopId || Roles.userIsInRole(
-      userId, permission,
-      Roles.GLOBAL_GROUP
-    ))) {
+    if (userId && Reaction.hasPermission(permission, userId, this.shopId)) {
       return "checked";
     }
   },

--- a/imports/plugins/core/cart/server/methods/addToCart.js
+++ b/imports/plugins/core/cart/server/methods/addToCart.js
@@ -1,6 +1,5 @@
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
 import addCartItems from "../no-meteor/mutations/addCartItems";
@@ -32,7 +31,7 @@ export default function addToCart(cartId, token, items) {
   // it was auto-created as a kind of session. If so, we fool the createCart mutation
   // into thinking there is no user so that it will create an anonymous cart.
   const userId = Reaction.getUserId();
-  const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
+  const anonymousUser = Reaction.hasPermission("anonymous", userId, shopId, { appendOwner: false });
   const userIdForContext = anonymousUser ? null : userId;
 
   const context = Promise.await(getGraphQLContextInMeteorMethod(userIdForContext));

--- a/imports/plugins/core/cart/server/methods/createCart.js
+++ b/imports/plugins/core/cart/server/methods/createCart.js
@@ -1,6 +1,5 @@
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
-import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
@@ -25,7 +24,7 @@ export default function createCartMethod(items) {
   // it was auto-created as a kind of session. If so, we fool the createCart mutation
   // into thinking there is no user so that it will create an anonymous cart.
   const userId = Reaction.getUserId();
-  const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
+  const anonymousUser = Reaction.hasPermission("anonymous", userId, shopId, { appendOwner: false });
   const userIdForContext = anonymousUser ? null : userId;
 
   const context = Promise.await(getGraphQLContextInMeteorMethod(userIdForContext));

--- a/imports/plugins/core/cart/server/methods/setShipmentAddress.js
+++ b/imports/plugins/core/cart/server/methods/setShipmentAddress.js
@@ -1,6 +1,5 @@
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import { Address as AddressSchema } from "/imports/collections/schemas";
 import ReactionError from "@reactioncommerce/reaction-error";
@@ -30,7 +29,7 @@ export default function setShipmentAddress(cartId, cartToken, address) {
   // In Meteor app we always have a user, but it may have "anonymous" role, meaning
   // it was auto-created as a kind of session.
   const userId = Reaction.getUserId();
-  const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
+  const anonymousUser = Reaction.hasPermission("anonymous", userId, shopId, { appendOwner: false });
   const userIdForContext = anonymousUser ? null : userId;
 
   const context = Promise.await(getGraphQLContextInMeteorMethod(userIdForContext));

--- a/imports/plugins/core/cart/server/methods/setShipmentMethod.js
+++ b/imports/plugins/core/cart/server/methods/setShipmentMethod.js
@@ -1,6 +1,5 @@
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import getCart from "/imports/plugins/core/cart/server/util/getCart";
@@ -38,7 +37,7 @@ export default function setShipmentMethod(cartId, cartToken, methodId) {
   // In Meteor app we always have a user, but it may have "anonymous" role, meaning
   // it was auto-created as a kind of session.
   const userId = Reaction.getUserId();
-  const anonymousUser = Roles.userIsInRole(userId, "anonymous", shopId);
+  const anonymousUser = Reaction.hasPermission("anonymous", userId, shopId, { appendOwner: false });
   const userIdForContext = anonymousUser ? null : userId;
 
   const context = Promise.await(getGraphQLContextInMeteorMethod(userIdForContext));

--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import Logger from "@reactioncommerce/logger";
 import { Meteor } from "meteor/meteor";
-import { Roles } from "meteor/alanning:roles";
 import { Accounts, Groups } from "/lib/collections";
 import { lifecycle } from "recompose";
 import { composeWithTracker } from "./composer";
@@ -101,10 +100,7 @@ export function withCurrentAccount(component) {
     // shoppers should always be guests
     const isGuest = Reaction.hasPermission("guest");
     // but if a user has never logged in then they are anonymous
-    const isAnonymous = Roles.userIsInRole(user, "anonymous", shopId);
-    // this check for "anonymous" uses userIsInRole instead of hasPermission because hasPermission
-    // always return `true` when logged in as the owner.
-    // But in this case, the anonymous check should be false when a user is logged in
+    const isAnonymous = Reaction.hasPermission("anonymous", user._id, shopId, { appendOwner: false });
 
     onData(null, { currentAccount: isGuest && !isAnonymous && account });
   }, false)(component);

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -126,12 +126,16 @@ export default {
    * @param {String | Array} checkPermissions -String or Array of permissions if empty, defaults to "admin, owner"
    * @param {String} userId - userId, defaults to logged in userId
    * @param {String} checkGroup group - default to shopId
+   * @param {Object} options - options object containing additional flags
+   * @param {Boolean} options.appendOwner - Set to false to avoid owner role being appended to checkPermissions
    * @return {Boolean} Boolean - true if has permission
    */
-  hasPermission(checkPermissions, userId = getUserId(), checkGroup = this.getShopId()) {
+  hasPermission(checkPermissions, userId = getUserId(), checkGroup = this.getShopId(), options = {}) {
     // check(checkPermissions, Match.OneOf(String, Array)); check(userId, String); check(checkGroup,
     // Match.Optional(String));
     let permissions;
+    // set default behavior to grant owner global access
+    if (options.appendOwner === undefined) options.appendOwner = true;
     // default group to the shop or global if shop isn't defined for some reason.
     let group;
     if (checkGroup !== undefined && typeof checkGroup === "string") {
@@ -142,16 +146,14 @@ export default {
 
     // permissions can be either a string or an array we'll force it into an array and use that
     if (checkPermissions === undefined) {
-      permissions = ["owner"];
+      permissions = [];
     } else if (typeof checkPermissions === "string") {
       permissions = [checkPermissions];
     } else {
       permissions = checkPermissions;
     }
 
-    // if the user has admin, owner permissions we'll always check if those roles are enough
-    permissions.push("owner");
-    permissions = _.uniq(permissions);
+    if (options.appendOwner) permissions.push("owner");
 
     // return if user has permissions in the group
     return Roles.userIsInRole(userId, permissions, group);

--- a/imports/plugins/core/core/server/publications/accounts/serviceConfiguration.js
+++ b/imports/plugins/core/core/server/publications/accounts/serviceConfiguration.js
@@ -1,7 +1,6 @@
 import { ServiceConfiguration } from "meteor/service-configuration";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
@@ -15,10 +14,7 @@ Meteor.publish("ServiceConfiguration", function (checkUserId) {
     return this.ready();
   }
   // Admins and account managers can manage the login methods for the shop
-  if (Roles.userIsInRole(
-    this.userId, ["owner", "admin", "dashboard/accounts"],
-    Reaction.getShopId()
-  )) {
+  if (Reaction.hasPermission(["owner", "admin", "dashboard/accounts"], this.userId, Reaction.getShopId())) {
     return ServiceConfiguration.configurations.find({}, {
       fields: {
         secret: 1

--- a/imports/plugins/core/core/server/publications/collections/accounts.js
+++ b/imports/plugins/core/core/server/publications/collections/accounts.js
@@ -28,13 +28,13 @@ Meteor.publish("Accounts", function () {
   }).fetch().map((group) => group._id);
 
   // global admin can get all accounts
-  if (Roles.userIsInRole(userId, ["owner"], Roles.GLOBAL_GROUP)) {
+  if (Reaction.hasPermission(["owner"], userId, Roles.GLOBAL_GROUP)) {
     return Collections.Accounts.find({
       groups: { $nin: nonAdminGroups }
     });
 
   // shop admin gets accounts for just this shop
-  } else if (Roles.userIsInRole(userId, ["admin", "owner", "reaction-accounts"], shopId)) {
+  } else if (Reaction.hasPermission(["admin", "owner", "reaction-accounts"], userId, shopId)) {
     return Collections.Accounts.find({
       groups: { $nin: nonAdminGroups },
       shopId
@@ -53,75 +53,10 @@ Meteor.publish("UserAccount", function (userId) {
   check(userId, Match.OneOf(String, null));
 
   const shopId = Reaction.getShopId();
-  if (Roles.userIsInRole(this.userId, ["admin", "owner"], shopId)) {
+  if (Reaction.hasPermission(["admin", "owner"], this.userId, shopId)) {
     return Collections.Accounts.find({
       userId
     });
   }
   return this.ready();
-});
-
-/**
- * userProfile
- * @deprecated since version 0.10.2
- * get any user name,social profile image
- * should be limited, secure information
- * users with permissions  ["dashboard/orders", "owner", "admin", "dashboard/
- * customers"] may view the profileUserId"s profile data.
- *
- * @params {String} profileUserId -  view this users profile when permitted
- */
-Meteor.publish("UserProfile", function (profileUserId) {
-  check(profileUserId, Match.OneOf(String, null));
-  if (this.userId === null) {
-    return this.ready();
-  }
-  const shopId = Reaction.getShopId();
-  if (!shopId) {
-    return this.ready();
-  }
-  const permissions = ["dashboard/orders", "owner", "admin",
-    "dashboard/customers"];
-  // no need to normal user so see his password hash
-  const fields = {
-    "emails": 1,
-    "name": 1,
-    "profile.lang": 1,
-    "profile.firstName": 1,
-    "profile.lastName": 1,
-    "profile.familyName": 1,
-    "profile.secondName": 1,
-    "profile.name": 1,
-    "services.twitter.profile_image_url_https": 1,
-    "services.facebook.id": 1,
-    "services.google.picture": 1,
-    "services.github.username": 1,
-    "services.instagram.profile_picture": 1
-  };
-  // TODO: this part currently not working as expected.
-  // we could have three situation here:
-  // 1 - registered user log in.
-  // 2 - admin log in
-  // 3 - admin want to get user data
-  // I'm not sure about the 3rd case, but we do not cover 2nd case here, because
-  // we can see a situation when anonymous user still represented by
-  // `profileUserId`, but admin user already could be found by `this.userId`
-  // In that case what we should do here?
-  if (profileUserId !== this.userId && Roles.userIsInRole(
-    this.userId,
-    permissions, shopId ||
-    Roles.userIsInRole(this.userId, permissions, Roles.GLOBAL_GROUP)
-  )) {
-    return Meteor.users.find({
-      _id: profileUserId
-    }, {
-      fields
-    });
-  }
-
-  return Meteor.users.find({
-    _id: this.userId
-  }, {
-    fields
-  });
 });

--- a/imports/plugins/core/core/server/publications/collections/members.js
+++ b/imports/plugins/core/core/server/publications/collections/members.js
@@ -1,7 +1,6 @@
 import Logger from "@reactioncommerce/logger";
 import { Meteor } from "meteor/meteor";
 import { EJSON } from "meteor/ejson";
-import { Roles } from "meteor/alanning:roles";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /* eslint quote-props: 0 */
@@ -23,7 +22,7 @@ Meteor.publish("ShopMembers", function () {
     return this.ready();
   }
 
-  if (Roles.userIsInRole(this.userId, readPermissions, shopId)) {
+  if (Reaction.hasPermission(readPermissions, this.userId, shopId)) {
     // seems like we can't use "`" inside db.call directly
     // do not add comments or otherwise format this query
     const selector = `{"roles.${shopId}": {"$nin": ["anonymous"]}}`;

--- a/imports/plugins/core/core/server/publications/collections/orders.js
+++ b/imports/plugins/core/core/server/publications/collections/orders.js
@@ -1,6 +1,5 @@
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Roles } from "meteor/alanning:roles";
 import { ReactiveAggregate } from "./reactiveAggregate";
 import { Accounts, MediaRecords, Orders } from "/lib/collections";
 import { Counts } from "meteor/tmeasday:publish-counts";
@@ -80,7 +79,7 @@ Meteor.publish("Orders", function () {
   };
   const aggregate = createAggregate(shopId);
 
-  if (Roles.userIsInRole(this.userId, ["admin", "owner", "orders"], shopId)) {
+  if (Reaction.hasPermission(["admin", "owner", "orders"], this.userId, shopId)) {
     ReactiveAggregate(this, Orders, aggregate, aggregateOptions);
   } else {
     const account = Accounts.findOne({ userId: this.userId });
@@ -113,7 +112,8 @@ Meteor.publish("PaginatedOrders", function (query, options) {
   const limit = (options && options.limit) ? options.limit : 0;
   const skip = (options && options.skip) ? options.skip : 0;
   const aggregate = createAggregate(shopId, { createdAt: -1 }, limit, query, skip);
-  if (Roles.userIsInRole(this.userId, ["admin", "owner", "orders"], shopId)) {
+
+  if (Reaction.hasPermission(["admin", "owner", "orders"], this.userId, shopId)) {
     Counts.publish(this, "orders-count", Orders.find(), { noReady: true });
     ReactiveAggregate(this, Orders, aggregate, aggregateOptions);
   } else {

--- a/imports/plugins/core/core/server/publications/collections/packages.js
+++ b/imports/plugins/core/core/server/publications/collections/packages.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { check, Match } from "meteor/check";
-import { Roles } from "meteor/alanning:roles";
 import { Packages } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import { translateRegistry } from "/lib/api";
@@ -22,7 +21,8 @@ function transform(doc, userId) {
   permissions = _.uniq(permissions);
 
   // check for admin,owner or package permissions to view settings
-  const hasAdmin = Roles.userIsInRole(userId, permissions, doc.shopId);
+
+  const hasAdmin = Reaction.hasPermission(permissions, userId, doc.shopId);
 
   if (doc.registry) {
     for (let registry of doc.registry) {
@@ -93,11 +93,7 @@ Meteor.publish("Packages", function (shopId) {
     // we should always have a shop
     if (myShopId) {
       // if admin user, return all shop properties
-      if (Roles.userIsInRole(self.userId, [
-        "dashboard", "owner", "admin"
-      ], Reaction.getShopId() || Roles.userIsInRole(self.userId, [
-        "owner", "admin"
-      ], Roles.GLOBAL_GROUP))) {
+      if (Reaction.hasPermission(["dashboard", "owner", "admin"], self.userId, Reaction.getShopId())) {
         options = {};
       }
       // observe and transform Package registry adds i18n and other meta data

--- a/imports/plugins/core/core/server/startup/collection-security.js
+++ b/imports/plugins/core/core/server/startup/collection-security.js
@@ -1,9 +1,8 @@
 import Hooks from "@reactioncommerce/hooks";
 import { Security } from "meteor/ongoworks:security";
-import { Roles } from "meteor/alanning:roles";
 import * as Collections from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
-
+/* eslint-disable require-jsdoc */
 const {
   Accounts,
   Packages,
@@ -49,9 +48,9 @@ export default function () {
         // if not passed, getShopId can default to primaryShopId if userId is not available in the context the code is run
         const shopId = Reaction.getUserShopId(userId) || Reaction.getShopId();
 
-        return Roles.userIsInRole(userId, arg.role, shopId);
+        return Reaction.hasPermission(arg.role, userId, shopId);
       }
-      return Roles.userIsInRole(userId, arg);
+      return Reaction.hasPermission(arg, userId);
     }
   });
 

--- a/imports/plugins/core/orders/client/components/lineItems.js
+++ b/imports/plugins/core/orders/client/components/lineItems.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { isEmpty } from "lodash";
 import classnames from "classnames";
-import { Roles } from "meteor/alanning:roles";
 import { formatPriceString, Reaction } from "/client/api";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 
@@ -343,7 +342,7 @@ class LineItems extends Component {
         ))}
 
         {
-          Roles.userIsInRole(Reaction.getUserId(), ["orders", "dashboard/orders"], Reaction.getShopId()) &&
+          Reaction.hasPermission(["orders", "dashboard/orders"], Reaction.getUserId(), Reaction.getShopId()) &&
           this.renderPopOver()
         }
       </Components.Button>

--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -2,7 +2,6 @@ import Logger from "@reactioncommerce/logger";
 import _ from "lodash";
 import escapeStringRegex from "escape-string-regexp";
 import { Meteor } from "meteor/meteor";
-import { Roles } from "meteor/alanning:roles";
 import { check, Match } from "meteor/check";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import { ProductSearch, OrderSearch, AccountSearch } from "/lib/collections";
@@ -18,7 +17,7 @@ function getProductFindTerm(searchTerm, searchTags, userId) {
   if (searchTags.length) {
     findTerm.hashtags = { $all: searchTags };
   }
-  if (!Roles.userIsInRole(userId, ["admin", "owner"], shopId)) {
+  if (!Reaction.hasPermission(["admin", "owner"], userId, shopId)) {
     findTerm.isVisible = true;
   }
   // Deletes the shopId field from "findTerm" for primary shop


### PR DESCRIPTION
Resolves #2895  
Type: **fix|?feat**

## Task
Fix `Reaction.hasPermission` to work properly with “anonymous” role check.

Reason: This change is needed so we can be able to replace ALL current use of `Roles.userIsInRole` in the code to `hasPermission` (thus paving the way for removing dependency on Roles package later). See issues #2895 (old but yet-to-be-fixed issue) and #4525 for more details.

## Overview
**Brief summary chosen approach:** Add an extra `option` param to hasPermission. This will allow us to call hasPermission in a no “appendOwner” mode. This mode will not append the “owner” role as we currently have it. Existing checks that do not pass a “appendOwner” flag will go ahead with appending the “owner” role.

## Other Approaches
**Approach A:** Remove the addition/appending of the “owner” role happening within the hasPermission method. This will require explicitly adding “owner” to the list of roles in the arguments passed to ALL existing hasPermission calls.

**Why not chosen:** This approach will be very extensive (with a large surface area of code to change). It will also be a “avoidable” breaking change for plugins.

## Negatives
None that I can think of. Going the route of adding an extra field doesn't affect current code setup.

## Structure
Where will this code live: The changes are done in the current Reaction.hasPermission (in the frontend code and server code)

## User Interface Changes
None

## Breaking Changes
None

## Future Effects
What effects on future code (either positive or negative) will this have?

**Positive:** The addition of an options object introduces a way to later extend the behavior of this function. More options can be added when needed.

## Security Concerns
None


