### PR TITLE
feat: Setup IDP flows for Hydra auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       MONGO_OPLOG_URL: "mongodb://mongo:27017/local"
       ROOT_URL: "http://localhost:3000"
       BABEL_DISABLE_CACHE: 1 # This is needed to pick up changes to .graphql files. See https://www.npmjs.com/package/babel-plugin-inline-import#caveats
+      HYDRA_ADMIN_URL: "http://hydra:4445"
       HYDRA_OAUTH2_INTROSPECT_URL: "http://hydra:4445/oauth2/introspect"
     networks:
       default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ networks:
   api:
     external:
       name: api.reaction.localhost
+  auth:
+    external:
+      name: auth.reaction.localhost
 
 services:
 
@@ -49,6 +52,7 @@ services:
     networks:
       default:
       api:
+      auth:
     ports:
       - "3000:3000"
     volumes:

--- a/imports/plugins/core/accounts/client/components/login.js
+++ b/imports/plugins/core/accounts/client/components/login.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Random from "@reactioncommerce/random";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
+import { Router } from "/client/api";
 
 class Login extends Component {
   static propTypes = {
@@ -54,6 +55,20 @@ class Login extends Component {
 
   render() {
     if (this.state.currentView === "loginFormSignInView" || this.state.currentView === "loginFormSignUpView") {
+      const currentRoute = Router.current().route;
+      const isOauthFlow = currentRoute.options && currentRoute.options.meta && currentRoute.options.meta.oauthLoginFlow;
+      if (isOauthFlow) {
+        return (
+          <Components.OAuthFormContainer
+            credentials={this.props.credentials}
+            uniqueId={this.props.uniqueId}
+            currentView={this.state.currentView}
+            onForgotPasswordClick={this.showForgotPasswordView}
+            onSignUpClick={this.showSignUpView}
+            onSignInClick={this.showSignInView}
+          />
+        );
+      }
       return (
         <Components.AuthContainer
           credentials={this.props.credentials}

--- a/imports/plugins/core/hydra-oauth/client/containers/auth.js
+++ b/imports/plugins/core/hydra-oauth/client/containers/auth.js
@@ -1,0 +1,155 @@
+import _ from "lodash";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Components, registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
+import { Meteor } from "meteor/meteor";
+import { Accounts } from "meteor/accounts-base";
+import { Router } from "/client/api";
+import { LoginFormValidation } from "/lib/api";
+
+class OAuthFormContainer extends Component {
+  static propTypes = {
+    currentRoute: PropTypes.object,
+    currentView: PropTypes.string,
+    formMessages: PropTypes.object
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      formMessages: props.formMessages || {},
+      isLoading: false
+    };
+  }
+
+  handleFormSubmit = (event, email, password) => {
+    event.preventDefault();
+
+    this.setState({
+      isLoading: true
+    });
+    const errors = {};
+    const username = email ? email.trim() : null;
+    const pword = password ? password.trim() : null;
+
+    const validatedEmail = LoginFormValidation.email(username);
+    const validatedPassword = LoginFormValidation.password(pword, { validationLevel: "exists" });
+    const challenge = Router.current().query.login_challenge;
+
+    if (validatedEmail !== true) {
+      errors.email = validatedEmail;
+    }
+
+    if (validatedPassword !== true) {
+      errors.password = validatedPassword;
+    }
+
+    if (_.isEmpty(errors) === false) {
+      this.setState({
+        isLoading: false,
+        formMessages: {
+          errors
+        }
+      });
+      return;
+    }
+
+    if (this.props.currentView === "loginFormSignInView") {
+      Meteor.loginWithPassword(username, pword, (error) => {
+        if (error) {
+          this.setState({
+            isLoading: false,
+            formMessages: {
+              alerts: [error]
+            }
+          });
+        } else {
+          Meteor.call("oauth/login", { challenge }, (err, redirectUrl) => {
+            window.location.href = redirectUrl;
+          });
+        }
+      });
+    } else if (this.props.currentView === "loginFormSignUpView") {
+      const newUserData = {
+        email: username,
+        password: pword
+      };
+
+      Accounts.createUser(newUserData, (error) => {
+        if (error) {
+          this.setState({
+            isLoading: false,
+            formMessages: {
+              alerts: [error]
+            }
+          });
+        } else {
+          Meteor.call("oauth/login", { challenge }, (err, redirectUrl) => {
+            window.location.href = redirectUrl;
+          });
+        }
+      });
+    }
+  }
+
+  hasError = (error) => {
+    // True here means the field is valid
+    // We're checking if theres some other message to display
+    if (error !== true && typeof error !== "undefined") {
+      return true;
+    }
+
+    return false;
+  }
+
+  formMessages = () => (
+    <Components.LoginFormMessages
+      messages={this.state.formMessages}
+    />
+  )
+
+  hasPasswordService = () => !!Package["accounts-password"]
+
+  renderAuthView() {
+    if (this.props.currentView === "loginFormSignInView") {
+      return (
+        <Components.SignIn
+          {...this.props}
+          onFormSubmit={this.handleFormSubmit}
+          messages={this.state.formMessages}
+          onError={this.hasError}
+          loginFormMessages={this.formMessages}
+          isLoading={this.state.isLoading}
+        />
+      );
+    }
+    return (
+      <Components.SignUp
+        {...this.props}
+        onFormSubmit={this.handleFormSubmit}
+        messages={this.state.formMessages}
+        onError={this.hasError}
+        loginFormMessages={this.formMessages}
+        hasPasswordService={this.hasPasswordService}
+        isLoading={this.state.isLoading}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        {this.renderAuthView()}
+      </div>
+    );
+  }
+}
+
+function composer(props, onData) {
+  onData(null, { currentRoute: Router.current() });
+}
+
+registerComponent("OAuthFormContainer", OAuthFormContainer, composeWithTracker(composer));
+
+export default composeWithTracker(composer)(OAuthFormContainer);

--- a/imports/plugins/core/hydra-oauth/client/index.js
+++ b/imports/plugins/core/hydra-oauth/client/index.js
@@ -1,0 +1,4 @@
+export { default as OAuthFormContainer } from "./containers/auth";
+
+import "./templates.html";
+import "./templates.js";

--- a/imports/plugins/core/hydra-oauth/client/templates.html
+++ b/imports/plugins/core/hydra-oauth/client/templates.html
@@ -1,0 +1,5 @@
+<template name="hydraOauthLoginForm">
+  <div class="hdyra-oauth-login col-sm-4 col-sm-offset-4">
+    {{> React component}}
+  </div>
+</template>

--- a/imports/plugins/core/hydra-oauth/client/templates.js
+++ b/imports/plugins/core/hydra-oauth/client/templates.js
@@ -1,0 +1,8 @@
+import { Components } from "@reactioncommerce/reaction-components";
+import { Template } from "meteor/templating";
+
+Template.hydraOauthLoginForm.helpers({
+  component() {
+    return { component: Components.Login };
+  }
+});

--- a/imports/plugins/core/hydra-oauth/register.js
+++ b/imports/plugins/core/hydra-oauth/register.js
@@ -1,0 +1,34 @@
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+
+/**
+ * @file Hydra Oauth plugin
+ *
+ * @namespace HydraOauth
+ */
+
+Reaction.registerPackage({
+  label: "HydraOauth",
+  name: "reaction-hydra-oauth",
+  autoEnable: true,
+  registry: [{
+    route: "/account/login",
+    name: "OAuth Login",
+    label: "oauth-login",
+    meta: { oauthLoginFlow: true },
+    description: "Oauth Login Provider Page",
+    workflow: "hydraOauthLogin",
+    template: "hydraOauthLoginForm"
+  }],
+  layout: [{
+    layout: "hydraOauthLogin",
+    workflow: "hydraOauthLogin",
+    theme: "default",
+    enabled: true,
+    structure: {
+      layout: "hydraOauthLogin",
+      layoutHeader: "",
+      layoutFooter: "",
+      notFound: "notFound"
+    }
+  }]
+});

--- a/imports/plugins/core/hydra-oauth/server/index.js
+++ b/imports/plugins/core/hydra-oauth/server/index.js
@@ -1,0 +1,9 @@
+import { Meteor } from "meteor/meteor";
+import { oauthLogin } from "./oauthMethods";
+
+Meteor.methods({
+  "oauth/login": oauthLogin
+});
+
+// Init endpoints
+import "./oauthEndpoints";

--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -1,0 +1,50 @@
+import Logger from "@reactioncommerce/logger";
+import { WebApp } from "meteor/webapp";
+import hydra from "./util/hydra";
+
+const { HYDRA_OAUTH2_ERROR_URL } = process.env;
+const errorHandler = (errorMessage, res) => {
+  Logger.error(`Error while performing Hydra login request - ${errorMessage}`);
+  if (HYDRA_OAUTH2_ERROR_URL) {
+    Logger.error(`Redirecting to HYDRA_OAUTH2_ERROR_URL: ${HYDRA_OAUTH2_ERROR_URL}`);
+    res.writeHead(500, { Location: HYDRA_OAUTH2_ERROR_URL });
+    return res.end();
+  }
+  Logger.warn("No HYDRA_OAUTH2_ERROR_URL set in ENV.");
+  return res.end();
+};
+
+WebApp.connectHandlers.use("/login", (req, res) => {
+  const challenge = req.query.login_challenge;
+
+  hydra.getLoginRequest(challenge)
+    .then(async (getLoginRequestRes) => {
+      // If Hydra was already able to authenticate the user, skip will be true
+      // and there will be no need to present a login form to the user.
+      if (getLoginRequestRes.skip) {
+        const acceptLoginResponse = await hydra.acceptLoginRequest(challenge, {
+          subject: getLoginRequestRes.subject
+        });
+        Logger.debug(`Auth status confirmed from Hydra. Redirecting to: ${acceptLoginResponse.redirect_to}`);
+        res.redirect(acceptLoginResponse.redirect_to);
+      }
+
+      res.writeHead(301, { Location: `/account/login?login_challenge=${challenge}` });
+      Logger.debug("Redirecting to Login Form for user login");
+      return res.end();
+    })
+    .catch((errorMessage) => errorHandler(errorMessage, res));
+});
+
+WebApp.connectHandlers.use("/consent", (req, res) => {
+  const challenge = req.query.consent_challenge;
+  // Call acceptConsent without presenting a consent form to the user
+  hydra
+    .acceptConsentRequest(challenge, {})
+    .then((consentResponse) => {
+      Logger.debug(`Consent call complete. Redirecting to: ${consentResponse.redirect_to}`);
+      res.writeHead(301, { Location: consentResponse.redirect_to });
+      return res.end();
+    })
+    .catch((errorMessage) => errorHandler(errorMessage, res));
+});

--- a/imports/plugins/core/hydra-oauth/server/oauthMethods.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthMethods.js
@@ -1,0 +1,31 @@
+import { check, Match } from "meteor/check";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import Logger from "@reactioncommerce/logger";
+import hydra from "./util/hydra";
+
+/**
+ * @name oauthLogin
+ * @method
+ * @param  {Object} options - options passed from client call
+ * @param {String} options.challenge Used to fetch information about the login request from Hydra.
+ * @param {Boolean} options.remember tells hydra to remember the browser and automatically authenticate the user in future requests
+ * @return {String} redirectUrl
+ */
+export function oauthLogin(options) {
+  check(options, Object);
+  check(options.challenge, String);
+  check(options.remember, Match.Maybe(Boolean));
+  const { challenge, remember = false } = options;
+
+  return hydra
+    .acceptLoginRequest(challenge, {
+      subject: Reaction.getUserId(),
+      remember,
+      remember_for: 3600 // eslint-disable-line camelcase
+    })
+    .then((response) => response.redirect_to)
+    .catch((error) => {
+      Logger.error(error);
+      throw error;
+    });
+}

--- a/imports/plugins/core/hydra-oauth/server/util/hydra.js
+++ b/imports/plugins/core/hydra-oauth/server/util/hydra.js
@@ -1,0 +1,69 @@
+import Logger from "@reactioncommerce/logger";
+import fetch from "node-fetch";
+
+const { HYDRA_ADMIN_URL } = process.env;
+let mockTlsTermination = {};
+
+if (process.env.MOCK_TLS_TERMINATION) {
+  mockTlsTermination = {
+    "X-Forwarded-Proto": "https"
+  };
+}
+
+/**
+ * @name get
+ * @method
+ * @private
+ * @param  {String} flow Request or Consent
+ * @param  {String} challenge To fetch information about the login/consent
+ * @return {Object|String} API res
+ */
+function get(flow, challenge) {
+  return fetch(`${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}/${challenge}`)
+    .then(async (res) => {
+      if (res.status < 200 || res.status > 302) {
+        const json = await res.json();
+        Logger.error(`An error occurred while making GET ${flow}-${challenge} HTTP request to Hydra: `, json.error_description);
+        return Promise.reject(new Error(json.error_description));
+      }
+      return res.json();
+    });
+}
+
+/**
+ * @name put
+ * @method
+ * @private
+ * @param  {String} flow Request or Consent
+ * @param  {String} action Accept/Reject
+ * @param  {String} challenge To fetch information about the login/consent
+ * @param  {String} body Request body
+ * @return {Object|String} API res
+ */
+function put(flow, action, challenge, body) {
+  return fetch(`${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}/${challenge}/${action}`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+      ...mockTlsTermination
+    }
+  })
+    .then(async (res) => {
+      if (res.status < 200 || res.status > 302) {
+        const json = await res.json();
+        Logger.error(`An error occurred while making PUT ${flow}-${challenge} request to Hydra: `, json.error_description);
+        return Promise.reject(new Error(json.error_description));
+      }
+      return res.json();
+    });
+}
+
+export default {
+  getLoginRequest: (challenge) => get("login", challenge),
+  acceptLoginRequest: (challenge, body) => put("login", "accept", challenge, body),
+  rejectLoginRequest: (challenge) => put("login", "reject", challenge),
+  getConsentRequest: (challenge) => get("consent", challenge),
+  acceptConsentRequest: (challenge, body) => put("consent", "accept", challenge, body),
+  rejectConsentRequest: (challenge, body) => put("consent", "reject", challenge, body)
+};

--- a/imports/plugins/core/ui/client/components/app/app.js
+++ b/imports/plugins/core/ui/client/components/app/app.js
@@ -47,6 +47,11 @@ class App extends Component {
     return this.props.hasDashboardAccess;
   }
 
+  get isOauthProvider() {
+    const currentRoute = this.props.currentRoute.route;
+    return currentRoute && currentRoute.options && currentRoute.options.meta && currentRoute.options.meta.oauthLoginFlow;
+  }
+
   handleViewContextChange = (event, value) => {
     Reaction.setUserPreferences("reaction-dashboard", "viewAs", value);
 
@@ -110,7 +115,7 @@ class App extends Component {
     const { currentRoute } = this.props;
     const layout = currentRoute && currentRoute.route && currentRoute.route.options && currentRoute.route.options.layout;
 
-    if (this.isAdminApp && layout !== "printLayout") {
+    if (this.isAdminApp && layout !== "printLayout" && !this.isOauthProvider) {
       return this.renderAdminApp();
     }
 


### PR DESCRIPTION
## Task #4619 

## Overview
This PR sets up an Identity provider functionality that communicates with Hydra for auth.

- It adds `hydra-oauth` plugin to the core plugin registry, that creates: 
- Two endpoints in the Meteor backend: `/login` and `/consent`
- A `/account/login` UI that allows users to "Create Account" and "Log in"
- "Forgot password" flow will be completed on a separate PR



## Testing
- Ensure you have Hydra running in Docker. Then start this branch
- Test with this Starterkit branch
- You should be able to complete the Login and Create Account flows. 
- Both ending you getting an access token and being redirected to the Starterkit