### PR TITLE
fix: submitting the template edit form now works .. Resolves #4774

### DIFF
--- a/imports/plugins/core/templates/client/templates/settings.html
+++ b/imports/plugins/core/templates/client/templates/settings.html
@@ -13,11 +13,14 @@
         <div>
           {{#autoForm
             collection=Collections.Templates
-            schema=emailTemplateSchema
-            id="email-template-edit-form"
-            template="bootstrap3-inline"
             doc=template
-            }}
+            id="email-template-edit-form"
+            meteormethod="templates/email/update"
+            schema=emailTemplateSchema
+            template="bootstrap3-inline"
+            type="method-update"
+            validation="none"
+          }}
 
             <div class="panel panel-default">
               <div class="panel-heading" data-i18n="templateUpdateForm.emailTemplates.updateEmailTemplate">Update email template</div>
@@ -33,7 +36,12 @@
 
               <div class="panel-footer">
                 <div class="right">
-                  {{> templateSubmitButton instance=instance }}
+                  <div class="clearfix">
+                    <div class="pull-right">
+                      <button type="button" class="btn btn-primary cancel" data-i18n="app.cancel">Cancel</button>
+                      <button type="submit" class="btn btn-primary" data-i18n="app.saveChanges">Save Changes</button>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -56,14 +64,4 @@
       {{/if}}
     {{/if}}
   {{/if}}
-</template>
-
-
-<template name="templateSubmitButton">
-   <div class="clearfix">
-    <div class="pull-right">
-      <button type="button" class="btn btn-primary cancel" data-i18n="app.cancel">Cancel</button>
-      <button type="submit" class="btn btn-primary" data-i18n="app.saveChanges">Save Changes</button>
-    </div>
-  </div>
 </template>

--- a/imports/plugins/core/templates/client/templates/settings.js
+++ b/imports/plugins/core/templates/client/templates/settings.js
@@ -1,5 +1,4 @@
 import { $ } from "meteor/jquery";
-import { Meteor } from "meteor/meteor";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { Blaze } from "meteor/blaze";
 import { ReactiveDict } from "meteor/reactive-dict";
@@ -144,22 +143,11 @@ Template.templateSettings.events({
 
 AutoForm.hooks({
   "email-template-edit-form": {
-    onSubmit(insertDoc) {
-      this.event.preventDefault();
-
-      const templateId = this.docId;
-
-      Meteor.call("templates/email/update", templateId, insertDoc, (error, result) => {
-        if (error) {
-          Alerts.toast(i18next.t("templateUpdateForm.alerts.failedToUpdate", { err: error.message }), "error");
-          this.done(new Error("Failed to update template: ", error));
-          return false;
-        }
-        if (result) {
-          Alerts.toast(i18next.t("templateUpdateForm.alerts.templateUpdated", "Template successfully updated"), "success");
-          this.done();
-        }
-      });
+    onSuccess() {
+      return Alerts.toast(i18next.t("templateUpdateForm.alerts.templateUpdated", "Template successfully updated"), "success");
+    },
+    onError(operation, error) {
+      return Alerts.toast(i18next.t("templateUpdateForm.alerts.failedToUpdate", { err: error.message }), "error");
     }
   }
 });

--- a/imports/plugins/core/templates/server/methods.js
+++ b/imports/plugins/core/templates/server/methods.js
@@ -16,15 +16,13 @@ export const methods = {
    * @name templates/email/update
    * @method
    * @memberof Templates/Methods
-   * @todo Add permissions
    * @summary Updates email template in Templates collection
-   * @param {String} templateId - id of template to remove
-   * @param {Object} doc - data to update
-   * @return {Number} remove template
+   * @param {String} details._id - id of template to update
+   * @param {Object} details.modifier - data to update
+   * @return {Number} update template
    */
-  "templates/email/update"(templateId, doc) {
-    check(templateId, String);
-    check(doc, Object);
+  "templates/email/update"(details) {
+    check(details, Object);
 
     const shopId = Reaction.getShopId();
     const userId = Reaction.getUserId();
@@ -35,19 +33,10 @@ export const methods = {
     }
 
     return Templates.update({
-      _id: templateId,
+      _id: details._id,
       type: "email",
       shopId // Ensure that the template we're attempting to update is owned by the active shop.
-    }, {
-      $set: {
-        title: doc.title,
-        name: doc.name,
-        language: doc.language,
-        template: doc.template,
-        subject: doc.subject,
-        enabled: doc.enabled
-      }
-    });
+    }, details.modifier);
   }
 };
 


### PR DESCRIPTION
Resolves #4774  
Impact: **major**  
Type: **bugfix**

## Issue
Clicking on "Save" after making an edit to an email template seems to do nothing, so edits are never saved.

## Solution
This issue was previously solved in the 2.x branch by @aldeed. This PR ports that fix into the 1.17 release candidate.

## Breaking changes
This required changing the signature of the "templates/email/update" Meteor method. This could be breaking to customized code.

## Testing
Verify you can save changes to templates as an operator.
