### PR TITLE
feat: Show correct form state during create account oauth flow

### DIFF
--- a/imports/plugins/core/accounts/client/components/login.js
+++ b/imports/plugins/core/accounts/client/components/login.js
@@ -63,10 +63,7 @@ class Login extends Component {
           <Components.OAuthFormContainer
             credentials={this.props.credentials}
             uniqueId={this.props.uniqueId}
-            currentView={this.state.currentView}
             onForgotPasswordClick={this.showForgotPasswordView}
-            onSignUpClick={this.showSignUpView}
-            onSignInClick={this.showSignInView}
           />
         );
       }

--- a/imports/plugins/core/accounts/client/components/signIn.js
+++ b/imports/plugins/core/accounts/client/components/signIn.js
@@ -8,6 +8,7 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
  * @memberof Accounts
  * @extends {Component}
  * @property {Object} credentials
+ * @property {Boolean} hasSwitchLinks
  * @property {Boolean} isLoading
  * @property {Function} loginFormMessages
  * @property {Object} messages
@@ -20,6 +21,7 @@ import { Components, registerComponent } from "@reactioncommerce/reaction-compon
 class SignIn extends Component {
   static propTypes = {
     credentials: PropTypes.object,
+    hasSwitchLinks: PropTypes.bool,
     isLoading: PropTypes.bool,
     loginFormMessages: PropTypes.func,
     messages: PropTypes.object,
@@ -28,6 +30,10 @@ class SignIn extends Component {
     onFormSubmit: PropTypes.func,
     onSignUpClick: PropTypes.func,
     uniqueId: PropTypes.string
+  }
+
+  static defaultProps = {
+    hasSwitchLinks: true
   }
 
   constructor(props) {
@@ -179,19 +185,20 @@ class SignIn extends Component {
               data-event-category="accounts"
               onClick={this.props.onForgotPasswordClick}
             />
-            <Components.Button
-              tagName="span"
-              className={{
-                "btn": false,
-                "btn-default": false
-              }}
-              label="Register"
-              i18nKeyLabel="accountsUI.signUp"
-              data-event-category="accounts"
-              onClick={this.props.onSignUpClick}
-            />
+            {this.props.hasSwitchLinks &&
+              <Components.Button
+                tagName="span"
+                className={{
+                  "btn": false,
+                  "btn-default": false
+                }}
+                label="Register"
+                i18nKeyLabel="accountsUI.signUp"
+                data-event-category="accounts"
+                onClick={this.props.onSignUpClick}
+              />
+            }
           </div>
-
         </form>
       </div>
     );

--- a/imports/plugins/core/accounts/client/components/signUp.js
+++ b/imports/plugins/core/accounts/client/components/signUp.js
@@ -7,6 +7,7 @@ class SignUp extends Component {
   static propTypes = {
     credentials: PropTypes.object,
     hasPasswordService: PropTypes.func,
+    hasSwitchLinks: PropTypes.bool,
     isLoading: PropTypes.bool,
     loginFormMessages: PropTypes.func,
     messages: PropTypes.object,
@@ -14,6 +15,10 @@ class SignUp extends Component {
     onFormSubmit: PropTypes.func,
     onSignInClick: PropTypes.func,
     uniqueId: PropTypes.string
+  }
+
+  static defaultProps = {
+    hasSwitchLinks: true
   }
 
   constructor(props) {
@@ -137,19 +142,21 @@ class SignUp extends Component {
             {this.renderSpinnerOnWait()}
           </div>
 
-          <div className="form-group">
-            <Components.Button
-              tagName="span"
-              className={{
-                "btn": false,
-                "btn-default": false
-              }}
-              label="Sign In"
-              i18nKeyLabel="accountsUI.signIn"
-              data-event-category="accounts"
-              onClick={this.props.onSignInClick}
-            />
-          </div>
+          {this.props.hasSwitchLinks &&
+            <div className="form-group">
+              <Components.Button
+                tagName="span"
+                className={{
+                  "btn": false,
+                  "btn-default": false
+                }}
+                label="Sign In"
+                i18nKeyLabel="accountsUI.signIn"
+                data-event-category="accounts"
+                onClick={this.props.onSignInClick}
+              />
+            </div>
+          }
         </form>
       );
     }

--- a/imports/plugins/core/hydra-oauth/client/containers/auth.js
+++ b/imports/plugins/core/hydra-oauth/client/containers/auth.js
@@ -10,7 +10,6 @@ import { LoginFormValidation } from "/lib/api";
 class OAuthFormContainer extends Component {
   static propTypes = {
     currentRoute: PropTypes.object,
-    currentView: PropTypes.string,
     formMessages: PropTypes.object
   }
 
@@ -24,6 +23,7 @@ class OAuthFormContainer extends Component {
   }
 
   handleFormSubmit = (event, email, password) => {
+    const currentRouteView = this.props.currentRoute.query.action;
     event.preventDefault();
 
     this.setState({
@@ -55,7 +55,7 @@ class OAuthFormContainer extends Component {
       return;
     }
 
-    if (this.props.currentView === "loginFormSignInView") {
+    if (currentRouteView === "signin") {
       Meteor.loginWithPassword(username, pword, (error) => {
         if (error) {
           this.setState({
@@ -70,7 +70,7 @@ class OAuthFormContainer extends Component {
           });
         }
       });
-    } else if (this.props.currentView === "loginFormSignUpView") {
+    } else {
       const newUserData = {
         email: username,
         password: pword
@@ -112,13 +112,16 @@ class OAuthFormContainer extends Component {
   hasPasswordService = () => !!Package["accounts-password"]
 
   renderAuthView() {
-    if (this.props.currentView === "loginFormSignInView") {
+    const currentRouteView = this.props.currentRoute.query.action;
+
+    if (currentRouteView === "signin") {
       return (
         <Components.SignIn
           {...this.props}
           onFormSubmit={this.handleFormSubmit}
           messages={this.state.formMessages}
           onError={this.hasError}
+          hasSwitchLinks={false}
           loginFormMessages={this.formMessages}
           isLoading={this.state.isLoading}
         />
@@ -130,6 +133,7 @@ class OAuthFormContainer extends Component {
         onFormSubmit={this.handleFormSubmit}
         messages={this.state.formMessages}
         onError={this.hasError}
+        hasSwitchLinks={false}
         loginFormMessages={this.formMessages}
         hasPasswordService={this.hasPasswordService}
         isLoading={this.state.isLoading}

--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -3,7 +3,7 @@ import Logger from "@reactioncommerce/logger";
 import { WebApp } from "meteor/webapp";
 import hydra from "./util/hydra";
 
-const { HYDRA_OAUTH2_ERROR_URL } = process.env;
+const { HYDRA_OAUTH2_ERROR_URL, HYDRA_SESSION_LIFESPAN } = process.env;
 const errorHandler = (errorMessage, res) => {
   Logger.error(`Error while performing Hydra login request - ${errorMessage}`);
   if (HYDRA_OAUTH2_ERROR_URL) {
@@ -23,13 +23,14 @@ WebApp.connectHandlers.use("/login", (req, res) => {
       const requestUrl = url.parse(getLoginRequestRes.request_url, true);
       const { loginAction } = requestUrl.query;
       // If Hydra was already able to authenticate the user, skip will be true
-      // and there will be no need to present a login form to the user.
+      // we do not need to re-authenticate the user.
       if (getLoginRequestRes.skip) {
         const acceptLoginResponse = await hydra.acceptLoginRequest(challenge, {
           subject: getLoginRequestRes.subject
         });
         Logger.debug(`Auth status confirmed from Hydra. Redirecting to: ${acceptLoginResponse.redirect_to}`);
-        res.redirect(acceptLoginResponse.redirect_to);
+        res.writeHead(301, { Location: acceptLoginResponse.redirect_to });
+        return res.end();
       }
 
       res.writeHead(301, { Location: `/account/login?action=${loginAction}&login_challenge=${challenge}` });
@@ -41,9 +42,16 @@ WebApp.connectHandlers.use("/login", (req, res) => {
 
 WebApp.connectHandlers.use("/consent", (req, res) => {
   const challenge = req.query.consent_challenge;
-  // Call acceptConsent without presenting a consent form to the user
+  // Here, we accept consent directly without presenting a consent form to the user
+  // because this was built for a trusted Consumer client.
+  // For non-trusted Consumer clients, this should be updated to present a Consent UI to
+  // the user grant or deny specific scopes
   hydra
-    .acceptConsentRequest(challenge, {})
+    .acceptConsentRequest(challenge, {
+      remember: true,
+      remember_for: HYDRA_SESSION_LIFESPAN || 3600, // eslint-disable-line camelcase
+      session: {} // we are not adding any extra user, we use only the sub value already present
+    })
     .then((consentResponse) => {
       Logger.debug(`Consent call complete. Redirecting to: ${consentResponse.redirect_to}`);
       res.writeHead(301, { Location: consentResponse.redirect_to });

--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -5,7 +5,7 @@ import hydra from "./util/hydra";
 
 const { HYDRA_OAUTH2_ERROR_URL, HYDRA_SESSION_LIFESPAN } = process.env;
 const errorHandler = (errorMessage, res) => {
-  Logger.error(`Error while performing Hydra login request - ${errorMessage}`);
+  Logger.error(`Error while performing Hydra request - ${errorMessage}`);
   if (HYDRA_OAUTH2_ERROR_URL) {
     Logger.error(`Redirecting to HYDRA_OAUTH2_ERROR_URL: ${HYDRA_OAUTH2_ERROR_URL}`);
     res.writeHead(500, { Location: HYDRA_OAUTH2_ERROR_URL });

--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -59,3 +59,14 @@ WebApp.connectHandlers.use("/consent", (req, res) => {
     })
     .catch((errorMessage) => errorHandler(errorMessage, res));
 });
+
+WebApp.connectHandlers.use("/logout", (req, res) => {
+  hydra
+    .deleteUserSession(req.query.userId)
+    .then(() => {
+      Logger.debug(`Delete user session complete for userId: ${req.query.userId}`);
+      res.writeHead(200);
+      return res.end();
+    })
+    .catch((errorMessage) => errorHandler(errorMessage, res));
+});

--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -1,3 +1,4 @@
+import url from "url";
 import Logger from "@reactioncommerce/logger";
 import { WebApp } from "meteor/webapp";
 import hydra from "./util/hydra";
@@ -19,6 +20,8 @@ WebApp.connectHandlers.use("/login", (req, res) => {
 
   hydra.getLoginRequest(challenge)
     .then(async (getLoginRequestRes) => {
+      const requestUrl = url.parse(getLoginRequestRes.request_url, true);
+      const { loginAction } = requestUrl.query;
       // If Hydra was already able to authenticate the user, skip will be true
       // and there will be no need to present a login form to the user.
       if (getLoginRequestRes.skip) {
@@ -29,7 +32,7 @@ WebApp.connectHandlers.use("/login", (req, res) => {
         res.redirect(acceptLoginResponse.redirect_to);
       }
 
-      res.writeHead(301, { Location: `/account/login?login_challenge=${challenge}` });
+      res.writeHead(301, { Location: `/account/login?action=${loginAction}&login_challenge=${challenge}` });
       Logger.debug("Redirecting to Login Form for user login");
       return res.end();
     })

--- a/imports/plugins/core/hydra-oauth/server/oauthMethods.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthMethods.js
@@ -3,6 +3,8 @@ import Reaction from "/imports/plugins/core/core/server/Reaction";
 import Logger from "@reactioncommerce/logger";
 import hydra from "./util/hydra";
 
+const { HYDRA_SESSION_LIFESPAN } = process.env;
+
 /**
  * @name oauthLogin
  * @method
@@ -15,13 +17,13 @@ export function oauthLogin(options) {
   check(options, Object);
   check(options.challenge, String);
   check(options.remember, Match.Maybe(Boolean));
-  const { challenge, remember = false } = options;
+  const { challenge, remember = true } = options;
 
   return hydra
     .acceptLoginRequest(challenge, {
       subject: Reaction.getUserId(),
       remember,
-      remember_for: 3600 // eslint-disable-line camelcase
+      remember_for: HYDRA_SESSION_LIFESPAN || 3600 // eslint-disable-line camelcase
     })
     .then((response) => response.redirect_to)
     .catch((error) => {

--- a/imports/plugins/core/hydra-oauth/server/util/hydra.js
+++ b/imports/plugins/core/hydra-oauth/server/util/hydra.js
@@ -59,11 +59,31 @@ function put(flow, action, challenge, body) {
     });
 }
 
+/**
+ * @name deleteUserSession
+ * @method
+ * @private
+ * @param  {String} id userId
+ * @return {Object|String} API res
+ */
+function deleteUserSession(id) {
+  return fetch(`${HYDRA_ADMIN_URL}/oauth2/auth/sessions/login/${id}`, { method: "DELETE" })
+    .then(async (res) => {
+      if (res.status < 200 || res.status > 302) {
+        const json = await res.json();
+        Logger.error(`An error occurred while deleting session in Hydra for user ${id} `, json.error_description);
+        return Promise.reject(new Error(json.error_description));
+      }
+      return null;
+    });
+}
+
 export default {
   getLoginRequest: (challenge) => get("login", challenge),
   acceptLoginRequest: (challenge, body) => put("login", "accept", challenge, body),
   rejectLoginRequest: (challenge) => put("login", "reject", challenge),
   getConsentRequest: (challenge) => get("consent", challenge),
   acceptConsentRequest: (challenge, body) => put("consent", "accept", challenge, body),
-  rejectConsentRequest: (challenge, body) => put("consent", "reject", challenge, body)
+  rejectConsentRequest: (challenge, body) => put("consent", "reject", challenge, body),
+  deleteUserSession: (id) => deleteUserSession(id)
 };


### PR DESCRIPTION
Part of reactioncommerce/reaction/issues/4640
Type: **feature**

## Issue
When a Starterkit user clicks "Register", we redirect to the Reaction Hydra login page, but it shows the "Sign In" view rather than "Create Account" view.


## Solution
Use extra query info passed from the client app (Starterkit) in the auth URL in Hydra (reactioncommerce/reaction-next-starterkit/pull/320). 

## Changes
- Get the auth URL connected to the Login request from Hydra. Get the `loginAction` field and pass it in the UI route query param (?action={loginAction}) to serve as state info to the Login component.
- Update the Auth components to show appropriate form fields based on route query param (e.g ?action=signin)
- Update the SignIn and SignUp core components to have a new `hasSwitchLinks` prop. This will determine if link to toggle between SignIn and SignUp views should be displayed. It defaults to true (so previous behaviour is kept - no breaking change)
- Update Auth container for OAuth IDP flow with hasSwitchLinks=false. This makes the state of the form depend on ONLY the route query
- Fix the Hydra session feature. Now, when a user who already signed in (and is sill within the set HYDRA_SESSION_LIFESPAN), tries to login again, we won't show the login form again.
- Add /logout endpoint for Consumer apps (like Starterkit) to call to delete user sessions from Hydra. The delete session endpoint in Hydra lives on the Administrative port (4445), so we are not exposing it to Consumer apps to consume directly.



## Breaking changes
N/A


## Testing
NB: This is to be tested along with reactioncommerce/reaction-next-starterkit/pull/320

1. From Starterkit, click "Sign In"
2. Confirm that you see a "Sign In" form on the Meteor Login page
3. From Starterkit, click "Create Account"
4. Confirm that you see a "Create Account" form on the Meteor Login page

Regression Testing
This PR touched SignIn and SignUp core components
1. In the Meteor app, open the login dropdown
2. Confirm that the SignIn and SignUp components behave as before
