### PR TITLE
Fix identity provider login page not found due to missing permission

### DIFF
--- a/imports/plugins/core/hydra-oauth/server/index.js
+++ b/imports/plugins/core/hydra-oauth/server/index.js
@@ -1,8 +1,20 @@
 import { Meteor } from "meteor/meteor";
+import Hooks from "@reactioncommerce/hooks";
 import { oauthLogin } from "./oauthMethods";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 Meteor.methods({
   "oauth/login": oauthLogin
+});
+
+// Allow the login forms to be shown to all visitors.
+// Without this, the route for the login page will not be published because of permission checks
+Hooks.Events.add("afterCoreInit", () => {
+  Reaction.addRolesToGroups({
+    allShops: true,
+    groups: ["guest", "customer"],
+    roles: ["reaction-hydra-oauth"]
+  });
 });
 
 // Init endpoints


### PR DESCRIPTION
Resolves #4794  
Impact: **major**  
Type: **bugfix**

## Issue
OAuth IDP login pages created by the Hydra plugin are not showing up after recent  updates. So `/account/login` returns Not Found.

This started happening after the permission update to Package routes publication.

## Solution
Add the permission for the Hydra plugin to guest groups. This allows the route to be published for anyone visitor to the meteor app trying to login from the Starterkit. 

This should be done for plugins that add public routes.

## Breaking changes
N/A

No migration needed.


## Testing
1. Start up Starterkit (develop), Hydra (master) and Reaction API (this branch)
2. On the Starterkit, try to login (i.e click the login button)
3. You should be redirected to the Meteor app; and you should be able to see the login form (that's the fix).
4. Test this in incognito as well.


## Docs
I'll go through the docs and creating a public that adds a public route. It should say that the permission for the plugin needs to be granted to anonymous users, otherwise the route will not be accessible to non-admin users.

**Update:** In fact, there is no docs concern. Because in a post 2.0 world, our process now is that UI should be driven separately from the API (as seen in the warning message [here](https://docs.reactioncommerce.com/docs/1.16.0/swag-shop-initialization#getting-started-creating-a-plugin)