### PR TITLE
fix: orders dashboard layout issue

### DIFF
--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -98,9 +98,9 @@ const getStyles = (props) => {
       "flex": "1 1 auto",
       "maxWidth": viewMaxSize,
       "@media only screen and (max-width: 1500px)": {
-        "flex": "0 1 auto",
+        flex: "0 1 auto",
         maxWidth: "100%",
-        "width": "55vw"
+        width: "55vw"
       },
       "@media only screen and (max-width: 949px)": {
         width: "100vw"

--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -8,11 +8,7 @@ import { EJSON } from "meteor/ejson";
 import { Admin } from "/imports/plugins/core/ui/client/providers";
 import Radium from "radium";
 import debounce from "lodash/debounce";
-import {
-  IconButton,
-  Translation,
-  Overlay
-} from "/imports/plugins/core/ui/client/components";
+import { IconButton, Translation, Overlay } from "/imports/plugins/core/ui/client/components";
 
 const getStyles = (props) => {
   const minWidth = Math.min(props.viewportWidth, 400);
@@ -22,8 +18,8 @@ const getStyles = (props) => {
   const provides = actionView.provides || [];
   // legacy provides could be a string, is an array since 1.5.0, check for either.
   // prototype.includes has the fortunate side affect of checking string equality as well as array inclusion.
-  const isBigView = provides.includes("dashboard") ||
-                    (provides.includes("shortcut") && actionView.container === "dashboard");
+  const isBigView =
+    provides.includes("dashboard") || (provides.includes("shortcut") && actionView.container === "dashboard");
 
   if (isBigView) {
     viewSize = "90vw";
@@ -97,10 +93,8 @@ const getStyles = (props) => {
       "flexDirection": "column",
       "flex": "1 1 auto",
       "maxWidth": viewMaxSize,
-      "@media only screen and (max-width: 1500px)": {
-        flex: "0 1 auto",
-        maxWidth: "100%",
-        width: "55vw"
+      "@media only screen and (max-width: 1420px)": {
+        minWidth: "55vw"
       },
       "@media only screen and (max-width: 949px)": {
         width: "100vw"
@@ -121,15 +115,15 @@ const getStyles = (props) => {
       "backgroundColor": "white",
       "borderRight": "1px solid #ccc",
       "width": "24vw",
-      "@media only screen and (max-width: 1500px)": {
+      "@media only screen and (max-width: 1420px)": {
+        width: "35vw"
+      },
+      "@media only screen and (max-width: 1024px)": {
         position: "absolute",
         top: 0,
         right: 0,
-        width: "35vw",
+        width: "100vw",
         zIndex: 1050
-      },
-      "@media only screen and (max-width: 1200px)": {
-        width: "96vw"
       }
     },
     detailView: {
@@ -162,7 +156,7 @@ class ActionView extends Component {
     isDetailViewAtRootView: PropTypes.bool,
     language: PropTypes.string,
     viewportWidth: PropTypes.number
-  }
+  };
 
   static getDerivedStateFromProps(props) {
     const { actionView, detailView, prevProps = {} } = props;
@@ -224,10 +218,7 @@ class ActionView extends Component {
       } catch (error) {
         return (
           <div style={this.styles.masterView} className="master">
-            <Blaze
-              {...actionView.data}
-              template={actionView.template}
-            />
+            <Blaze {...actionView.data} template={actionView.template} />
           </div>
         );
       }
@@ -241,10 +232,7 @@ class ActionView extends Component {
     if (detailView && typeof detailView.template === "string") {
       return (
         <div style={this.styles.detailView} className="detail">
-          <Blaze
-            {...detailView.data}
-            template={detailView.template}
-          />
+          <Blaze {...detailView.data} template={detailView.template} />
         </div>
       );
     }
@@ -264,28 +252,14 @@ class ActionView extends Component {
     let button;
 
     if (this.props.isActionViewAtRootView === false) {
-      button = (
-        <IconButton
-          bezelStyle={"flat"}
-          icon="fa fa-arrow-left"
-          onClick={this.props.handleActionViewBack}
-        />
-      );
+      button = <IconButton bezelStyle={"flat"} icon="fa fa-arrow-left" onClick={this.props.handleActionViewBack} />;
     } else {
-      button = (
-        <IconButton
-          bezelStyle={"flat"}
-          icon="fa fa-times"
-          onClick={this.props.handleActionViewClose}
-        />
-      );
+      button = <IconButton bezelStyle={"flat"} icon="fa fa-times" onClick={this.props.handleActionViewClose} />;
     }
 
     return (
       <div style={this.styles.backButton}>
-        <div style={this.styles.backButtonContainers}>
-          {button}
-        </div>
+        <div style={this.styles.backButtonContainers}>{button}</div>
       </div>
     );
   }
@@ -320,23 +294,13 @@ class ActionView extends Component {
       return (
         <div style={this.styles.backButton}>
           <div style={this.styles.backButtonContainers}>
-            <IconButton
-              bezelStyle={"flat"}
-              icon="fa fa-arrow-left"
-              onClick={this.props.handleActionViewDetailBack}
-            />
+            <IconButton bezelStyle={"flat"} icon="fa fa-arrow-left" onClick={this.props.handleActionViewDetailBack} />
           </div>
         </div>
       );
     }
 
-    return (
-      <IconButton
-        bezelStyle={"flat"}
-        icon="fa fa-times"
-        onClick={this.props.handleActionViewDetailClose}
-      />
-    );
+    return <IconButton bezelStyle={"flat"} icon="fa fa-times" onClick={this.props.handleActionViewDetailClose} />;
   }
 
   get styles() {
@@ -359,17 +323,12 @@ class ActionView extends Component {
             </h3>
           </div>
 
-          <div className="controls»">
-            {/* Controls */}
-          </div>
+          <div className="controls»">{/* Controls */}</div>
         </div>
         <div style={this.styles.body} className="admin-controls-content action-view-body">
-
           {this.renderControlComponent()}
-
         </div>
       </div>
-
     );
   }
 
@@ -390,19 +349,13 @@ class ActionView extends Component {
 
           <div style={this.styles.heading} className="heading">
             <h3 className="title" style={this.styles.title}>
-              <Translation
-                defaultValue={actionView.label}
-                i18nKey={actionView.i18nKeyLabel}
-              />
+              <Translation defaultValue={actionView.label} i18nKey={actionView.i18nKeyLabel} />
             </h3>
           </div>
 
-          <div className="controls">
-            {/* Controls */}
-          </div>
+          <div className="controls">{/* Controls */}</div>
         </div>
         <div style={this.styles.body} className="admin-controls-content action-view-body">
-
           {/* this.renderControlComponent() */}
           {this.renderDetailComponent()}
         </div>
@@ -426,10 +379,7 @@ class ActionView extends Component {
     return (
       <div style={this.styles.base} className={baseClassName} role="complementary" key="action-view">
         {this.renderMasterView()}
-        <Overlay
-          isVisible={this.showDetailViewOverlay}
-          onClick={this.props.handleActionViewDetailClose}
-        />
+        <Overlay isVisible={this.showDetailViewOverlay} onClick={this.props.handleActionViewDetailClose} />
         <CSSTransition
           in={this.props.detailViewIsOpen}
           unmountOnExit
@@ -441,11 +391,8 @@ class ActionView extends Component {
           {this.renderDetailView()}
         </CSSTransition>
 
-
         <div className="admin-controls-footer">
-          <div className="admin-controls-container">
-            {this.renderFooter()}
-          </div>
+          <div className="admin-controls-container">{this.renderFooter()}</div>
         </div>
       </div>
     );
@@ -470,16 +417,10 @@ class ActionView extends Component {
         >
           {this.renderActionView()}
         </CSSTransition>
-        <Overlay
-          isVisible={this.showOverlay}
-          onClick={this.props.handleActionViewClose}
-        />
+        <Overlay isVisible={this.showOverlay} onClick={this.props.handleActionViewClose} />
       </div>
     );
   }
 }
 
-export default Admin()(compose(
-  withCSSTransition,
-  Radium
-)(ActionView));
+export default Admin()(compose(withCSSTransition, Radium)(ActionView));

--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -97,9 +97,13 @@ const getStyles = (props) => {
       "flexDirection": "column",
       "flex": "1 1 auto",
       "maxWidth": viewMaxSize,
+      "@media only screen and (max-width: 1500px)": {
+        "flex": "0 1 auto",
+        maxWidth: "100%",
+        "width": "55vw"
+      },
       "@media only screen and (max-width: 949px)": {
-        width: "100vw",
-        maxWidth: "100%"
+        width: "100vw"
       }
     },
     masterView: {
@@ -116,12 +120,16 @@ const getStyles = (props) => {
       "height": "100vh",
       "backgroundColor": "white",
       "borderRight": "1px solid #ccc",
-      "@media only screen and (max-width: 949px)": {
+      "width": "24vw",
+      "@media only screen and (max-width: 1500px)": {
         position: "absolute",
         top: 0,
         right: 0,
-        width: "96vw",
+        width: "35vw",
         zIndex: 1050
+      },
+      "@media only screen and (max-width: 1200px)": {
+        width: "96vw"
       }
     },
     detailView: {


### PR DESCRIPTION
Resolves #4666   
Impact: **minor**  
Type: **bugfix**

## Issue
In the admin dashboard orders panel, one would occasionally see an issue where the orders "sub" panel would either not render or be obscured by the "modal overlay". This issue only happened with screen sizes between `950px - 1100px`.

## Solution
Updated a few `panel` styles to fit within the viewport better and not end up behind the "modal overlay"

## Breaking changes
N/A

## Testing
TBD