### PR TITLE
fix: custom tax rates not applied

### DIFF
--- a/imports/collections/schemas/cart.js
+++ b/imports/collections/schemas/cart.js
@@ -123,6 +123,10 @@ export const CartItem = new SimpleSchema({
     index: 1,
     label: "Cart Item shopId"
   },
+  "subtotal": {
+    type: Number,
+    optional: true
+  },
   "taxCode": {
     type: String,
     optional: true
@@ -133,6 +137,10 @@ export const CartItem = new SimpleSchema({
     blackbox: true
   },
   "taxRate": {
+    type: Number,
+    optional: true
+  },
+  "tax": {
     type: Number,
     optional: true
   },

--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -107,7 +107,7 @@ export default async function addCartItems(collections, currentItems, inputItems
     const cartItem = {
       _id: Random.id(),
       attributes,
-      isTaxable: chosenVariant.taxable || false,
+      isTaxable: chosenVariant.isTaxable || false,
       metafields,
       optionTitle: chosenVariant.optionTitle,
       parcel: chosenVariant.parcel,

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -128,13 +128,12 @@ export const cartOrderTransform = {
    * @returns {Number} Total price of taxes for an order
    */
   getTaxTotal() {
-    // taxes are calculated in a Cart.after.update hooks
-    // the tax value stored with the cart/order is the effective tax rate
-    // calculated by line items
-    // in the imports/core/taxes plugin
-    const tax = this.tax || 0;
-    const subTotal = parseFloat(this.getSubTotal());
-    const taxTotal = subTotal * tax;
+    const taxTotal = this.items.reduce((acc, item) => {
+      if (item.tax) {
+        return acc + item.tax;
+      }
+      return acc;
+    }, 0);
     return accounting.toFixed(taxTotal, 2);
   },
   /**


### PR DESCRIPTION
Resolves #4775 
Impact: **critical**  
Type: **bugfix**

## Issue
Custom tax rates were not being applied.

## Solution
Issue was primarily that within the `addCartItems` method, there was a line using `chosenVariant.taxable` instead of `isTaxable`. As the property `taxable` was changed to `isTaxable` in a previous version, this caused custom tax rates not to work.

This solution caused some other issues to show that were resolved by adding `subtotal` and `tax` to the `CartItem` schema.

## Breaking changes
none

## Testing
1. As an operator create a custom tax rate (I've been using NY with postal 11011), setup flat rate shipping, and example payment.
2. As a customer add an example product to cart, proceed to checkout, and use an address that matches your custom tax rate.
3. Confirm that the tax rate is applied to the cart and order.