### PR TITLE
chore: fix eslint issues

### DIFF
--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 import { getComponent, withCSSTransition } from "@reactioncommerce/reaction-components";
 import Blaze from "meteor/gadicc:blaze-react-component";
+import { EJSON } from "meteor/ejson";
 import { Admin } from "/imports/plugins/core/ui/client/providers";
 import Radium from "radium";
 import debounce from "lodash/debounce";
@@ -189,10 +190,6 @@ class ActionView extends Component {
 
     if (EJSON.equals(actionView, prevProps.actionView) === false) {
       this.setState({ actionView });
-    }
-
-    if (actionView.template && actionView.template !== prevProps.actionView.template) {
-
     }
   }
 


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Description
There were 2 eslint issues found in a fix I recently pushed to 1.16. Specifically:

- Not importing EJSON - EJSON was available as a global, but should still be imported so that it's clear where it's coming from
- Empty if block - Simply left an old if block by mistake, but moved the code within to a separate if block