### PR TITLE
2.0 migrations

### DIFF
--- a/imports/plugins/core/orders/server/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/util/sendOrderEmail.js
@@ -94,10 +94,11 @@ export default function sendOrderEmail(order, action) {
   const refundResult = Meteor.call("orders/refunds/list", order);
   const refundTotal = Array.isArray(refundResult) && refundResult.reduce((acc, refund) => acc + refund.amount, 0);
 
-  const userCurrencyFormatting = _.omit(shop.currencies[currency.userCurrency], ["enabled", "rate"]);
+  const userCurrency = (currency && currency.userCurrency) || shop.currency;
+  const userCurrencyFormatting = _.omit(shop.currencies[userCurrency], ["enabled", "rate"]);
 
   // Get user currency exchange rate at time of transaction
-  const userCurrencyExchangeRate = currency.exchangeRate;
+  const userCurrencyExchangeRate = (currency && currency.exchangeRate) || 1;
 
   // Combine same products into single "product" for display purposes
   const combinedItems = [];

--- a/imports/plugins/core/versions/server/migrations/40_two_point_oh.js
+++ b/imports/plugins/core/versions/server/migrations/40_two_point_oh.js
@@ -1,0 +1,33 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Cart, Notifications, Orders, Packages } from "/lib/collections";
+import { convertCart, convertOrder } from "../util/convert20";
+import findAndConvertInBatches from "../util/findAndConvertInBatches";
+
+Migrations.add({
+  version: 40,
+  up() {
+    const packages = Packages.find({}).fetch();
+
+    // Orders
+    findAndConvertInBatches({
+      collection: Orders,
+      converter: (order) => convertOrder(order, packages)
+    });
+
+    // Carts
+    findAndConvertInBatches({
+      collection: Cart,
+      converter: convertCart
+    });
+
+    // Notifications
+    // The status should always be set, but we'll make sure since it's now a required field.
+    Notifications.update({
+      status: null
+    }, {
+      $set: {
+        status: "unread"
+      }
+    }, { multi: true, bypassCollection2: true });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -37,3 +37,4 @@ import "./36_convert_requiresShipping";
 import "./37_change_shipping_rate_settings_template_name";
 import "./38_registry_products_template";
 import "./39_example_payment_template";
+import "./40_two_point_oh";

--- a/imports/plugins/core/versions/server/startup.js
+++ b/imports/plugins/core/versions/server/startup.js
@@ -28,6 +28,12 @@ Hooks.Events.add("afterCoreInit", () => {
     Logger.fatal("If you really want to downgrade to this version, you should restore your DB to a previous state from your backup.");
     process.exit(0);
   } else if (!Meteor.isAppTest) {
-    Migrations.migrateTo("latest");
+    try {
+      Migrations.migrateTo("latest");
+    } catch (error) {
+      Logger.error("Error while migrating", error);
+      // Make sure the migration control record is unlocked so they can attempt to run again next time
+      Migrations.unlock();
+    }
   }
 });

--- a/imports/plugins/core/versions/server/util/convert20.js
+++ b/imports/plugins/core/versions/server/util/convert20.js
@@ -1,0 +1,214 @@
+/**
+ * Reaction 2.0 conversions
+ */
+
+/**
+ * @param {Object} cart The cart document to transform
+ * @returns {Object} The converted cart document
+ */
+export function convertCart(cart) {
+  const convertedCart = { ...cart };
+
+  // Set `cart.billingAddress`
+  if (!cart.billingAddress && Array.isArray(cart.billing) && cart.billing[0]) {
+    convertedCart.billingAddress = cart.billing[0].address || null;
+  }
+
+  // Delete removed props
+  convertedCart.tax = null;
+  convertedCart.taxes = null;
+  convertedCart.taxRatesByShop = null;
+
+  // Remove everything from billing array unless it's a discount
+  if (Array.isArray(cart.billing)) {
+    convertedCart.billing = cart.billing.reduce((list, payment) => {
+      if (payment.paymentMethod && (payment.paymentMethod.processor === "code" || payment.paymentMethod.processor === "rate")) {
+        list.push({
+          _id: payment._id || payment.paymentMethod.id,
+          amount: payment.paymentMethod.amount,
+          createdAt: payment.createdAt || new Date(),
+          currencyCode: cart.currencyCode || "USD",
+          data: {
+            discountId: payment.paymentMethod.id,
+            code: payment.paymentMethod.code
+          },
+          displayName: `Discount Code: ${payment.paymentMethod.code}`,
+          method: payment.paymentMethod.method,
+          mode: "discount",
+          name: payment.paymentMethod.processor === "code" ? "discount_code" : "discount_rate",
+          paymentPluginName: payment.paymentMethod.processor === "code" ? "discount-codes" : "discount-rates",
+          processor: payment.paymentMethod.processor,
+          shopId: payment.shopId || cart.shopId,
+          status: payment.paymentMethod.status || "created",
+          transactionId: payment.paymentMethod.transactionId
+        });
+      } else if (payment.displayName) {
+        // Previously converted. Keep it.
+        list.push(payment);
+      }
+      return list;
+    }, []);
+  }
+
+  return convertedCart;
+}
+
+/**
+ * @summary Converts a single order item
+ * @param {Object} item The order item document to transform
+ * @returns {Object} The converted order item document
+ */
+function convertOrderItem(item) {
+  const convertedItem = { ...item };
+
+  if (!item.price && item.priceWhenAdded) {
+    convertedItem.price = item.priceWhenAdded;
+    convertedItem.priceWhenAdded = null;
+  }
+
+  convertedItem.subtotal = (item.quantity || 0) * (convertedItem.price.amount || 0);
+
+  return convertedItem;
+}
+
+/**
+ * @summary Converts a single invoice object
+ * @param {Object} invoice The invoice document to transform
+ * @returns {Object} The converted invoice document
+ */
+function convertInvoice(invoice) {
+  const discounts = invoice.discounts || 0;
+  const taxes = invoice.taxes || 0;
+  const preTaxTotal = Math.max(0, invoice.subtotal - discounts);
+  const effectiveTaxRate = preTaxTotal > 0 && taxes > 0 ? taxes / preTaxTotal : 0;
+  return {
+    ...invoice,
+    discounts,
+    effectiveTaxRate,
+    taxes
+  };
+}
+
+/**
+ * @summary Converts a single order fulfillment group
+ * @param {Object} group The order fulfillment group document to transform
+ * @param {Object} order The order document in which this group lives
+ * @param {Object[]} packages Array of all Package docs from the database
+ * @returns {Object} The converted order document
+ */
+function convertOrderFulfillmentGroup(group, order, packages) {
+  // If already converted previously, leave it alone.
+  if (group.items) {
+    return group;
+  }
+
+  const convertedGroup = { ...group };
+
+  // Add items to the group
+  convertedGroup.items = (order.items || []).reduce((list, item) => {
+    if (item.shopId === group.shopId) {
+      list.push(convertOrderItem(item));
+    }
+    return list;
+  }, []);
+
+  // Set `itemIds` and `totalItemQuantity`
+  let totalItemQuantity = 0;
+  convertedGroup.itemIds = group.items.map((item) => {
+    totalItemQuantity += item.quantity || 0;
+    return item._id;
+  });
+  convertedGroup.totalItemQuantity = totalItemQuantity;
+
+  // Set `group.shipmentMethod.currencyCode`
+  if (group.shipmentMethod && !group.shipmentMethod.currencyCode) {
+    convertedGroup.shipmentMethod.currencyCode = order.currencyCode || "USD";
+  }
+
+  // Convert group.invoice
+  if (group.invoice) {
+    convertedGroup.invoice = convertInvoice(group.invoice);
+  }
+
+  // Set `group.payment`. There is a `paymentId` that should point at the _id in `order.billing` array
+  if (group.paymentId) {
+    const payment = (order.billing || []).find((billingItem) => billingItem._id === group.paymentId);
+    if (payment && payment.paymentMethod) {
+      let paymentPluginName = "unknown";
+      let name = "unknown";
+      if (payment.paymentMethod.paymentPackageId) {
+        const pkg = packages.find((pkgDoc) => pkgDoc._id === payment.paymentMethod.paymentPackageId);
+        if (pkg) {
+          paymentPluginName = pkg.name;
+          if (paymentPluginName === "reaction-stripe") {
+            name = "stripe_card";
+          } else if (paymentPluginName === "example-paymentmethod") {
+            name = "iou_example";
+          }
+        }
+      }
+
+      convertedGroup.payment = {
+        amount: payment.paymentMethod.amount,
+        createdAt: payment.createdAt || new Date(),
+        currency: payment.paymentMethod.currency,
+        currencyCode: order.currencyCode || "USD",
+        data: {
+          billingAddress: payment.address,
+          chargeId: payment.paymentMethod.transactionId
+        },
+        displayName: payment.paymentMethod.storedCard,
+        invoice: payment.invoice ? convertInvoice(payment.invoice) : convertedGroup.invoice,
+        method: payment.paymentMethod.method,
+        mode: payment.paymentMethod.mode,
+        name,
+        paymentPluginName,
+        processor: payment.paymentMethod.processor,
+        riskLevel: payment.paymentMethod.riskLevel,
+        status: payment.paymentMethod.status,
+        transactionId: payment.paymentMethod.transactionId,
+        transactions: payment.paymentMethod.transactions
+      };
+    }
+    group.paymentId = null;
+  }
+
+  return convertedGroup;
+}
+
+/**
+ * @param {Object} order The order document to transform
+ * @param {Object[]} packages Array of all Package docs from the database
+ * @returns {Object} The converted order document
+ */
+export function convertOrder(order, packages) {
+  const convertedOrder = { ...order };
+
+  // Add `discounts` array to `order`. Take these from billing array.
+  if (Array.isArray(order.billing)) {
+    convertedOrder.discounts = order.billing.reduce((list, payment) => {
+      if (payment.paymentMethod && (payment.paymentMethod.processor === "code" || payment.paymentMethod.processor === "rate")) {
+        list.push({
+          amount: payment.paymentMethod.amount,
+          discountId: payment.paymentMethod.id
+        });
+      }
+      return list;
+    }, []);
+    convertedOrder.billing = null;
+  }
+
+  // Convert all the fulfillment groups
+  if (Array.isArray(order.shipping)) {
+    convertedOrder.shipping = order.shipping.map((group) => convertOrderFulfillmentGroup(group, order, packages));
+  } else {
+    convertedOrder.shipping = [];
+  }
+
+  // Set `order.totalItemQuantity`
+  if (!order.totalItemQuantity) {
+    convertedOrder.totalItemQuantity = (convertedOrder.shipping || []).reduce((sum, group) => sum + group.totalItemQuantity, 0);
+  }
+
+  return convertedOrder;
+}

--- a/imports/plugins/core/versions/server/util/convert20.js
+++ b/imports/plugins/core/versions/server/util/convert20.js
@@ -131,6 +131,10 @@ function convertOrderFulfillmentGroup(group, order, packages) {
     convertedGroup.shipmentMethod.currencyCode = order.currencyCode || "USD";
   }
 
+  if (convertedGroup.shipmentMethod) {
+    delete convertedGroup.shipmentMethod.enabled;
+  }
+
   // Convert group.invoice
   if (group.invoice) {
     convertedGroup.invoice = convertInvoice(group.invoice);

--- a/imports/plugins/core/versions/server/util/convert20.js
+++ b/imports/plugins/core/versions/server/util/convert20.js
@@ -10,8 +10,9 @@ export function convertCart(cart) {
   const convertedCart = { ...cart };
 
   // Set `cart.billingAddress`
-  if (!cart.billingAddress && Array.isArray(cart.billing) && cart.billing[0]) {
-    convertedCart.billingAddress = cart.billing[0].address;
+  if (!cart.billingAddress && Array.isArray(cart.billing)) {
+    const firstRecordWithAddress = cart.billing.find((record) => !!record.address);
+    convertedCart.billingAddress = firstRecordWithAddress && firstRecordWithAddress.address;
     if (!convertedCart.billingAddress) delete convertedCart.billingAddress;
   }
 
@@ -72,7 +73,8 @@ function convertOrderItem(item) {
   }
 
   convertedItem.subtotal = (item.quantity || 0) * (convertedItem.price.amount || 0);
-  convertedItem.tax = convertedItem.subtotal * (convertedItem.taxRate || 0);
+  if (!convertedItem.taxRate) convertedItem.taxRate = 0;
+  convertedItem.tax = convertedItem.subtotal * convertedItem.taxRate;
 
   return convertedItem;
 }

--- a/imports/plugins/core/versions/server/util/convert20cart.test.js
+++ b/imports/plugins/core/versions/server/util/convert20cart.test.js
@@ -1,0 +1,235 @@
+import { convertCart } from "./convert20";
+
+const beforeCart = {
+  _id: "6nWt7o6pWzXfdsS7A",
+  accountId: null,
+  anonymousAccessToken: "g2DgjyFt3yXulzlLFaJM296vZv9WYNvcya1zTlwqDA8=",
+  billing: [
+    {
+      _id: "5EJqJfWe56Pmbh4qQ",
+      address: {
+        country: "US",
+        fullName: "Big John",
+        address1: "2110 Main Street",
+        address2: "Suite 207",
+        postal: "90405",
+        city: "Santa Monica",
+        region: "CA",
+        phone: "5555555555",
+        isShippingDefault: true,
+        isBillingDefault: true,
+        isCommercial: false,
+        _id: "XgC7vnPhJK2S2Crzn",
+        failedValidation: false
+      },
+      currency: {
+        userCurrency: "USD"
+      }
+    }
+  ],
+  currencyCode: "USD",
+  createdAt: new Date("2018-09-20T20:29:23.674+0000"),
+  items: [
+    {
+      _id: "9QYm3oHAwGFPgowyA",
+      attributes: [
+        {
+          label: null,
+          value: "Silver frame"
+        }
+      ],
+      isTaxable: false,
+      optionTitle: "Untitled Option",
+      parcel: {
+        weight: 10,
+        height: 10,
+        width: 10,
+        length: 10
+      },
+      priceWhenAdded: {
+        amount: 119,
+        currencyCode: "USD"
+      },
+      productId: "TXPc3HumuTv3KMqS5",
+      productSlug: "classic-aviator-shades",
+      productVendor: "Pilot, Inc.",
+      productType: "product-simple",
+      quantity: 1,
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      taxCode: "0000",
+      title: "Classic Aviator Shades",
+      updatedAt: new Date("2018-09-20T20:29:23.667+0000"),
+      variantId: "jwPJFv4ygy4o2H4zp",
+      variantTitle: "Silver frame",
+      addedAt: new Date("2018-09-20T20:29:23.667+0000"),
+      createdAt: new Date("2018-09-20T20:29:23.667+0000")
+    },
+    {
+      _id: "juqNCv6TreaWrNxgB",
+      attributes: [
+        {
+          label: null,
+          value: "Green & Red Leather Handbag"
+        }
+      ],
+      isTaxable: false,
+      optionTitle: "Untitled Option",
+      parcel: {
+        weight: 2,
+        height: 2,
+        width: 2,
+        length: 2
+      },
+      priceWhenAdded: {
+        amount: 299.99,
+        currencyCode: "USD"
+      },
+      productId: "S3NLiQDxuhpGzLxkk",
+      productSlug: "green-and-red-leather-handbag",
+      productVendor: "Bags Bags Bags",
+      productType: "product-simple",
+      quantity: 1,
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      taxCode: "0000",
+      title: "Green & Red Leather Handbag",
+      updatedAt: new Date("2018-09-20T20:29:30.523+0000"),
+      variantId: "fdqkxaiLuSGTpWnFi",
+      variantTitle: "Green & Red Leather Handbag",
+      addedAt: new Date("2018-09-20T20:29:30.523+0000"),
+      createdAt: new Date("2018-09-20T20:29:30.523+0000")
+    }
+  ],
+  shopId: "J8Bhq3uTtdgwZx3rz",
+  updatedAt: new Date("2018-09-20T20:29:30.634+0000"),
+  workflow: {
+    status: "new"
+  },
+  shipping: [
+    {
+      _id: "dJdgaGkP7ywveweSs",
+      itemIds: [
+        "9QYm3oHAwGFPgowyA",
+        "juqNCv6TreaWrNxgB"
+      ],
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      type: "shipping"
+    }
+  ],
+  discount: 0
+};
+
+const afterCart = {
+  _id: "6nWt7o6pWzXfdsS7A",
+  accountId: null,
+  anonymousAccessToken: "g2DgjyFt3yXulzlLFaJM296vZv9WYNvcya1zTlwqDA8=",
+  billing: [],
+  billingAddress: {
+    country: "US",
+    fullName: "Big John",
+    address1: "2110 Main Street",
+    address2: "Suite 207",
+    postal: "90405",
+    city: "Santa Monica",
+    region: "CA",
+    phone: "5555555555",
+    isShippingDefault: true,
+    isBillingDefault: true,
+    isCommercial: false,
+    _id: "XgC7vnPhJK2S2Crzn",
+    failedValidation: false
+  },
+  currencyCode: "USD",
+  createdAt: new Date("2018-09-20T20:29:23.674+0000"),
+  items: [
+    {
+      _id: "9QYm3oHAwGFPgowyA",
+      attributes: [
+        {
+          label: null,
+          value: "Silver frame"
+        }
+      ],
+      isTaxable: false,
+      optionTitle: "Untitled Option",
+      parcel: {
+        weight: 10,
+        height: 10,
+        width: 10,
+        length: 10
+      },
+      priceWhenAdded: {
+        amount: 119,
+        currencyCode: "USD"
+      },
+      productId: "TXPc3HumuTv3KMqS5",
+      productSlug: "classic-aviator-shades",
+      productVendor: "Pilot, Inc.",
+      productType: "product-simple",
+      quantity: 1,
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      taxCode: "0000",
+      title: "Classic Aviator Shades",
+      updatedAt: new Date("2018-09-20T20:29:23.667+0000"),
+      variantId: "jwPJFv4ygy4o2H4zp",
+      variantTitle: "Silver frame",
+      addedAt: new Date("2018-09-20T20:29:23.667+0000"),
+      createdAt: new Date("2018-09-20T20:29:23.667+0000")
+    },
+    {
+      _id: "juqNCv6TreaWrNxgB",
+      attributes: [
+        {
+          label: null,
+          value: "Green & Red Leather Handbag"
+        }
+      ],
+      isTaxable: false,
+      optionTitle: "Untitled Option",
+      parcel: {
+        weight: 2,
+        height: 2,
+        width: 2,
+        length: 2
+      },
+      priceWhenAdded: {
+        amount: 299.99,
+        currencyCode: "USD"
+      },
+      productId: "S3NLiQDxuhpGzLxkk",
+      productSlug: "green-and-red-leather-handbag",
+      productVendor: "Bags Bags Bags",
+      productType: "product-simple",
+      quantity: 1,
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      taxCode: "0000",
+      title: "Green & Red Leather Handbag",
+      updatedAt: new Date("2018-09-20T20:29:30.523+0000"),
+      variantId: "fdqkxaiLuSGTpWnFi",
+      variantTitle: "Green & Red Leather Handbag",
+      addedAt: new Date("2018-09-20T20:29:30.523+0000"),
+      createdAt: new Date("2018-09-20T20:29:30.523+0000")
+    }
+  ],
+  shopId: "J8Bhq3uTtdgwZx3rz",
+  updatedAt: new Date("2018-09-20T20:29:30.634+0000"),
+  workflow: {
+    status: "new"
+  },
+  shipping: [
+    {
+      _id: "dJdgaGkP7ywveweSs",
+      itemIds: [
+        "9QYm3oHAwGFPgowyA",
+        "juqNCv6TreaWrNxgB"
+      ],
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      type: "shipping"
+    }
+  ],
+  discount: 0
+};
+
+test("converts a cart correctly", () => {
+  const doc = convertCart(beforeCart);
+  expect(doc).toEqual(afterCart);
+});

--- a/imports/plugins/core/versions/server/util/convert20order.test.js
+++ b/imports/plugins/core/versions/server/util/convert20order.test.js
@@ -5,6 +5,14 @@ const beforeOrder = {
   accountId: "NGn6GR8L7DfWnfGCh",
   billing: [
     {
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      currency: {
+        userCurrency: "USD",
+        exchangeRate: 1
+      },
+      _id: "other"
+    },
+    {
       paymentMethod: {
         processor: "Example",
         paymentPackageId: "euAJq7W8MzPJPm7Ne",
@@ -99,7 +107,6 @@ const beforeOrder = {
       variantTitle: "Large",
       addedAt: new Date("2018-09-20T19:30:53.025+0000"),
       createdAt: new Date("2018-09-20T19:30:53.025+0000"),
-      taxRate: 0,
       product: {
         _id: "FjcfCt6qBBxLskWDn",
         createdAt: new Date("2018-06-22T21:42:38.869+0000"),

--- a/imports/plugins/core/versions/server/util/convert20order.test.js
+++ b/imports/plugins/core/versions/server/util/convert20order.test.js
@@ -1,0 +1,823 @@
+import { convertOrder } from "./convert20";
+
+const beforeOrder = {
+  _id: "pLtmCazjBSy5F9uuu",
+  accountId: "NGn6GR8L7DfWnfGCh",
+  billing: [
+    {
+      paymentMethod: {
+        processor: "Example",
+        paymentPackageId: "euAJq7W8MzPJPm7Ne",
+        paymentSettingsKey: "example-paymentmethod",
+        storedCard: "Visa 1111",
+        method: "credit",
+        transactionId: "ur4eYdBoQQffQoquE",
+        riskLevel: "normal",
+        currency: "USD",
+        amount: 738.97,
+        status: "created",
+        mode: "authorize",
+        createdAt: new Date("2018-09-20T20:25:37.025+0000"),
+        transactions: [
+          {
+            amount: 738.97,
+            transactionId: "ur4eYdBoQQffQoquE",
+            currency: "USD"
+          }
+        ],
+        workflow: {
+
+        }
+      },
+      invoice: {
+        shipping: 2.99,
+        subtotal: 735.98,
+        taxes: 0,
+        discounts: 0,
+        total: 738.97
+      },
+      address: {
+        country: "US",
+        fullName: "Some Guy",
+        address1: "2110 Main Street",
+        address2: "Suite 207",
+        postal: "90405",
+        city: "Santa Monica",
+        region: "CA",
+        phone: "5555555555",
+        isShippingDefault: true,
+        isBillingDefault: true,
+        isCommercial: false,
+        _id: "u7HFEFBKhhGkGMPcB",
+        failedValidation: false
+      },
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      currency: {
+        userCurrency: "USD",
+        exchangeRate: 1
+      },
+      _id: "WdupGyFiowxb54s8S"
+    }
+  ],
+  currencyCode: "USD",
+  createdAt: new Date("2018-09-20T20:25:37.253+0000"),
+  items: [
+    {
+      _id: "zY9RxcqdgLvJ3zYRz",
+      attributes: [
+        {
+          label: null,
+          value: "Ticket to Anywhere"
+        },
+        {
+          label: null,
+          value: "Large"
+        }
+      ],
+      isTaxable: false,
+      optionTitle: "Large",
+      parcel: {
+        weight: 10,
+        height: 10,
+        width: 10,
+        length: 1
+      },
+      priceWhenAdded: {
+        amount: 35.99,
+        currencyCode: "USD"
+      },
+      productId: "FjcfCt6qBBxLskWDn",
+      productSlug: "ticket-to-anywhere-t-shirt",
+      productVendor: "Wanderlust, Inc.",
+      productType: "product-simple",
+      quantity: 1,
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      taxCode: "0000",
+      title: "Ticket to Anywhere T-Shirt",
+      updatedAt: new Date("2018-09-20T19:30:53.025+0000"),
+      variantId: "L9w5FsbEuxiTcYPCT",
+      variantTitle: "Large",
+      addedAt: new Date("2018-09-20T19:30:53.025+0000"),
+      createdAt: new Date("2018-09-20T19:30:53.025+0000"),
+      taxRate: 0,
+      product: {
+        _id: "FjcfCt6qBBxLskWDn",
+        createdAt: new Date("2018-06-22T21:42:38.869+0000"),
+        description: "Show your penchant for the wild and free. The world is your oyster.",
+        isBackorder: false,
+        isDeleted: false,
+        isLowQuantity: false,
+        isSoldOut: false,
+        isVisible: true,
+        pageTitle: "Destination Unknown.",
+        price: {
+          range: "35.99",
+          min: 35.99,
+          max: 35.99
+        },
+        shopId: "J8Bhq3uTtdgwZx3rz",
+        supportedFulfillmentTypes: [
+          "shipping"
+        ],
+        title: "Ticket to Anywhere T-Shirt",
+        type: "product-simple",
+        updatedAt: new Date("2018-09-20T19:27:52.665+0000"),
+        vendor: "Wanderlust, Inc.",
+        workflow: {
+          status: "new"
+        },
+        template: "productDetailSimple",
+        ancestors: [
+
+        ]
+      },
+      shippingMethod: {
+        _id: "jWXqro78KkztEWZ7j",
+        itemIds: [
+          "zY9RxcqdgLvJ3zYRz",
+          "2MBFE2JeKHmBMna9h"
+        ],
+        shopId: "J8Bhq3uTtdgwZx3rz",
+        type: "shipping",
+        shipmentQuotes: [
+          {
+            carrier: "Flat Rate",
+            method: {
+              name: "Free",
+              label: "Free Shipping",
+              group: "Ground",
+              handling: 0,
+              rate: 0,
+              enabled: true,
+              _id: "6MugCf3Pn5rpfNke2",
+              carrier: "Flat Rate"
+            },
+            rate: 0,
+            shopId: "J8Bhq3uTtdgwZx3rz"
+          },
+          {
+            carrier: "Flat Rate",
+            method: {
+              name: "Standard",
+              label: "Standard",
+              group: "Ground",
+              handling: 0,
+              rate: 2.99,
+              enabled: true,
+              _id: "SPbMh5gdz24Wr4J94",
+              carrier: "Flat Rate"
+            },
+            rate: 2.99,
+            shopId: "J8Bhq3uTtdgwZx3rz"
+          },
+          {
+            carrier: "Flat Rate",
+            method: {
+              name: "Priority",
+              label: "Priority",
+              group: "Priority",
+              handling: 0,
+              rate: 6.99,
+              enabled: true,
+              _id: "hmP2ePcxoTHnPxZmW",
+              carrier: "Flat Rate"
+            },
+            rate: 6.99,
+            shopId: "J8Bhq3uTtdgwZx3rz"
+          }
+        ],
+        shipmentQuotesQueryStatus: {
+          requestStatus: "success",
+          numOfShippingMethodsFound: 3
+        },
+        address: {
+          country: "US",
+          fullName: "Some Guy",
+          address1: "2110 Main Street",
+          address2: "Suite 207",
+          postal: "90405",
+          city: "Santa Monica",
+          region: "CA",
+          phone: "5555555555",
+          isShippingDefault: true,
+          isBillingDefault: true,
+          isCommercial: false,
+          _id: "cBd5HcGDa9tFjPgdS",
+          failedValidation: false
+        },
+        shipmentMethod: {
+          name: "Standard",
+          label: "Standard",
+          group: "Ground",
+          handling: 0,
+          rate: 2.99,
+          enabled: true,
+          _id: "SPbMh5gdz24Wr4J94",
+          carrier: "Flat Rate"
+        },
+        paymentId: "WdupGyFiowxb54s8S",
+        workflow: {
+          status: "new",
+          workflow: [
+            "coreOrderWorkflow/notStarted"
+          ]
+        }
+      },
+      variants: {
+        _id: "L9w5FsbEuxiTcYPCT",
+        createdAt: new Date("2018-09-20T19:27:53.110+0000"),
+        height: 10,
+        index: 0,
+        inventoryManagement: true,
+        inventoryPolicy: true,
+        isLowQuantity: false,
+        isSoldOut: false,
+        length: 1,
+        lowInventoryWarningThreshold: 0,
+        optionTitle: "Large",
+        price: 35.99,
+        shopId: "J8Bhq3uTtdgwZx3rz",
+        taxCode: "0000",
+        title: "Large",
+        updatedAt: new Date("2018-09-20T19:27:53.110+0000"),
+        weight: 10,
+        width: 10,
+        ancestors: [
+
+        ],
+        isVisible: false,
+        isDeleted: false,
+        compareAtPrice: 0,
+        inventoryQuantity: 0,
+        type: "variant",
+        taxable: true,
+        workflow: {
+          status: "new"
+        }
+      },
+      workflow: {
+        status: "new",
+        workflow: [
+          "coreOrderWorkflow/created"
+        ]
+      }
+    },
+    {
+      _id: "2MBFE2JeKHmBMna9h",
+      attributes: [
+        {
+          label: null,
+          value: "Gold Band w/ Black Face"
+        }
+      ],
+      isTaxable: false,
+      optionTitle: "Untitled Option - copy",
+      parcel: {
+        weight: 2,
+        height: 2,
+        width: 2,
+        length: 2
+      },
+      priceWhenAdded: {
+        amount: 699.99,
+        currencyCode: "USD"
+      },
+      productId: "ar2n4c6qthsidHHoi",
+      productSlug: "curren-three-dial-watch",
+      productVendor: "Curren",
+      productType: "product-simple",
+      quantity: 1,
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      taxCode: "0000",
+      title: "Curren Three-dial Watch",
+      updatedAt: new Date("2018-09-20T19:31:03.143+0000"),
+      variantId: "tDyeLgiKEfKzAJnRn",
+      variantTitle: "Gold Band w/ Black Face",
+      addedAt: new Date("2018-09-20T19:31:03.143+0000"),
+      createdAt: new Date("2018-09-20T19:31:03.143+0000"),
+      taxRate: 0,
+      product: {
+        _id: "ar2n4c6qthsidHHoi",
+        createdAt: new Date("2018-06-24T23:28:06.356+0000"),
+        description: "Always show up on time with this classic three-dial watch from Curren.",
+        isBackorder: false,
+        isDeleted: false,
+        isLowQuantity: false,
+        isSoldOut: false,
+        isVisible: true,
+        pageTitle: "Timed Style.",
+        price: {
+          range: "599.99 - 699.99",
+          min: 599.99,
+          max: 699.99
+        },
+        shopId: "J8Bhq3uTtdgwZx3rz",
+        supportedFulfillmentTypes: [
+          "shipping"
+        ],
+        title: "Curren Three-dial Watch",
+        type: "product-simple",
+        updatedAt: new Date("2018-09-20T19:27:52.797+0000"),
+        vendor: "Curren",
+        workflow: {
+          status: "new"
+        },
+        template: "productDetailSimple",
+        ancestors: [
+
+        ]
+      },
+      shippingMethod: {
+        _id: "jWXqro78KkztEWZ7j",
+        itemIds: [
+          "zY9RxcqdgLvJ3zYRz",
+          "2MBFE2JeKHmBMna9h"
+        ],
+        shopId: "J8Bhq3uTtdgwZx3rz",
+        type: "shipping",
+        shipmentQuotes: [
+          {
+            carrier: "Flat Rate",
+            method: {
+              name: "Free",
+              label: "Free Shipping",
+              group: "Ground",
+              handling: 0,
+              rate: 0,
+              enabled: true,
+              _id: "6MugCf3Pn5rpfNke2",
+              carrier: "Flat Rate"
+            },
+            rate: 0,
+            shopId: "J8Bhq3uTtdgwZx3rz"
+          },
+          {
+            carrier: "Flat Rate",
+            method: {
+              name: "Standard",
+              label: "Standard",
+              group: "Ground",
+              handling: 0,
+              rate: 2.99,
+              enabled: true,
+              _id: "SPbMh5gdz24Wr4J94",
+              carrier: "Flat Rate"
+            },
+            rate: 2.99,
+            shopId: "J8Bhq3uTtdgwZx3rz"
+          },
+          {
+            carrier: "Flat Rate",
+            method: {
+              name: "Priority",
+              label: "Priority",
+              group: "Priority",
+              handling: 0,
+              rate: 6.99,
+              enabled: true,
+              _id: "hmP2ePcxoTHnPxZmW",
+              carrier: "Flat Rate"
+            },
+            rate: 6.99,
+            shopId: "J8Bhq3uTtdgwZx3rz"
+          }
+        ],
+        shipmentQuotesQueryStatus: {
+          requestStatus: "success",
+          numOfShippingMethodsFound: 3
+        },
+        address: {
+          country: "US",
+          fullName: "Some Guy",
+          address1: "2110 Main Street",
+          address2: "Suite 207",
+          postal: "90405",
+          city: "Santa Monica",
+          region: "CA",
+          phone: "5555555555",
+          isShippingDefault: true,
+          isBillingDefault: true,
+          isCommercial: false,
+          _id: "cBd5HcGDa9tFjPgdS",
+          failedValidation: false
+        },
+        shipmentMethod: {
+          name: "Standard",
+          label: "Standard",
+          group: "Ground",
+          handling: 0,
+          rate: 2.99,
+          enabled: true,
+          _id: "SPbMh5gdz24Wr4J94",
+          carrier: "Flat Rate"
+        },
+        paymentId: "WdupGyFiowxb54s8S",
+        workflow: {
+          status: "new",
+          workflow: [
+            "coreOrderWorkflow/notStarted"
+          ]
+        }
+      },
+      variants: {
+        _id: "tDyeLgiKEfKzAJnRn",
+        createdAt: new Date("2018-09-20T19:27:53.621+0000"),
+        height: 2,
+        index: 0,
+        inventoryManagement: true,
+        inventoryPolicy: false,
+        isLowQuantity: false,
+        isSoldOut: false,
+        length: 2,
+        lowInventoryWarningThreshold: 0,
+        optionTitle: "Untitled Option - copy",
+        originCountry: "US",
+        price: 699.99,
+        shopId: "J8Bhq3uTtdgwZx3rz",
+        taxCode: "0000",
+        title: "Gold Band w/ Black Face",
+        updatedAt: new Date("2018-09-20T19:27:53.621+0000"),
+        weight: 2,
+        width: 2,
+        ancestors: [
+
+        ],
+        isVisible: false,
+        isDeleted: false,
+        compareAtPrice: 0,
+        inventoryQuantity: 0,
+        type: "variant",
+        taxable: true,
+        workflow: {
+          status: "new"
+        }
+      },
+      workflow: {
+        status: "new",
+        workflow: [
+          "coreOrderWorkflow/created"
+        ]
+      }
+    }
+  ],
+  shopId: "J8Bhq3uTtdgwZx3rz",
+  updatedAt: new Date("2018-09-20T20:25:37.253+0000"),
+  workflow: {
+    status: "new",
+    workflow: [
+      "coreOrderWorkflow/created"
+    ]
+  },
+  shipping: [
+    {
+      _id: "jWXqro78KkztEWZ7j",
+      itemIds: [
+        "zY9RxcqdgLvJ3zYRz",
+        "2MBFE2JeKHmBMna9h"
+      ],
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      type: "shipping",
+      shipmentQuotes: [
+        {
+          carrier: "Flat Rate",
+          method: {
+            name: "Free",
+            label: "Free Shipping",
+            group: "Ground",
+            handling: 0,
+            rate: 0,
+            enabled: true,
+            _id: "6MugCf3Pn5rpfNke2",
+            carrier: "Flat Rate"
+          },
+          rate: 0,
+          shopId: "J8Bhq3uTtdgwZx3rz"
+        },
+        {
+          carrier: "Flat Rate",
+          method: {
+            name: "Standard",
+            label: "Standard",
+            group: "Ground",
+            handling: 0,
+            rate: 2.99,
+            enabled: true,
+            _id: "SPbMh5gdz24Wr4J94",
+            carrier: "Flat Rate"
+          },
+          rate: 2.99,
+          shopId: "J8Bhq3uTtdgwZx3rz"
+        },
+        {
+          carrier: "Flat Rate",
+          method: {
+            name: "Priority",
+            label: "Priority",
+            group: "Priority",
+            handling: 0,
+            rate: 6.99,
+            enabled: true,
+            _id: "hmP2ePcxoTHnPxZmW",
+            carrier: "Flat Rate"
+          },
+          rate: 6.99,
+          shopId: "J8Bhq3uTtdgwZx3rz"
+        }
+      ],
+      shipmentQuotesQueryStatus: {
+        requestStatus: "success",
+        numOfShippingMethodsFound: 3
+      },
+      address: {
+        country: "US",
+        fullName: "Some Guy",
+        address1: "2110 Main Street",
+        address2: "Suite 207",
+        postal: "90405",
+        city: "Santa Monica",
+        region: "CA",
+        phone: "5555555555",
+        isShippingDefault: true,
+        isBillingDefault: true,
+        isCommercial: false,
+        _id: "cBd5HcGDa9tFjPgdS",
+        failedValidation: false
+      },
+      shipmentMethod: {
+        name: "Standard",
+        label: "Standard",
+        group: "Ground",
+        handling: 0,
+        rate: 2.99,
+        enabled: true,
+        _id: "SPbMh5gdz24Wr4J94",
+        carrier: "Flat Rate"
+      },
+      paymentId: "WdupGyFiowxb54s8S",
+      workflow: {
+        status: "new",
+        workflow: [
+          "coreOrderWorkflow/notStarted"
+        ]
+      }
+    }
+  ],
+  discount: 0,
+  tax: 0,
+  taxRatesByShop: {
+    J8Bhq3uTtdgwZx3rz: 0.06
+  },
+  cartId: "Z7cWgoi8DGC3buZ9r",
+  email: "admin@localhost",
+  taxCalculationFailed: false,
+  bypassAddressValidation: false
+};
+
+const afterOrder = {
+  _id: "pLtmCazjBSy5F9uuu",
+  accountId: "NGn6GR8L7DfWnfGCh",
+  currencyCode: "USD",
+  createdAt: new Date("2018-09-20T20:25:37.253+0000"),
+  shopId: "J8Bhq3uTtdgwZx3rz",
+  updatedAt: new Date("2018-09-20T20:25:37.253+0000"),
+  workflow: {
+    status: "new",
+    workflow: [
+      "coreOrderWorkflow/created"
+    ]
+  },
+  shipping: [
+    {
+      _id: "jWXqro78KkztEWZ7j",
+      itemIds: [
+        "zY9RxcqdgLvJ3zYRz",
+        "2MBFE2JeKHmBMna9h"
+      ],
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      type: "shipping",
+      address: {
+        country: "US",
+        fullName: "Some Guy",
+        address1: "2110 Main Street",
+        address2: "Suite 207",
+        postal: "90405",
+        city: "Santa Monica",
+        region: "CA",
+        phone: "5555555555",
+        isShippingDefault: true,
+        isBillingDefault: true,
+        isCommercial: false,
+        _id: "cBd5HcGDa9tFjPgdS",
+        failedValidation: false
+      },
+      shipmentMethod: {
+        name: "Standard",
+        label: "Standard",
+        group: "Ground",
+        handling: 0,
+        rate: 2.99,
+        _id: "SPbMh5gdz24Wr4J94",
+        carrier: "Flat Rate",
+        currencyCode: "USD"
+      },
+      workflow: {
+        status: "new",
+        workflow: [
+          "coreOrderWorkflow/notStarted"
+        ]
+      },
+      items: [
+        {
+          _id: "zY9RxcqdgLvJ3zYRz",
+          isTaxable: false,
+          optionTitle: "Large",
+          attributes: [
+            {
+              label: null,
+              value: "Ticket to Anywhere"
+            },
+            {
+              label: null,
+              value: "Large"
+            }
+          ],
+          parcel: {
+            weight: 10,
+            height: 10,
+            width: 10,
+            length: 1
+          },
+          productId: "FjcfCt6qBBxLskWDn",
+          productSlug: "ticket-to-anywhere-t-shirt",
+          productVendor: "Wanderlust, Inc.",
+          productType: "product-simple",
+          quantity: 1,
+          shopId: "J8Bhq3uTtdgwZx3rz",
+          taxCode: "0000",
+          title: "Ticket to Anywhere T-Shirt",
+          updatedAt: new Date("2018-09-20T19:30:53.025+0000"),
+          variantId: "L9w5FsbEuxiTcYPCT",
+          variantTitle: "Large",
+          addedAt: new Date("2018-09-20T19:30:53.025+0000"),
+          createdAt: new Date("2018-09-20T19:30:53.025+0000"),
+          taxRate: 0,
+          workflow: {
+            status: "new",
+            workflow: [
+              "coreOrderWorkflow/created"
+            ]
+          },
+          price: {
+            amount: 35.99,
+            currencyCode: "USD"
+          },
+          subtotal: 35.99,
+          tax: 0
+        },
+        {
+          _id: "2MBFE2JeKHmBMna9h",
+          isTaxable: false,
+          optionTitle: "Untitled Option - copy",
+          attributes: [
+            {
+              label: null,
+              value: "Gold Band w/ Black Face"
+            }
+          ],
+          parcel: {
+            weight: 2,
+            height: 2,
+            width: 2,
+            length: 2
+          },
+          productId: "ar2n4c6qthsidHHoi",
+          productSlug: "curren-three-dial-watch",
+          productVendor: "Curren",
+          productType: "product-simple",
+          quantity: 1,
+          shopId: "J8Bhq3uTtdgwZx3rz",
+          taxCode: "0000",
+          title: "Curren Three-dial Watch",
+          updatedAt: new Date("2018-09-20T19:31:03.143+0000"),
+          variantId: "tDyeLgiKEfKzAJnRn",
+          variantTitle: "Gold Band w/ Black Face",
+          addedAt: new Date("2018-09-20T19:31:03.143+0000"),
+          createdAt: new Date("2018-09-20T19:31:03.143+0000"),
+          taxRate: 0,
+          workflow: {
+            status: "new",
+            workflow: [
+              "coreOrderWorkflow/created"
+            ]
+          },
+          price: {
+            amount: 699.99,
+            currencyCode: "USD"
+          },
+          subtotal: 699.99,
+          tax: 0
+        }
+      ],
+      totalItemQuantity: 2,
+      payment: {
+        _id: "WdupGyFiowxb54s8S",
+        address: {
+          country: "US",
+          fullName: "Some Guy",
+          address1: "2110 Main Street",
+          address2: "Suite 207",
+          postal: "90405",
+          city: "Santa Monica",
+          region: "CA",
+          phone: "5555555555",
+          isShippingDefault: true,
+          isBillingDefault: true,
+          isCommercial: false,
+          _id: "u7HFEFBKhhGkGMPcB",
+          failedValidation: false
+        },
+        amount: 738.97,
+        createdAt: jasmine.any(Date),
+        currency: {
+          userCurrency: "USD",
+          exchangeRate: 1
+        },
+        currencyCode: "USD",
+        data: {
+          billingAddress: {
+            country: "US",
+            fullName: "Some Guy",
+            address1: "2110 Main Street",
+            address2: "Suite 207",
+            postal: "90405",
+            city: "Santa Monica",
+            region: "CA",
+            phone: "5555555555",
+            isShippingDefault: true,
+            isBillingDefault: true,
+            isCommercial: false,
+            _id: "u7HFEFBKhhGkGMPcB",
+            failedValidation: false
+          },
+          chargeId: "ur4eYdBoQQffQoquE"
+        },
+        displayName: "Visa 1111",
+        invoice: {
+          shipping: 2.99,
+          subtotal: 735.98,
+          taxes: 0,
+          discounts: 0,
+          total: 738.97,
+          effectiveTaxRate: 0
+        },
+        method: "credit",
+        mode: "authorize",
+        name: "iou_example",
+        paymentPluginName: "example-paymentmethod",
+        processor: "Example",
+        riskLevel: "normal",
+        shopId: "J8Bhq3uTtdgwZx3rz",
+        status: "created",
+        transactionId: "ur4eYdBoQQffQoquE",
+        transactions: [
+          {
+            amount: 738.97,
+            transactionId: "ur4eYdBoQQffQoquE",
+            currency: "USD"
+          }
+        ]
+      },
+      invoice: {
+        shipping: 2.99,
+        subtotal: 735.98,
+        taxes: 0,
+        discounts: 0,
+        total: 738.97,
+        effectiveTaxRate: 0
+      }
+    }
+  ],
+  tax: 0,
+  cartId: "Z7cWgoi8DGC3buZ9r",
+  email: "admin@localhost",
+  taxCalculationFailed: false,
+  bypassAddressValidation: false,
+  discounts: [],
+  totalItemQuantity: 2
+};
+
+const packages = [
+  {
+    _id: "euAJq7W8MzPJPm7Ne",
+    name: "example-paymentmethod"
+  },
+  {
+    _id: "z67os7RfrJ4D8Z9HW",
+    name: "reaction-stripe"
+  }
+];
+
+test("converts an order correctly", () => {
+  const doc = convertOrder(beforeOrder, packages);
+  expect(doc).toEqual(afterOrder);
+});

--- a/imports/plugins/core/versions/server/util/findAndConvertInBatches.js
+++ b/imports/plugins/core/versions/server/util/findAndConvertInBatches.js
@@ -1,0 +1,35 @@
+// Do this migration in batches of 200 to avoid memory issues
+const LIMIT = 200;
+
+/**
+ * @summary Find documents in a collection that need to be converted, and convert them
+ *   in small batches.
+ * @param {Object} options Options
+ * @param {Object} options.collection The Meteor collection instance
+ * @param {Object} [options.query] Optional MongoDB query that will only find not-yet-converted docs
+ * @param {Function} options.converter Conversion function for a single doc
+ * @returns {undefined}
+ */
+export default function findAndConvertInBatches({ collection, converter }) {
+  let docs;
+  let skip = 0;
+
+  do {
+    docs = collection.find({}, {
+      limit: LIMIT,
+      skip,
+      sort: {
+        _id: 1
+      }
+    }).fetch();
+    skip += LIMIT;
+
+    if (docs.length) {
+      docs.forEach((doc) => {
+        collection.update({
+          _id: doc._id
+        }, converter(doc), { bypassCollection2: true });
+      });
+    }
+  } while (docs.length);
+}


### PR DESCRIPTION
Resolves #4630
Impact: **minor**  
Type: **feature**

## Changes
Migrate existing data for cart and orders after an upgrade

## Breaking changes
No, quite the opposite hopefully

## Testing
1. Check out `master`
2. Run Reaction and do complete checkout flow for anonymous and logged in. Also add some more items to carts that you do not check out. With at least one of the carts, do the checkout flow but don't click the final place order button. The goal is to have some carts in various stages of data collection, and some orders for different types of users.
    - It can be good to also enable taxes and add some taxes for your shipping postal code, since some of the conversions are related to taxes.
    - I recommend having at least one order paid for with "example" method and at least one paid for with a credit card through Stripe package.
3. Stop Reaction and check out this branch.
4. In the `Migrations` collection in MongoDB, make sure that the control document has `locked === false` and a version at or less than 38.
5. Run Reaction and verify that you see a message on startup that it ran the migrations up to version 40.
6. Smoke test in the app, including running the existing converted orders through all possible statuses.