### PR TITLE
Fix aldeed reaction error swallowing

### DIFF
--- a/imports/plugins/core/versions/server/migrations/24_publish_all_existing_visible_products.js
+++ b/imports/plugins/core/versions/server/migrations/24_publish_all_existing_visible_products.js
@@ -13,7 +13,14 @@ Migrations.add({
       isVisible: true,
       type: "simple"
     }, { _id: 1 }).map((product) => product._id);
-    const success = Promise.await(publishProductsToCatalog(visiblePublishedProducts, collections));
+
+    let success = false;
+    try {
+      success = Promise.await(publishProductsToCatalog(visiblePublishedProducts, collections));
+    } catch (error) {
+      Logger.error("Error in migration 24, publishProductsToCatalog", error);
+    }
+
     if (!success) {
       Logger.error("Migration 24 failed to create catalog products for some published products.");
     }

--- a/imports/plugins/core/versions/server/migrations/28_add_hash_to_products.js
+++ b/imports/plugins/core/versions/server/migrations/28_add_hash_to_products.js
@@ -1,3 +1,4 @@
+import Logger from "@reactioncommerce/logger";
 import { Migrations } from "meteor/percolate:migrations";
 import { Catalog } from "/lib/collections";
 import collections from "/imports/collections/rawCollections";
@@ -10,6 +11,10 @@ Migrations.add({
       "product.type": "product-simple"
     }).fetch();
 
-    products.forEach((product) => Promise.await(hashProduct(product.product._id, collections)));
+    try {
+      products.forEach((product) => Promise.await(hashProduct(product.product._id, collections)));
+    } catch (error) {
+      Logger.error("Error in migration 28, hashProduct", error);
+    }
   }
 });

--- a/imports/plugins/core/versions/server/migrations/32_publish_all_existing_visible_products.js
+++ b/imports/plugins/core/versions/server/migrations/32_publish_all_existing_visible_products.js
@@ -13,7 +13,13 @@ Migrations.add({
       isVisible: true,
       type: "simple"
     }, { _id: 1 }).map((product) => product._id);
-    const success = Promise.await(publishProductsToCatalog(visiblePublishedProducts, collections));
+    let success = false;
+    try {
+      success = Promise.await(publishProductsToCatalog(visiblePublishedProducts, collections));
+    } catch (error) {
+      Logger.error("Error in migration 32, publishProductsToCatalog", error);
+    }
+
     if (!success) {
       Logger.error("Migration 32 failed to create catalog products for some published products.");
     }

--- a/imports/utils/ReactionError.js
+++ b/imports/utils/ReactionError.js
@@ -1,5 +1,3 @@
-import ExtendableError from "es6-error";
-
 /**
  * @name ReactionError
  * @class
@@ -7,11 +5,22 @@ import ExtendableError from "es6-error";
  * @summary A type of error that allows additional details to be provided, which can
  *   then be sent back to the client for a GraphQL request.
  */
-export default class ReactionError extends ExtendableError {
-  constructor(error, message, eventData = {}) {
+export default class ReactionError extends Error {
+  constructor(error, message = "", eventData = {}) {
     super(message);
+
+    // In Node (7.2) console.log will print custom errors a bit differently unless all properties are defined as non-enumerable
+    Object.defineProperty(this, "name", {
+      value: this.constructor.name
+    });
+
+    Object.defineProperty(this, "message", {
+      value: message
+    });
+
     this.eventData = eventData;
     this.error = error;
+
     // Newer versions of DDP use this property to signify that an error
     // can be sent back and reconstructed on the calling client.
     this.isClientSafe = true;
@@ -19,6 +28,11 @@ export default class ReactionError extends ExtendableError {
     this.reason = message;
     // DDP expects this to be in a property named `details`
     this.details = eventData;
+
+    // Keep this after everything is defined on `this`
+    if ({}.hasOwnProperty.call(Error, "captureStackTrace")) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 
   clone() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1806,7 +1806,6 @@
         "prop-types": "15.6.2",
         "react-event-listener": "0.6.2",
         "react-jss": "8.6.1",
-        "react-transition-group": "2.4.0",
         "recompose": "0.28.2",
         "warning": "4.0.1"
       },
@@ -1894,8 +1893,7 @@
             "memoize-one": "4.0.0",
             "prop-types": "15.6.2",
             "raf": "3.4.0",
-            "react-input-autosize": "2.2.1",
-            "react-transition-group": "2.4.0"
+            "react-input-autosize": "2.2.1"
           }
         }
       }
@@ -3794,6 +3792,11 @@
         "type-detect": "4.0.8"
       }
     },
+    "chain-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
+      "integrity": "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -5116,11 +5119,6 @@
         "is-date-object": "1.0.1",
         "is-symbol": "1.0.1"
       }
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "es6-promise": {
       "version": "4.2.4",
@@ -12956,6 +12954,16 @@
       "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
       "dev": true
     },
+    "react-animate-height": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.0.3.tgz",
+      "integrity": "sha512-IrzXf029kby15pnpsd7SOYML+pT0wZBZe/0O51dggw3l4D59BYmMXPhOUPYjzfrGcy9DNN0PKyZZN65kCMcO6A==",
+      "requires": {
+        "@types/react": ">=16",
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.1"
+      }
+    },
     "react-apollo": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.1.9.tgz",
@@ -13436,14 +13444,15 @@
       }
     },
     "react-transition-group": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
-      "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
       "requires": {
-        "dom-helpers": "3.3.1",
-        "loose-envify": "1.4.0",
-        "prop-types": "15.6.2",
-        "react-lifecycles-compat": "3.0.4"
+        "chain-function": "^1.0.0",
+        "dom-helpers": "^3.2.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.5.6",
+        "warning": "^3.0.0"
       }
     },
     "react-with-direction": {
@@ -15694,6 +15703,7 @@
     },
     "transliteration": {
       "version": "github:reactioncommerce/transliteration#699d48cc8dd9a64f1a2773e1b36b6faa4bbdca2f",
+      "from": "github:reactioncommerce/transliteration",
       "requires": {
         "yargs": "8.0.2"
       },
@@ -16202,22 +16212,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "velocity-animate": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.5.1.tgz",
-      "integrity": "sha512-VJ3csMz5zP1ifkbBlsNYpxnoWkPHfVRQ8tUongS78W5DxSGHB68pjYHDTgUYBkVM7P/HpYdVukgVUFcxjr1gGg=="
-    },
-    "velocity-react": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.4.1.tgz",
-      "integrity": "sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==",
-      "requires": {
-        "lodash": "4.17.10",
-        "prop-types": "15.6.2",
-        "react-transition-group": "2.4.0",
-        "velocity-animate": "1.5.1"
-      }
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "deep-diff": "^0.3.8",
     "deep-equal": "^1.0.1",
     "dnd-core": "^2.5.4",
-    "es6-error": "^4.1.1",
     "escape-string-regexp": "^1.0.5",
     "express": "4.16.2",
     "faker": "^4.1.0",


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
When migrations run in staging, there seem to be errors getting swallowed. The migrations stop at version 24 but no errors are printed.

## Solution
- Wrapped all `Promise.await` in mutations in try/catch with logging
- Updated `ReactionError` to be essentially the same, but without relying on the `es6-error` NPM package. This will help rule out that extra layer of inheritance as the cause of the error swallowing.

## Breaking changes
None

## Testing
There is no great way to test this unless you manually add some error throwing in one of the awaited functions. As long as all automatic tests are still passing, just a code review of this PR should suffice.