### PR TITLE
fix: resolve errors in jsdoc Promise returns

### DIFF
--- a/imports/plugins/core/cart/client/util/buildOrderInputFromCart.js
+++ b/imports/plugins/core/cart/client/util/buildOrderInputFromCart.js
@@ -6,7 +6,7 @@ import getOpaqueIds from "/imports/plugins/core/core/client/util/getOpaqueIds";
  * @summary "catalog/getCurrentCatalogPriceForProductConfigurations" Meteor method wrapped in Promise
  * @param {Object[]} productConfigurations Array of product configurations
  * @param {String} currencyCode Currency in which to get prices
- * @returns {<Promise>Object[]} Same productConfigurations array, with price added
+ * @returns {Promise<Object[]>} Same productConfigurations array, with price added
  */
 function getCurrentCatalogPriceForProductConfigurations(productConfigurations, currencyCode) {
   return new Promise((resolve, reject) => {

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/connection.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/connection.js
@@ -5,7 +5,7 @@ import { connectionFromArray } from "graphql-relay";
  * @method
  * @memberof GraphQL/Transforms
  * @param {Object} connectionArgs GraphQL connection arguments
- * @param {Array|<Promise>Array} results The array of results
+ * @param {Array|Promise<Array>} results The array of results
  * @return {Object} A connection shaped object of the results array
  */
 export async function xformArrayToConnection(connectionArgs, results) {


### PR DESCRIPTION
Resolves unreported issue
Impact: **critical**  
Type: **bugfix**

I've classified this as a **critical** impact bug because the build is currently broken (just doc deployment) and displays a failing badge. I'll merge this directly to master and release rc.3 once it's been approved.

Found a few files where we were using the jsdoc syntax
```
@return <Promise>Object
```

The jsdoc parser is unable to parse any return type starting with a `<`
and throws an error. This error is thrown during the `Deploy Docs` CI step
and ultimately results in a Failing Build badge shown on the readme.

I've updated the syntax to use
```
@return Promise<Object>
```
which parses correctly.
