### PR TITLE
fix: update file-collections dependency from 0.5.0 to 0.6.0

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,21 +4,12 @@ version: v1.11.0
 ignore:
   'npm:bootstrap:20160627':
     - bootstrap:
-        reason: We're not going to update to Bootstrap 4 any time soon
-        expires: '2018-08-26T20:23:03.274Z'
-  'npm:hoek:20180212':
-    - '*':
-      reason: "PR Accepted to tus-node-server which will resolve this vulnerability https://github.com/tus/tus-node-server/pull/120"
-      expires: '2018-08-26T20:23:03.274Z'
-  'npm:tunnel-agent:20170305':
-    - '*':
-      reason: "PR Accepted to tus-node-server which will resolve this vulnerability https://github.com/tus/tus-node-server/pull/120"
-      expires: '2018-08-26T20:23:03.274Z'
-  'npm:cryptiles:20180710':
-    - '*':
-      reason: "PR Accepted to tus-node-server which will resolve this vulnerability https://github.com/tus/tus-node-server/pull/120"
-      expires: '2018-08-26T20:23:03.274Z'
+      reason: We're not going to update to Bootstrap 4 any time soon
+      expires: '2018-10-26T20:23:03.274Z'
   'npm:chownr:20180731':
     - '*':
-      reason: "waiting on chownr to resolve issue"
-      expires: '2018-09-01T20:23:03.274Z'
+      reason: "PR in chownr to resolve issue will require node >= 10.8 https://github.com/isaacs/chownr/pull/15"
+      expires: '2018-09-29T20:23:03.274Z'
+  'npm:mem:20180117':
+    - '*':
+      reason: String of dependencies that need to be updated - oslocale (PR https://github.com/sindresorhus/os-locale/pull/31) followed by yargs then transliteration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1725,9 +1725,9 @@
       "integrity": "sha512-dEv1n+IFtlvLQ8/FsTOtBCC1aNT4B5abE8ODF5wk2tpWnjvgGNRMvHCeJGbVHjFfer4h8MH2w9c2/6eoJHclMg=="
     },
     "@google-cloud/common": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.13.6.tgz",
-      "integrity": "sha1-qdjhN7xCmkSrqWif5qDkMxeE+FM=",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
       "requires": {
         "array-uniq": "1.0.3",
         "arrify": "1.0.1",
@@ -1736,7 +1736,7 @@
         "duplexify": "3.6.0",
         "ent": "2.2.0",
         "extend": "3.0.2",
-        "google-auto-auth": "0.7.2",
+        "google-auto-auth": "0.10.1",
         "is": "3.2.1",
         "log-driver": "1.2.7",
         "methmeth": "1.1.0",
@@ -1747,42 +1747,34 @@
         "stream-events": "1.0.4",
         "string-format-obj": "1.1.1",
         "through2": "2.0.3"
-      },
-      "dependencies": {
-        "google-auto-auth": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.7.2.tgz",
-          "integrity": "sha512-ux2n2AE2g3+vcLXwL4dP/M12SFMRX5dzCzBfhAEkTeAB7dpyGdOIEj7nmUx0BHKaCcUQrRWg9kT63X/Mmtk1+A==",
-          "requires": {
-            "async": "2.6.1",
-            "gcp-metadata": "0.3.1",
-            "google-auth-library": "0.10.0",
-            "request": "2.87.0"
-          }
-        }
       }
     },
     "@google-cloud/storage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.1.1.tgz",
-      "integrity": "sha1-ZZC1zm53lVbJzHBDvWRJ1rwHgd4=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.7.0.tgz",
+      "integrity": "sha512-QaAxzCkbhspwajoaEnT0GcnQcpjPRcBrHYuQsXtD05BtOJgVnHCLXSsfUiRdU0nVpK+Thp7+sTkQ0fvk5PanKg==",
       "requires": {
-        "@google-cloud/common": "0.13.6",
+        "@google-cloud/common": "0.17.0",
         "arrify": "1.0.1",
         "async": "2.6.1",
+        "compressible": "2.0.14",
         "concat-stream": "1.6.2",
         "create-error-class": "3.0.2",
         "duplexify": "3.6.0",
         "extend": "3.0.2",
-        "gcs-resumable-upload": "0.7.7",
+        "gcs-resumable-upload": "0.10.2",
         "hash-stream-validation": "0.2.1",
         "is": "3.2.1",
+        "mime": "2.3.1",
         "mime-types": "2.1.19",
         "once": "1.4.0",
         "pumpify": "1.5.1",
+        "request": "2.87.0",
+        "safe-buffer": "5.1.2",
+        "snakeize": "0.1.0",
         "stream-events": "1.0.4",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
+        "through2": "2.0.3",
+        "xdg-basedir": "3.0.0"
       }
     },
     "@material-ui/core": {
@@ -1931,9 +1923,9 @@
       "dev": true
     },
     "@reactioncommerce/file-collections": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections/-/file-collections-0.5.0.tgz",
-      "integrity": "sha512-92983/xIT6xAnHR0+4XKVY9jUp0vpobLhG0wCyegvX/dkSRO5srL4tz1ZN/77pxe7d1MfEEYo6MLQ/YmluIw6A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections/-/file-collections-0.6.0.tgz",
+      "integrity": "sha512-Y2ymZlCqY+tx8qMjIU+UHwiwBrgd01h72h7sIIMc//NagouEn9bKjMntJkmytPU4j8ExJSVgYtbal1wJTzHPVA==",
       "requires": {
         "babel-runtime": "6.26.0",
         "content-disposition": "0.5.2",
@@ -1941,7 +1933,7 @@
         "path-parser": "4.2.0",
         "query-string": "5.1.1",
         "tus-js-client": "1.5.1",
-        "tus-node-server": "0.2.11"
+        "tus-node-server": "0.3.1"
       },
       "dependencies": {
         "debug": {
@@ -2611,6 +2603,63 @@
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
       "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA=="
     },
+    "aws-sdk": {
+      "version": "2.306.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.306.0.tgz",
+      "integrity": "sha512-GEvZJ8J9+bSMHUjlXcUS5TOWCxirQDiMIdvSwXV/okKC4lJ/mQc3C/pPiSM/ppsMQRoMFJlYxO9uubkmGgwCwQ==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "1.3.0",
+            "ieee754": "1.1.8",
+            "isarray": "1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2620,6 +2669,15 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "1.5.7",
+        "is-buffer": "1.1.6"
+      }
     },
     "axobject-query": {
       "version": "2.0.1",
@@ -3376,14 +3434,6 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "bootstrap": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
@@ -3593,11 +3643,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
-    },
-    "buffer-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -4003,7 +4048,8 @@
     "commander": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -4022,6 +4068,14 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
+    },
+    "compressible": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
+      "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
+      "requires": {
+        "mime-db": "1.35.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -4204,14 +4258,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.10.1"
-      }
     },
     "crypto-rand": {
       "version": "0.0.2",
@@ -5466,6 +5512,11 @@
         "through": "2.3.8"
       }
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "exec-sh": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
@@ -6078,6 +6129,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/flushwritable/-/flushwritable-1.0.0.tgz",
       "integrity": "sha1-PjKNj95BKtR+c44751C00pAENJg="
+    },
+    "follow-redirects": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "font-awesome": {
       "version": "4.7.0",
@@ -6865,166 +6934,25 @@
       }
     },
     "gcp-metadata": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
-      "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
+      "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
       "requires": {
+        "axios": "0.18.0",
         "extend": "3.0.2",
-        "retry-request": "3.3.2"
+        "retry-axios": "0.3.2"
       }
     },
     "gcs-resumable-upload": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.7.7.tgz",
-      "integrity": "sha1-2clyWvlwu8hsvwr+8kBtwizpGGQ=",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.10.2.tgz",
+      "integrity": "sha1-fymz7iPc7EFwNnwHEUGCScZgVF8=",
       "requires": {
-        "buffer-equal": "1.0.0",
         "configstore": "3.1.2",
-        "google-auto-auth": "0.6.1",
+        "google-auto-auth": "0.10.1",
         "pumpify": "1.5.1",
         "request": "2.87.0",
-        "stream-events": "1.0.4",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.19"
-          }
-        },
-        "gcp-metadata": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.1.0.tgz",
-          "integrity": "sha1-q+IfHqMk3Qs0o/BsqBdj+x7uN9k=",
-          "requires": {
-            "extend": "3.0.2",
-            "retry-request": "1.3.2"
-          }
-        },
-        "google-auto-auth": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.6.1.tgz",
-          "integrity": "sha1-wF2CDpRUc57PKKiJLuqz0WJPLLM=",
-          "requires": {
-            "async": "2.6.1",
-            "gcp-metadata": "0.1.0",
-            "google-auth-library": "0.10.0",
-            "object-assign": "3.0.0",
-            "request": "2.87.0"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.16.0",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-        },
-        "retry-request": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-1.3.2.tgz",
-          "integrity": "sha1-Wa0k5x+K4/MS1fe0vPRnpeWle9Y=",
-          "requires": {
-            "request": "2.76.0",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "request": {
-              "version": "2.76.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
-              "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.7.0",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.19",
-                "node-uuid": "1.4.8",
-                "oauth-sign": "0.8.2",
-                "qs": "6.3.2",
-                "stringstream": "0.0.6",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.4.3"
-              }
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
-      }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "1.0.2"
+        "stream-events": "1.0.4"
       }
     },
     "get-caller-file": {
@@ -7235,47 +7163,37 @@
       }
     },
     "google-auth-library": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-      "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
+      "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
       "requires": {
-        "gtoken": "1.2.3",
+        "axios": "0.18.0",
+        "gcp-metadata": "0.6.3",
+        "gtoken": "2.3.0",
         "jws": "3.1.5",
-        "lodash.noop": "3.0.1",
-        "request": "2.87.0"
+        "lodash.isstring": "4.0.1",
+        "lru-cache": "4.1.3",
+        "retry-axios": "0.3.2"
       }
     },
     "google-auto-auth": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.8.2.tgz",
-      "integrity": "sha512-W91J1paFbyG45gpDWdTu9tKDxbiTDWYkOAxytNVF4oHVVgTCBV/8+lWdjj/6ldjN3eb+sEd9PKJBjm0kmCxvcw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
+      "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
       "requires": {
         "async": "2.6.1",
-        "gcp-metadata": "0.3.1",
-        "google-auth-library": "0.12.0",
+        "gcp-metadata": "0.6.3",
+        "google-auth-library": "1.6.1",
         "request": "2.87.0"
-      },
-      "dependencies": {
-        "google-auth-library": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
-          "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
-          "requires": {
-            "gtoken": "1.2.3",
-            "jws": "3.1.5",
-            "lodash.isstring": "4.0.1",
-            "lodash.merge": "4.6.1",
-            "request": "2.87.0"
-          }
-        }
       }
     },
     "google-p12-pem": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
-      "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
+      "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "requires": {
-        "node-forge": "0.7.5"
+        "node-forge": "0.7.6",
+        "pify": "3.0.0"
       }
     },
     "got": {
@@ -7426,14 +7344,15 @@
       "dev": true
     },
     "gtoken": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
-      "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
+      "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "requires": {
-        "google-p12-pem": "0.1.2",
+        "axios": "0.18.0",
+        "google-p12-pem": "1.0.2",
         "jws": "3.1.5",
-        "mime": "1.6.0",
-        "request": "2.87.0"
+        "mime": "2.3.1",
+        "pify": "3.0.0"
       }
     },
     "handlebars": {
@@ -7564,17 +7483,6 @@
         "through2": "2.0.3"
       }
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
     "history": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
@@ -7586,11 +7494,6 @@
         "value-equal": "0.4.0",
         "warning": "3.0.0"
       }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hoist-non-react-statics": {
       "version": "2.5.5",
@@ -8110,23 +8013,6 @@
         "is-path-inside": "1.0.1"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -8214,11 +8100,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -9902,6 +9783,11 @@
         "merge-stream": "1.0.1"
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "jquery-i18next": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jquery-i18next/-/jquery-i18next-1.2.1.tgz",
@@ -10071,11 +9957,6 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -10284,9 +10165,9 @@
       }
     },
     "libphonenumber-js": {
-      "version": "1.2.21",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.2.21.tgz",
-      "integrity": "sha512-JmBdkEXfmadHZBVqGQtga+oVkK0bIxfSTIeq7+AmsxCcvezJv9qF6J6R0MpISHQhtvTb81WjPbVKN1QAioZdRQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.4.2.tgz",
+      "integrity": "sha512-yt2aUW10S+07wM/ZCrR4GCBVwBUuiiiitVOR0Zahgaa23zXElY3GUCGpoUl4sxj5aQb9XS1WAotAwtq+27Istg==",
       "requires": {
         "minimist": "1.2.0",
         "semver-compare": "1.0.0",
@@ -10568,11 +10449,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
       "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
-    },
-    "lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -11478,9 +11354,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
     },
     "mime-db": {
       "version": "1.35.0",
@@ -11874,9 +11750,9 @@
       "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "node-forge": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
-      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-geocoder": {
       "version": "3.22.0",
@@ -12582,12 +12458,14 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -14048,6 +13926,11 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retry-axios": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
+      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
+    },
     "retry-request": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.2.tgz",
@@ -14493,6 +14376,11 @@
       "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
       "dev": true
     },
+    "snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -14599,14 +14487,6 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
-      }
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.16.3"
       }
     },
     "snyk": {
@@ -15265,11 +15145,6 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -15897,17 +15772,15 @@
       }
     },
     "tus-node-server": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/tus-node-server/-/tus-node-server-0.2.11.tgz",
-      "integrity": "sha512-1Eb/GGejUTUpCpuHbol8OsQDk38Mx8jPLne+0VvPTKVv6Gvoj+Q7trjc5mQHQqCd8vIYsXHEEJ/46YR1bZZJig==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tus-node-server/-/tus-node-server-0.3.1.tgz",
+      "integrity": "sha512-tcb9HLfX8TSnjpQZ2jOtuSHx5vxf4TEG5XZ2/TDrJxnQO7lgftxEZ9XiEqrIbtH5xmunRN2ao0GC1nfF/t5IAg==",
       "requires": {
-        "@google-cloud/storage": "1.1.1",
+        "@google-cloud/storage": "1.7.0",
+        "aws-sdk": "2.306.0",
         "configstore": "3.1.2",
         "crypto-rand": "0.0.2",
-        "debug": "3.1.0",
-        "google-auto-auth": "0.8.2",
-        "object-assign": "4.1.1",
-        "request": "2.87.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@reactioncommerce/components": "0.21.0",
     "@reactioncommerce/components-context": "1.0.0",
     "@reactioncommerce/data-factory": "^1.0.0",
-    "@reactioncommerce/file-collections": "0.5.0",
+    "@reactioncommerce/file-collections": "0.6.0",
     "@reactioncommerce/file-collections-sa-gridfs": "0.0.2",
     "@reactioncommerce/hooks": "1.0.2",
     "@reactioncommerce/job-queue": "1.0.4",


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

Update @reactioncommerce/file-collections from 0.5.0 to 0.6.0.

This eliminates vulnerabilities introduced through dependencies on `hoek`, `tunnel-agent`, and `cryptiles` which were introduced through an older version of `tus-node-server`