### PR TITLE
refactor: remove all grid positions code and UI

### DIFF
--- a/imports/collections/schemas/catalog.js
+++ b/imports/collections/schemas/catalog.js
@@ -349,7 +349,6 @@ const CatalogVariantSchema = VariantBaseSchema.clone().extend({
  * @property {String} originCountry optional
  * @property {String} pageTitle optional
  * @property {ShippingParcel} parcel optional
- * @property {Object} positions optional
  * @property {CatalogPriceRange} price optional
  * @property {Object} pricing required
  * @property {ImageInfo} primaryImage optional
@@ -482,12 +481,6 @@ export const CatalogProduct = new SimpleSchema({
   "parcel": {
     type: ShippingParcel,
     label: "Shipping parcel",
-    optional: true
-  },
-  "positions": {
-    type: Object,
-    label: "Product positions",
-    blackbox: true,
     optional: true
   },
   "price": {

--- a/imports/collections/schemas/products.js
+++ b/imports/collections/schemas/products.js
@@ -392,7 +392,6 @@ registerSchema("PriceRange", PriceRange);
  * @property {String} type default value: `"simple"`
  * @property {String} vendor optional
  * @property {Metafield[]} metafields optional
- * @property {Object} positions ProductPosition
  * @property {PriceRange} price denormalized, object with range string, min and max
  * @property {Boolean} isLowQuantity denormalized, true when at least 1 variant is below `lowInventoryWarningThreshold`
  * @property {Boolean} isSoldOut denormalized, Indicates when all variants `inventoryQuantity` is zero
@@ -470,11 +469,6 @@ export const Product = new SimpleSchema({
   },
   "metafields.$": {
     type: Metafield
-  },
-  "positions": {
-    type: Object, // ProductPosition
-    blackbox: true,
-    optional: true
   },
   "price": {
     label: "Price",

--- a/imports/plugins/core/catalog/server/methods/catalog.app-test.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.app-test.js
@@ -500,47 +500,6 @@ describe("core product methods", function () {
     });
   });
 
-  describe("updateProductPosition", function () {
-    let product;
-    let tag;
-
-    beforeEach(function () {
-      Tags.remove({});
-
-      product = addProduct();
-      tag = Factory.create("tag");
-    });
-
-    it("should throw 403 error by non admin", function () {
-      sandbox.stub(Reaction, "hasPermission", () => false);
-      const updateProductSpy = sandbox.spy(Products, "update");
-
-      expect(() => Meteor.call(
-        "products/updateProductPosition",
-        product._id, {}, tag._id
-      )).to.throw(ReactionError, /Access Denied/);
-
-      expect(updateProductSpy).to.not.have.been.called;
-    });
-
-    it("should update product position by admin", function (done) {
-      sandbox.stub(Reaction, "hasPermission", () => true);
-      const position = {
-        position: 0,
-        weight: 0,
-        updatedAt: new Date()
-      };
-      expect(() => Meteor.call(
-        "products/updateProductPosition",
-        product._id, position, tag.slug
-      )).to.not.throw(ReactionError, /Access Denied/);
-      const updatedProduct = Products.findOne(product._id);
-      expect(updatedProduct.positions).to.be.defined;
-
-      return done();
-    });
-  });
-
   describe("updateMetaFields position", () => {
     it("should throw 403 error by non admin", function () {
       sandbox.stub(Reaction, "hasPermission", () => false);

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -1265,53 +1265,6 @@ Meteor.methods({
   },
 
   /**
-   * @name products/updateProductPosition
-   * @memberof Methods/Products
-   * @method
-   * @summary update product grid positions
-   * @param {String} productId - productId
-   * @param {Object} positionData -  an object with position,dimensions
-   * @param {String} tagId - The tag route for which this position is intended, or the string "_default" for default/home route
-   * @return {Number} collection update returns
-   */
-  "products/updateProductPosition"(productId, positionData, tagId) {
-    check(productId, String);
-    check(positionData, Object);
-    check(tagId, String);
-
-    // Check first if Product exists and then if user has the proper rights
-    const product = Products.findOne(productId);
-    if (!product) {
-      throw new ReactionError("not-found", "Product not found");
-    } else if (!Reaction.hasPermission("createProduct", this.userId, product.shopId)) {
-      throw new ReactionError("access-denied", "Access Denied");
-    }
-
-    this.unblock();
-
-    const position = `positions.${tagId}.position`;
-    const pinned = `positions.${tagId}.pinned`;
-    const weight = `positions.${tagId}.weight`;
-    const updatedAt = `positions.${tagId}.updatedAt`;
-
-    return updateCatalogProduct(
-      this.userId,
-      {
-        _id: productId
-      },
-      {
-        $set: {
-          [position]: positionData.position,
-          [pinned]: positionData.pinned,
-          [weight]: positionData.weight,
-          [updatedAt]: new Date(),
-          type: "simple" // for multi-schema
-        }
-      }
-    );
-  },
-
-  /**
    * @name products/updateVariantsPosition
    * @memberof Methods/Products
    * @method

--- a/imports/plugins/core/catalog/server/no-meteor/mutations/hashProduct.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/mutations/hashProduct.test.js
@@ -22,7 +22,6 @@ const productSlug = "fake-product";
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
-const positionUpdatedAt = new Date("2018-04-15T15:34:28.043Z");
 
 const mockVariants = [
   {
@@ -142,14 +141,6 @@ const mockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,
@@ -233,14 +224,6 @@ const updatedMockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,

--- a/imports/plugins/core/catalog/server/no-meteor/utils/createCatalogProduct.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/createCatalogProduct.js
@@ -173,7 +173,6 @@ export default async function createCatalogProduct(product, collections) {
     originCountry: product.originCountry,
     pageTitle: product.pageTitle,
     parcel: product.parcel,
-    positions: product.positions,
     price: product.price,
     pricing: {
       [shop.currency]: {

--- a/imports/plugins/core/catalog/server/no-meteor/utils/createCatalogProduct.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/createCatalogProduct.test.js
@@ -22,7 +22,6 @@ const productSlug = "fake-product";
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
-const positionUpdatedAt = new Date("2018-04-15T15:34:28.043Z");
 
 const mockVariants = [
   {
@@ -144,14 +143,6 @@ const mockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,
@@ -249,14 +240,6 @@ const mockCatalogProduct = {
     length: 4.44,
     weight: 7.77,
     width: 5.55
-  },
-  positions: {
-    _default: {
-      pinned: true,
-      position: 1,
-      updatedAt: "2018-04-15T15:34:28.043Z",
-      weight: 1
-    }
   },
   price: {
     max: 5.99,

--- a/imports/plugins/core/catalog/server/no-meteor/utils/getProductPriceRange.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/getProductPriceRange.test.js
@@ -19,7 +19,6 @@ const productSlug = "fake-product";
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
-const positionUpdatedAt = new Date("2018-04-15T15:34:28.043Z");
 
 const mockVariants = [
   {
@@ -139,14 +138,6 @@ const mockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,

--- a/imports/plugins/core/catalog/server/no-meteor/utils/getTopLevelProduct.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/getTopLevelProduct.test.js
@@ -16,7 +16,6 @@ const productSlug = "fake-product";
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
-const positionUpdatedAt = new Date("2018-04-15T15:34:28.043Z");
 
 const mockVariants = [
   {
@@ -138,14 +137,6 @@ const mockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,

--- a/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalog.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalog.test.js
@@ -22,7 +22,6 @@ const productSlug = "fake-product";
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
-const positionUpdatedAt = new Date("2018-04-15T15:34:28.043Z");
 
 const mockVariants = [
   {
@@ -142,14 +141,6 @@ const mockProduct = {
     height: 6.66,
     weight: 7.77
   },
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,
@@ -213,14 +204,6 @@ const updatedMockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,

--- a/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalogById.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalogById.test.js
@@ -20,7 +20,6 @@ const productSlug = "fake-product";
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
-const positionUpdatedAt = new Date("2018-04-15T15:34:28.043Z");
 
 const mockVariants = [
   {
@@ -140,14 +139,6 @@ const mockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,

--- a/imports/plugins/core/catalog/server/no-meteor/utils/publishProductsToCatalog.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/publishProductsToCatalog.test.js
@@ -20,7 +20,6 @@ const productSlug = "fake-product";
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
-const positionUpdatedAt = new Date("2018-04-15T15:34:28.043Z");
 
 const mockVariants = [
   {
@@ -140,14 +139,6 @@ const mockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,

--- a/imports/plugins/core/catalog/server/no-meteor/utils/updateCatalogProductInventoryStatus.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/updateCatalogProductInventoryStatus.test.js
@@ -18,7 +18,6 @@ const productSlug = "fake-product";
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
-const positionUpdatedAt = new Date("2018-04-15T15:34:28.043Z");
 
 const mockVariants = [
   {
@@ -138,14 +137,6 @@ const mockProduct = {
     weight: 7.77
   },
   pinterestMsg: "pinterestMessage",
-  positions: {
-    _default: {
-      weight: 1,
-      position: 1,
-      pinned: true,
-      updatedAt: positionUpdatedAt.toISOString()
-    }
-  },
   price: {
     max: 5.99,
     min: 2.99,

--- a/imports/plugins/core/versions/server/migrations/25_update_catalog_schema.js
+++ b/imports/plugins/core/versions/server/migrations/25_update_catalog_schema.js
@@ -1,6 +1,6 @@
 import { Migrations } from "meteor/percolate:migrations";
 import _ from "lodash";
-import { Catalog, Shops, Tags } from "/lib/collections";
+import { Catalog, Shops } from "/lib/collections";
 import convertCatalogItem from "../util/convertCatalogItem";
 
 // Do this migration in batches of 200 to avoid memory issues
@@ -17,31 +17,6 @@ function getShopsForItems(items) {
       fields: {
         currencies: 1,
         currency: 1
-      }
-    }
-  ).fetch();
-}
-
-function getTagsForItems(items) {
-  const uniquePositionKeys = [];
-  items.forEach(({ positions }) => {
-    Object.keys(positions || {}).forEach((key) => {
-      if (uniquePositionKeys.indexOf(key) === -1) {
-        uniquePositionKeys.push(key);
-      }
-    });
-  });
-
-  return Tags.find(
-    {
-      $or: [
-        { _id: { $in: uniquePositionKeys } },
-        { slug: { $in: uniquePositionKeys } }
-      ]
-    },
-    {
-      fields: {
-        slug: 1
       }
     }
   ).fetch();
@@ -66,11 +41,10 @@ Migrations.add({
 
       if (items.length) {
         const shops = getShopsForItems(items);
-        const tags = getTagsForItems(items);
 
         items.forEach((item) => {
           const shop = shops.find(({ _id }) => _id === item.shopId);
-          const doc = convertCatalogItem(item, shop, tags);
+          const doc = convertCatalogItem(item, shop);
           Catalog.update({ _id: item._id }, doc, { bypassCollection2: true });
         });
       }

--- a/imports/plugins/core/versions/server/util/convertCatalogItem.js
+++ b/imports/plugins/core/versions/server/util/convertCatalogItem.js
@@ -53,35 +53,11 @@ function xformVariant(variant, variantPriceInfo, shopCurrencyCode, updatedAt) {
 }
 
 /**
- * @method
- * @summary Converts the old positions object into the new positions object
- * @param {Object} positions The old positions object
- * @param {Object[]} tags Array of tag objects with `_id` and `slug` props
- * @private
- * @return {Object} The new positions object
- */
-function xformPositions(positions, tags) {
-  const newPositions = {};
-  Object.keys(positions || {}).forEach((key) => {
-    let newKey;
-    const positionTag = tags.find((tag) => tag.slug === key || tag._id === key);
-    if (positionTag) {
-      newKey = positionTag._id;
-    } else {
-      newKey = "_default";
-    }
-    newPositions[newKey] = positions[key];
-  });
-  return newPositions;
-}
-
-/**
  * @param {Object} item The catalog item to transform
  * @param {Object} shop The shop document
- * @param {Object[]} tags Array of tag documents
  * @returns {Object} The converted item document
  */
-export default function convertCatalogItem(item, shop, tags) {
+export default function convertCatalogItem(item, shop) {
   if (!shop) {
     Logger.info("Cannot update catalog item: shop not found");
     return false;
@@ -178,7 +154,6 @@ export default function convertCatalogItem(item, shop, tags) {
     originCountry: item.originCountry,
     pageTitle: item.pageTitle,
     parcel: item.parcel,
-    positions: xformPositions(item.positions, tags),
     price: item.price,
     pricing: {
       [shop.currency]: {

--- a/imports/plugins/core/versions/server/util/convertCatalogItem.test.js
+++ b/imports/plugins/core/versions/server/util/convertCatalogItem.test.js
@@ -50,20 +50,6 @@ const beforeDoc = {
   barcode: "barcode1",
   sku: "PROD_SKU",
   parcel: "PARCEL",
-  positions: {
-    "some shop": {
-      position: 1,
-      pinned: false,
-      weight: 2,
-      updatedAt: new Date("2018-05-26T14:43:26.282+0000")
-    },
-    "some-tag-slug": {
-      position: 2,
-      pinned: true,
-      weight: 1,
-      updatedAt: new Date("2018-05-26T15:43:26.282+0000")
-    }
-  },
   lowInventoryWarningThreshold: 2,
   metaDescription: "metaDescription",
   media: [
@@ -283,20 +269,6 @@ const afterDoc = {
     originCountry: "US",
     pageTitle: "This is a basic product. You can do a lot with it.",
     parcel: "PARCEL",
-    positions: {
-      _default: {
-        position: 1,
-        pinned: false,
-        weight: 2,
-        updatedAt: new Date("2018-05-26T14:43:26.282+0000")
-      },
-      rpjCvTBGjhBi2xdro: {
-        position: 2,
-        pinned: true,
-        weight: 1,
-        updatedAt: new Date("2018-05-26T15:43:26.282+0000")
-      }
-    },
     price: {
       range: "12.99 - 19.99",
       min: 12.99,
@@ -508,13 +480,6 @@ test("returns correctly converted doc", () => {
     }
   };
 
-  const tags = [
-    {
-      _id: "rpjCvTBGjhBi2xdro",
-      slug: "some-tag-slug"
-    }
-  ];
-
-  const doc = convertCatalogItem(beforeDoc, shop, tags);
+  const doc = convertCatalogItem(beforeDoc, shop);
   expect(doc).toEqual(afterDoc);
 });

--- a/imports/plugins/included/default-theme/client/styles/products/products.less
+++ b/imports/plugins/included/default-theme/client/styles/products/products.less
@@ -1,79 +1,6 @@
-
-
 .product-settings-mock-grid > .product-grid-item {
   width: 100%;
   max-width: 100%;
-}
-
-
-.product-settings-size-controls {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.product-settings-size-control {
-  display: flex;
-  flex: 1 1 auto;
-  width: 50px;
-  max-width: 50px;
-  height: 50px;
-  margin: 10px;
-
-  .main {
-    position: relative;
-    .flex(1 1 auto);
-    height: 100%;
-    background-color: @black20;
-    border: 1px solid @white;
-  }
-
-  .side {
-    .display(flex);
-    .flex-direction(column);
-    .flex(0 0 auto);
-
-    width: 20px;
-    height: 100%;
-  }
-
-  .side span {
-    .flex(1 1 auto);
-    display: block;
-    height: 25%;
-    background-color: @black20;
-    border-top: 1px solid @white;
-    border-right: 1px solid @white;
-
-    &:last-child {
-      border-bottom: 1px solid @white;
-    }
-  }
-
-  .main .overlay {
-    width: 45%;
-    height: 25%;
-    position: absolute;
-    background-color: @brand-primary-dark;
-    left: 0.5rem;
-    bottom: 0.5rem;
-  }
-}
-
-.product-settings-size-control.main-wide {
-  max-width: 100px;
-}
-
-.product-settings-size-control.main-full {
-  max-width: 150px;
-}
-
-.product-settings-size-controls .list-group-item {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex: 1 1 auto;
-  width: 33%;
-  border: none;
 }
 
 .product-settings-list-item a {
@@ -91,7 +18,6 @@
   align-items: center;
   padding: 2rem;
 }
-
 
 .product-load-more {
   padding: 0 60px;

--- a/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productSettings/productSettings.html
@@ -48,43 +48,6 @@
         {{> productSettingsListItem product}}
       {{/each}}
     </div>
-
-  </div>
-
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h4 class="panel-title" data-i18n="productDetailEdit.size">Size</h4>
-    </div>
-
-    <div class="product-settings-size-controls list-group">
-
-      <div class="list-group-item {{itemWeightActive 0}}" data-event-action="changeProductWeight" data-event-data="0">
-        <div class="product-settings-size-control">
-            <div class="main"></div>
-        </div>
-      </div>
-
-      <div class="list-group-item {{itemWeightActive 1}}" data-event-action="changeProductWeight" data-event-data="1">
-
-        <div class="product-settings-size-control main-wide">
-            <div class="main"></div>
-            <div class="side">
-              <span></span>
-              <span></span>
-              <span></span>
-            </div>
-        </div>
-      </div>
-
-      <div class="list-group-item {{itemWeightActive 2}}" data-event-action="changeProductWeight" data-event-data="2">
-        <div class="product-settings-size-control main-full">
-          <div class="main">
-            <div class="overlay"></div>
-          </div>
-        </div>
-      </div>
-
-    </div>
   </div>
   {{else}}
     <div class="panel panel-default">

--- a/imports/plugins/included/product-variant/components/customer/productGrid.js
+++ b/imports/plugins/included/product-variant/components/customer/productGrid.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Components } from "@reactioncommerce/reaction-components";
-import { ReactionProduct } from "/lib/api";
 
 class ProductGrid extends Component {
   static propTypes = {
@@ -63,7 +62,6 @@ class ProductGrid extends Component {
   // render the product grid
   renderProductGrid() {
     const { products, shopCurrencyCode } = this.props;
-    const currentTagId = ReactionProduct.getTagIdForPosition();
 
     return (
       <div className="product-grid">
@@ -72,7 +70,6 @@ class ProductGrid extends Component {
             <Components.ProductGridItemCustomer
               shopCurrencyCode={shopCurrencyCode}
               product={product}
-              position={(product.positions && product.positions[currentTagId]) || {}}
               key={product._id}
             />
           ))}

--- a/imports/plugins/included/product-variant/components/customer/productGridItem.js
+++ b/imports/plugins/included/product-variant/components/customer/productGridItem.js
@@ -6,7 +6,6 @@ import { registerComponent, Components } from "@reactioncommerce/reaction-compon
 
 class ProductGridItem extends Component {
   static propTypes = {
-    position: PropTypes.object,
     product: PropTypes.shape({
       _id: PropTypes.string,
       description: PropTypes.string,
@@ -37,19 +36,6 @@ class ProductGridItem extends Component {
     });
   }
 
-  // get weight class name
-  get weightClass() {
-    const { weight } = this.props.position || { weight: 0 };
-    switch (weight) {
-      case 1:
-        return "product-medium";
-      case 2:
-        return "product-large";
-      default:
-        return "product-small";
-    }
-  }
-
   // get notice class names
   get noticeClassNames() {
     const { product: { isSoldOut, isLowQuantity, isBackorder } } = this.props;
@@ -58,16 +44,6 @@ class ProductGridItem extends Component {
       "variant-qty-sold-out": (isSoldOut || (isSoldOut && isBackorder)),
       "badge-danger": (isSoldOut && !isBackorder),
       "badge-low-inv-warning": (isLowQuantity && !isSoldOut)
-    });
-  }
-
-  // get product item class names
-  get productClassNames() {
-    const { position } = this.props;
-    return classnames({
-      "product-grid-item": true,
-      [this.weightClass]: true,
-      "pinned": position.pinned
     });
   }
 
@@ -121,32 +97,6 @@ class ProductGridItem extends Component {
     );
   }
 
-
-  renderAdditionalMedia() {
-    const { product: { media }, position: { weight } } = this.props;
-
-    // if product is not medium weight
-    // or the media array is empty exit
-    if (weight !== 1 || (!media || media.length === 0)) return null;
-
-    // creating an additional madia array with
-    // the 2nd, 3rd and 4th images returned
-    // in the media array
-    const additionalMedia = [...media.slice(1, 4)];
-
-    return (
-      <div className="product-additional-images">
-        {additionalMedia.map((img) => (
-          <span
-            key={img.URLs.small}
-            className="product-image"
-            style={{ backgroundImage: `url("${img.URLs.medium}")` }}
-          />
-        ))}
-      </div>
-    );
-  }
-
   renderGridContent() {
     const { product, shopCurrencyCode } = this.props;
     const pricing = product.pricing.find((price) => price.currency.code === shopCurrencyCode);
@@ -173,7 +123,7 @@ class ProductGridItem extends Component {
     const { product } = this.props;
     return (
       <li
-        className={this.productClassNames}
+        className="product-grid-item product-small"
         data-id={product._id}
         id={product._id}
       >
@@ -190,8 +140,6 @@ class ProductGridItem extends Component {
             <div className="product-primary-images">
               {this.renderMedia()}
             </div>
-
-            {this.renderAdditionalMedia()}
           </a>
 
           {this.renderNotices()}

--- a/imports/plugins/included/product-variant/components/gridItemControls.js
+++ b/imports/plugins/included/product-variant/components/gridItemControls.js
@@ -4,25 +4,32 @@ import { Components } from "@reactioncommerce/reaction-components";
 
 class GridItemControls extends Component {
   static propTypes = {
-    checked: PropTypes.func,
-    hasChanges: PropTypes.func,
-    hasCreateProductPermission: PropTypes.func,
+    hasChanges: PropTypes.bool,
+    hasCreateProductPermission: PropTypes.bool,
+    isSelected: PropTypes.bool,
     isValid: PropTypes.bool,
     product: PropTypes.object
   }
 
   renderArchived() {
-    if (this.props.product.isDeleted) {
+    const { product } = this.props;
+
+    if (product.isDeleted) {
       return (
         <span className="badge badge-danger">
           <Components.Translation defaultValue="Archived" i18nKey="app.archived" />
         </span>
       );
     }
+    return null;
   }
 
   renderVisibilityButton() {
-    if (!this.props.product.__isValid && this.props.hasChanges()) {
+    const { hasChanges, product } = this.props;
+
+    if (!hasChanges) return null;
+
+    if (!product.__isValid) {
       return (
         <div>
           <Components.IconButton
@@ -32,40 +39,41 @@ class GridItemControls extends Component {
           />
         </div>
       );
-    } else if (this.props.hasChanges()) {
-      return (
-        <div>
-          <Components.IconButton
-            icon=""
-            onIcon=""
-            status="info"
-          />
-        </div>
-      );
     }
+
+    return (
+      <div>
+        <Components.IconButton
+          icon=""
+          onIcon=""
+          status="info"
+        />
+      </div>
+    );
   }
 
   render() {
-    if (this.props.hasCreateProductPermission()) {
-      return (
-        <div className="product-grid-controls">
-          <label className="like-button hidden" htmlFor={`select-product-${this.props.product._id}`}>
-            <input
-              type="checkbox"
-              name="selectProduct"
-              value={this.props.product._id}
-              id={`select-product-${this.props.product._id}`}
-              checked={this.props.checked()}
-              readOnly
-            />
-          </label>
+    const { isSelected, hasCreateProductPermission, product } = this.props;
 
-          {this.renderArchived()}
-          {this.renderVisibilityButton()}
-        </div>
-      );
-    }
-    return null;
+    if (!hasCreateProductPermission) return null;
+
+    return (
+      <div className="product-grid-controls">
+        <label className="like-button hidden" htmlFor={`select-product-${product._id}`}>
+          <input
+            type="checkbox"
+            name="selectProduct"
+            value={product._id}
+            id={`select-product-${product._id}`}
+            checked={isSelected}
+            readOnly
+          />
+        </label>
+
+        {this.renderArchived()}
+        {this.renderVisibilityButton()}
+      </div>
+    );
   }
 }
 

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -1,6 +1,9 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Components } from "@reactioncommerce/reaction-components";
+import { Session } from "meteor/session";
+import { Reaction } from "/client/api";
 
 class ProductGrid extends Component {
   static propTypes = {
@@ -12,10 +15,27 @@ class ProductGrid extends Component {
     productMediaById: {}
   };
 
-  renderProductGridItems = (products) => {
-    if (Array.isArray(products)) {
-      const { productMediaById } = this.props;
+  onPageClick = (event) => {
+    // Do nothing if we are in preview mode
+    if (Reaction.isPreview() === false) {
+      // Don't trigger the clear selection if we're clicking on a grid item.
+      if (event.target.closest(".product-grid-item") === null) {
+        const selectedProducts = Session.get("productGrid/selectedProducts");
 
+        // Do we have any selected products?
+        // If we do then lets reset the Grid Settings ActionView
+        if (Array.isArray(selectedProducts) && selectedProducts.length) {
+          // Reset sessions ver of selected products
+          Session.set("productGrid/selectedProducts", []);
+        }
+      }
+    }
+  }
+
+  renderProductGridItems() {
+    const { productMediaById, products } = this.props;
+
+    if (Array.isArray(products) && products.length > 0) {
       return products.map((product, index) => (
         <Components.ProductGridItems
           {...this.props}
@@ -40,13 +60,11 @@ class ProductGrid extends Component {
 
   render() {
     return (
-      <div className="container-main">
+      <div className="container-main" onClick={this.onPageClick}>
         <div className="product-grid">
-          <Components.DragDropProvider>
-            <ul className="product-grid-list list-unstyled" id="product-grid-list">
-              {this.renderProductGridItems(this.props.products)}
-            </ul>
-          </Components.DragDropProvider>
+          <ul className="product-grid-list list-unstyled" id="product-grid-list">
+            {this.renderProductGridItems()}
+          </ul>
         </div>
       </div>
     );

--- a/imports/plugins/included/product-variant/components/productGridItems.js
+++ b/imports/plugins/included/product-variant/components/productGridItems.js
@@ -5,20 +5,14 @@ import { formatPriceString } from "/client/api";
 
 class ProductGridItems extends Component {
   static propTypes = {
-    canEdit: PropTypes.bool,
-    connectDragSource: PropTypes.func,
-    connectDropTarget: PropTypes.func,
     displayPrice: PropTypes.func,
-    isMediumWeight: PropTypes.func,
     isSearch: PropTypes.bool,
     isSelected: PropTypes.func,
     onClick: PropTypes.func,
     onDoubleClick: PropTypes.func,
     pdpPath: PropTypes.func,
-    positions: PropTypes.func,
     product: PropTypes.object,
-    productMedia: PropTypes.object,
-    weightClass: PropTypes.func
+    productMedia: PropTypes.object
   }
 
   static defaultProps = {
@@ -38,10 +32,6 @@ class ProductGridItems extends Component {
     this.props.onClick(event);
   }
 
-  renderPinned() {
-    return this.props.positions().pinned ? "pinned" : "";
-  }
-
   renderVisible() {
     return this.props.product.isVisible ? "" : "not-visible";
   }
@@ -52,6 +42,7 @@ class ProductGridItems extends Component {
         <div className="product-grid-overlay" />
       );
     }
+    return null;
   }
 
   renderMedia() {
@@ -62,34 +53,14 @@ class ProductGridItems extends Component {
     );
   }
 
-  renderAdditionalMedia() {
-    const { isMediumWeight, productMedia } = this.props;
-    if (!isMediumWeight()) return null;
-
-    const mediaArray = productMedia.additionalMedia;
-    if (!mediaArray || mediaArray.length === 0) return null;
-
-    return (
-      <div className={`product-additional-images ${this.renderVisible()}`}>
-        {mediaArray.map((media) => (
-          <span
-            key={media._id}
-            className="product-image"
-            style={{ backgroundImage: `url('${media.url({ store: "medium" })}')` }}
-          />
-        ))}
-        {this.renderOverlay()}
-      </div>
-    );
-  }
-
   renderNotices() {
+    const { product } = this.props;
+
     return (
       <div className="grid-alerts">
-        <Components.GridItemNotice product={this.props.product} />
-        <Components.GridItemControls product={this.props.product} />
+        <Components.GridItemNotice product={product} />
+        <Components.GridItemControls product={product} />
       </div>
-
     );
   }
 
@@ -117,25 +88,23 @@ class ProductGridItems extends Component {
     );
   }
 
-  renderHoverClassName() {
-    return this.props.isSearch ? "item-content" : "";
-  }
-
   render() {
+    const { isSearch, isSelected, pdpPath, product } = this.props;
+
     const productItem = (
       <li
-        className={`product-grid-item ${this.renderPinned()} ${this.props.weightClass()} ${this.props.isSelected()}`}
-        data-id={this.props.product._id}
-        id={this.props.product._id}
+        className={`product-grid-item product-small ${isSelected() ? "active" : ""}`}
+        data-id={product._id}
+        id={product._id}
       >
-        <div className={this.renderHoverClassName()}>
+        <div className={isSearch ? "item-content" : ""}>
           <span className="product-grid-item-alerts" />
 
           <a className="product-grid-item-images"
-            href={this.props.pdpPath()}
+            href={pdpPath()}
             data-event-category="grid"
             data-event-label="grid product click"
-            data-event-value={this.props.product._id}
+            data-event-value={product._id}
             onDoubleClick={this.handleDoubleClick}
             onClick={this.handleClick}
           >
@@ -143,21 +112,13 @@ class ProductGridItems extends Component {
               {this.renderMedia()}
               {this.renderOverlay()}
             </div>
-
-            {this.renderAdditionalMedia()}
           </a>
 
-          {!this.props.isSearch && this.renderNotices()}
+          {!isSearch && this.renderNotices()}
           {this.renderGridContent()}
         </div>
       </li>
     );
-
-    if (this.props.canEdit) {
-      return (
-        this.props.connectDropTarget(this.props.connectDragSource(productItem))
-      );
-    }
 
     return productItem;
   }

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -1,15 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import update from "immutability-helper";
 import _ from "lodash";
 import { compose } from "recompose";
-import { Components, composeWithTracker, registerComponent } from "@reactioncommerce/reaction-components";
-import { Meteor } from "meteor/meteor";
+import { composeWithTracker, registerComponent } from "@reactioncommerce/reaction-components";
 import { Session } from "meteor/session";
-import { Reaction } from "/client/api";
-import ReactionError from "@reactioncommerce/reaction-error";
 import { Media } from "/imports/plugins/core/files/client";
-import Logger from "/client/modules/logger";
 import { ReactionProduct } from "/lib/api";
 import ProductGrid from "../components/productGrid";
 
@@ -17,7 +12,7 @@ const wrapComponent = (Comp) => (
   class ProductGridContainer extends Component {
     static propTypes = {
       isSearch: PropTypes.bool,
-      productIds: PropTypes.array,
+      productIds: PropTypes.arrayOf(PropTypes.string),
       products: PropTypes.array,
       productsByKey: PropTypes.object
     }
@@ -26,151 +21,41 @@ const wrapComponent = (Comp) => (
       super(props);
 
       this.state = {
-        products: props.products,
-        productsByKey: props.productsByKey,
-        productIds: props.productIds,
         initialLoad: true,
         slug: "",
         canLoadMoreProducts: false
       };
     }
 
-    UNSAFE_componentWillMount() { // eslint-disable-line camelcase
-      const selectedProducts = Reaction.getUserPreferences("reaction-product-variant", "selectedGridItems");
-      const { products } = this;
-
-      if (Array.isArray(selectedProducts) && _.isEmpty(selectedProducts)) {
-        Reaction.setUserPreferences("reaction-product-variant", "selectedGridItems", undefined);
-        return Reaction.hideActionView();
-      }
-
-
-      if (products && selectedProducts) {
-        // Save the selected items to the Session
-        Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
-        const filteredProducts = products.filter((product) => selectedProducts.includes(product._id));
-
-        if (Reaction.isPreview() === false) {
-          Reaction.showActionView({
-            label: "Grid Settings",
-            i18nKeyLabel: "gridSettingsPanel.title",
-            template: "productSettings",
-            type: "product",
-            data: { products: filteredProducts }
-          });
-        }
-      }
-
-      return null;
-    }
-
-    UNSAFE_componentWillReceiveProps = (nextProps) => { // eslint-disable-line camelcase
-      this.setState({
-        products: nextProps.products,
-        productIds: nextProps.productIds,
-        productsByKey: nextProps.productsByKey
-      });
-    }
-
     handleSelectProductItem = (isChecked, productId) => {
-      let selectedProducts = Session.get("productGrid/selectedProducts");
+      let selectedProducts = Session.get("productGrid/selectedProducts") || [];
 
       if (isChecked) {
         selectedProducts.push(productId);
+        selectedProducts = _.uniq(selectedProducts);
       } else {
         selectedProducts = _.without(selectedProducts, productId);
       }
 
-      Reaction.setUserPreferences("reaction-product-variant", "selectedGridItems", selectedProducts);
-
-      const { products } = this;
-
-      if (products && selectedProducts) {
-        // Save the selected items to the Session
-        Session.set("productGrid/selectedProducts", _.uniq(selectedProducts));
-        const filteredProducts = products.filter((product) => selectedProducts.includes(product._id));
-
-        Reaction.showActionView({
-          label: "Grid Settings",
-          i18nKeyLabel: "gridSettingsPanel.title",
-          template: "productSettings",
-          type: "product",
-          data: { products: filteredProducts }
-        });
-      }
-    }
-
-    handleProductDrag = (dragIndex, hoverIndex) => {
-      const tagId = ReactionProduct.getTagIdForPosition();
-      const dragProductId = this.state.productIds[dragIndex];
-      const hoverProductId = this.state.productIds[hoverIndex];
-      const dragProductWeight = _.get(this, `state.productsByKey[${dragProductId}].positions[${tagId}].weight`, 0);
-      const dropProductWeight = _.get(this, `state.productsByKey[${hoverProductId}].positions[${tagId}].weight`, 0);
-
-      const newState = update(this.state, {
-        productsByKey: {
-          [dragProductId]: {
-            $merge: {
-              positions: {
-                [tagId]: {
-                  weight: dropProductWeight
-                }
-              }
-            }
-          },
-          [hoverProductId]: {
-            $merge: {
-              positions: {
-                [tagId]: {
-                  weight: dragProductWeight
-                }
-              }
-            }
-          }
-        },
-        productIds: {
-          $splice: [
-            [dragIndex, 1],
-            [hoverIndex, 0, dragProductId]
-          ]
-        }
-      });
-
-      this.setState(newState);
-    }
-
-    handleProductDrop = () => {
-      const tagId = ReactionProduct.getTagIdForPosition();
-      this.state.productIds.map((productId, index) => {
-        const position = { position: index, updatedAt: new Date() };
-
-        return Meteor.call("products/updateProductPosition", productId, position, tagId, (error) => {
-          if (error) {
-            Logger.error(error);
-            throw new ReactionError("error-occurred", error);
-          }
-        });
-      });
+      // Save the selected items to the Session
+      Session.set("productGrid/selectedProducts", selectedProducts);
     }
 
     get products() {
-      if (this.props.isSearch) {
-        return this.state.products;
+      const { isSearch, products, productsByKey, productIds } = this.props;
+      if (isSearch) {
+        return products;
       }
-      return this.state.productIds.map((id) => this.state.productsByKey[id]);
+      return productIds.map((id) => productsByKey[id]);
     }
 
     render() {
       return (
-        <Components.DragDropProvider>
-          <Comp
-            {...this.props}
-            products={this.products}
-            onMove={this.handleProductDrag}
-            onDrop={this.handleProductDrop}
-            itemSelectHandler={this.handleSelectProductItem}
-          />
-        </Components.DragDropProvider>
+        <Comp
+          {...this.props}
+          itemSelectHandler={this.handleSelectProductItem}
+          products={this.products}
+        />
       );
     }
   }

--- a/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
@@ -5,53 +5,15 @@ import { compose } from "recompose";
 import { registerComponent } from "@reactioncommerce/reaction-components";
 import { Session } from "meteor/session";
 import { Reaction } from "/client/api";
-import { ReactionProduct } from "/lib/api";
-import { SortableItem } from "/imports/plugins/core/ui/client/containers";
 import ProductGridItems from "../components/productGridItems";
 
 const wrapComponent = (Comp) => (
   class ProductGridItemsContainer extends Component {
     static propTypes = {
-      connectDragSource: PropTypes.func,
-      connectDropTarget: PropTypes.func,
       isSearch: PropTypes.bool,
       itemSelectHandler: PropTypes.func,
       product: PropTypes.object,
       unmountMe: PropTypes.func
-    }
-
-    componentDidMount() {
-      document.querySelector(".page > main").addEventListener("click", this.onPageClick);
-    }
-
-    componentWillUnmount() {
-      document.querySelector(".page > main").removeEventListener("click", this.onPageClick);
-    }
-
-    onPageClick = (event) => {
-      // Do nothing if we are in preview mode
-      if (Reaction.isPreview() === false) {
-        // Don't trigger the clear selection if we're clicking on a grid item.
-        if (event.target.closest(".product-grid-item") === null) {
-          const selectedProducts = Session.get("productGrid/selectedProducts");
-
-          // Do we have any selected products?
-          // If we do then lets reset the Grid Settings ActionView
-          if (Array.isArray(selectedProducts) && selectedProducts.length) {
-            // Reset sessions ver of selected products
-            Session.set("productGrid/selectedProducts", []);
-
-            // Reset the action view of selected products
-            Reaction.setActionView({
-              label: "Grid Settings",
-              i18nKeyLabel: "gridSettingsPanel.title",
-              template: "productSettings",
-              type: "product",
-              data: {}
-            });
-          }
-        }
-      }
     }
 
     productPath = () => {
@@ -72,36 +34,11 @@ const wrapComponent = (Comp) => (
       return "/";
     }
 
-    positions = () => {
-      const tagId = ReactionProduct.getTagIdForPosition();
-      return (this.props.product.positions && this.props.product.positions[tagId]) || {};
-    }
-
-    weightClass = () => {
-      const positions = this.positions();
-      const weight = positions.weight || 0;
-      switch (weight) {
-        case 1:
-          return "product-medium";
-        case 2:
-          return "product-large";
-        default:
-          return "product-small";
-      }
-    }
-
     isSelected = () => {
       if (Reaction.isPreview() === false) {
         return _.includes(Session.get("productGrid/selectedProducts"), this.props.product._id) ? "active" : "";
       }
       return false;
-    }
-
-    isMediumWeight = () => {
-      const positions = this.positions();
-      const weight = positions.weight || 0;
-
-      return weight === 1;
     }
 
     displayPrice = () => {
@@ -213,10 +150,7 @@ const wrapComponent = (Comp) => (
         <Comp
           product={this.props.product}
           pdpPath={this.productPath}
-          positions={this.positions}
-          weightClass={this.weightClass}
           isSelected={this.isSelected}
-          isMediumWeight={this.isMediumWeight}
           displayPrice={this.displayPrice}
           onDoubleClick={this.onDoubleClick}
           onClick={this.onClick}
@@ -228,11 +162,7 @@ const wrapComponent = (Comp) => (
 );
 
 registerComponent("ProductGridItems", ProductGridItems, [
-  SortableItem("productGridItem"),
   wrapComponent
 ]);
 
-export default compose(
-  SortableItem("productGridItem"),
-  wrapComponent
-)(ProductGridItems);
+export default compose(wrapComponent)(ProductGridItems);

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -1,12 +1,11 @@
 import i18next from "i18next";
-import orderBy from "lodash/orderBy";
 import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { ReactiveDict } from "meteor/reactive-dict";
 import { ReactiveVar } from "meteor/reactive-var";
 import ReactionError from "@reactioncommerce/reaction-error";
 import { Router } from "/imports/plugins/core/router/lib";
-import { Products, Tags } from "/lib/collections";
+import { Products } from "/lib/collections";
 import Catalog from "./catalog";
 import { MetaData } from "/lib/api/router/metadata";
 
@@ -47,29 +46,6 @@ export function variantIsSelected(variantId) {
   }
   return false;
 }
-
-/**
- * @name sortProducts
- * @method
- * @memberof ReactionProduct
- * @summary Sort products by tag, creation date by tag and creation date
- * @param  {Array} products Array of products
- * @param  {String} tagId     Tag ID
- * @return {Array}         Array of products
- */
-ReactionProduct.sortProducts = (products, tagId) => {
-  let sorted = [];
-
-  sorted = orderBy(
-    products,
-    // Sort by postion for tag
-    (product) => product.positions && product.positions[tagId] && product.positions[tagId].position,
-    // Then by product creation date
-    "createdAt"
-  );
-
-  return sorted;
-};
 
 /**
  * @name setCurrentVariant
@@ -321,21 +297,6 @@ ReactionProduct.getVariantParent = (variant) => Catalog.getVariantParent(variant
  * @return {Array} Product top level variants or empty array
  */
 ReactionProduct.getTopVariants = (id) => Catalog.getTopVariants(id || ReactionProduct.selectedProductId());
-
-/**
- * @name getTagIdForPosition
- * @method
- * @memberof ReactionProduct
- * @summary This needed for naming `positions` object. Method could return `tag`
- * route name or shop name as default name.
- * @return {String} Tag ID, if there is a current tag slug, or the string "_default" if on home page.
- */
-ReactionProduct.getTagIdForPosition = function () {
-  if (Router.getRouteName() !== "tag") return "_default";
-  const { slug } = Router.current().params;
-  const tag = Tags.findOne({ slug });
-  return (tag && tag._id) || "_default";
-};
 
 /**
  * @name getProductsByTag


### PR DESCRIPTION
Resolves #4542   
Impact: **minor**  
Type: **refactor**

## Issue
The customer-facing grid UI no longer supports manually positioned or pinned items, or differing weights. Features similar to this will be reimplemented in a different way. However, the operator UI for the grid still allowed you drag and drop items and change their weights.

## Solution
When logged in as a user with "createProduct" permission and with edit mode on, you can no longer drag and drop items on the grid and the "Size" area in the panel no longer appears. All grid items are always "small" size and in ascending order by creation date (for now).

Pulling this code out caused the grid to have rerendering issues, which were fixed by some refactoring of the grid item selection code to make it cleaner and less prone to excessive rerendering.

## Testing
1. Log in as a user with "createProduct" permission.
2. Toggle on edit mode in the upper left corner.
3. Try to drag/drop items on the grid and verify that you cannot.
4. Click items in the grid. Verify they still appear in the action panel, but that the "Size" area allowing you to choose different "weights" for the item is no longer there.