### PR TITLE
fix: 4694 nnnnat edit groups panel

### DIFF
--- a/imports/plugins/core/accounts/client/components/editGroup.js
+++ b/imports/plugins/core/accounts/client/components/editGroup.js
@@ -43,7 +43,7 @@ class EditGroup extends Component {
 
   componentWillReceiveProps(nextProps) {
     const { groups, selectedGroup } = nextProps;
-    this.setState({ groups, selectedGroup });
+    this.setState({ groups, selectedGroup: selectedGroup || {} });
   }
 
   selectGroup = (grp) => (event) => {


### PR DESCRIPTION
Resolves #4694   
Impact: **minor**  
Type: **bugfix**

## Issue
The `editGroup` component inside the accounts plugin would throw an error in the client when `state.selectedGroup` was set to `undefined`. The component receives `selectedGroup` via `props` and set that value as `state.selectedGroup` inside the `constructor` and `componentWillRecieveProps` methods. Inside the `componentWillRecieveProps` method, however, we're not guarding against `props.selectedGroup === undefined` which is causing the error.

## Solution
Updated the `editGroup`'s `componentWillReceiveProps` method to protect agaiant `props.selectedGroup === undefined`.

## Breaking changes
N/A

## Testing

1. Log-in as Admin account
2. Click Accounts
3. Edit an existing group's properties, see no console error and the setting updates.
