### PR TITLE
fix: email settings update on cancel

### DIFF
--- a/imports/plugins/core/email/client/actions/settings.js
+++ b/imports/plugins/core/email/client/actions/settings.js
@@ -72,8 +72,9 @@ export default {
           if (result.value) {
             save();
             resolve(true);
+          } else {
+            resolve(false);
           }
-          resolve(false);
         } else {
           save();
           resolve(true);

--- a/imports/plugins/core/email/client/actions/settings.js
+++ b/imports/plugins/core/email/client/actions/settings.js
@@ -10,7 +10,7 @@ export default {
    * @param {Function} callback - optional callback
    * @return {Boolean} returns true if all fields provided and update method called
    */
-  saveSettings(settings, callback) {
+  async saveSettings(settings, callback) {
     const { service, host, port, user, password } = settings;
 
     if (!service) {
@@ -55,24 +55,31 @@ export default {
     };
 
     // check if the settings work first
-    Meteor.call("email/verifySettings", settings, (error) => {
-      callback();
-      // if the connection fails
-      if (error) {
-        Alert({
-          title: i18next.t("mail.alerts.connectionFailed"),
-          text: i18next.t("mail.alerts.saveAnyway"),
-          type: "warning",
-          showCancelButton: true,
-          cancelButtonText: i18next.t("app.cancel"),
-          confirmButtonColor: "#DD6B55",
-          confirmButtonText: i18next.t("app.save")
-        }).then(() => save()).catch(() => true);
-      } else {
-        save();
-      }
+    const settingsVerified = await new Promise((resolve) => {
+      Meteor.call("email/verifySettings", settings, async (error) => {
+        callback();
+        // if the connection fails
+        if (error) {
+          const result = await Alert({
+            title: i18next.t("mail.alerts.connectionFailed"),
+            text: i18next.t("mail.alerts.saveAnyway"),
+            type: "warning",
+            showCancelButton: true,
+            cancelButtonText: i18next.t("app.cancel"),
+            confirmButtonColor: "#DD6B55",
+            confirmButtonText: i18next.t("app.save")
+          });
+          if (result.value) {
+            save();
+            resolve(true);
+          }
+          resolve(false);
+        } else {
+          save();
+          resolve(true);
+        }
+      });
     });
-
-    return true;
+    return settingsVerified;
   }
 };


### PR DESCRIPTION
Resolves #4773 
Impact: **minor**  
Type: **bugfix**

## Issue
In the Email settings configuration panel on the admin sidebar, attempting to cancel a change to the email provider settings when the email provider settings are not verifiable is impossible and the changes will be saved regardless of clicking "Save" or "Cancel"

## Solution
Resolves #4773 E-mail settings update despite "Cancel" on verification prompt
Issue was that settings were being saved for both confirm and cancel choices.
Fixes the "email settings could not be verified" alert to save only on "confirm"

## Breaking changes
n/a

## Testing
1. As an admin, open the email settings configuration panel
2. Change the settings to something invalid such as
```
  service: custom
  host: 123
  port: 123
  user: 12345
  password: 00000
```
and click "save" when presented with an option.
3. Change at least one of the settings again, and click "cancel" 
4. Verify that the changes were not saved when you clicked cancel.

Note: the form will not be reset to the original values, but the unsaved values will not be persisted to the database