### PR TITLE
fix: resolve react-transition-group dependencies in package-lock

### DIFF
--- a/imports/plugins/core/components/lib/hoc.js
+++ b/imports/plugins/core/components/lib/hoc.js
@@ -181,14 +181,14 @@ export function withIsOwner(component) {
 }
 
 /**
- * @name withCSSTransitionGroup
+ * @name withCSSTransition
  * @method
- * @summary A wrapper to reactively inject react-transition-group's <CSSTransitionGroup /> into a component
+ * @summary A wrapper to dynamically import & inject react-transition-group's <CSSTransition /> into a component
  * @param {Function|React.Component} component - the component to wrap
- * @return {Function} the new wrapped component with a "CSSTransitionGroup" prop
+ * @return {Object} the new wrapped component with a "CSSTransition" prop
  * @memberof Components/Helpers
  */
-export function withCSSTransitionGroup(component) {
+export function withCSSTransition(component) {
   return lifecycle({
     componentDidMount() {
       import("react-transition-group")
@@ -198,7 +198,7 @@ export function withCSSTransitionGroup(component) {
           }
 
           this.setState({
-            CSSTransitionGroup: module.CSSTransitionGroup
+            CSSTransition: module.CSSTransition
           });
 
           return null;

--- a/imports/plugins/core/ui/client/components/modal/overlay.js
+++ b/imports/plugins/core/ui/client/components/modal/overlay.js
@@ -3,7 +3,7 @@ import { compose } from "recompose";
 import PropTypes from "prop-types";
 import Radium from "radium";
 import classnames from "classnames";
-import { registerComponent, withCSSTransitionGroup } from "@reactioncommerce/reaction-components";
+import { registerComponent, withCSSTransition } from "@reactioncommerce/reaction-components";
 
 const styles = {
   base: {
@@ -24,31 +24,30 @@ class Overlay extends Component {
   };
 
   static propTypes = {
-    CSSTransitionGroup: PropTypes.func,
+    CSSTransition: PropTypes.func,
     children: PropTypes.node,
     isVisible: PropTypes.bool,
     onClick: PropTypes.func
   };
 
-  state = {
-    enterAnimation: {
-      animation: { opacity: 1 },
-      duration: 200
-    },
-    leaveAnimation: {
-      animation: { opacity: 0 },
-      duration: 200
+  render() {
+    const { CSSTransition, isVisible } = this.props;
+    if (CSSTransition === undefined) {
+      return null;
     }
-  }
 
-  renderOverlay() {
-    if (this.props.isVisible) {
-      const baseClassName = classnames({
-        rui: true,
-        overlay: true
-      });
+    const baseClassName = classnames({
+      rui: true,
+      overlay: true
+    });
 
-      return (
+    return (
+      <CSSTransition
+        in={isVisible}
+        unmountOnExit
+        classNames="fade-in-out"
+        timeout={200}
+      >
         <div
           aria-hidden={true}
           className={baseClassName}
@@ -56,36 +55,17 @@ class Overlay extends Component {
           onClick={this.props.onClick}
           key="overlay"
         />
-      );
-    }
-
-    return null;
-  }
-
-  render() {
-    const { CSSTransitionGroup } = this.props;
-    if (CSSTransitionGroup === undefined) {
-      return null;
-    }
-
-    return (
-      <CSSTransitionGroup
-        transitionName="fade-in-out"
-        transitionEnterTimeout={200}
-        transitionLeaveTimeout={200}
-      >
-        {this.renderOverlay()}
-      </CSSTransitionGroup>
+      </CSSTransition>
     );
   }
 }
 
 registerComponent("Overlay", Overlay, [
-  withCSSTransitionGroup,
+  withCSSTransition,
   Radium
 ]);
 
 export default compose(
-  withCSSTransitionGroup,
+  withCSSTransition,
   Radium
 )(Overlay);

--- a/imports/plugins/included/default-theme/client/styles/dashboard/console.less
+++ b/imports/plugins/included/default-theme/client/styles/dashboard/console.less
@@ -84,18 +84,18 @@ html:not(.rtl) .rui.admin.action-view {
 // Admin action pane slide in/out animation
 .admin.rui.action-view-pane {
   &.slide-in-out-enter,
-  &.slide-in-out-leave-active {
+  &.slide-in-out-exit-active {
     transform: translateX(100%);
   }
   &.slide-in-out-rtl-enter,
-  &.slide-in-out-rtl-leave-active {
+  &.slide-in-out-rtl-exit-active {
     transform: translateX(-100%);
   }
 
   &.slide-in-out-enter-active,
   &.slide-in-out-rtl-enter-active,
-  &.slide-in-out-leave-active,
-  &.slide-in-out-rtl-leave-active {
+  &.slide-in-out-exit-active,
+  &.slide-in-out-rtl-exit-active {
     transition: transform 200ms ease-in-out;
   }
 

--- a/imports/plugins/included/default-theme/client/styles/overlay.less
+++ b/imports/plugins/included/default-theme/client/styles/overlay.less
@@ -1,16 +1,16 @@
 // Overlay opacity animation
 .rui.overlay {
   &.fade-in-out-enter,
-  &.fade-in-out-leave-active {
+  &.fade-in-out-exit-active {
     opacity: 0;
   }
 
   &.fade-in-out-enter-active,
-  &.fade-in-out-leave-active {
+  &.fade-in-out-exit-active {
     transition: opacity 200ms;
   }
 
   &.fade-in-out-enter-active {
-    opacity: 1;  
+    opacity: 1;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1830,6 +1830,17 @@
           "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.1.tgz",
           "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w=="
         },
+        "react-transition-group": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
+          "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
+          "requires": {
+            "dom-helpers": "^3.3.1",
+            "loose-envify": "^1.3.1",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
         "recompose": {
           "version": "0.28.2",
           "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.28.2.tgz",
@@ -1896,6 +1907,19 @@
             "raf": "3.4.0",
             "react-input-autosize": "2.2.1",
             "react-transition-group": "2.4.0"
+          },
+          "dependencies": {
+            "react-transition-group": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
+              "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
+              "requires": {
+                "dom-helpers": "^3.3.1",
+                "loose-envify": "^1.3.1",
+                "prop-types": "^15.6.2",
+                "react-lifecycles-compat": "^3.0.4"
+              }
+            }
           }
         }
       }
@@ -12956,6 +12980,16 @@
       "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
       "dev": true
     },
+    "react-animate-height": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.0.3.tgz",
+      "integrity": "sha512-IrzXf029kby15pnpsd7SOYML+pT0wZBZe/0O51dggw3l4D59BYmMXPhOUPYjzfrGcy9DNN0PKyZZN65kCMcO6A==",
+      "requires": {
+        "@types/react": ">=16",
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.1"
+      }
+    },
     "react-apollo": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.1.9.tgz",
@@ -13440,10 +13474,10 @@
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
       "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
       "requires": {
-        "dom-helpers": "3.3.1",
-        "loose-envify": "1.4.0",
-        "prop-types": "15.6.2",
-        "react-lifecycles-compat": "3.0.4"
+        "dom-helpers": "^3.3.1",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "react-with-direction": {
@@ -15694,6 +15728,7 @@
     },
     "transliteration": {
       "version": "github:reactioncommerce/transliteration#699d48cc8dd9a64f1a2773e1b36b6faa4bbdca2f",
+      "from": "transliteration@github:reactioncommerce/transliteration#699d48cc8dd9a64f1a2773e1b36b6faa4bbdca2f",
       "requires": {
         "yargs": "8.0.2"
       },
@@ -16202,22 +16237,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "velocity-animate": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.5.1.tgz",
-      "integrity": "sha512-VJ3csMz5zP1ifkbBlsNYpxnoWkPHfVRQ8tUongS78W5DxSGHB68pjYHDTgUYBkVM7P/HpYdVukgVUFcxjr1gGg=="
-    },
-    "velocity-react": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.4.1.tgz",
-      "integrity": "sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==",
-      "requires": {
-        "lodash": "4.17.10",
-        "prop-types": "15.6.2",
-        "react-transition-group": "2.4.0",
-        "velocity-animate": "1.5.1"
-      }
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-taco-table": "^0.5.1",
     "react-tether": "^0.6.1",
     "react-textarea-autosize": "^5.2.1",
-    "react-transition-group": "1.2.1",
+    "react-transition-group": "2.4.0",
     "reacto-form": "0.0.2",
     "recompose": "^0.26.0",
     "shallowequal": "^1.0.2",


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
#4500 made changes to package.json but did not update package-lock.json
Additionally, #4500 introduced a new dependency on an older version of `react-transition-group` causing us to have dependencies on two separate versions of that package.


## Solution
1. Updated our direct dependency of `react-transition-group` to the latest `2.4.0`
2. Ran `meteor npm install` to update `package-lock.json`


## Breaking changes
N/A

## Testing
1. Ensure that the CSS animations introduced in #4500 still work correctly with the latest version of `react-transition-group`