### PR TITLE
fix: keep toggles shown, width 100% in action view

### DIFF
--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -93,9 +93,6 @@ const getStyles = (props) => {
       "flexDirection": "column",
       "flex": "1 1 auto",
       "maxWidth": viewMaxSize,
-      "@media only screen and (max-width: 1420px)": {
-        minWidth: "55vw"
-      },
       "@media only screen and (max-width: 949px)": {
         width: "100vw"
       }


### PR DESCRIPTION
Resolves #4713   
Impact: **minor**  
Type: **bugfix**

## Issue
When screen width is > 949px and < 1420px, a style is applied to the action view that causes it to be wider than the width of its container. The right side of fields and the enable/disable toggles are hidden because of this.

## Solution
Removed the style that was causing this.

## Testing
See linked issue. The "Shop" settings is a good place to test.