### PR TITLE
fix: Add missing Shops.layout migration

### DIFF
--- a/imports/plugins/core/versions/server/migrations/13_add_shopId_on_shipping.js
+++ b/imports/plugins/core/versions/server/migrations/13_add_shopId_on_shipping.js
@@ -2,6 +2,8 @@ import { Migrations } from "meteor/percolate:migrations";
 import { Cart, Orders } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 
+const shippingFieldExistsAndHasItems = { shipping: { $exists: true, $ne: [] } };
+
 Migrations.add({
   version: 13,
   up() {
@@ -9,11 +11,11 @@ Migrations.add({
     // This adds shopId field to each shipping object in orders and carts.
     const shopId = Reaction.getShopId();
 
-    Orders.update({}, {
+    Orders.update(shippingFieldExistsAndHasItems, {
       $set: { "shipping.0.shopId": shopId }
     }, { bypassCollection2: true, multi: true });
 
-    Cart.update({}, {
+    Cart.update(shippingFieldExistsAndHasItems, {
       $set: { "shipping.0.shopId": shopId }
     }, { bypassCollection2: true, multi: true });
   },
@@ -23,7 +25,7 @@ Migrations.add({
     }, { bypassCollection2: true, multi: true });
 
     Cart.update({}, {
-      $set: { "shipping.0.shopId": "" }
+      $unset: { "shipping.0.shopId": "" }
     }, { bypassCollection2: true, multi: true });
   }
 });

--- a/imports/plugins/core/versions/server/migrations/38_registry_products_template.js
+++ b/imports/plugins/core/versions/server/migrations/38_registry_products_template.js
@@ -1,0 +1,82 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Packages, Shops } from "/lib/collections";
+
+/**
+ * This is an update to migration 33, which missed a couple things:
+ * (1) The $ by default updates only the first matching array, but we want to update all
+ * (2) The layouts are also stored in the Shops collection and need to be updated there as well.
+ *
+ * Note that we use rawCollection because Meteor collections do not forward the arrayFilters option yet.
+ */
+
+Migrations.add({
+  version: 38,
+  up() {
+    Packages.rawCollection().update({
+      "layout.structure.template": "products"
+    }, {
+      $set: {
+        "layout.$[elem].structure.template": "Products"
+      }
+    }, {
+      arrayFilters: [{ "elem.structure.template": "products" }],
+      multi: true
+    });
+
+    Packages.rawCollection().update({
+      "registry.template": "products"
+    }, {
+      $set: {
+        "registry.$[elem].template": "Products"
+      }
+    }, {
+      arrayFilters: [{ "elem.template": "products" }],
+      multi: true
+    });
+
+    Shops.rawCollection().update({
+      "layout.structure.template": "products"
+    }, {
+      $set: {
+        "layout.$[elem].structure.template": "Products"
+      }
+    }, {
+      arrayFilters: [{ "elem.structure.template": "products" }],
+      multi: true
+    });
+  },
+  down() {
+    Packages.rawCollection().update({
+      "layout.structure.template": "Products"
+    }, {
+      $set: {
+        "layout.$[elem].structure.template": "products"
+      }
+    }, {
+      arrayFilters: [{ "elem.structure.template": "Products" }],
+      multi: true
+    });
+
+    Packages.rawCollection().update({
+      "registry.template": "Products"
+    }, {
+      $set: {
+        "registry.$[elem].template": "products"
+      }
+    }, {
+      arrayFilters: [{ "elem.template": "Products" }],
+      multi: true
+    });
+
+    Shops.rawCollection().update({
+      "layout.structure.template": "Products"
+    }, {
+      $set: {
+        "layout.$[elem].structure.template": "products"
+      }
+    }, {
+      arrayFilters: [{ "elem.structure.template": "Products" }],
+      multi: true
+    });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -35,3 +35,4 @@ import "./34_remove_order_shipping_items";
 import "./35_add_type_to_carts";
 import "./36_convert_requiresShipping";
 import "./37_change_shipping_rate_settings_template_name";
+import "./38_registry_products_template";


### PR DESCRIPTION
Resolves #4608 (hopefully also #4585)
Impact: **minor**  
Type: **bugfix**

## Issue
Migration 33 was added in v1.15.0 to change the "products" template name to "Products". It neglected to do this in the Shops collection, which also has layouts stored there. Depending on whether you are upgrading, whether your Packages collection is regenerated on startup, and what version your database is already on, this sometimes leads to the app starting as just a white screen with no errors in the console.

This is actually pretty likely to happen in an upgrade situation.

## Solution
Adds another migration, covering what the first migration missed.

## Other changes
I also made a couple minor fixes to migration 13. This was something I encountered while debugging. If any carts or orders do not have a `shipping` field set, then setting `shipping.0.shopId` in the migration actually creates a `shipping` object rather than an array. This is a known quirk of MongoDB. So I added a filter to run the migration only for documents that already have an array there.

Since this has only caused problems in a weird artificial situation I created, I opted to only fix the existing migration rather than write a new one.

## Breaking changes
None

## Testing
This is easiest to test if you already have a database that's causing this issue. Otherwise, you can fake it by manually creating the problem in your database and then verify the migration fixes it:

1. In your primary shop, look at the `layout` array and find the item with `workflow = "coreWorkflow"`. Change `structure.template` of that item to "products" (lowercase first letter).
1. When you start the Meteor app (on release-1.16.0 branch, without this fix), it should now be a blank screen.
1. Stop the app, check out this branch, start the app and verify that migration 38 runs. If you now refresh the browser, the app should appear normally.