### PR TITLE
feat(GraphQL): add `Account.primaryEmailAddress` resolver

### DIFF
--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/index.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/index.js
@@ -10,5 +10,9 @@ export default {
   currency: (account) => getXformedCurrencyByCode(account.profile && account.profile.currency),
   emailRecords: (account) => account.emails,
   preferences: (account) => get(account, "profile.preferences"),
+  primaryEmailAddress: (account) => {
+    const primaryRecord = (account.emails || []).find((record) => record.provides === "default");
+    return (primaryRecord && primaryRecord.address) || null;
+  },
   shop: resolveShopFromShopId
 };

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/viewer.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/viewer.js
@@ -10,8 +10,14 @@ import { optimizeIdOnly } from "@reactioncommerce/reaction-graphql-utils";
  * @param {Object} context - an object containing the per-request state
  * @return {Object} user account object
  */
-export default function viewer(_, __, context, info) {
+export default async function viewer(_, __, context, info) {
   if (!context.userId) return null;
+
+  // Classic Meteor UI creates dummy accounts for "anonymous" user. We should ignore those.
+  const user = await context.collections.users.findOne({ _id: context.userId });
+  if (!user || !user.roles || !Array.isArray(user.roles[Object.keys(user.roles)[0]]) || user.roles[Object.keys(user.roles)[0]].indexOf("anonymous") !== -1) {
+    return null;
+  }
 
   return optimizeIdOnly(context.userId, info, context.queries.userAccount)(context, context.userId);
 }

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/viewer.test.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/viewer.test.js
@@ -7,12 +7,25 @@ const mockAccount = {
   name: "Reaction"
 };
 
+const mockUser = {
+  _id: "123",
+  roles: {
+    abc: []
+  }
+};
+
 test("calls queries.userAccount and returns the viewing user", async () => {
   require("graphql-fields").mockReturnValueOnce({ _id: "1", name: "1" });
 
+  const findOne = jest.fn().mockName("collections.users.findOne").mockReturnValueOnce(Promise.resolve(mockUser));
   const userAccount = jest.fn().mockName("queries.userAccount").mockReturnValueOnce(Promise.resolve(mockAccount));
 
   const user = await viewer(null, null, {
+    collections: {
+      users: {
+        findOne
+      }
+    },
     queries: { userAccount },
     userId: "123"
   });
@@ -25,9 +38,15 @@ test("calls queries.userAccount and returns the viewing user", async () => {
 test("returns without calling queries.userAccount if only _id requested", async () => {
   require("graphql-fields").mockReturnValueOnce({ _id: "1" });
 
+  const findOne = jest.fn().mockName("collections.users.findOne").mockReturnValueOnce(Promise.resolve(mockUser));
   const userAccount = jest.fn().mockName("userAccount");
 
   const user = await viewer(null, null, {
+    collections: {
+      users: {
+        findOne
+      }
+    },
     queries: { userAccount },
     userId: "123"
   });

--- a/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
+++ b/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
@@ -142,6 +142,11 @@ type Account implements Node {
   "An object storing plugin-specific preferences for this account"
   preferences: JSONObject
 
+  """
+  The primary email address for the account. This matches the address in `emailRecords` where `provides` is "default".
+  """
+  primaryEmailAddress: Email!
+
   "The shop to which this account belongs, if it is associated with a specific shop"
   shop: Shop
 


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Changes
Provide a simpler way for GraphQL clients to get the default account email address: `Account.primaryEmailAddress`

## Breaking changes
None

## Testing
```
{
  viewer {
    name
    emailRecords {
      provides
      address
      verified
    }
    primaryEmailAddress
  }
}
```

`primaryEmailAddress` should be set and should match the email record with "default" as its `provides` value.