### PR TITLE
Support for Google Search Console Site Verification

### DIFF
--- a/imports/plugins/included/google-webtools/client/components/googleWebToolsSettings.js
+++ b/imports/plugins/included/google-webtools/client/components/googleWebToolsSettings.js
@@ -1,0 +1,51 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { uniqueId } from "lodash";
+import { Form } from "reacto-form";
+import Button from "@reactioncommerce/components/Button/v1";
+import ErrorsBlock from "@reactioncommerce/components/ErrorsBlock/v1";
+import Field from "@reactioncommerce/components/Field/v1";
+import TextInput from "@reactioncommerce/components/TextInput/v1";
+import { i18next } from "/client/api";
+
+class GoogleWebToolsSettings extends Component {
+  handleSave = () => {
+    if (this.form) {
+      this.form.submit();
+    }
+  }
+
+  uniqueInstanceIdentifier = uniqueId("GoogleWebToolsSettingsForm");
+
+  render() {
+    const { onSubmit, validator, values } = this.props;
+
+    const siteVerificationTokenInputId = `siteVerificationToken_${this.uniqueInstanceIdentifier}`;
+
+    return (
+      <div>
+        <Form ref={(formRef) => { this.form = formRef; }} onSubmit={onSubmit} validator={validator} value={values}>
+          <div className="row">
+            <div className="col-md-12">
+              <Field name="siteVerificationToken" label={i18next.t("admin.dashboard.siteVerificationToken")} labelFor={siteVerificationTokenInputId}>
+                <TextInput id={siteVerificationTokenInputId} name="siteVerificationToken" />
+                <ErrorsBlock names={["siteVerificationToken"]} />
+              </Field>
+            </div>
+          </div>
+          <div className="row" style={{ margin: "20px 0" }}>
+            <Button actionType="default" onClick={this.handleSave}>{i18next.t("admin.dashboard.save")}</Button>
+          </div>
+        </Form>
+      </div>
+    );
+  }
+}
+
+GoogleWebToolsSettings.propTypes = {
+  onSubmit: PropTypes.func,
+  validator: PropTypes.func,
+  values: PropTypes.object
+};
+
+export default GoogleWebToolsSettings;

--- a/imports/plugins/included/google-webtools/client/components/index.js
+++ b/imports/plugins/included/google-webtools/client/components/index.js
@@ -1,0 +1,1 @@
+export { default as GoogleWebToolsSettings } from "./googleWebToolsSettings";

--- a/imports/plugins/included/google-webtools/client/containers/googleWebToolsSettingsContainer.js
+++ b/imports/plugins/included/google-webtools/client/containers/googleWebToolsSettingsContainer.js
@@ -1,0 +1,71 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { compose } from "recompose";
+import SimpleSchema from "simpl-schema";
+import Alert from "sweetalert2";
+import { composeWithTracker, registerComponent } from "@reactioncommerce/reaction-components";
+import { Meteor } from "meteor/meteor";
+import { Packages } from "/lib/collections";
+import { Reaction, i18next } from "/client/api";
+import { GoogleWebToolsSettings } from "../components";
+
+const GoogleWebToolsSettingsFormSchema = new SimpleSchema({
+  siteVerificationToken: String
+});
+
+const GoogleWebToolsSettingsValidator = GoogleWebToolsSettingsFormSchema.getFormValidator();
+
+const wrapComponent = (Comp) => (
+  class GoogleWebToolsSettingsContainer extends Component {
+    static propTypes = {
+      pkg: PropTypes.object
+    }
+
+    handleFormValidate = (values) => GoogleWebToolsSettingsValidator(GoogleWebToolsSettingsFormSchema.clean(values));
+
+    handleSubmit = (values) => {
+      Meteor.call("googleWebTools/updateGoogleWebToolsSettings", values, (error) => {
+        if (error) {
+          return Alert(i18next.t("app.error"), error.message, "error");
+        }
+        return Alert(i18next.t("app.success"), i18next.t("admin.alerts.siteVerificationTokenSaved"), "success");
+      });
+    }
+
+    render() {
+      const { pkg: { settings: { public: { siteVerificationToken } } } } = this.props;
+
+      GoogleWebToolsSettingsFormSchema.labels({
+        siteVerificationToken: i18next.t("admin.dashboard.siteVerificationToken")
+      });
+
+      return (
+        <Comp
+          onSubmit={this.handleSubmit}
+          validator={this.handleFormValidate}
+          values={{ siteVerificationToken }}
+          {...this.props}
+        />
+      );
+    }
+  }
+);
+
+const composer = (props, onData) => {
+  const shopId = Reaction.getShopId();
+  const packageSub = Meteor.subscribe("Packages", shopId);
+  if (packageSub.ready()) {
+    const pkg = Packages.findOne({ shopId, name: "google-webtools" });
+    onData(null, { pkg, ...props });
+  }
+};
+
+registerComponent("GoogleWebToolsSettings", GoogleWebToolsSettings, [
+  composeWithTracker(composer),
+  wrapComponent
+]);
+
+export default compose(
+  composeWithTracker(composer),
+  wrapComponent
+)(GoogleWebToolsSettings);

--- a/imports/plugins/included/google-webtools/client/containers/index.js
+++ b/imports/plugins/included/google-webtools/client/containers/index.js
@@ -1,0 +1,1 @@
+import "./googleWebToolsSettingsContainer";

--- a/imports/plugins/included/google-webtools/client/index.js
+++ b/imports/plugins/included/google-webtools/client/index.js
@@ -1,0 +1,3 @@
+import "./containers";
+import "./components";
+import "./templates";

--- a/imports/plugins/included/google-webtools/client/templates/index.js
+++ b/imports/plugins/included/google-webtools/client/templates/index.js
@@ -1,0 +1,2 @@
+import "./settings.html";
+import "./settings.js";

--- a/imports/plugins/included/google-webtools/client/templates/settings.html
+++ b/imports/plugins/included/google-webtools/client/templates/settings.html
@@ -1,0 +1,5 @@
+<template name="googleWebToolsSettings">
+  <div>
+    {{> React component=GoogleWebToolsSettings }}
+  </div>
+</template>

--- a/imports/plugins/included/google-webtools/client/templates/settings.js
+++ b/imports/plugins/included/google-webtools/client/templates/settings.js
@@ -1,0 +1,8 @@
+import { Template } from "meteor/templating";
+import { Components } from "@reactioncommerce/reaction-components";
+
+Template.googleWebToolsSettings.helpers({
+  GoogleWebToolsSettings() {
+    return Components.GoogleWebToolsSettings;
+  }
+});

--- a/imports/plugins/included/google-webtools/register.js
+++ b/imports/plugins/included/google-webtools/register.js
@@ -1,0 +1,28 @@
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import resolvers from "./server/no-meteor/resolvers";
+import schemas from "./server/no-meteor/schemas";
+
+Reaction.registerPackage({
+  label: "Google Web Tools",
+  name: "google-webtools",
+  icon: "fa fa-search-plus",
+  autoEnable: true,
+  graphQL: {
+    resolvers,
+    schemas
+  },
+  settings: {
+    enabled: true,
+    public: {
+      siteVerificationToken: ""
+    }
+  },
+  registry: [{
+    label: "Google Web Tools",
+    icon: "fa fa-search-plus",
+    provides: ["shopSettings"],
+    container: "dashboard",
+    template: "googleWebToolsSettings",
+    showForShopTypes: ["primary"]
+  }]
+});

--- a/imports/plugins/included/google-webtools/server/i18n/en.json
+++ b/imports/plugins/included/google-webtools/server/i18n/en.json
@@ -1,0 +1,18 @@
+[{
+  "language": "English",
+  "i18n": "en",
+  "ns": "google-webtools",
+  "translation": {
+    "google-webtools": {
+      "admin": {
+        "dashboard": {
+          "siteVerificationToken": "Site Verification Token",
+          "save": "Save Changes"
+        },
+        "alerts": {
+          "siteVerificationTokenSaved": "Google web tools settings saved."
+        }
+      }
+    }
+  }
+}]

--- a/imports/plugins/included/google-webtools/server/i18n/index.js
+++ b/imports/plugins/included/google-webtools/server/i18n/index.js
@@ -1,0 +1,10 @@
+import { loadTranslations } from "/imports/plugins/core/core/server/startup/i18n";
+
+import en from "./en.json";
+
+//
+// we want all the files in individual
+// imports for easier handling by
+// automated translation software
+//
+loadTranslations([en]);

--- a/imports/plugins/included/google-webtools/server/index.js
+++ b/imports/plugins/included/google-webtools/server/index.js
@@ -1,0 +1,2 @@
+import "./i18n";
+import "./methods";

--- a/imports/plugins/included/google-webtools/server/methods.js
+++ b/imports/plugins/included/google-webtools/server/methods.js
@@ -1,0 +1,30 @@
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import { EJSON } from "meteor/ejson";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import { Packages } from "/lib/collections";
+
+export const methods = {
+  /**
+   * @name googleWebTools/updateGoogleWebToolsSettings
+   * @summary Updates Google web tools settings
+   * @method
+   * @param  {Object} values - Object with field names as key and field values as value
+   * @return {Promise} - Promise
+   */
+  "googleWebTools/updateGoogleWebToolsSettings"(values) {
+    check(values, Object);
+    check(values.siteVerificationToken, String);
+
+    // must have core permissions
+    if (!Reaction.hasPermission("core")) {
+      throw new Meteor.Error("access-denied", "Access Denied");
+    }
+
+    const stringValue = EJSON.stringify(values);
+    const update = EJSON.parse(stringValue);
+    return Packages.update({ name: "google-webtools" }, { $set: { settings: { public: update } } });
+  }
+};
+
+Meteor.methods(methods);

--- a/imports/plugins/included/google-webtools/server/no-meteor/resolvers/Query/index.js
+++ b/imports/plugins/included/google-webtools/server/no-meteor/resolvers/Query/index.js
@@ -1,0 +1,5 @@
+import siteVerificationToken from "./siteVerificationToken";
+
+export default {
+  siteVerificationToken
+};

--- a/imports/plugins/included/google-webtools/server/no-meteor/resolvers/Query/siteVerificationToken.js
+++ b/imports/plugins/included/google-webtools/server/no-meteor/resolvers/Query/siteVerificationToken.js
@@ -1,0 +1,22 @@
+/**
+ * @name Query.siteVerificationToken
+ * @method
+ * @memberof GoogleWebToolsSettimgs/GraphQL
+ * @summary Gets the site verification token
+ * @param {Object} _ - unused
+ * @param {Object} __ - unused
+ * @param {Object} context an object containing the pre-request state
+ * @return {String} Radial public key
+ */
+export default async function siteVerificationToken(_, __, context) {
+  const pkg = await context.collections.Packages.findOne({
+    "name": "google-webtools",
+    "settings.enabled": true
+  });
+  try {
+    const { settings: { public: { siteVerificationToken } } } = pkg;
+    return siteVerificationTokenn;
+  } catch (error) {
+    return "";
+  }
+}

--- a/imports/plugins/included/google-webtools/server/no-meteor/resolvers/index.js
+++ b/imports/plugins/included/google-webtools/server/no-meteor/resolvers/index.js
@@ -1,0 +1,5 @@
+import Query from "./Query";
+
+export default {
+  Query
+};

--- a/imports/plugins/included/google-webtools/server/no-meteor/schemas/index.js
+++ b/imports/plugins/included/google-webtools/server/no-meteor/schemas/index.js
@@ -1,0 +1,3 @@
+import schema from "./schema.graphql";
+
+export default [schema];

--- a/imports/plugins/included/google-webtools/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/included/google-webtools/server/no-meteor/schemas/schema.graphql
@@ -1,0 +1,8 @@
+########################
+## Queries
+########################
+
+extend type Query {
+  "Returns the site verification token to be used in the client"
+  siteVerificationToken: String
+}


### PR DESCRIPTION
Resolves #4784
Impact: **minor**  
Type: **feature**

## Issue
This allows a shop owner to verify their ownership of their site for Google Search Console for better SEO performance.

## Solution
I created a new plugin `google-webtools` to set up the token that should be present in a header meta tag in the storefront.

## Breaking changes
None

## Testing
1. As an admin, go to the shop dashboard panel, and enter a string in Site Verification Token field and click save. The string is supposed to be the token provided in the Google Search Console dashboard.
2. The same string should be returned by the following query:
```
query siteVerificationTokenQuery {
  siteVerificationToken
}
```