### PR TITLE
fix: apply requested sort to Cart.items in GraphQL resolver

### DIFF
--- a/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Cart/items.js
+++ b/imports/plugins/core/graphql/server/no-meteor/resolvers/cart/Cart/items.js
@@ -1,5 +1,30 @@
+import { orderBy } from "lodash";
 import { xformArrayToConnection } from "@reactioncommerce/reaction-graphql-xforms/connection";
 import { xformCartItems } from "@reactioncommerce/reaction-graphql-xforms/cart";
+
+/**
+ * @summary Sorts the provided cart items according to the connectionArgs.
+ * @param {Object[]} cartItems Array of cart items
+ * @param {ConnectionArgs} connectionArgs - An object of all arguments that were sent by the client
+ * @returns {Object[]} Sorted list of cart items
+ */
+function sortCartItems(cartItems, connectionArgs) {
+  const { sortOrder, sortBy } = connectionArgs;
+
+  let sortedItems;
+  switch (sortBy) {
+    case "addedAt":
+      sortedItems = orderBy(cartItems, ["addedAt", "_id"], [sortOrder, sortOrder]);
+      break;
+
+    // sort alpha by _id
+    default:
+      sortedItems = orderBy(cartItems, ["_id"], [sortOrder]);
+      break;
+  }
+
+  return sortedItems;
+}
 
 /**
  * @name "Cart.items"
@@ -7,10 +32,16 @@ import { xformCartItems } from "@reactioncommerce/reaction-graphql-xforms/cart";
  * @memberof Accounts/GraphQL
  * @summary converts the `items` prop on the provided cart to a connection
  * @param {Object} cart - result of the parent resolver, which is a Cart object in GraphQL schema format
+ * @param {ConnectionArgs} connectionArgs - An object of all arguments that were sent by the client
+ * @param {Object} context - The per-request context object
  * @return {Promise<Object>} A connection object
  */
 export default async function items(cart, connectionArgs, context) {
-  if (!Array.isArray(cart.items)) return null;
+  let { items: cartItems } = cart;
+  if (!Array.isArray(cartItems) || cartItems.length === 0) return xformArrayToConnection(connectionArgs, []);
 
-  return xformArrayToConnection(connectionArgs, xformCartItems(context, cart.items));
+  // Apply requested sorting
+  cartItems = sortCartItems(cartItems, connectionArgs);
+
+  return xformArrayToConnection(connectionArgs, xformCartItems(context, cartItems));
 }


### PR DESCRIPTION
Resolves #4587   
Impact: **minor**  
Type: **bugfix**

## Issue
See issue description. Cart.items connection sorting was never implemented

## Solution
Sort the items array before converting it to a connection

## Breaking changes
NONE

## Testing
Follow the steps in the linked issue and verify that your sortOrder and sortBy are respected, and that the default if you supply no sorting args is items sorted by `addedAt` descending.
