### PR TITLE
feat: Add a CORS-enabled endpoint for token refresh in Hydra plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       HYDRA_ADMIN_URL: "http://hydra:4445"
       HYDRA_TOKEN_URL: "http://hydra:4444/oauth2/token"
       HYDRA_OAUTH2_INTROSPECT_URL: "http://hydra:4445/oauth2/introspect"
-      OAUTH2_CLIENT_DOMAIN: "http://localhost:4000"
+      OAUTH2_CLIENT_DOMAINS: "http://localhost:4000"
     networks:
       default:
       api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
       MONGO_OPLOG_URL: "mongodb://mongo:27017/local"
       ROOT_URL: "http://localhost:3000"
       HYDRA_ADMIN_URL: "http://hydra:4445"
+      HYDRA_TOKEN_URL: "http://hydra:4444/oauth2/token"
       HYDRA_OAUTH2_INTROSPECT_URL: "http://hydra:4445/oauth2/introspect"
+      OAUTH2_CLIENT_DOMAIN: "http://localhost:4000"
     networks:
       default:
       api:

--- a/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthEndpoints.js
@@ -68,6 +68,19 @@ WebApp.connectHandlers.use("/consent", (req, res) => {
     .catch((errorMessage) => errorHandler(errorMessage, res));
 });
 
+WebApp.connectHandlers.use("/token/refresh", (req, res) => {
+  res.setHeader("Access-Control-Allow-Origin", process.env.OAUTH2_CLIENT_DOMAIN);
+
+  hydra
+    .refreshAuthToken(req.query)
+    .then((apiRes) => {
+      Logger.debug(`Refresh auth token call successful: ${apiRes.statusCode}`);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify(apiRes));
+    })
+    .catch((errorMessage) => errorHandler(errorMessage, res));
+});
+
 WebApp.connectHandlers.use("/logout", (req, res) => {
   hydra
     .deleteUserSession(req.query.userId)

--- a/imports/plugins/core/hydra-oauth/server/util/hydra.js
+++ b/imports/plugins/core/hydra-oauth/server/util/hydra.js
@@ -85,20 +85,15 @@ function deleteUserSession(id) {
  * @param  {String} options options
  * @return {Object|String} API res
  */
-function refreshAuthToken({ refreshToken, clientId, clientSecret }) {
-  return fetch(`${HYDRA_TOKEN_URL}`, {
+async function refreshAuthToken({ refreshToken, clientId, clientSecret }) {
+  const res = await fetch(`${HYDRA_TOKEN_URL}`, {
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     method: "POST",
     body: `grant_type=refresh_token&refresh_token=${refreshToken}&response_type=token&client_id=${clientId}&client_secret=${clientSecret}`
-  })
-    .then(async (res) => {
-      if (res.status < 200 || res.status > 302) {
-        const json = await res.json();
-        Logger.error("An error occurred while calling refresh API", json.error_description);
-        return Promise.reject(new Error(json.error_description));
-      }
-      return res.json();
-    });
+  });
+
+  const json = await res.json();
+  return json;
 }
 
 export default {
@@ -108,6 +103,6 @@ export default {
   getConsentRequest: (challenge) => get("consent", challenge),
   acceptConsentRequest: (challenge, body) => put("consent", "accept", challenge, body),
   rejectConsentRequest: (challenge, body) => put("consent", "reject", challenge, body),
-  deleteUserSession: (id) => deleteUserSession(id),
-  refreshAuthToken: (options) => refreshAuthToken(options)
+  deleteUserSession,
+  refreshAuthToken
 };


### PR DESCRIPTION
Part of reactioncommerce/reaction-next-starterkit#350
Type: **feature**

## Issue
To help enable refresh token in Starterkit (reactioncommerce/reaction-next-starterkit#350)

## Changes
- Adds CORS-enabled endpoint to be called from Starterkit for token refresh

## Breaking changes
n/a

## Testing
1. Test steps in reactioncommerce/reaction-next-starterkit#394 
