### PR TITLE
docs: Link readers to Reaction Platform install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ We love your pull requests! Check our our [`Good First Issue`](https://github.co
 
 Pull requests should:
 
-- Pass all pull request Circle CI checks: Run `npm run lint` and `reaction test` to make sure you're following the [Reaction Code Style Guide](https://docs.reactioncommerce.com/reaction-docs/master/styleguide) and passing [acceptance tests and unit tests](https://docs.reactioncommerce.com/reaction-docs/master/testing-reaction).
+- Pass all Circle CI checks: 
+    - Run `docker-compose run --rm reaction npm run lint` to make sure your code follows [Reaction's ESLint rules](https://github.com/reactioncommerce/reaction-eslint-config).
+    - Run `docker-compose run --rm reaction reaction test` to run [acceptance tests and unit tests](https://docs.reactioncommerce.com/reaction-docs/master/testing-reaction).
+    - Make sure you're following the [Reaction Code Style Guide](https://docs.reactioncommerce.com/reaction-docs/master/styleguide) and 
 - Follow the pull request template.
 
 Get more details in our [Contributing Guide](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Follow the documentation for installing pre-2.0 Reaction on [OS X](https://docs.
 ## Read documentation & tutorials
 
 -   [Reaction Commerce: Developer documentation](https://docs.reactioncommerce.com)
+-   [Reaction Design System](http://designsystem.reactioncommerce.com/)
 -   [Reaction Commerce: API documentation](http://api.docs.reactioncommerce.com)
 -   [Reaction Commerce engineering blog posts](https://blog.reactioncommerce.com/tag/engineering/)
 -   [Reaction Commerce YouTube videos](https://www.youtube.com/user/reactioncommerce/videos)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Reaction’s out-of-the-box core features include:
 
--	One step cart and checkout
+-	One-step cart and checkout
 -   Order processing
 -   Payments with Stripe
 -   Shipping

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Circle CI](https://circleci.com/gh/reactioncommerce/reaction.svg?style=svg)](https://circleci.com/gh/reactioncommerce/reaction) [![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/reactioncommerce/reaction?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Open Source Helpers](https://www.codetriage.com/reactioncommerce/reaction/badges/users.svg)](https://www.codetriage.com/reactioncommerce/reaction)
 
-
 [Reaction](http://reactioncommerce.com) is an event-driven, real-time reactive commerce platform built with JavaScript (ES6). It plays nicely with npm, Docker, and React.
 
 ![Reaction v.1.x](https://raw.githubusercontent.com/reactioncommerce/reaction-docs/v1.7.0/assets/Reaction-Commerce-Illustration-BG-800px.png)
@@ -26,46 +25,13 @@ Since anything in our codebase can be extended, overwritten, or installed as a p
 
 # Getting started
 
-### Requirements
+## Reaction 2.0
 
-Reaction requires Meteor, Git, Mongo DB, OS-specific build tools. For step-by-step instructions, follow the documentation for [OS X](https://docs.reactioncommerce.com/docs/next/installation-osx), [Windows](https://docs.reactioncommerce.com/docs/next/installation-windows) or [Linux](https://docs.reactioncommerce.com/docs/next/installation-linux).
+Follow the documentation for [Reaction Platform](https://docs.reactioncommerce.com/docs/installation-reaction-platform) for all operating systems.
 
-### Install and run with CLI
+## Pre-2.0 Reaction
 
-Install the [Reaction CLI](https://github.com/reactioncommerce/reaction-cli) to get started with Reaction:
-
-```sh
-npm install -g reaction-cli
-```
-
-Create your store:
-
-```sh
-reaction init
-cd reaction
-reaction
-```
-
-Open `localhost:3000`
-
-Learn more on how to [configure your project](https://docs.reactioncommerce.com/reaction-docs/master/configuration).
-
-Having installation issues? Check out our [troubleshooting docs](https://docs.reactioncommerce.com/docs/next/troubleshooting-development).
-
-### Install and run with Docker
-
-You can also run the app locally using [`docker-compose`](https://docs.docker.com/compose/) by running:
-
-```sh
-docker network create api.reaction.localhost
-docker-compose up
-```
-
-Open `localhost:3000`
-
-This will use the `docker-compose.yml` file.
-
-To learn more on how to develop on Docker, read our documentation on [developing Reaction on Docker](https://docs.reactioncommerce.com/docs/next/installation-docker-development) and [troubleshooting Docker](https://docs.reactioncommerce.com/docs/next/troubleshooting-development#docker-issues).
+Follow the documentation for installing pre-2.0 Reaction on [OS X](https://docs.reactioncommerce.com/docs/next/installation-osx), [Windows](https://docs.reactioncommerce.com/docs/next/installation-windows) or [Linux](https://docs.reactioncommerce.com/docs/next/installation-linux).
 
 # Get involved
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We love your pull requests! Check our our [`Good First Issue`](https://github.co
 
 Pull requests should:
 
-- Pass all pull request Cirlce CI checks: Run `npm run lint` and `reaction test` to make sure you're following the [Reaction Code Style Guide](https://docs.reactioncommerce.com/reaction-docs/master/styleguide) and passing [acceptance tests and unit tests](https://docs.reactioncommerce.com/reaction-docs/master/testing-reaction).
+- Pass all pull request Circle CI checks: Run `npm run lint` and `reaction test` to make sure you're following the [Reaction Code Style Guide](https://docs.reactioncommerce.com/reaction-docs/master/styleguide) and passing [acceptance tests and unit tests](https://docs.reactioncommerce.com/reaction-docs/master/testing-reaction).
 - Follow the pull request template.
 
 Get more details in our [Contributing Guide](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction).

--- a/README.md
+++ b/README.md
@@ -25,13 +25,9 @@ Since anything in our codebase can be extended, overwritten, or installed as a p
 
 # Getting started
 
-## Reaction 2.0
+Follow the documentation to install Reaction with [Reaction Platform](https://docs.reactioncommerce.com/docs/installation-reaction-platform) for all operating systems.
 
-Follow the documentation for [Reaction Platform](https://docs.reactioncommerce.com/docs/installation-reaction-platform) for all operating systems.
-
-## Pre-2.0 Reaction
-
-Follow the documentation for installing pre-2.0 Reaction on [OS X](https://docs.reactioncommerce.com/docs/next/installation-osx), [Windows](https://docs.reactioncommerce.com/docs/next/installation-windows) or [Linux](https://docs.reactioncommerce.com/docs/next/installation-linux).
+> Installing an older version of Reaction? Follow the documentation for installing pre-2.0 Reaction on [OS X](https://docs.reactioncommerce.com/docs/1.16.0/installation-osx), [Windows](https://docs.reactioncommerce.com/docs/1.16.0/installation-windows) or [Linux](https://docs.reactioncommerce.com/docs/1.16.0/installation-linux).
 
 # Get involved
 
@@ -53,7 +49,7 @@ Follow the documentation for installing pre-2.0 Reaction on [OS X](https://docs.
 
 :star: Star us on GitHub — it helps!
 
-Want to request a feature? Use our Reaction Feature Requests repository to file a request.
+Want to request a feature? Use our [Reaction Feature Requests repository](https://github.com/reactioncommerce/reaction-feature-requests) to file a request.
 
 We love your pull requests! Check our our [`Good First Issue`](https://github.com/reactioncommerce/reaction/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) and [`Help Wanted`](https://github.com/reactioncommerce/reaction/issues?q=label%3A%22help+wanted%22) tags for good issues to tackle.
 


### PR DESCRIPTION
Resolves https://github.com/reactioncommerce/reaction-docs/issues/687
Impact: **minor**  
Type: **docs|chore**

## Issue
- We want all Reaction Platform install docs to live in one, official, canonical spot.
- That spot is here: https://docs.reactioncommerce.com/docs/installation-reaction-platform

## Solution
- I created a 2.0 section updated the README to link to https://docs.reactioncommerce.com/docs/installation-reaction-platform
- I kept a pre-2.0 section with links to the old instructions for OS X, Linux and Windows

## Breaking changes
None

## Testing
1. Test that the link works and docs look good: https://github.com/reactioncommerce/reaction-next-starterkit/blob/6418fa744dd3d6e111a8fc1b4dfb4cf50121c552/README.md
2. Test that the docs don't leave out anything necessary for starting starterkit