### PR TITLE
Feat 4718 enable payment method for shop

### DIFF
--- a/imports/plugins/core/payments/register.js
+++ b/imports/plugins/core/payments/register.js
@@ -1,4 +1,5 @@
 import Reaction from "/imports/plugins/core/core/server/Reaction";
+import mutations from "./server/no-meteor/mutations";
 import queries from "./server/no-meteor/queries";
 import resolvers from "./server/no-meteor/resolvers";
 import schemas from "./server/no-meteor/schemas";
@@ -13,6 +14,7 @@ Reaction.registerPackage({
     schemas
   },
   queries,
+  mutations,
   settings: {
     payments: {
       enabled: true

--- a/imports/plugins/core/payments/server/no-meteor/mutations/__snapshots__/enablePaymentMethodForShop.test.js.snap
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/__snapshots__/enablePaymentMethodForShop.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`errors on invalid payment method 1`] = `"Requested payment method is invalid"`;
+
+exports[`errors on invalid shop 1`] = `"Shop not found"`;
+
+exports[`errors on missing arguments 1`] = `"Is enabled is required"`;
+
+exports[`throws if userHasPermission returns false 1`] = `"The first argument of validate() must be an object"`;

--- a/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
@@ -4,21 +4,21 @@ import { Shops } from "/lib/collections";
 import { paymentMethods as allPaymentMethods } from "/imports/plugins/core/core/server/no-meteor/pluginRegistration";
 
 const paramsSchema = new SimpleSchema({
-  shopId: String,
+  isEnabled: Boolean,
   paymentMethodName: String,
-  isEnabled: Boolean
+  shopId: String
 });
 
 export default async function enablePaymentMethodForShop(context, input = {}) {
   paramsSchema.validate(input);
-  const { shopId, paymentMethodName, isEnabled } = input;
+  const { isEnabled, paymentMethodName, shopId } = input;
 
   if (!allPaymentMethods[paymentMethodName]) {
     throw new ReactionError("not-found", "Requested payment method is invalid");
   }
 
   const shop = await context.queries.shopById(context, shopId);
-  const methods = new Set(shop.availablePaymentMethods)
+  const methods = new Set(shop.availablePaymentMethods);
 
   if (isEnabled) {
     methods.add(paymentMethodName);
@@ -32,8 +32,5 @@ export default async function enablePaymentMethodForShop(context, input = {}) {
     { bypassCollection2: true }
   );
 
-  const paymentMethods = await context.queries.paymentMethods(context, shopId);
-  return {
-    paymentMethods
-  };
+  return context.queries.paymentMethods(context, shopId);
 }

--- a/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
@@ -25,6 +25,10 @@ export default async function enablePaymentMethodForShop(context, input = {}) {
   const { Shops } = context.collections;
   const { isEnabled, paymentMethodName, shopId } = input;
 
+  if (!context.userHasPermission(["owner", "admin"], shopId)) {
+    throw new ReactionError("access-denied", "Access denied");
+  }
+
   if (!allPaymentMethods[paymentMethodName]) {
     throw new ReactionError("not-found", "Requested payment method is invalid");
   }

--- a/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
@@ -1,0 +1,35 @@
+import SimpleSchema from "simpl-schema";
+import { Shops } from "/lib/collections";
+import { paymentMethods as allPaymentMethods } from "/imports/plugins/core/core/server/no-meteor/pluginRegistration";
+
+const paramsSchema = new SimpleSchema({
+  shopId: String,
+  paymentMethodName: String,
+  isEnabled: Boolean
+});
+
+export default async function enablePaymentMethodForShop(context, input = {}) {
+  paramsSchema.validate(input);
+
+  const { shopId, paymentMethodName, isEnabled } = input;
+  const shop = await context.queries.shopById(context, shopId);
+  const methods = new Set(shop.availablePaymentMethods)
+
+  if (isEnabled) {
+    methods.add(paymentMethodName);
+  } else {
+    methods.delete(paymentMethodName);
+  }
+
+  await Shops.update(
+    { _id: shop._id },
+    { $set: { availablePaymentMethods: Array.from(methods) } },
+    { bypassCollection2: true }
+  );
+
+  const paymentMethods = await context.queries.paymentMethods(context, shopId);
+
+  return {
+    paymentMethods
+  };
+}

--- a/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
@@ -5,8 +5,7 @@ import { paymentMethods as allPaymentMethods } from "/imports/plugins/core/core/
 const paramsSchema = new SimpleSchema({
   isEnabled: Boolean,
   paymentMethodName: String,
-  shopId: String,
-  clientMutationId: { type: String, optional: true }
+  shopId: String
 });
 
 /**
@@ -21,7 +20,7 @@ const paramsSchema = new SimpleSchema({
  * @return {Promise<Array<Object>>} Array<PaymentMethod>
  */
 export default async function enablePaymentMethodForShop(context, input = {}) {
-  paramsSchema.validate(input);
+  paramsSchema.validate(input, { ignore: [SimpleSchema.ErrorTypes.KEY_NOT_IN_SCHEMA] });
   const { Shops } = context.collections;
   const { isEnabled, paymentMethodName, shopId } = input;
 

--- a/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
@@ -1,3 +1,4 @@
+import ReactionError from "@reactioncommerce/reaction-error";
 import SimpleSchema from "simpl-schema";
 import { Shops } from "/lib/collections";
 import { paymentMethods as allPaymentMethods } from "/imports/plugins/core/core/server/no-meteor/pluginRegistration";
@@ -10,8 +11,12 @@ const paramsSchema = new SimpleSchema({
 
 export default async function enablePaymentMethodForShop(context, input = {}) {
   paramsSchema.validate(input);
-
   const { shopId, paymentMethodName, isEnabled } = input;
+
+  if (!allPaymentMethods[paymentMethodName]) {
+    throw new ReactionError("not-found", "Requested payment method is invalid");
+  }
+
   const shop = await context.queries.shopById(context, shopId);
   const methods = new Set(shop.availablePaymentMethods)
 
@@ -28,7 +33,6 @@ export default async function enablePaymentMethodForShop(context, input = {}) {
   );
 
   const paymentMethods = await context.queries.paymentMethods(context, shopId);
-
   return {
     paymentMethods
   };

--- a/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.js
@@ -6,9 +6,21 @@ import { paymentMethods as allPaymentMethods } from "/imports/plugins/core/core/
 const paramsSchema = new SimpleSchema({
   isEnabled: Boolean,
   paymentMethodName: String,
-  shopId: String
+  shopId: String,
+  clientMutationId: { type: String, optional: true }
 });
 
+/**
+ * @method enablePaymentMethodForShop
+ * @summary Enables (or disables) payment method for a given shop
+ * @param {Object} context -  an object containing the per-request state
+ * @param {Object} input - EnablePaymentMethodForShopInput
+ * @param {String} input.isEnabled - Whether to enable or disable specified payment method
+ * @param {String} input.paymentMethodName - The name of the payment method to enable or disable
+ * @param {String} input.shopId - The id of the shop to enable payment method on
+ * @param {String} [input.clientMutationId] - An optional string identifying the mutation call
+ * @return {Promise<Array<Object>>} Array<PaymentMethod>
+ */
 export default async function enablePaymentMethodForShop(context, input = {}) {
   paramsSchema.validate(input);
   const { isEnabled, paymentMethodName, shopId } = input;

--- a/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.test.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.test.js
@@ -69,7 +69,7 @@ test("errors on invalid shop", async () => {
 });
 
 test("enables payment method for valid shop", async () => {
-  fakeShop.availablePaymentMethods = [ "mockPaymentMethod" ];
+  fakeShop.availablePaymentMethods = ["mockPaymentMethod"];
   mockContext.userHasPermission.mockReturnValue(true);
   mockShopById.mockReturnValue(fakeShop);
   mockPaymentMethods.mockReturnValue([{

--- a/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.test.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/enablePaymentMethodForShop.test.js
@@ -1,0 +1,101 @@
+import Factory from "/imports/test-utils/helpers/factory";
+import enablePaymentMethodForShop from "./enablePaymentMethodForShop";
+import mockContext from "/imports/test-utils/helpers/mockContext";
+import paymentMethods from "../queries/paymentMethods";
+
+jest.mock("/imports/plugins/core/core/server/no-meteor/pluginRegistration", () => ({
+  paymentMethods: {
+    mockPaymentMethod: {
+      name: "mockPaymentMethod",
+      displayName: "Mock!",
+      pluginName: "mock-plugin"
+    }
+  }
+}));
+
+const fakeShop = Factory.Shop.makeOne();
+const mockShopById = jest.fn().mockName("shopById");
+const mockEnablePaymentMethod = jest.fn().mockName("enablePaymentMethodForShop");
+
+beforeAll(() => {
+  mockContext.queries = {
+    paymentMethods,
+    shopById: mockShopById
+  };
+  mockContext.mutations = { enablePaymentMethodForShop: mockEnablePaymentMethod };
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockShopById.mockClear();
+  mockEnablePaymentMethod.mockClear();
+  fakeShop.availablePaymentMethods = [];
+});
+
+test("throws if userHasPermission returns false", async () => {
+  mockContext.userHasPermission.mockReturnValue(false);
+  mockShopById.mockReturnValue(fakeShop);
+
+  await expect(enablePaymentMethodForShop(mockContext, mockContext.shopId)).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("errors on missing arguments", async () => {
+  mockContext.userHasPermission.mockReturnValue(true);
+  mockShopById.mockReturnValue(fakeShop);
+
+  await expect(enablePaymentMethodForShop(mockContext, {})).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("errors on invalid payment method", async () => {
+  mockContext.userHasPermission.mockReturnValue(true);
+  mockShopById.mockReturnValue(fakeShop);
+
+  await expect(enablePaymentMethodForShop(mockContext, {
+    shopId: fakeShop._id,
+    paymentMethodName: "does not exist",
+    isEnabled: true
+  })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("errors on invalid shop", async () => {
+  mockContext.userHasPermission.mockReturnValue(true);
+  mockShopById.mockReturnValue();
+
+  await expect(enablePaymentMethodForShop(mockContext, {
+    shopId: "does not exist",
+    paymentMethodName: "mockPaymentMethod",
+    isEnabled: true
+  })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("enables payment method for valid shop", async () => {
+  mockContext.userHasPermission.mockReturnValue(true);
+  mockShopById.mockReturnValue(fakeShop);
+
+  await expect(enablePaymentMethodForShop(mockContext, {
+    shopId: fakeShop._id,
+    paymentMethodName: "mockPaymentMethod",
+    isEnabled: true
+  })).resolves.toEqual([{
+    name: "mockPaymentMethod",
+    displayName: "Mock!",
+    pluginName: "mock-plugin",
+    isEnabled: true
+  }]);
+});
+
+test("disables payment method for valid shop", async () => {
+  mockContext.userHasPermission.mockReturnValue(true);
+  mockShopById.mockReturnValue(fakeShop);
+
+  await expect(enablePaymentMethodForShop(mockContext, {
+    shopId: fakeShop._id,
+    paymentMethodName: "mockPaymentMethod",
+    isEnabled: false
+  })).resolves.toEqual([{
+    name: "mockPaymentMethod",
+    displayName: "Mock!",
+    pluginName: "mock-plugin",
+    isEnabled: false
+  }]);
+});

--- a/imports/plugins/core/payments/server/no-meteor/mutations/index.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/index.js
@@ -1,0 +1,5 @@
+import enablePaymentMethodForShop from "./enablePaymentMethodForShop";
+
+export default {
+  enablePaymentMethodForShop
+};

--- a/imports/plugins/core/payments/server/no-meteor/queries/paymentMethods.js
+++ b/imports/plugins/core/payments/server/no-meteor/queries/paymentMethods.js
@@ -1,5 +1,5 @@
 import ReactionError from "@reactioncommerce/reaction-error";
-import { paymentMethods as paymentMethodList } from "/imports/plugins/core/core/server/no-meteor/pluginRegistration";
+import { paymentMethods as allPaymentMethods } from "/imports/plugins/core/core/server/no-meteor/pluginRegistration";
 
 /**
  * @name paymentMethods
@@ -19,9 +19,9 @@ export default async function paymentMethods(context, shopId) {
     throw new ReactionError("access-denied", "Access denied");
   }
 
-  return Object.keys(paymentMethodList)
+  return Object.keys(allPaymentMethods)
     .map((name) => ({
-      ...paymentMethodList[name],
+      ...allPaymentMethods[name],
       isEnabled: availablePaymentMethods.includes(name)
     }));
 }

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
@@ -1,0 +1,6 @@
+import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+
+export default async function enablePaymentMethodForShop(parentResult, { input }, context) {
+  input.shopId = decodeShopOpaqueId(input.shopId);
+  return context.mutations.enablePaymentMethodForShop(context, input);
+}

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
@@ -1,10 +1,22 @@
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
+/**
+ * @name "Mutation.enablePaymentMethodForShop"
+ * @method
+ * @memberof Payment/GraphQL
+ * @summary resolver for the enablePaymentMethodForShop GraphQL mutation
+ * @param {Object} parentResult - unused
+ * @param {Object} args.input - EnablePaymentMethodForShopInput
+ * @param {String} args.input.isEnabled - Whether to enable or disable specified payment method
+ * @param {String} args.input.paymentMethodName - The name of the payment method to enable or disable
+ * @param {String} args.input.shopId - The id of the shop to enable payment method on
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Array<Object>>} EnablePaymentMethodForShopPayload
+ */
 export default async function enablePaymentMethodForShop(parentResult, { input }, context) {
   const { clientMutationId } = input;
   input.shopId = decodeShopOpaqueId(input.shopId);
-  delete input.clientMutationId;
-
   const paymentMethods = await context.mutations.enablePaymentMethodForShop(context, input);
 
   return {

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
@@ -1,6 +1,14 @@
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 export default async function enablePaymentMethodForShop(parentResult, { input }, context) {
+  const { clientMutationId } = input;
   input.shopId = decodeShopOpaqueId(input.shopId);
-  return context.mutations.enablePaymentMethodForShop(context, input);
+  delete input.clientMutationId;
+
+  const paymentMethods = await context.mutations.enablePaymentMethodForShop(context, input);
+
+  return {
+    clientMutationId,
+    paymentMethods
+  };
 }

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
@@ -16,8 +16,10 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
  */
 export default async function enablePaymentMethodForShop(parentResult, { input }, context) {
   const { clientMutationId } = input;
-  input.shopId = decodeShopOpaqueId(input.shopId);
-  const paymentMethods = await context.mutations.enablePaymentMethodForShop(context, input);
+  const paymentMethods = await context.mutations.enablePaymentMethodForShop(context, {
+    ...input,
+    shopId: decodeShopOpaqueId(input.shopId)
+  });
 
   return {
     clientMutationId,

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.test.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.test.js
@@ -1,0 +1,35 @@
+import enablePaymentMethodForShop from "./enablePaymentMethodForShop";
+
+const internalShopId = "555";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDo1NTU=";
+
+test("correctly passes through to mutations.enablePaymentMethodForShop", async () => {
+  const fakeResult = {
+    shop: { _id: "123" }
+  };
+
+  const mockMutation = jest.fn().mockName("mutations.enablePaymentMethodForShop");
+  mockMutation.mockReturnValueOnce(fakeResult);
+  const context = {
+    mutations: {
+      enablePaymentMethodForShop: mockMutation
+    }
+  };
+
+  const result = await enablePaymentMethodForShop(null, {
+    input: {
+      shopId: opaqueShopId,
+      clientMutationId: "clientMutationId"
+    }
+  }, context);
+
+  expect(result).toEqual({
+    paymentMethods: { ...fakeResult },
+    clientMutationId: "clientMutationId"
+  });
+
+  expect(mockMutation).toHaveBeenCalledWith(context, {
+    shopId: internalShopId,
+    clientMutationId: "clientMutationId"
+  });
+});

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/index.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/index.js
@@ -1,0 +1,5 @@
+import enablePaymentMethodForShop from "./enablePaymentMethodForShop";
+
+export default {
+  enablePaymentMethodForShop
+};

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/index.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/index.js
@@ -1,7 +1,9 @@
+import Mutation from "./Mutation";
 import Payment from "./Payment";
 import Query from "./Query";
 
 export default {
+  Mutation,
   Payment,
   Query
 };

--- a/imports/plugins/core/payments/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/payments/server/no-meteor/schemas/schema.graphql
@@ -10,6 +10,10 @@ extend type Query {
   paymentMethods(shopId: ID!): [PaymentMethod]!
 }
 
+extend type Mutation {
+  enablePaymentMethodForShop(input: EnablePaymentMethodForShopInput!): EnablePaymentMethodForShopPayload!
+}
+
 """
 Information about a payment made
 """
@@ -85,4 +89,27 @@ type PaymentMethod {
 
   "Name of the plugin that added the payment method"
   pluginName: String!
+}
+
+"Input for the `enablePaymentMethodForShop` mutation"
+input EnablePaymentMethodForShopInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "True to enable it or false to disable it"
+  isEnabled: Boolean!
+
+  "The name of the payment method to enable or disable"
+  paymentMethodName: String!
+
+  "The ID of the shop for which this payment method should be enabled or disabled"
+  shopId: ID!
+}
+
+type EnablePaymentMethodForShopPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "The full list of payment methods for the shop"
+  paymentMethods: [PaymentMethod]!
 }


### PR DESCRIPTION
Resolves #4718   
Impact: **minor**  
Type: **feature**

## Description
Created a mutation that allows an admin to enable/disable a payment method for a shop.

> NOTE: I don't like that the mutation itself is testing for validity of payment methods when modifying them. I now think we should make `paymentMethods` a data structure with add, delete, list, get, and some other methods, instead of the basic `{}` it currently is. But I would like to hear thoughts on this.

## Breaking changes
None.

## Testing
Try queries similar to the following:

```graphql
mutation {
  enablePaymentMethodForShop(
    input: {
      clientMutationId: "foo"
      shopId: "<shopOpaqueId>"
      paymentMethodName: "<paymentMethodName>"
      isEnabled: true # or false
    }
  ) {
    clientMutationId
    paymentMethods {
      name
      displayName
      pluginName
      isEnabled
    }
  }
}
```

1. Try a payment method that exists (`iou_example`)
2. Try a payment method that does not exist (`foo`), and make sure it throws an error
3. Try with and without a `clientMutationId`