### PR TITLE
Fix Auth Consent scopes issue

### DIFF
--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -49,7 +49,7 @@ WebApp.connectHandlers.use("/consent", (req, res) => {
   hydra
     .acceptConsentRequest(challenge, {
       remember: true,
-      remember_for: HYDRA_SESSION_LIFESPAN || 3600, // eslint-disable-line camelcase
+      remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 3600, // eslint-disable-line camelcase
       session: {} // we are not adding any extra user, we use only the sub value already present
     })
     .then((consentResponse) => {

--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -50,10 +50,12 @@ WebApp.connectHandlers.use("/consent", (req, res) => {
     .then(async (response) => {
       // eslint-disable-next-line camelcase
       const options = { grant_scope: response.requested_scope };
-      if (!response.skip) { // if skip is true (i.e no form UI is shown, there's no need to set `remember`)
-        // `remember` tells Hydra to remember this consent grant and reuse it if request is from the same user on the
-        // same client. Ideally, this should be longer than token lifespan. Set default is 24 hrs (set in seconds).
-        // Depending on preferred setup, you can allow users decide if to enable or disable
+      // if skip is true (i.e no form UI is shown, there's no need to set `remember`)
+      if (!response.skip) {
+        // `remember` tells Hydra to remember this consent grant and reuse it if request is from
+        // the same user on the same client. Ideally, this should be longer than token lifespan.
+        // Set default is 24 hrs (set in seconds). Depending on preferred setup, you can allow
+        // users decide if to enable or disable
         options.remember = true;
         // eslint-disable-next-line camelcase
         options.remember_for = HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 86400;

--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -49,7 +49,10 @@ WebApp.connectHandlers.use("/consent", (req, res) => {
   hydra
     .acceptConsentRequest(challenge, {
       remember: true,
-      remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 3600, // eslint-disable-line camelcase
+      // `remember` tells Hydra to remember this consent grant and reuse it if request is from the same user on the
+      // same client. Ideally, this should be longer than token lifespan. Set default is 24 hrs (set in seconds).
+      // Depending on preferred setup, you can allow users decide if to enable or disable
+      remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 86400, // eslint-disable-line camelcase
       session: {} // we are not adding any extra user, we use only the sub value already present
     })
     .then((consentResponse) => {

--- a/imports/plugins/core/hydra-oauth/server/oauthMethods.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthMethods.js
@@ -23,10 +23,12 @@ export function oauthLogin(options) {
     .acceptLoginRequest(challenge, {
       subject: Reaction.getUserId(),
       remember,
-      // `remember` tells Hydra to remember this login and reuse it if the same user on the same client tries to
-      // log-in again. Ideally, this should be longer than token lifespan. Set default is 24 hrs (set in seconds).
-      // Depending on preferred setup, you can allow users decide if to enable or disable
-      remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 86400 // eslint-disable-line camelcase
+      // `remember` tells Hydra to remember this login and reuse it if the same user on the same
+      // client tries to log-in again. Ideally, this should be longer than token lifespan.
+      // Set default is 24 hrs (set in seconds). Depending on preferred setup, you can allow
+      // users decide if to enable or disable.
+      // eslint-disable-next-line camelcase
+      remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 86400
     })
     .then((response) => response.redirect_to)
     .catch((error) => {

--- a/imports/plugins/core/hydra-oauth/server/oauthMethods.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthMethods.js
@@ -23,7 +23,10 @@ export function oauthLogin(options) {
     .acceptLoginRequest(challenge, {
       subject: Reaction.getUserId(),
       remember,
-      remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 3600 // eslint-disable-line camelcase
+      // `remember` tells Hydra to remember this login and reuse it if the same user on the same client tries to
+      // log-in again. Ideally, this should be longer than token lifespan. Set default is 24 hrs (set in seconds).
+      // Depending on preferred setup, you can allow users decide if to enable or disable
+      remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 86400 // eslint-disable-line camelcase
     })
     .then((response) => response.redirect_to)
     .catch((error) => {

--- a/imports/plugins/core/hydra-oauth/server/oauthMethods.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthMethods.js
@@ -23,7 +23,7 @@ export function oauthLogin(options) {
     .acceptLoginRequest(challenge, {
       subject: Reaction.getUserId(),
       remember,
-      remember_for: HYDRA_SESSION_LIFESPAN || 3600 // eslint-disable-line camelcase
+      remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 3600 // eslint-disable-line camelcase
     })
     .then((response) => response.redirect_to)
     .catch((error) => {


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issues
- HYDRA_SESSION_LIFESPAN env value should be a Number (else it will be ignored). Setting via ENV passes a string, so it should be converted.
- The granted scopes during user consent flow are not correctly passed back to Hydra. This can be seen when `openid` scope is added at the beginning of the auth flow by the consumer app, and there is no issuance of an id_token on completion of the auth. This was also preventing refresh-tokens from being granted (seen while fixing reactioncommerce/reaction-next-starterkit#350)

## Solution
- HYDRA_SESSION_LIFESPAN: If the env is passed in, convert it to Number before using.
- Scopes: Make `getConsent` call to retrieve the list of the client-requested scope, and pass them when granting the consent in the `acceptConsentRequest` call.

## Testing
1. You need to have Starterkit (develop branch), Hydra (master) and Reaction services running
2. First, without using this branch (use rc-5) , see that refresh_token is not issued after logging in. You can add a console.log in the strategy [callback](https://github.com/reactioncommerce/reaction-next-starterkit/blob/develop/src/server.js#L34)
3. Switch your Reaction service to run on this branch, perform the login flow again, and confirm that you see id_token and refresh_tokens in your log.
