### PR TITLE
Fix: Import Babel config from package.json and export in babel.config.js to fix Jest tests in custom plugins that have a package.json

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+
+/**
+ * @summary Babel 7 doesn't transpile files in sub-directories that have a package.json when Babel is configured
+ * through package.json or .babelrc. This causes Jest test failures in custom plugins that have a package.json. It
+ * isn't an issue with non-test files because those are imported through the main Reaction app (see /server/plugins.js
+ * and client/plugins.js). Babel does transpile these files when it is configured through the new babel.config.js.
+ * Meteor currently only loads Babel config through .babelrc or package.json. So, in order to support Babel transpiling
+ * of Jest tests, we load the babel config defined in package.json and export it here.
+ * See this Github comment: https://github.com/facebook/jest/issues/6053#issuecomment-383632515
+ */
+module.exports = function(api) {
+  api.cache(false);
+
+  const file = fs.readFileSync("./package.json");
+  const packageJSON = JSON.parse(file);
+
+  return packageJSON.babel;
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,11 +9,11 @@ const fs = require("fs");
  * of Jest tests, we load the babel config defined in package.json and export it here.
  * See this Github comment: https://github.com/facebook/jest/issues/6053#issuecomment-383632515
  */
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(false);
 
   const file = fs.readFileSync("./package.json");
   const packageJSON = JSON.parse(file);
 
   return packageJSON.babel;
-}
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,11 @@ const fs = require("fs");
 module.exports = function (api) {
   api.cache(false);
 
+  /**
+   * Meteor only reads the babel config from .babelrc or package.json. So with just babel.config.js,
+   * the Meteor app fails but the Jest tests pass. With just package.json, the Jest tests in custom plugins
+   * fail but the app runs.
+   */
   const file = fs.readFileSync("./package.json");
   const packageJSON = JSON.parse(file);
 


### PR DESCRIPTION
Resolves #4781   
Impact: **minor**  
Type: **bugfix**

## Issue
Babel 7 doesn't transpile files in sub-directories that have a package.json when Babel is configured through package.json or .babelrc. This causes Jest test failures in custom plugins that have a package.json. It isn't an issue with non-test files because those are imported through the main Reaction app (see /server/plugins.js and client/plugins.js). Babel does transpile these files when it is configured through the new babel.config.js. Meteor currently only loads Babel config through .babelrc or package.json, though.

## Solution
Meteor only reads the babel config from .babelrc or package.json. So with just babel.config.js, the Meteor app fails but the Jest tests pass. With just package.json, the Jest tests in custom plugins fail but the app runs.

In order to support Babel transpiling of Jest tests, we load the babel config defined in package.json and export it in the new babel.config.js.

## Breaking changes
None


## Testing
1. Create a folder inside `imports/plugins/custom`
2. In the folder, run `npm init` and create an empty package.json
3. Create a file named log.js with `console.log("test");` in it
3. Create a log.test.js file with the following content:
```
import "./log";
test("Simple test", () => { expect(true).toBe(true); });
```
4. Back in the reaction root dir, run `meteor npm run test:unit`
5. Confirm "Simple test" passes
