### PR TITLE
(fix) Fix custom taxes

### DIFF
--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -107,7 +107,7 @@ export default async function addCartItems(collections, currentItems, inputItems
     const cartItem = {
       _id: Random.id(),
       attributes,
-      isTaxable: chosenVariant.taxable || false,
+      isTaxable: chosenVariant.isTaxable || false,
       metafields,
       optionTitle: chosenVariant.optionTitle,
       parcel: chosenVariant.parcel,

--- a/imports/plugins/core/orders/server/no-meteor/mutations/createOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/createOrder.js
@@ -179,7 +179,7 @@ async function buildOrderItem(inputItem, currencyCode, context) {
     _id: Random.id(),
     addedAt: addedAt || now,
     createdAt: now,
-    isTaxable: (chosenVariant && chosenVariant.taxable) || false,
+    isTaxable: (chosenVariant && chosenVariant.isTaxable) || false,
     optionTitle: chosenVariant && chosenVariant.optionTitle,
     parcel: chosenVariant.parcel,
     price: {

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -128,14 +128,8 @@ export const cartOrderTransform = {
    * @returns {Number} Total price of taxes for an order
    */
   getTaxTotal() {
-    // taxes are calculated in a Cart.after.update hooks
-    // the tax value stored with the cart/order is the effective tax rate
-    // calculated by line items
-    // in the imports/core/taxes plugin
-    const tax = this.tax || 0;
-    const subTotal = parseFloat(this.getSubTotal());
-    const taxTotal = subTotal * tax;
-    return accounting.toFixed(taxTotal, 2);
+    const taxTotal = accounting.toFixed(this.items.reduce((acc, item) => acc + item.tax, 0), 2);
+    return taxTotal;
   },
   /**
    * @summary Discount for cart/order.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
-  "version": "1.16.0",
+  "version": "2.0.0",
   "main": "main.js",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
Resolves #4655 
Impact: **critical**  
Type: **bugfix**

## Issue
Sometimes it's `taxable` sometimes it's `isTaxable`. Also calculate taxes from cart.items rather than the global tax item.

## Solution
Make it `isTaxable`. Calculate taxes from `items.tax`


## Breaking changes
None

## Testing
1. Add a custom tax rate for CA
1. Check out with an address in CA
1. Observe that taxes are properly applied
