### PR TITLE
fix: cart item attributes

### DIFF
--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -95,10 +95,12 @@ export default async function addCartItems(collections, currentItems, inputItems
     const attributes = [];
     if (parentVariant) {
       attributes.push({
+        label: null, // Set label to null for now. We expect to use it in the future.
         value: parentVariant.title
       });
     }
     attributes.push({
+      label: null, // Set label to null for now. We expect to use it in the future.
       value: chosenVariant.title
     });
 

--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -94,9 +94,13 @@ export default async function addCartItems(collections, currentItems, inputItems
     // The main issue is we do not have labels.
     const attributes = [];
     if (parentVariant) {
-      attributes.push({ value: parentVariant.optionTitle || parentVariant.title });
+      attributes.push({
+        value: parentVariant.title
+      });
     }
-    attributes.push({ value: chosenVariant.optionTitle || chosenVariant.title });
+    attributes.push({
+      value: chosenVariant.title
+    });
 
     const cartItem = {
       _id: Random.id(),


### PR DESCRIPTION
Resolves #4606  
Impact: **minor**  
Type: **bugfix**

## Issue

Item attributes for cart items use incorrect values. The `optionTitle` is used in place of `title` which sometimes leads to incorrect values being saved into the database.

## Solution

- Use only the title for the attributes

## Testing
1. Using reaction with [sample data](https://github.com/reactioncommerce/reaction-catalog-sample-data)
1. Add items to the cart
2. Open database in Robo3T to port `27017`, if running in docker
3. In the `Cart` collection, expand what should be the only cart
4. Check the items attributes They should look something like for following depending on products added to the cart. (there should be no `Unitited Option` attributes) 

![robo_3t_-_1_2](https://user-images.githubusercontent.com/42217/45181807-5b6f3d00-b1d4-11e8-98a4-769029404541.png)
