### PR TITLE
fix: update detailView when its data changes

### DIFF
--- a/imports/plugins/core/dashboard/client/components/actionView.js
+++ b/imports/plugins/core/dashboard/client/components/actionView.js
@@ -156,6 +156,21 @@ class ActionView extends Component {
     viewportWidth: PropTypes.number
   }
 
+  static getDerivedStateFromProps(props) {
+    const { actionView, detailView, prevProps = {} } = props;
+
+    const stateUpdates = { prevProps: props };
+
+    if (!EJSON.equals(actionView, prevProps.actionView)) {
+      stateUpdates.actionView = actionView;
+    }
+    if (!EJSON.equals(detailView, prevProps.detailView)) {
+      stateUpdates.detailView = detailView;
+    }
+
+    return stateUpdates;
+  }
+
   constructor(props) {
     super(props);
 
@@ -177,19 +192,6 @@ class ActionView extends Component {
   componentDidMount() {
     if (window) {
       window.addEventListener("resize", this.handleResize, false);
-    }
-
-    const { actionView } = this.props;
-    if (actionView) {
-      this.setState({ actionView });
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    const { actionView } = this.props;
-
-    if (EJSON.equals(actionView, prevProps.actionView) === false) {
-      this.setState({ actionView });
     }
   }
 
@@ -425,8 +427,8 @@ class ActionView extends Component {
           unmountOnExit
           classNames={`slide-in-out${(isRtl && "-rtl") || ""}`}
           timeout={200}
-          onEnter={() => this.setState({ detailView }) }
-          onExited={() => this.setState({ detailView }) }
+          onEnter={() => this.setState({ detailView })}
+          onExited={() => this.setState({ detailView })}
         >
           {this.renderDetailView()}
         </CSSTransition>
@@ -455,8 +457,8 @@ class ActionView extends Component {
           unmountOnExit
           classNames={`slide-in-out${(isRtl && "-rtl") || ""}`}
           timeout={200}
-          onEnter={() => this.setState({ actionView }) }
-          onExited={() => this.setState({ actionView }) }
+          onEnter={() => this.setState({ actionView })}
+          onExited={() => this.setState({ actionView })}
         >
           {this.renderActionView()}
         </CSSTransition>


### PR DESCRIPTION
Resolves #4777 
Impact: **major**  
Type: **bugfix**

## Issue
Selected order does not update order detail view.
If you select orders in the order list screen the order details screen doesn't change to reflect that
http://g.recordit.co/mQXkXwNZcM.gif


## Solution
Port solution from #4659 directly.
> Properly handle detail view state in ActionView component.

Create function to get derived state from props and remove `this.setState` method calls from `componentDidUpdate` lifecycle methods.

## Breaking changes
n/a

## Testing
1. Create some orders
2. Select the first order and observe the proper details are shown
3. Select another order and ensure that the proper details are still shown.