### PR TITLE
(feat) Add meteor caching

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       HYDRA_TOKEN_URL: "http://hydra:4444/oauth2/token"
       HYDRA_OAUTH2_INTROSPECT_URL: "http://hydra:4445/oauth2/introspect"
       OAUTH2_CLIENT_DOMAINS: "http://localhost:4000"
+      METEOR_DISABLE_OPTIMISTIC_CACHING: 1
     networks:
       default:
       api:


### PR DESCRIPTION
Resolves #NA 
Impact: **minor**  
Type: **performance**

## Issue
Many developers use the `METEOR_DISABLE_OPTIMISTIC_CACHING` variable, but it's not set when using Docker

## Solution
Setting the environment variable `METEOR_DISABLE_OPTIMISTIC_CACHING` tends to make restarts faster and reduces CPU usage. Setting this in the dockerfile so that `reaction-platform` users can benefit from settings this variable


## Breaking changes
None


## Testing
1. Start `reaction-platform` and observe that this setting is in effect.