### PR TITLE
feat: GraphQL query & resolver for loading the primary shop

### DIFF
--- a/imports/plugins/core/core/server/no-meteor/queries.js
+++ b/imports/plugins/core/core/server/no-meteor/queries.js
@@ -1,4 +1,16 @@
+import url from "url";
+
 export default {
   shopById: (context, _id) => context.collections.Shops.findOne({ _id }),
-  shopBySlug: (context, slug) => context.collections.Shops.findOne({ slug })
+  shopBySlug: (context, slug) => context.collections.Shops.findOne({ slug }),
+  primaryShop: async (context) => {
+    const { collections, rootUrl } = context;
+    const { Shops } = collections;
+    const domain = url.parse(rootUrl).hostname;
+    let shop = await Shops.findOne({ domains: domain });
+    if (!shop) {
+      shop = await Shops.findOne({ shopType: "primary" });
+    }
+    return shop;
+  }
 };

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/index.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/index.js
@@ -1,4 +1,5 @@
 import primaryShopId from "./primaryShopId";
+import primaryShop from "./primaryShop";
 import shop from "./shop";
 import shopBySlug from "./shopBySlug";
 import tag from "./tag";
@@ -6,6 +7,7 @@ import tags from "./tags";
 
 export default {
   primaryShopId,
+  primaryShop,
   shop,
   shopBySlug,
   tag,

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.js
@@ -1,0 +1,15 @@
+/**
+ * @name "Query.primaryShop"
+ * @method
+ * @memberof Shop/GraphQL
+ * @summary Gets the primary shop
+ * @param {Object} parentObject - unused
+ * @param {Object} args - unused
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<o>} The shop, based on the domain in ROOT_URL
+ */
+export default async function primaryShopId(_, __, context) {
+  const shopId = await context.queries.primaryShopId(context.collections);
+  const shop = await context.queries.shopById(context, shopId);
+  return shop;
+}

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.js
@@ -6,10 +6,9 @@
  * @param {Object} parentObject - unused
  * @param {Object} args - unused
  * @param {Object} context - an object containing the per-request state
- * @return {Promise<o>} The shop, based on the domain in ROOT_URL
+ * @return {Promise<Object>} The shop, based on the domain in ROOT_URL
  */
-export default async function primaryShopId(_, __, context) {
-  const shopId = await context.queries.primaryShopId(context.collections);
-  const shop = await context.queries.shopById(context, shopId);
+export default async function primaryShop(_, __, context) {
+  const shop = await context.queries.primaryShop(context);
   return shop;
 }

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.test.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.test.js
@@ -1,7 +1,6 @@
 import primaryShop from "./primaryShop";
 
 const fakeShopId = "W64ZQe9RUMuAoKrli";
-const opaqueShopId = "cmVhY3Rpb24vc2hvcDpXNjRaUWU5UlVNdUFvS3JsaQ==";
 
 const fakeShop = {
   _id: fakeShopId,

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.test.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.test.js
@@ -1,0 +1,27 @@
+import primaryShop from "./primaryShop";
+
+const fakeShopId = "W64ZQe9RUMuAoKrli";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDpXNjRaUWU5UlVNdUFvS3JsaQ==";
+
+const fakeShop = {
+  _id: fakeShopId,
+  name: "Reaction"
+};
+
+test("calls queries.primaryShop and returns the correct shop", async () => {
+  const primaryShopIdMock = jest.fn().mockName("queries.primaryShopId").mockReturnValueOnce(Promise.resolve(fakeShopId));
+  const shopByIdMock = jest.fn().mockName("queries.shopById").mockReturnValueOnce(Promise.resolve(fakeShop));
+
+  const shopObject = await primaryShop(null, null, {
+    queries: {
+      primaryShopId: primaryShopIdMock,
+      shopById: shopByIdMock,
+      primaryShop
+    }
+  });
+
+  expect(shopObject).toEqual(fakeShop);
+
+  expect(primaryShopIdMock).toHaveBeenCalled();
+  expect(shopByIdMock).toHaveBeenCalled();
+});

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.test.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShop.test.js
@@ -8,19 +8,15 @@ const fakeShop = {
 };
 
 test("calls queries.primaryShop and returns the correct shop", async () => {
-  const primaryShopIdMock = jest.fn().mockName("queries.primaryShopId").mockReturnValueOnce(Promise.resolve(fakeShopId));
-  const shopByIdMock = jest.fn().mockName("queries.shopById").mockReturnValueOnce(Promise.resolve(fakeShop));
+  const primaryShopMock = jest.fn().mockName("queries.primaryShop").mockReturnValueOnce(Promise.resolve(fakeShop));
 
   const shopObject = await primaryShop(null, null, {
     queries: {
-      primaryShopId: primaryShopIdMock,
-      shopById: shopByIdMock,
-      primaryShop
+      primaryShop: primaryShopMock
     }
   });
 
   expect(shopObject).toEqual(fakeShop);
 
-  expect(primaryShopIdMock).toHaveBeenCalled();
-  expect(shopByIdMock).toHaveBeenCalled();
+  expect(primaryShopMock).toHaveBeenCalled();
 });

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -88,4 +88,7 @@ extend type Query {
 
   "Returns the ID of the primary shop for the domain"
   primaryShopId: ID
+
+  "Returns the primary shop for the domain"
+  primaryShop: Shop
 }


### PR DESCRIPTION
Resolves #4727   
Impact: **minor**  
Type: **feature**

## Solution
This PR adds a `primaryShop` GraphQL query & resolver, eliminating the need to first query for the primary shop ID, followed by another query for shop by ID.

## Breaking changes
None


## Testing
1. Open Graphiql and run this query:
```
{
  primaryShop {
    _id
    name
  }
}
```