### PR TITLE
Add product tags to order item

### DIFF
--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -235,6 +235,12 @@ export const OrderItem = new SimpleSchema({
     type: String,
     optional: true
   },
+  "productTagIds": {
+    label: "Product Tags",
+    type: Array,
+    optional: true
+  },
+  "productTagIds.$": String,
   "productVendor": {
     label: "Product Vendor",
     type: String,

--- a/imports/plugins/core/orders/server/no-meteor/mutations/createOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/createOrder.js
@@ -193,6 +193,7 @@ async function buildOrderItem(inputItem, currencyCode, context) {
     productId: chosenProduct._id,
     productSlug: chosenProduct.slug,
     productType: chosenProduct.type,
+    productTagIds: chosenProduct.tagIds,
     productVendor: chosenProduct.vendor,
     quantity,
     shopId: chosenProduct.shopId,

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/OrderItem/index.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/OrderItem/index.js
@@ -1,7 +1,9 @@
 import { encodeOrderItemOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/order";
 import { resolveShopFromShopId } from "@reactioncommerce/reaction-graphql-utils";
+import productTags from "./productTags";
 
 export default {
   _id: (node) => encodeOrderItemOpaqueId(node._id),
+  productTags,
   shop: resolveShopFromShopId
 };

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/OrderItem/productTags.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/OrderItem/productTags.js
@@ -2,17 +2,17 @@ import { getPaginatedResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { xformArrayToConnection } from "@reactioncommerce/reaction-graphql-xforms/connection";
 
 /**
- * @name "CartItem.productTags"
+ * @name "OrderItem.productTags"
  * @method
  * @memberof Catalog/GraphQL
- * @summary Returns the tags for a CartItem
- * @param {Object} product - CartItem from parent resolver
+ * @summary Returns the tags for an OrderItem
+ * @param {Object} order - OrderItem from parent resolver
  * @param {TagConnectionArgs} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<Object[]>} Promise that resolves with array of Tag objects
  */
-export default async function tags(cartItem, connectionArgs, context) {
-  const { productTagIds } = cartItem;
+export default async function tags(OrderItem, connectionArgs, context) {
+  const { productTagIds } = OrderItem;
   if (!productTagIds || productTagIds.length === 0) return xformArrayToConnection(connectionArgs, []);
 
   const query = await context.queries.tagsByIds(context, productTagIds, connectionArgs);

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/OrderItem/productTags.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/OrderItem/productTags.js
@@ -6,13 +6,13 @@ import { xformArrayToConnection } from "@reactioncommerce/reaction-graphql-xform
  * @method
  * @memberof Catalog/GraphQL
  * @summary Returns the tags for an OrderItem
- * @param {Object} order - OrderItem from parent resolver
+ * @param {Object} orderItem - OrderItem from parent resolver
  * @param {TagConnectionArgs} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<Object[]>} Promise that resolves with array of Tag objects
  */
-export default async function tags(OrderItem, connectionArgs, context) {
-  const { productTagIds } = OrderItem;
+export default async function productTags(orderItem, connectionArgs, context) {
+  const { productTagIds } = orderItem;
   if (!productTagIds || productTagIds.length === 0) return xformArrayToConnection(connectionArgs, []);
 
   const query = await context.queries.tagsByIds(context, productTagIds, connectionArgs);

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -105,6 +105,9 @@ type OrderItem implements Node {
   "The type of product, used to display cart items differently"
   productType: String
 
+   "The list of tags that have been applied to this product"
+  productTags(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: TagSortByField = _id): TagConnection
+
   "The product vendor"
   productVendor: String
 


### PR DESCRIPTION
Impact: minor
Type: feature

## Summary
Adds product tags to the `OrderItem` type

## Testing
1. Place an order in the starter kit
2. Verify returned order items have the prop `productTags`
