### PR TITLE
chore: Rename the reaction-api Docker network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@
 version: '3.4'
 
 networks:
-  reaction-api:
+  graphql:
     external:
-      name: reaction-api
+      name: graphql.reaction.localhost
 
 services:
 
@@ -24,7 +24,7 @@ services:
       BABEL_DISABLE_CACHE: 1 # This is needed to pick up changes to .graphql files. See https://www.npmjs.com/package/babel-plugin-inline-import#caveats
     networks:
       default:
-      reaction-api:
+      graphql:
     ports:
       - "3030:3030"
     volumes:
@@ -46,7 +46,7 @@ services:
       BABEL_DISABLE_CACHE: 1 # This is needed to pick up changes to .graphql files. See https://www.npmjs.com/package/babel-plugin-inline-import#caveats
     networks:
       default:
-      reaction-api:
+      graphql:
     ports:
       - "3000:3000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@
 version: '3.4'
 
 networks:
-  graphql:
+  api:
     external:
-      name: graphql.reaction.localhost
+      name: api.reaction.localhost
 
 services:
 
@@ -24,7 +24,7 @@ services:
       BABEL_DISABLE_CACHE: 1 # This is needed to pick up changes to .graphql files. See https://www.npmjs.com/package/babel-plugin-inline-import#caveats
     networks:
       default:
-      graphql:
+      api:
     ports:
       - "3030:3030"
     volumes:
@@ -46,7 +46,7 @@ services:
       BABEL_DISABLE_CACHE: 1 # This is needed to pick up changes to .graphql files. See https://www.npmjs.com/package/babel-plugin-inline-import#caveats
     networks:
       default:
-      graphql:
+      api:
     ports:
       - "3000:3000"
     volumes:

--- a/imports/plugins/core/core/server/util/getRootUrl.test.js
+++ b/imports/plugins/core/core/server/util/getRootUrl.test.js
@@ -4,7 +4,7 @@ test("returns process.env.ROOT_URL with trailing slash if set", () => {
   process.env.ROOT_URL = "http://localhost:3000";
   const request = {
     protocol: "https",
-    hostname: "graphql.reaction.localhost"
+    hostname: "api.reaction.localhost"
   };
 
   expect(getRootUrl(request)).toBe("http://localhost:3000/");

--- a/imports/plugins/core/core/server/util/getRootUrl.test.js
+++ b/imports/plugins/core/core/server/util/getRootUrl.test.js
@@ -4,7 +4,7 @@ test("returns process.env.ROOT_URL with trailing slash if set", () => {
   process.env.ROOT_URL = "http://localhost:3000";
   const request = {
     protocol: "https",
-    hostname: "reaction-api"
+    hostname: "graphql.reaction.localhost"
   };
 
   expect(getRootUrl(request)).toBe("http://localhost:3000/");


### PR DESCRIPTION
Related to https://github.com/reactioncommerce/reaction/issues/4447
Impact: **minor**  
Type: **chore**

## Issue
Renames the Docker network on which GraphQL enabled web services are attached to:

    api.reaction.localhost

Networks in the Docker environment should be named as `*.reaction.localhost`. The localhost TLD is reserved and guaranteed to not conflict with a real TLD.

## Solution
Rename the network as a subdomain of `localhost` which is [reserved by ICANN](https://tools.ietf.org/html/rfc6761).

[This Medium article](https://medium.engineering/use-a-dev-domain-not-anymore-95219778e6fd) written by [@koop](https://medium.engineering/@koop), a developer at Medium, is a great explanation along with a really interesting history of gTLDs and common usage of the `.dev` domain. Reasoning applies to any non-reserved TLD.

Changes in Chromium prompted the above article. Docker **does resolve DNS internally** and should be smart enough to avoid querying the outside world when resolving it's own networks. Still, I think it's good to use a reserved domain as an ultimate backstop.
## Breaking changes

* To enable network communication, projects communicating with Reaction's GraphQL server must be on the `api.reaction.localhost` Docker network.
* PRs related to reactioncommerce/reaction#4447 should be coordinated.


## Testing
1. Ensure the new network exists by running `docker network create api.reaction.localhost`
2. Stop and remove all running reaction Docker containers.
3. Restart the application.
4. Repeat steps 2 and 3 for any project that connects over the former `reaction-api` network.
5. Ensure projects have proper networking.