### PR TITLE
Ensure MongoDB replica set is ready before start

### DIFF
--- a/.reaction/waitForReplica.js
+++ b/.reaction/waitForReplica.js
@@ -1,0 +1,144 @@
+const { MongoClient } = require("mongodb");
+
+/**
+ * Print a message to the console (no trailing newline)
+ * @param {string} message User progress message to print
+ * @returns {undefined}
+ */
+function defaultOut(message) {
+  process.stdout.write(message);
+}
+
+/**
+ * Print a message to the console (no trailing newline)
+ * @param {Object} options - Named options object
+ * @param {function()} options.out Function to show progress
+ * @param {number} options.max Number of retries attempted before full failure
+ * @param {function():Promise} options.check async/Promise function that implements
+ *   the main check operation. Throw an exception to cause a retry. Resolve the
+ *   promise to indicate success.
+ * @param {number} options.waitMs milliseconds to wait between checks
+ * @param {string} options.timeoutMessage for final timeout
+ * @returns {Promise} a promise indicating success/failure of the check
+ */
+async function checkWaitRetry({
+  out = defaultOut,
+  max = 30,
+  check = null,
+  waitMs = 1000,
+  timeoutMessage = "Timed out waiting for a prerequisite"
+} = {}) {
+  const messages = new Set();
+  /**
+   * Show a progress/info message, but not over and over again
+   *
+   * @param {string} message to be printed
+   * @param {number} count retry number for progress dots
+  * @returns {undefined}
+  */
+  function showOnce(message, count) {
+    if (!messages.has(message)) {
+      messages.add(message);
+      out(message);
+    }
+    if (count % 10 === 0) {
+      out(".");
+    }
+  }
+  return new Promise((resolve, reject) => {
+    let count = 0;
+    /**
+     * Inner retry loop. Resolves/rejects the promise when done.
+     *
+     * @returns {undefined}
+     */
+    function loop() {
+      count += 1;
+      if (count >= max) {
+        reject(new Error(timeoutMessage));
+        return;
+      }
+      check()
+        .then(resolve)
+        .catch((error) => {
+          showOnce(error.message, count);
+          setTimeout(loop, waitMs);
+        });
+    }
+    loop();
+  });
+}
+
+/**
+ * Connect to mongodb
+ *
+ * @param {string} mongoUrl URL to mongodb server and database name
+ * @returns {Promise} a promise resolving to the mongodb db instance
+ */
+async function connect(mongoUrl) {
+  const lastSlash = mongoUrl.lastIndexOf("/");
+  const dbUrl = mongoUrl.slice(0, lastSlash);
+  const dbName = mongoUrl.slice(lastSlash + 1);
+
+  const client = await MongoClient.connect(
+    dbUrl,
+    { useNewUrlParser: true }
+  );
+  return client.db(dbName);
+}
+
+/**
+ * Check if replication is ready
+ *
+ * @param {objecct} db connected mongo db instance
+ * @returns {Promise} indication of success/failure
+ */
+async function checkReplicaSetStatus(db) {
+  const status = await db.admin().replSetGetStatus();
+  if (status.ok !== 1) {
+    throw new Error("Replica set not yet initialized");
+  }
+}
+
+/**
+ * Start the replica check/wait/retry loop
+ * @returns {Promise} indication of success/failure
+ */
+async function main() {
+  const { MONGO_URL } = process.env;
+  if (!MONGO_URL) {
+    throw new Error("You must set MONGO_URL environment variable.");
+  }
+  const db = await connect(MONGO_URL);
+  await checkWaitRetry({
+    timeoutMessage: "ERROR: MongoDB replica set not ready in time.",
+    check: checkReplicaSetStatus.bind(null, db)
+  });
+  defaultOut("MongoDB replica set initialized and ready.\n");
+  process.exit();
+}
+
+/**
+ * Print an error message and exit with nonzero exit code
+ *
+ * @param {Error} error cause of failure
+ * @returns {undefined} exits the process
+ */
+function exit(error) {
+  console.error(error.message); // eslint-disable-line no-console
+  process.exit(10);
+}
+
+// Allow this module to be run directly as a node program or imported as lib
+if (require.main === module) {
+  process.on("unhandledRejection", exit);
+  try {
+    main();
+  } catch (error) {
+    exit(error);
+  }
+}
+
+module.exports = {
+  checkWaitRetry
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     build:
       context: .
       target: meteor-dev
-    command: bash -c "npm install && reaction" #TODO; Revert to Meteor NPM. See comment in Dockerfile about Meteor1.7 NPM version issue.
+    command: bash -c "npm install && node ./.reaction/waitForReplica.js && reaction" #TODO; Revert to Meteor NPM. See comment in Dockerfile about Meteor1.7 NPM version issue.
     depends_on:
       - mongo-init-replica
     environment:

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    "require-jsdoc": "off"
+  }
+};

--- a/tests/waitForReplica.test.js
+++ b/tests/waitForReplica.test.js
@@ -1,0 +1,73 @@
+import { checkWaitRetry } from "../.reaction/waitForReplica";
+
+test("should work in immediate success case", async () => {
+  const outLog = [];
+  function out(message) {
+    outLog.push(message);
+  }
+  async function check() {}
+  try {
+    await checkWaitRetry({ out, check, max: 2, waitMs: 10 });
+  } catch (error) {
+    expect(error).toBeFalsy();
+    expect(outLog).toEqual([]);
+  }
+});
+
+test("should work for timeout case with 1 progress dot", async () => {
+  const outLog = [];
+  function out(message) {
+    outLog.push(message);
+  }
+  async function check() {
+    throw new Error("unit-test-error");
+  }
+  try {
+    await checkWaitRetry({ out, check, max: 12, waitMs: 10 });
+    expect(false).toBeTruthy("Should have thrown");
+  } catch (error) {
+    expect(error).toBeTruthy();
+    expect(error.message).toContain("Timed out");
+    expect(outLog).toEqual(["unit-test-error", "."]);
+  }
+});
+
+test("should retry until success before first progress dot", async () => {
+  const outLog = [];
+  function out(message) {
+    outLog.push(message);
+  }
+  let failCount = 9;
+  async function check() {
+    failCount -= 1;
+    if (failCount >= 0) {
+      throw new Error("unit-test-error");
+    }
+  }
+  try {
+    await checkWaitRetry({ out, check, waitMs: 10 });
+    expect(outLog).toEqual(["unit-test-error"]);
+  } catch (error) {
+    expect(error).toBeFalsy();
+  }
+});
+
+test("should retry until success with progress dots", async () => {
+  const outLog = [];
+  function out(message) {
+    outLog.push(message);
+  }
+  let failCount = 30;
+  async function check() {
+    failCount -= 1;
+    if (failCount >= 0) {
+      throw new Error("unit-test-error");
+    }
+  }
+  try {
+    await checkWaitRetry({ out, check, max: 40, waitMs: 10 });
+    expect(outLog).toEqual(["unit-test-error", ".", ".", "."]);
+  } catch (error) {
+    expect(error).toBeFalsy();
+  }
+});


### PR DESCRIPTION
Resolves #4629   
Impact: **minor**  
Type: **bugfix**

## Issue
There's a docker startup race condition which can cause the application to not start if the mongodb replica set is not ready in time. See #4629 for details.

## Solution

Add a small node program to reaction startup that polls for replica set ready before starting reaction.

## Testing

  - Test against pristine install, should wait for replica then start properly without much delay
  - Test against existing install with healthy replica, should start properly without much/any delay
  - Test against pristine install where replica never becomes ready
   - You can force this by hacking the `docker-compose.yml` file to have reaction depend on `mongo` instead of `mongo-init-replica`. It should retry for 30s then fail with a clear error message and not starting reaction.
   - Same setup can test retry if you manually run `docker-compose up -d mongo-init-replica` while the reaction container is wating (you have a 30s window)

There are also some automated unit tests for the core retry logic code.

## Lint

Both files pass eslint for me locally but the `.reaction` directory is ignored in our eslint config it seems. It is likely my jsdoc does not meet all of our conventions but I put something reasonable in there.