### PR TITLE
fix(startup): init mongo replica set after waiting for connection

### DIFF
--- a/.reaction/waitForMongo.js
+++ b/.reaction/waitForMongo.js
@@ -35,8 +35,8 @@ async function checkWaitRetry({
    *
    * @param {string} message to be printed
    * @param {number} count retry number for progress dots
-  * @returns {undefined}
-  */
+   * @returns {undefined}
+   */
   function showOnce(message, count) {
     if (!messages.has(message)) {
       messages.add(message);
@@ -89,6 +89,29 @@ async function connect(mongoUrl) {
 }
 
 /**
+ * Runs the mongo command replSetInitiate,
+ * which we need for the oplog for meteor real-time
+ *
+ * @param {objecct} db connected mongo db instance
+ * @returns {Promise} indication of success/failure
+ */
+async function initReplicaSet(db) {
+  try {
+    await db.admin().command({
+      replSetInitiate: {
+        _id: "rs0",
+        members: [{ _id: 0, host: "localhost:27017" }]
+      }
+    });
+  } catch (error) {
+    // AlreadyInitialized is OK to treat as success
+    if (error.codeName !== "AlreadyInitialized") {
+      throw error;
+    }
+  }
+}
+
+/**
  * Check if replication is ready
  *
  * @param {objecct} db connected mongo db instance
@@ -110,7 +133,11 @@ async function main() {
   if (!MONGO_URL) {
     throw new Error("You must set MONGO_URL environment variable.");
   }
-  const db = await connect(MONGO_URL);
+  const db = await checkWaitRetry({
+    timeoutMessage: "ERROR: MongoDB not reachable in time.",
+    check: connect.bind(null, MONGO_URL)
+  });
+  await initReplicaSet(db);
   await checkWaitRetry({
     timeoutMessage: "ERROR: MongoDB replica set not ready in time.",
     check: checkReplicaSetStatus.bind(null, db)
@@ -133,11 +160,7 @@ function exit(error) {
 // Allow this module to be run directly as a node program or imported as lib
 if (require.main === module) {
   process.on("unhandledRejection", exit);
-  try {
-    main();
-  } catch (error) {
-    exit(error);
-  }
+  main().catch(exit);
 }
 
 module.exports = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     build:
       context: .
       target: meteor-dev
-    command: bash -c "npm install && node ./.reaction/waitForReplica.js && reaction" #TODO; Revert to Meteor NPM. See comment in Dockerfile about Meteor1.7 NPM version issue.
+    command: bash -c "npm install && node ./.reaction/waitForMongo.js && reaction" #TODO; Revert to Meteor NPM. See comment in Dockerfile about Meteor1.7 NPM version issue.
     depends_on:
       - mongo
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       target: meteor-dev
     command: bash -c "npm install && node ./.reaction/waitForReplica.js && reaction" #TODO; Revert to Meteor NPM. See comment in Dockerfile about Meteor1.7 NPM version issue.
     depends_on:
-      - mongo-init-replica
+      - mongo
     environment:
       MONGO_URL: "mongodb://mongo:27017/reaction"
       MONGO_OPLOG_URL: "mongodb://mongo:27017/local"
@@ -44,13 +44,6 @@ services:
       - "27017:27017"
     volumes:
       - mongo-db:/data/db
-
-  # This container's job is just to run the command to initialize the replica set. It will stop after doing that.
-  mongo-init-replica:
-    image: mongo:3.6.3
-    command: 'mongo mongo/reaction --eval "rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})"'
-    depends_on:
-      - mongo
 
 volumes:
   mongo-db:

--- a/tests/waitForMongo.test.js
+++ b/tests/waitForMongo.test.js
@@ -1,4 +1,4 @@
-import { checkWaitRetry } from "../.reaction/waitForReplica";
+import { checkWaitRetry } from "../.reaction/waitForMongo";
 
 test("should work in immediate success case", async () => {
   const outLog = [];


### PR DESCRIPTION
Resolves #4745  
Impact: **minor**  
Type: **bugfix**

## Issue
See #4745 for detailed description of issue.

## Solution
Within the reaction container, wait for mongo to be reachable, connect to it, create the DB if needed, initiate the repl set if needed, and wait for the repl set to be *OK*. Should solve docker-compose startup race conditions.

## Testing
1. Test startup from a clean slate
1. Test startup with an existing mongodb in place
1. Temporarily edit the `docker-compose.yml` file and put this as the `command:` line in the `mongo` service
  * `    command: sh -c 'sleep 25 && uptime && echo HEY17 && mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger --bind_ip 0.0.0.0'`
 * (Aside, not sure why `--bind_ip 0.0.0.0` is needed but it seems necessary)
 * Run `docker-compose up`, this should test mongo starting on a delay while `waitForMongo.js` is already waiting for it.