### PR TITLE
fix: 4769 nnnnat edit groups panel

### DIFF
--- a/imports/plugins/core/accounts/client/components/editGroup.js
+++ b/imports/plugins/core/accounts/client/components/editGroup.js
@@ -43,7 +43,7 @@ class EditGroup extends Component {
 
   componentWillReceiveProps(nextProps) {
     const { groups, selectedGroup } = nextProps;
-    this.setState({ groups, selectedGroup });
+    this.setState({ groups, selectedGroup: selectedGroup || this.props.selectedGroup });
   }
 
   selectGroup = (grp) => (event) => {


### PR DESCRIPTION
Resolves #4769   
Impact: **minor**  
Type: **bugfix**

## Issue
see #4769 

## Solution
if `nextProps.selectedGroup` is undefined use `props.selectedGroup` in EditGroups component

## Breaking changes
N/A

## Testing
1. Log-in as Admin account
2. Click Accounts
3. Edit an existing group's properties, see no console error and the setting updates. 
