### PR TITLE
Fix tax calculation arguments, other tax fixes

### DIFF
--- a/imports/collections/schemas/cart.js
+++ b/imports/collections/schemas/cart.js
@@ -64,6 +64,10 @@ export const CartItem = new SimpleSchema({
     optional: true
   },
   "attributes.$": CartItemAttribute,
+  "compareAtPrice": {
+    type: Money,
+    optional: true
+  },
   "createdAt": Date,
   "metafields": {
     type: Array,
@@ -114,6 +118,7 @@ export const CartItem = new SimpleSchema({
     index: 1,
     label: "Cart Item shopId"
   },
+  "subtotal": Money,
   "title": {
     type: String,
     label: "CartItem Title"

--- a/imports/collections/schemas/cart.js
+++ b/imports/collections/schemas/cart.js
@@ -42,6 +42,7 @@ const CartItemAttribute = new SimpleSchema({
  * @property {Metafield[]} metafields
  * @property {String} optionTitle optionTitle from the selected variant
  * @property {ShippingParcel} parcel Currently, parcel is in simple product schema. Need to include it here as well.
+ * @property {Money} price The current price of this item
  * @property {Money} priceWhenAdded The price+currency at the moment this item was added to this cart
  * @property {String} productId required
  * @property {String} productSlug Product slug
@@ -77,6 +78,7 @@ export const CartItem = new SimpleSchema({
     type: ShippingParcel,
     optional: true
   },
+  "price": Money,
   "priceWhenAdded": Money,
   "productId": {
     type: String,

--- a/imports/plugins/core/cart/server/no-meteor/mutations/convertAnonymousCartToNewAccountCart.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/convertAnonymousCartToNewAccountCart.test.js
@@ -1,3 +1,4 @@
+import Factory from "/imports/test-utils/helpers/factory";
 import mockContext from "/imports/test-utils/helpers/mockContext";
 import convertAnonymousCartToNewAccountCart from "./convertAnonymousCartToNewAccountCart";
 
@@ -6,23 +7,7 @@ const currencyCode = "GBP";
 const accountId = "accountId";
 const anonymousCartSelector = { _id: "123" };
 const shopId = "shopId";
-const items = [
-  {
-    _id: "CartItemID",
-    addedAt: new Date("2018-01-01T00:00:00.000"),
-    createdAt: new Date("2018-01-01T00:00:00.000"),
-    productId: "productId",
-    quantity: 1,
-    shopId: "shopId",
-    title: "TITLE",
-    updatedAt: new Date("2018-01-01T00:00:00.000"),
-    variantId: "variantId",
-    priceWhenAdded: {
-      amount: 9.99,
-      currencyCode: "USD"
-    }
-  }
-];
+const items = [Factory.CartItem.makeOne()];
 
 test("inserts a cart with the existing cart's items and returns it", async () => {
   Cart.insertOne.mockReturnValueOnce(Promise.resolve({ result: { ok: 1 } }));

--- a/imports/plugins/core/cart/server/no-meteor/mutations/createCart.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/createCart.test.js
@@ -15,7 +15,15 @@ jest.mock("../util/addCartItems", () => jest.fn().mockImplementation(() => Promi
       title: "TITLE",
       updatedAt: new Date(),
       variantId: "variantId",
+      price: {
+        amount: 9.99,
+        currencyCode: "USD"
+      },
       priceWhenAdded: {
+        amount: 9.99,
+        currencyCode: "USD"
+      },
+      subtotal: {
         amount: 9.99,
         currencyCode: "USD"
       }
@@ -85,7 +93,15 @@ test("creates an anonymous cart if no user is logged in", async () => {
           title: "TITLE",
           updatedAt: jasmine.any(Date),
           variantId: "variantId",
+          price: {
+            amount: 9.99,
+            currencyCode: "USD"
+          },
           priceWhenAdded: {
+            amount: 9.99,
+            currencyCode: "USD"
+          },
+          subtotal: {
             amount: 9.99,
             currencyCode: "USD"
           }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/reconcileCartsKeepAnonymousCart.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/reconcileCartsKeepAnonymousCart.test.js
@@ -1,3 +1,4 @@
+import Factory from "/imports/test-utils/helpers/factory";
 import mockContext from "/imports/test-utils/helpers/mockContext";
 import reconcileCartsKeepAnonymousCart from "./reconcileCartsKeepAnonymousCart";
 
@@ -6,23 +7,7 @@ const accountId = "accountId";
 const accountCart = { _id: "ACCOUNT_CART", accountId };
 const accountCartSelector = { accountId };
 const anonymousCartSelector = { _id: "123" };
-const items = [
-  {
-    _id: "CartItemID",
-    addedAt: new Date("2018-01-01T00:00:00.000"),
-    createdAt: new Date("2018-01-01T00:00:00.000"),
-    productId: "productId",
-    quantity: 1,
-    shopId: "shopId",
-    title: "TITLE",
-    updatedAt: new Date("2018-01-01T00:00:00.000"),
-    variantId: "variantId",
-    priceWhenAdded: {
-      amount: 9.99,
-      currencyCode: "USD"
-    }
-  }
-];
+const items = [Factory.CartItem.makeOne()];
 
 test("overwrites account cart items, deletes anonymous cart, and returns updated account cart", async () => {
   const result = await reconcileCartsKeepAnonymousCart({

--- a/imports/plugins/core/cart/server/no-meteor/mutations/reconcileCartsMerge.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/reconcileCartsMerge.js
@@ -25,9 +25,7 @@ export default async function reconcileCartsMerge({
   // Convert item schema to input item schema
   const itemsInput = (anonymousCart.items || []).map((item) => ({
     metafields: item.metafields,
-    price: {
-      currencyCode: item.priceWhenAdded.currencyCode
-    },
+    price: item.price,
     productConfiguration: {
       productId: item.productId,
       productVariantId: item.variantId

--- a/imports/plugins/core/cart/server/no-meteor/mutations/reconcileCartsMerge.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/reconcileCartsMerge.test.js
@@ -1,3 +1,4 @@
+import Factory from "/imports/test-utils/helpers/factory";
 import mockContext from "/imports/test-utils/helpers/mockContext";
 import reconcileCartsMerge from "./reconcileCartsMerge";
 
@@ -15,7 +16,15 @@ jest.mock("../util/addCartItems", () => jest.fn().mockImplementation(() => Promi
       title: "UPDATED TITLE",
       updatedAt: new Date("2018-01-01T00:00:00.000"),
       variantId: "variantId",
+      price: {
+        amount: 9.99,
+        currencyCode: "USD"
+      },
       priceWhenAdded: {
+        amount: 9.99,
+        currencyCode: "USD"
+      },
+      subtotal: {
         amount: 9.99,
         currencyCode: "USD"
       }
@@ -29,30 +38,33 @@ const accountId = "accountId";
 const accountCart = { _id: "ACCOUNT_CART", accountId };
 const accountCartSelector = { accountId };
 const anonymousCartSelector = { _id: "123" };
-const items = [
-  {
-    _id: "CartItemID",
-    addedAt: new Date("2018-01-01T00:00:00.000"),
-    createdAt: new Date("2018-01-01T00:00:00.000"),
-    productId: "productId",
-    quantity: 1,
-    shopId: "shopId",
-    title: "TITLE",
-    updatedAt: new Date("2018-01-01T00:00:00.000"),
-    variantId: "variantId",
-    priceWhenAdded: {
-      amount: 9.99,
-      currencyCode: "USD"
-    }
-  }
-];
+const items = [Factory.CartItem.makeOne()];
 
 test("merges anonymous cart items into account cart items, deletes anonymous cart, and returns updated account cart", async () => {
   const updatedItems = [
     {
-      ...items[0],
+      _id: "CartItemID",
+      addedAt: new Date("2018-01-01T00:00:00.000"),
+      createdAt: new Date("2018-01-01T00:00:00.000"),
+      productId: "productId",
+      quantity: 1,
+      shopId: "shopId",
       // We can tell by the title that addCartItems was called
-      title: "UPDATED TITLE"
+      title: "UPDATED TITLE",
+      updatedAt: new Date("2018-01-01T00:00:00.000"),
+      variantId: "variantId",
+      price: {
+        amount: 9.99,
+        currencyCode: "USD"
+      },
+      priceWhenAdded: {
+        amount: 9.99,
+        currencyCode: "USD"
+      },
+      subtotal: {
+        amount: 9.99,
+        currencyCode: "USD"
+      }
     }
   ];
 

--- a/imports/plugins/core/cart/server/no-meteor/mutations/updateCartItemsQuantity.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/updateCartItemsQuantity.js
@@ -46,7 +46,15 @@ export default async function updateCartItemsQuantity(context, input) {
       list.push({ ...item });
     } else if (update.quantity > 0) {
       // Update quantity as instructed, while omitting the item if quantity is 0
-      list.push({ ...item, quantity: update.quantity });
+      list.push({
+        ...item,
+        quantity: update.quantity,
+        // Update the subtotal since it is a multiple of the price
+        subtotal: {
+          amount: item.price.amount * update.quantity,
+          currencyCode: item.subtotal.currencyCode
+        }
+      });
     }
     return list;
   }, []);

--- a/imports/plugins/core/cart/server/no-meteor/mutations/updateCartItemsQuantity.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/updateCartItemsQuantity.test.js
@@ -44,11 +44,19 @@ test("updates the quantity of multiple items in account cart", async () => {
       items: [
         {
           ...dbCart.items[0],
-          quantity: 1
+          quantity: 1,
+          subtotal: {
+            amount: dbCart.items[0].price.amount,
+            currencyCode: dbCart.items[0].subtotal.currencyCode
+          }
         },
         {
           ...dbCart.items[1],
-          quantity: 2
+          quantity: 2,
+          subtotal: {
+            amount: dbCart.items[1].price.amount * 2,
+            currencyCode: dbCart.items[1].subtotal.currencyCode
+          }
         }
       ],
       updatedAt: jasmine.any(Date)
@@ -65,11 +73,19 @@ test("updates the quantity of multiple items in account cart", async () => {
       items: [
         {
           ...dbCart.items[0],
-          quantity: 1
+          quantity: 1,
+          subtotal: {
+            amount: dbCart.items[0].price.amount,
+            currencyCode: dbCart.items[0].subtotal.currencyCode
+          }
         },
         {
           ...dbCart.items[1],
-          quantity: 2
+          quantity: 2,
+          subtotal: {
+            amount: dbCart.items[1].price.amount * 2,
+            currencyCode: dbCart.items[1].subtotal.currencyCode
+          }
         }
       ],
       updatedAt: jasmine.any(Date)
@@ -107,11 +123,19 @@ test("updates the quantity of multiple items in anonymous cart", async () => {
       items: [
         {
           ...dbCart.items[0],
-          quantity: 1
+          quantity: 1,
+          subtotal: {
+            amount: dbCart.items[0].price.amount,
+            currencyCode: dbCart.items[0].subtotal.currencyCode
+          }
         },
         {
           ...dbCart.items[1],
-          quantity: 2
+          quantity: 2,
+          subtotal: {
+            amount: dbCart.items[1].price.amount * 2,
+            currencyCode: dbCart.items[1].subtotal.currencyCode
+          }
         }
       ],
       updatedAt: jasmine.any(Date)
@@ -129,11 +153,19 @@ test("updates the quantity of multiple items in anonymous cart", async () => {
       items: [
         {
           ...dbCart.items[0],
-          quantity: 1
+          quantity: 1,
+          subtotal: {
+            amount: dbCart.items[0].price.amount,
+            currencyCode: dbCart.items[0].subtotal.currencyCode
+          }
         },
         {
           ...dbCart.items[1],
-          quantity: 2
+          quantity: 2,
+          subtotal: {
+            amount: dbCart.items[1].price.amount * 2,
+            currencyCode: dbCart.items[1].subtotal.currencyCode
+          }
         }
       ],
       updatedAt: jasmine.any(Date)
@@ -186,7 +218,11 @@ test("removes an item if quantity is 0", async () => {
       items: [
         {
           ...dbCart.items[1],
-          quantity: 2
+          quantity: 2,
+          subtotal: {
+            amount: dbCart.items[1].price.amount * 2,
+            currencyCode: dbCart.items[1].subtotal.currencyCode
+          }
         }
       ],
       updatedAt: jasmine.any(Date)
@@ -203,7 +239,11 @@ test("removes an item if quantity is 0", async () => {
       items: [
         {
           ...dbCart.items[1],
-          quantity: 2
+          quantity: 2,
+          subtotal: {
+            amount: dbCart.items[1].price.amount * 2,
+            currencyCode: dbCart.items[1].subtotal.currencyCode
+          }
         }
       ],
       updatedAt: jasmine.any(Date)

--- a/imports/plugins/core/cart/server/no-meteor/startup.js
+++ b/imports/plugins/core/cart/server/no-meteor/startup.js
@@ -1,5 +1,4 @@
 import Logger from "@reactioncommerce/logger";
-import appEvents from "/imports/node-app/core/util/appEvents";
 
 /**
  * @summary Called on startup
@@ -7,14 +6,65 @@ import appEvents from "/imports/node-app/core/util/appEvents";
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default function startup({ collections }) {
+export default function startup(context) {
+  const { appEvents, collections } = context;
+  const { Cart } = collections;
+
+  // When an order is created, delete the source cart
   appEvents.on("afterOrderCreate", async (order) => {
     const { cartId } = order;
     if (cartId) {
-      const { result } = await collections.Cart.deleteOne({ _id: cartId });
+      const { result } = await Cart.deleteOne({ _id: cartId });
       if (result.ok !== 1) {
         Logger.warn(`MongoDB error trying to delete cart ${cartId} in "afterOrderCreate" listener. Check MongoDB logs.`);
       }
     }
+  });
+
+  // When a variant's price changes, change the `price` field of all CartItems for that variant, too
+  appEvents.on("afterPublishProductToCatalog", async (product, catalogProduct) => {
+    const { variants } = catalogProduct;
+
+    // Build a map of variant IDs to their potentially-changed prices
+    const variantPricingMap = {};
+    variants.forEach((variant) => {
+      variantPricingMap[variant.variantId] = variant.pricing;
+      if (variant.options) {
+        variant.options.forEach((option) => {
+          variantPricingMap[option.variantId] = option.pricing;
+        });
+      }
+    });
+
+    // Update all cart items that are linked with the updated variants
+    await Promise.all(Object.keys(variantPricingMap).map(async (variantId) => {
+      const pricing = variantPricingMap[variantId];
+
+      // Do find + update because we need the `cart.currencyCode` to figure out pricing
+      const carts = await Cart.find({
+        "items.variantId": variantId
+      }, {
+        projection: { _id: 1, currencyCode: 1 }
+      }).toArray();
+
+      return Promise.all(carts.map(async (cart) => {
+        const prices = pricing[cart.currencyCode];
+        if (!prices) return Promise.resolve();
+
+        return Cart.updateMany({
+          _id: cart._id
+        }, {
+          $set: {
+            "items.$[elem].compareAtPrice.amount": prices.compareAtPrice,
+            "items.$[elem].price.amount": prices.price,
+            "updatedAt": new Date()
+          }
+        }, {
+          arrayFilters: [
+            { "elem.variantId": variantId }
+          ]
+        });
+      }));
+    }));
   });
 }

--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -132,6 +132,11 @@ export default async function addCartItems(collections, currentItems, inputItems
       productTagIds: catalogProduct.tagIds,
       quantity,
       shopId: catalogProduct.shopId,
+      // Subtotal will be kept updated by event handler watching for catalog changes.
+      subtotal: {
+        amount: variantPriceInfo.price * quantity,
+        currencyCode: price.currencyCode
+      },
       taxCode: chosenVariant.taxCode,
       title: catalogProduct.title,
       updatedAt: currentDateTime,

--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -107,10 +107,20 @@ export default async function addCartItems(collections, currentItems, inputItems
     const cartItem = {
       _id: Random.id(),
       attributes,
+      compareAtPrice: {
+        amount: variantPriceInfo.compareAtPrice,
+        currencyCode: price.currencyCode
+      },
       isTaxable: chosenVariant.isTaxable || false,
       metafields,
       optionTitle: chosenVariant.optionTitle,
       parcel: chosenVariant.parcel,
+      // This one will be kept updated by event handler watching for
+      // catalog changes whereas `priceWhenAdded` will not.
+      price: {
+        amount: variantPriceInfo.price,
+        currencyCode: price.currencyCode
+      },
       priceWhenAdded: {
         amount: variantPriceInfo.price,
         currencyCode: price.currencyCode

--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -107,10 +107,7 @@ export default async function addCartItems(collections, currentItems, inputItems
     const cartItem = {
       _id: Random.id(),
       attributes,
-      compareAtPrice: {
-        amount: variantPriceInfo.compareAtPrice,
-        currencyCode: price.currencyCode
-      },
+      compareAtPrice: null,
       isTaxable: chosenVariant.isTaxable || false,
       metafields,
       optionTitle: chosenVariant.optionTitle,
@@ -143,6 +140,13 @@ export default async function addCartItems(collections, currentItems, inputItems
       variantId: productVariantId,
       variantTitle: chosenVariant.title
     };
+
+    if (variantPriceInfo.compareAtPrice || variantPriceInfo.compareAtPrice === 0) {
+      cartItem.compareAtPrice = {
+        amount: variantPriceInfo.compareAtPrice,
+        currencyCode: price.currencyCode
+      };
+    }
 
     // Check whether this variant is already in the cart. If so, increment quantity.
     const currentMatchingItemIndex = currentItems.findIndex((item) => item.productId === productId && item.variantId === productVariantId);

--- a/imports/plugins/core/cart/server/no-meteor/util/updateCartItemsForVariantPriceChange.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/updateCartItemsForVariantPriceChange.js
@@ -1,0 +1,47 @@
+/**
+ * @summary Given cart items array, a variant ID, and the prices for that variant,
+ *   returns an updated cart items array. Updates `price`, `compareAtPrice`, and `subtotal`
+ *   as necessary. You need not know for sure whether prices have changed since
+ *   the cart items were last updated. The return object will have a `didUpdate`
+ *   boolean property that you can check to see whether any changes were made.
+ * @param {Object[]} items Cart items
+ * @param {String} variantId ID of variant to update items for
+ * @param {Object} prices Various updated price info for this variant
+ * @returns {Object} { didUpdate, updatedItems }
+ */
+export default function updateCartItemsForVariantPriceChange(items, variantId, prices) {
+  let didUpdate = false;
+
+  const updatedItems = items.map((item) => {
+    if (item.variantId !== variantId) return item;
+
+    // If price has changed
+    if (item.price.amount !== prices.price) {
+      didUpdate = true;
+      item.price.amount = prices.price;
+      item.subtotal.amount = prices.price * item.quantity;
+    }
+
+    // If compareAt price has changed
+    if (
+      (prices.compareAtPrice || prices.compareAtPrice === 0) &&
+      (!item.compareAtPrice || item.compareAtPrice.amount !== prices.compareAtPrice)
+    ) {
+      didUpdate = true;
+      item.compareAtPrice = {
+        amount: prices.compareAtPrice,
+        currencyCode: item.price.currencyCode
+      };
+    }
+
+    // If compareAt price has been cleared
+    if (!prices.compareAtPrice && prices.compareAtPrice !== 0 && item.compareAtPrice) {
+      didUpdate = true;
+      item.compareAtPrice = null;
+    }
+
+    return item;
+  });
+
+  return { didUpdate, updatedItems };
+}

--- a/imports/plugins/core/cart/server/no-meteor/util/xformCartGroupToCommonOrder.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/xformCartGroupToCommonOrder.js
@@ -25,6 +25,7 @@ export default async function xformCartGroupToCommonOrder(cart, group, context) 
       currencyCode
     },
     taxCode: item.taxCode,
+    title: item.title,
     variantId: item.variantId
   }));
 
@@ -32,6 +33,8 @@ export default async function xformCartGroupToCommonOrder(cart, group, context) 
   const shop = await collections.Shops.findOne({ _id: shopId });
 
   return {
+    billingAddress: null,
+    cartId: cart._id,
     currencyCode: cart.currencyCode,
     fulfillmentPrices: {
       handling: {
@@ -49,8 +52,10 @@ export default async function xformCartGroupToCommonOrder(cart, group, context) 
     },
     fulfillmentType,
     items,
+    orderId: null,
     originAddress: (shop && Array.isArray(shop.addressBook) && shop.addressBook[0]) || null,
     shippingAddress: address || null,
-    shopId
+    shopId,
+    sourceType: "cart"
   };
 }

--- a/imports/plugins/core/cart/server/no-meteor/util/xformCartGroupToCommonOrder.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/xformCartGroupToCommonOrder.js
@@ -1,0 +1,56 @@
+/**
+ * @param {Object} cart A cart
+ * @param {Object} group The cart fulfillment group
+ * @param {Object} context App context
+ * @returns {Object} Valid CommonOrder from a cart group
+ */
+export default async function xformCartGroupToCommonOrder(cart, group, context) {
+  const { collections } = context;
+  const { currencyCode } = cart;
+
+  let items = group.itemIds.map((itemId) => cart.items.find((item) => item._id === itemId));
+  items = items.filter((item) => !!item); // remove nulls
+
+  // We also need to add `subtotal` on each item, based on the current price of that item in
+  // the catalog. `getFulfillmentGroupTaxes` uses subtotal prop to calculate the tax.
+  items = items.map((item) => ({
+    _id: item._id,
+    isTaxable: item.isTaxable,
+    parcel: item.parcel,
+    price: item.price,
+    quantity: item.quantity,
+    shopId: item.shopId,
+    subtotal: {
+      amount: item.price.amount * item.quantity,
+      currencyCode
+    },
+    taxCode: item.taxCode,
+    variantId: item.variantId
+  }));
+
+  const { address, shipmentMethod, shopId, type: fulfillmentType } = group;
+  const shop = await collections.Shops.findOne({ _id: shopId });
+
+  return {
+    currencyCode: cart.currencyCode,
+    fulfillmentPrices: {
+      handling: {
+        amount: (shipmentMethod && shipmentMethod.handling) || 0,
+        currencyCode
+      },
+      shipping: {
+        amount: (shipmentMethod && shipmentMethod.rate) || 0,
+        currencyCode
+      },
+      total: {
+        amount: shipmentMethod ? ((shipmentMethod.handling || 0) + (shipmentMethod.rate || 0)) : 0,
+        currencyCode
+      }
+    },
+    fulfillmentType,
+    items,
+    originAddress: (shop && Array.isArray(shop.addressBook) && shop.addressBook[0]) || null,
+    shippingAddress: address || null,
+    shopId
+  };
+}

--- a/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalog.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalog.js
@@ -14,7 +14,8 @@ import createCatalogProduct from "./createCatalogProduct";
  * @return {boolean} true on successful publish, false if publish was unsuccessful
  */
 export default async function publishProductToCatalog(product, context) {
-  const { Catalog, Products } = context.collections;
+  const { appEvents, collections } = context;
+  const { Catalog, Products } = collections;
 
   // Convert Product schema object to Catalog schema object
   const catalogProduct = await createCatalogProduct(product, context);
@@ -69,6 +70,7 @@ export default async function publishProductToCatalog(product, context) {
 
     const updatedProduct = { ...product, ...productUpdates };
     Hooks.Events.run("afterPublishProductToCatalog", updatedProduct, catalogProduct);
+    appEvents.emit("afterPublishProductToCatalog", updatedProduct, catalogProduct);
   }
 
   return wasUpdateSuccessful;

--- a/imports/plugins/core/core/server/fixtures/cart.js
+++ b/imports/plugins/core/core/server/fixtures/cart.js
@@ -24,6 +24,10 @@ import { addProduct } from "./products";
 export function getCartItem(options = {}) {
   const product = addProduct();
   Promise.await(publishProductToCatalog(product, {
+    appEvents: {
+      emit() {},
+      on() {}
+    },
     collections: rawCollections,
     getFunctionsOfType: () => []
   }));

--- a/imports/plugins/core/core/server/fixtures/cart.js
+++ b/imports/plugins/core/core/server/fixtures/cart.js
@@ -34,12 +34,17 @@ export function getCartItem(options = {}) {
     ]
   }).fetch();
   const selectedOption = Random.choice(childVariants);
+  const quantity = _.random(1, selectedOption.inventoryQuantity);
   const defaults = {
     _id: Random.id(),
     addedAt: new Date(),
     createdAt: new Date(),
     isTaxable: false,
     optionTitle: selectedOption.optionTitle,
+    price: {
+      amount: selectedOption.price,
+      currencyCode: "USD"
+    },
     priceWhenAdded: {
       amount: selectedOption.price,
       currencyCode: "USD"
@@ -47,8 +52,12 @@ export function getCartItem(options = {}) {
     productId: product._id,
     productSlug: product.handle,
     productType: product.type,
+    quantity,
     shopId: options.shopId || getShop()._id,
-    quantity: _.random(1, selectedOption.inventoryQuantity),
+    subtotal: {
+      amount: selectedOption.price * quantity,
+      currencyCode: "USD"
+    },
     title: product.title,
     updatedAt: new Date(),
     variantId: selectedOption._id,
@@ -85,12 +94,17 @@ export function createCart(productId, variantId) {
   const variant = Products.findOne(variantId);
   const user = Factory.create("user");
   const account = Factory.create("account", { userId: user._id });
+  const quantity = _.random(1, variant.inventoryQuantity);
   const cartItem = {
     _id: Random.id(),
     addedAt: new Date(),
     createdAt: new Date(),
     isTaxable: false,
     optionTitle: variant.optionTitle,
+    price: {
+      amount: variant.price,
+      currencyCode: "USD"
+    },
     priceWhenAdded: {
       amount: variant.price,
       currencyCode: "USD"
@@ -98,8 +112,12 @@ export function createCart(productId, variantId) {
     productId: product._id,
     productSlug: product.handle,
     productType: product.type,
+    quantity,
     shopId: getShop()._id,
-    quantity: _.random(1, variant.inventoryQuantity),
+    subtotal: {
+      amount: variant.price * quantity,
+      currencyCode: "USD"
+    },
     title: product.title,
     updatedAt: new Date(),
     variantId: variant._id,

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
@@ -73,19 +73,11 @@ function xformCartItem(context, catalogItems, products, cartItem) {
 
   return {
     ...cartItem,
-    compareAtPrice: {
-      amount: variantPriceInfo.compareAtPrice,
-      currencyCode
-    },
     currentQuantity: variantSourceProduct && variantSourceProduct.inventoryQuantity,
     imageURLs: media && media.URLs,
     isBackorder: variant.isBackorder || false,
     isLowQuantity: variant.isLowQuantity || false,
     isSoldOut: variant.isSoldOut || false,
-    price: {
-      amount: variantPriceInfo.price,
-      currencyCode
-    },
     productConfiguration: {
       productId: cartItem.productId,
       productVariantId: cartItem.variantId

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
@@ -43,8 +43,7 @@ export function decodeCartItemsOpaqueIds(items) {
  * @return {Object} Same object with GraphQL-only props added
  */
 function xformCartItem(context, catalogItems, products, cartItem) {
-  const { priceWhenAdded, productId, variantId } = cartItem;
-  const { currencyCode } = priceWhenAdded;
+  const { productId, variantId } = cartItem;
 
   const catalogItem = catalogItems.find((cItem) => cItem.product.productId === productId);
   if (!catalogItem) {
@@ -55,11 +54,6 @@ function xformCartItem(context, catalogItems, products, cartItem) {
   const { variant } = findVariantInCatalogProduct(catalogProduct, variantId);
   if (!variant) {
     throw new ReactionError("invalid-param", `Product with ID ${productId} has no variant with ID ${variantId}`);
-  }
-
-  const variantPriceInfo = variant.pricing[currencyCode];
-  if (!variantPriceInfo) {
-    throw new ReactionError("invalid-param", `This product variant does not have a price for ${currencyCode}`);
   }
 
   let media;
@@ -81,10 +75,6 @@ function xformCartItem(context, catalogItems, products, cartItem) {
     productConfiguration: {
       productId: cartItem.productId,
       productVariantId: cartItem.variantId
-    },
-    subtotal: {
-      amount: variantPriceInfo.price * cartItem.quantity,
-      currencyCode
     }
   };
 }
@@ -190,7 +180,7 @@ function xformCartFulfillmentGroup(fulfillmentGroup, cart) {
  */
 export async function xformCartCheckout(collections, cart) {
   // itemTotal is qty * amount for each item, summed
-  const itemTotal = (cart.items || []).reduce((sum, item) => (sum + (item.quantity * item.priceWhenAdded.amount)), 0);
+  const itemTotal = (cart.items || []).reduce((sum, item) => (sum + item.subtotal.amount), 0);
 
   // shippingTotal is shipmentMethod.rate for each item, summed
   // handlingTotal is shipmentMethod.handling for each item, summed

--- a/imports/plugins/core/orders/server/no-meteor/mutations/createOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/createOrder.js
@@ -67,6 +67,54 @@ const inputSchema = new SimpleSchema({
   order: orderInputSchema
 });
 
+/**
+ * @param {Object} group The order fulfillment group
+ * @param {String} currencyCode The currency code
+ * @param {Object} collections Map of MongoDB collections
+ * @returns {Object} Valid TaxServiceOrderInput from a cart group
+ */
+async function buildOrderInputForTaxCalculation(group, currencyCode, collections) {
+  const items = group.items.map((item) => ({
+    _id: item._id,
+    isTaxable: item.isTaxable,
+    parcel: item.parcel,
+    price: item.price,
+    quantity: item.quantity,
+    shopId: item.shopId,
+    subtotal: {
+      amount: item.subtotal,
+      currencyCode
+    },
+    taxCode: item.taxCode,
+    variantId: item.variantId
+  }));
+
+  const { address, shipmentMethod, shopId, type: fulfillmentType } = group;
+  const shop = await collections.Shops.findOne({ _id: shopId });
+
+  return {
+    currencyCode,
+    fulfillmentPrices: {
+      handling: {
+        amount: shipmentMethod.handling || 0,
+        currencyCode
+      },
+      shipping: {
+        amount: shipmentMethod.rate || 0,
+        currencyCode
+      },
+      total: {
+        amount: (shipmentMethod.handling || 0) + (shipmentMethod.rate || 0),
+        currencyCode
+      }
+    },
+    fulfillmentType,
+    items,
+    originAddress: (shop && Array.isArray(shop.addressBook) && shop.addressBook[0]) || null,
+    shippingAddress: address || null,
+    shopId
+  };
+}
 
 /**
  * @summary Gets currency rates from a shop
@@ -275,8 +323,19 @@ export default async function createOrder(context, input) {
     // the price is what the shopper expects it to be.
     finalGroup.items = await Promise.all(finalGroup.items.map((item) => buildOrderItem(item, currencyCode, context)));
 
-    const { items, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, finalGroup, true);
-    finalGroup.items = items;
+    // Apply taxes
+    const orderInputForTaxes = await buildOrderInputForTaxCalculation(finalGroup, currencyCode, collections);
+    const { itemTaxes, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, { order: orderInputForTaxes, forceZeroes: true });
+    finalGroup.items = finalGroup.items.map((item) => {
+      const itemTax = itemTaxes.find((entry) => entry.itemId === item._id) || {};
+
+      return {
+        ...item,
+        tax: itemTax.tax,
+        taxableAmount: itemTax.taxableAmount,
+        taxes: itemTax.taxes
+      };
+    });
     finalGroup.taxSummary = taxSummary;
 
     // Add some more properties for convenience

--- a/imports/plugins/core/orders/server/no-meteor/mutations/createOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/createOrder.js
@@ -5,7 +5,7 @@ import Random from "@reactioncommerce/random";
 import ReactionError from "@reactioncommerce/reaction-error";
 import hashLoginToken from "/imports/node-app/core/util/hashLoginToken";
 import appEvents from "/imports/node-app/core/util/appEvents";
-import { Order as OrderSchema, Payment as PaymentSchema } from "/imports/collections/schemas";
+import { Address as AddressSchema, Order as OrderSchema, Payment as PaymentSchema } from "/imports/collections/schemas";
 import getDiscountsTotalForCart from "/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart";
 import xformOrderGroupToCommonOrder from "/imports/plugins/core/orders/server/util/xformOrderGroupToCommonOrder";
 
@@ -62,6 +62,13 @@ const orderInputSchema = new SimpleSchema({
 const inputSchema = new SimpleSchema({
   afterValidate: {
     type: Function,
+    optional: true
+  },
+  // Although billing address is typically needed only by the payment plugin,
+  // some tax services require it to calculate taxes for digital items. Thus
+  // it should be provided here in order to be added to the CommonOrder if possible.
+  billingAddress: {
+    type: AddressSchema,
     optional: true
   },
   createPaymentForFulfillmentGroup: Function,
@@ -231,7 +238,7 @@ export default async function createOrder(context, input) {
   const cleanedInput = inputSchema.clean(input); // add default values and such
   inputSchema.validate(cleanedInput);
 
-  const { afterValidate, createPaymentForFulfillmentGroup, order: orderInput } = cleanedInput;
+  const { afterValidate, billingAddress, createPaymentForFulfillmentGroup, order: orderInput } = cleanedInput;
   const { cartId, currencyCode, email, fulfillmentGroups, shopId } = orderInput;
   const { accountId, account, collections } = context;
   const { Orders } = collections;
@@ -240,6 +247,8 @@ export default async function createOrder(context, input) {
   // discount codes feature. We are planning to revamp discounts soon, but until then, we'll look up
   // any discounts on the related cart here.
   const { discounts, total: discountTotal } = await getDiscountsTotalForCart(context, cartId);
+
+  const orderId = Random.id();
 
   // Add more props to each fulfillment group, and validate/build the items in each group
   const finalFulfillmentGroups = await Promise.all(fulfillmentGroups.map(async (groupInput) => {
@@ -276,7 +285,14 @@ export default async function createOrder(context, input) {
     finalGroup.items = await Promise.all(finalGroup.items.map((item) => buildOrderItem(item, currencyCode, context)));
 
     // Apply taxes
-    const commonOrder = await xformOrderGroupToCommonOrder(finalGroup, currencyCode, collections);
+    const commonOrder = await xformOrderGroupToCommonOrder({
+      billingAddress,
+      cartId,
+      collections,
+      currencyCode,
+      group: finalGroup,
+      orderId
+    });
     const { itemTaxes, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, { order: commonOrder, forceZeroes: true });
     finalGroup.items = finalGroup.items.map((item) => {
       const itemTax = itemTaxes.find((entry) => entry.itemId === item._id) || {};
@@ -358,7 +374,7 @@ export default async function createOrder(context, input) {
   const now = new Date();
 
   const order = {
-    _id: Random.id(),
+    _id: orderId,
     accountId,
     anonymousAccessToken: anonymousAccessToken && hashLoginToken(anonymousAccessToken),
     cartId,

--- a/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
+++ b/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
@@ -30,6 +30,7 @@ const CommonOrderItem = new SimpleSchema({
     type: String,
     optional: true
   },
+  title: String,
   variantId: String
 });
 
@@ -50,6 +51,14 @@ const CommonOrderFulfillmentPrices = new SimpleSchema({
  *   caring whether it is for a Cart or an Order.
  */
 export const CommonOrder = new SimpleSchema({
+  billingAddress: {
+    type: Address,
+    optional: true
+  },
+  cartId: {
+    type: String,
+    optional: true
+  },
   currencyCode: String,
   fulfillmentPrices: CommonOrderFulfillmentPrices,
   fulfillmentType: {
@@ -57,6 +66,10 @@ export const CommonOrder = new SimpleSchema({
     allowedValues: ["shipping"]
   },
   items: [CommonOrderItem],
+  orderId: {
+    type: String,
+    optional: true
+  },
   originAddress: {
     type: Address,
     optional: true
@@ -65,5 +78,9 @@ export const CommonOrder = new SimpleSchema({
     type: Address,
     optional: true
   },
-  shopId: String
+  shopId: String,
+  sourceType: {
+    type: String,
+    allowedValues: ["cart", "order"]
+  }
 });

--- a/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
+++ b/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
@@ -1,0 +1,69 @@
+import SimpleSchema from "simpl-schema";
+import { Address, ShippingParcel } from "/imports/collections/schemas";
+
+const Money = new SimpleSchema({
+  currencyCode: String,
+  amount: {
+    type: Number,
+    min: 0
+  }
+});
+
+const CommonOrderItem = new SimpleSchema({
+  _id: String,
+  isTaxable: {
+    type: Boolean,
+    optional: true
+  },
+  parcel: {
+    type: ShippingParcel,
+    optional: true
+  },
+  price: Money,
+  quantity: {
+    type: SimpleSchema.Integer,
+    min: 0
+  },
+  shopId: String,
+  subtotal: Money,
+  taxCode: {
+    type: String,
+    optional: true
+  },
+  variantId: String
+});
+
+const CommonOrderFulfillmentPrices = new SimpleSchema({
+  handling: Money,
+  shipping: Money,
+  total: Money
+});
+
+/**
+ * @type {SimpleSchema}
+ * @summary The CommonOrder schema describes an order for a single shop, containing only
+ *   properties that can be provided by a Cart as well. Each fulfillment group in a Cart
+ *   or Order can be transformed into a single CommonOrder. This allows plugins that
+ *   operate on both cart and order to provide only a single function, accepting a CommonOrder,
+ *   where the caller can transform and store the result as necessary for either Cart or Order.
+ *   For example, tax services accept a CommonOrder and calculate taxes without knowing or
+ *   caring whether it is for a Cart or an Order.
+ */
+export const CommonOrder = new SimpleSchema({
+  currencyCode: String,
+  fulfillmentPrices: CommonOrderFulfillmentPrices,
+  fulfillmentType: {
+    type: String,
+    allowedValues: ["shipping"]
+  },
+  items: [CommonOrderItem],
+  originAddress: {
+    type: Address,
+    optional: true
+  },
+  shippingAddress: {
+    type: Address,
+    optional: true
+  },
+  shopId: String
+});

--- a/imports/plugins/core/orders/server/util/xformOrderGroupToCommonOrder.js
+++ b/imports/plugins/core/orders/server/util/xformOrderGroupToCommonOrder.js
@@ -1,10 +1,13 @@
 /**
- * @param {Object} group The order fulfillment group
- * @param {String} currencyCode The currency code
+ * @param {Object} [billingAddress] Billing address, if one was collected
+ * @param {String} [cartId] The source cart ID, if applicable
  * @param {Object} collections Map of MongoDB collections
+ * @param {String} currencyCode The currency code
+ * @param {Object} group The order fulfillment group
+ * @param {String} orderId The order ID
  * @returns {Object} Valid CommonOrder for the given order group
  */
-export default async function xformOrderGroupToCommonOrder(group, currencyCode, collections) {
+export default async function xformOrderGroupToCommonOrder({ billingAddress = null, cartId, collections, currencyCode, group, orderId }) {
   const items = group.items.map((item) => ({
     _id: item._id,
     isTaxable: item.isTaxable,
@@ -17,6 +20,7 @@ export default async function xformOrderGroupToCommonOrder(group, currencyCode, 
       currencyCode
     },
     taxCode: item.taxCode,
+    title: item.title,
     variantId: item.variantId
   }));
 
@@ -24,6 +28,8 @@ export default async function xformOrderGroupToCommonOrder(group, currencyCode, 
   const shop = await collections.Shops.findOne({ _id: shopId });
 
   return {
+    billingAddress,
+    cartId,
     currencyCode,
     fulfillmentPrices: {
       handling: {
@@ -41,8 +47,10 @@ export default async function xformOrderGroupToCommonOrder(group, currencyCode, 
     },
     fulfillmentType,
     items,
+    orderId,
     originAddress: (shop && Array.isArray(shop.addressBook) && shop.addressBook[0]) || null,
     shippingAddress: address || null,
-    shopId
+    shopId,
+    sourceType: "order"
   };
 }

--- a/imports/plugins/core/orders/server/util/xformOrderGroupToCommonOrder.js
+++ b/imports/plugins/core/orders/server/util/xformOrderGroupToCommonOrder.js
@@ -1,0 +1,48 @@
+/**
+ * @param {Object} group The order fulfillment group
+ * @param {String} currencyCode The currency code
+ * @param {Object} collections Map of MongoDB collections
+ * @returns {Object} Valid CommonOrder for the given order group
+ */
+export default async function xformOrderGroupToCommonOrder(group, currencyCode, collections) {
+  const items = group.items.map((item) => ({
+    _id: item._id,
+    isTaxable: item.isTaxable,
+    parcel: item.parcel,
+    price: item.price,
+    quantity: item.quantity,
+    shopId: item.shopId,
+    subtotal: {
+      amount: item.subtotal,
+      currencyCode
+    },
+    taxCode: item.taxCode,
+    variantId: item.variantId
+  }));
+
+  const { address, shipmentMethod, shopId, type: fulfillmentType } = group;
+  const shop = await collections.Shops.findOne({ _id: shopId });
+
+  return {
+    currencyCode,
+    fulfillmentPrices: {
+      handling: {
+        amount: shipmentMethod.handling || 0,
+        currencyCode
+      },
+      shipping: {
+        amount: shipmentMethod.rate || 0,
+        currencyCode
+      },
+      total: {
+        amount: (shipmentMethod.handling || 0) + (shipmentMethod.rate || 0),
+        currencyCode
+      }
+    },
+    fulfillmentType,
+    items,
+    originAddress: (shop && Array.isArray(shop.addressBook) && shop.addressBook[0]) || null,
+    shippingAddress: address || null,
+    shopId
+  };
+}

--- a/imports/plugins/core/taxes/lib/simpleSchemas.js
+++ b/imports/plugins/core/taxes/lib/simpleSchemas.js
@@ -1,4 +1,5 @@
 import SimpleSchema from "simpl-schema";
+import { Address, ShippingParcel } from "/imports/collections/schemas";
 
 export const Taxes = new SimpleSchema({
   _id: String,
@@ -56,4 +57,61 @@ export const TaxServiceResult = new SimpleSchema({
   },
   "itemTaxes.$.taxes": [Taxes],
   "taxSummary": TaxSummary
+});
+
+const Money = new SimpleSchema({
+  currencyCode: String,
+  amount: {
+    type: Number,
+    min: 0
+  }
+});
+
+const TaxServiceOrderInputItem = new SimpleSchema({
+  _id: String,
+  isTaxable: {
+    type: Boolean,
+    optional: true
+  },
+  parcel: {
+    type: ShippingParcel,
+    optional: true
+  },
+  price: Money,
+  quantity: {
+    type: SimpleSchema.Integer,
+    min: 0
+  },
+  shopId: String,
+  subtotal: Money,
+  taxCode: {
+    type: String,
+    optional: true
+  },
+  variantId: String
+});
+
+const TaxServiceOrderInputFulfillmentPrices = new SimpleSchema({
+  handling: Money,
+  shipping: Money,
+  total: Money
+});
+
+export const TaxServiceOrderInput = new SimpleSchema({
+  currencyCode: String,
+  fulfillmentPrices: TaxServiceOrderInputFulfillmentPrices,
+  fulfillmentType: {
+    type: String,
+    allowedValues: ["shipping"]
+  },
+  items: [TaxServiceOrderInputItem],
+  originAddress: {
+    type: Address,
+    optional: true
+  },
+  shippingAddress: {
+    type: Address,
+    optional: true
+  },
+  shopId: String
 });

--- a/imports/plugins/core/taxes/lib/simpleSchemas.js
+++ b/imports/plugins/core/taxes/lib/simpleSchemas.js
@@ -1,5 +1,4 @@
 import SimpleSchema from "simpl-schema";
-import { Address, ShippingParcel } from "/imports/collections/schemas";
 
 export const Taxes = new SimpleSchema({
   _id: String,
@@ -61,61 +60,4 @@ export const TaxServiceResult = new SimpleSchema({
   },
   "itemTaxes.$.taxes": [Taxes],
   "taxSummary": TaxSummary
-});
-
-const Money = new SimpleSchema({
-  currencyCode: String,
-  amount: {
-    type: Number,
-    min: 0
-  }
-});
-
-const TaxServiceOrderInputItem = new SimpleSchema({
-  _id: String,
-  isTaxable: {
-    type: Boolean,
-    optional: true
-  },
-  parcel: {
-    type: ShippingParcel,
-    optional: true
-  },
-  price: Money,
-  quantity: {
-    type: SimpleSchema.Integer,
-    min: 0
-  },
-  shopId: String,
-  subtotal: Money,
-  taxCode: {
-    type: String,
-    optional: true
-  },
-  variantId: String
-});
-
-const TaxServiceOrderInputFulfillmentPrices = new SimpleSchema({
-  handling: Money,
-  shipping: Money,
-  total: Money
-});
-
-export const TaxServiceOrderInput = new SimpleSchema({
-  currencyCode: String,
-  fulfillmentPrices: TaxServiceOrderInputFulfillmentPrices,
-  fulfillmentType: {
-    type: String,
-    allowedValues: ["shipping"]
-  },
-  items: [TaxServiceOrderInputItem],
-  originAddress: {
-    type: Address,
-    optional: true
-  },
-  shippingAddress: {
-    type: Address,
-    optional: true
-  },
-  shopId: String
 });

--- a/imports/plugins/core/taxes/lib/simpleSchemas.js
+++ b/imports/plugins/core/taxes/lib/simpleSchemas.js
@@ -28,6 +28,10 @@ export const Taxes = new SimpleSchema({
 
 export const TaxSummary = new SimpleSchema({
   calculatedAt: Date,
+  calculatedByTaxServiceName: {
+    type: String,
+    optional: true
+  },
   referenceId: {
     type: String,
     optional: true

--- a/imports/plugins/core/taxes/server/no-meteor/mutations/getFulfillmentGroupTaxes.js
+++ b/imports/plugins/core/taxes/server/no-meteor/mutations/getFulfillmentGroupTaxes.js
@@ -1,7 +1,8 @@
 import Logger from "@reactioncommerce/logger";
 import ReactionError from "@reactioncommerce/reaction-error";
+import { CommonOrder } from "/imports/plugins/core/orders/server/no-meteor/simpleSchemas";
 import { getActiveTaxServiceForShop } from "../registration";
-import { TaxServiceOrderInput, TaxServiceResult } from "../../../lib/simpleSchemas";
+import { TaxServiceResult } from "../../../lib/simpleSchemas";
 
 /**
  * @summary Returns all taxes that apply to a provided order, delegating to a more specific
@@ -17,7 +18,7 @@ import { TaxServiceOrderInput, TaxServiceResult } from "../../../lib/simpleSchem
  */
 export default async function getFulfillmentGroupTaxes(context, { order, forceZeroes }) {
   try {
-    TaxServiceOrderInput.validate(order);
+    CommonOrder.validate(order);
   } catch (error) {
     Logger.error("Invalid order input provided to getFulfillmentGroupTaxes", error);
     throw new ReactionError("internal-error", "Error while calculating taxes");

--- a/imports/plugins/core/taxes/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/taxes/server/no-meteor/schemas/schema.graphql
@@ -121,6 +121,9 @@ type TaxSummary {
   "The time at which taxes were last calculated for the cart or order group"
   calculatedAt: DateTime!
 
+  "The name of the tax service that last calculated taxes for the cart or order group"
+  calculatedByTaxServiceName: String
+
   "A reference ID for the external system that calculated the taxes"
   referenceId: String
 

--- a/imports/plugins/core/taxes/server/no-meteor/startup.js
+++ b/imports/plugins/core/taxes/server/no-meteor/startup.js
@@ -1,61 +1,5 @@
 import { isEqual } from "lodash";
-
-/**
- * @param {Object} cart A cart
- * @param {Object} group The cart fulfillment group
- * @param {Object} context App context
- * @returns {Object} Valid TaxServiceOrderInput from a cart group
- */
-async function buildOrderInputForTaxCalculation(cart, group, context) {
-  const { collections } = context;
-  const { currencyCode } = cart;
-
-  let items = group.itemIds.map((itemId) => cart.items.find((item) => item._id === itemId));
-  items = items.filter((item) => !!item); // remove nulls
-
-  // We also need to add `subtotal` on each item, based on the current price of that item in
-  // the catalog. `getFulfillmentGroupTaxes` uses subtotal prop to calculate the tax.
-  items = items.map((item) => ({
-    _id: item._id,
-    isTaxable: item.isTaxable,
-    parcel: item.parcel,
-    price: item.price,
-    quantity: item.quantity,
-    shopId: item.shopId,
-    subtotal: {
-      amount: item.price.amount * item.quantity,
-      currencyCode
-    },
-    taxCode: item.taxCode,
-    variantId: item.variantId
-  }));
-
-  const { address, shipmentMethod, shopId, type: fulfillmentType } = group;
-  const shop = await collections.Shops.findOne({ _id: shopId });
-
-  return {
-    currencyCode: cart.currencyCode,
-    fulfillmentPrices: {
-      handling: {
-        amount: (shipmentMethod && shipmentMethod.handling) || 0,
-        currencyCode
-      },
-      shipping: {
-        amount: (shipmentMethod && shipmentMethod.rate) || 0,
-        currencyCode
-      },
-      total: {
-        amount: shipmentMethod ? ((shipmentMethod.handling || 0) + (shipmentMethod.rate || 0)) : 0,
-        currencyCode
-      }
-    },
-    fulfillmentType,
-    items,
-    originAddress: (shop && Array.isArray(shop.addressBook) && shop.addressBook[0]) || null,
-    shippingAddress: address || null,
-    shopId
-  };
-}
+import xformCartGroupToCommonOrder from "/imports/plugins/core/cart/server/no-meteor/util/xformCartGroupToCommonOrder";
 
 /**
  * @summary Returns `cart.items` with tax-related props updated on them
@@ -65,7 +9,7 @@ async function buildOrderInputForTaxCalculation(cart, group, context) {
  */
 async function getUpdatedCartItems(cart, context) {
   const taxResultsByGroup = await Promise.all(cart.shipping.map(async (group) => {
-    const order = await buildOrderInputForTaxCalculation(cart, group, context);
+    const order = await xformCartGroupToCommonOrder(cart, group, context);
     return context.mutations.getFulfillmentGroupTaxes(context, { order, forceZeroes: false });
   }));
 

--- a/imports/plugins/core/taxes/server/no-meteor/startup.js
+++ b/imports/plugins/core/taxes/server/no-meteor/startup.js
@@ -1,77 +1,117 @@
 import { isEqual } from "lodash";
 
 /**
+ * @param {Object} cart A cart
+ * @param {Object} group The cart fulfillment group
+ * @param {Object} context App context
+ * @returns {Object} Valid TaxServiceOrderInput from a cart group
+ */
+async function buildOrderInputForTaxCalculation(cart, group, context) {
+  const { collections, queries } = context;
+  const { currencyCode } = cart;
+
+  let items = group.itemIds.map((itemId) => cart.items.find((item) => item._id === itemId));
+  items = items.filter((item) => !!item); // remove nulls
+
+  // We also need to add `subtotal` on each item, based on the current price of that item in
+  // the catalog. `getFulfillmentGroupTaxes` uses subtotal prop to calculate the tax.
+  items = await Promise.all(items.map(async (item) => {
+    const productConfiguration = {
+      productId: item.productId,
+      productVariantId: item.variantId
+    };
+    const {
+      price
+    } = await queries.getCurrentCatalogPriceForProductConfiguration(productConfiguration, currencyCode, collections);
+
+    return {
+      _id: item._id,
+      isTaxable: item.isTaxable,
+      parcel: item.parcel,
+      price: {
+        amount: price,
+        currencyCode
+      },
+      quantity: item.quantity,
+      shopId: item.shopId,
+      subtotal: {
+        amount: price * item.quantity,
+        currencyCode
+      },
+      taxCode: item.taxCode,
+      variantId: item.variantId
+    };
+  }));
+
+  const { address, shipmentMethod, shopId, type: fulfillmentType } = group;
+  const shop = await collections.Shops.findOne({ _id: shopId });
+
+  return {
+    currencyCode: cart.currencyCode,
+    fulfillmentPrices: {
+      handling: {
+        amount: (shipmentMethod && shipmentMethod.handling) || 0,
+        currencyCode
+      },
+      shipping: {
+        amount: (shipmentMethod && shipmentMethod.rate) || 0,
+        currencyCode
+      },
+      total: {
+        amount: shipmentMethod ? ((shipmentMethod.handling || 0) + (shipmentMethod.rate || 0)) : 0,
+        currencyCode
+      }
+    },
+    fulfillmentType,
+    items,
+    originAddress: (shop && Array.isArray(shop.addressBook) && shop.addressBook[0]) || null,
+    shippingAddress: address || null,
+    shopId
+  };
+}
+
+/**
  * @summary Returns `cart.items` with tax-related props updated on them
  * @param {Object} cart The cart
  * @param {Object} context App context
  * @returns {Object[]} Updated items array
  */
 async function getUpdatedCartItems(cart, context) {
-  const { collections } = context;
-
-  // This dance is because `getFulfillmentGroupTaxes` takes groups with `items` on them,
-  // like in the Order schema, whereas in the Cart schema, items are directly on the cart
-  // and each group has only `itemIds` on it. So we first adjust each group to look like
-  // an order fulfillment group.
-  const taxSummaries = [];
-  const itemsWithTax = await Promise.all(cart.shipping.map(async (group) => {
-    let items = group.itemIds.map((itemId) => cart.items.find((item) => item._id === itemId));
-    items = items.filter((item) => !!item); // remove nulls
-
-    // We also need to add `subtotal` on each item, based on the current price of that item in
-    // the catalog. `getFulfillmentGroupTaxes` uses subtotal prop to calculate the tax.
-    items = await Promise.all(items.map(async (item) => {
-      const productConfiguration = {
-        productId: item.productId,
-        productVariantId: item.variantId
-      };
-      const {
-        price
-      } = await context.queries.getCurrentCatalogPriceForProductConfiguration(productConfiguration, cart.currencyCode, collections);
-
-      return {
-        ...item,
-        subtotal: price * item.quantity
-      };
-    }));
-
-    const {
-      items: groupItemsWithTaxAdded,
-      taxSummary
-    } = await context.mutations.getFulfillmentGroupTaxes(context, { ...group, items }, false);
-
-    taxSummaries.push(taxSummary);
-
-    return groupItemsWithTaxAdded;
+  const taxResultsByGroup = await Promise.all(cart.shipping.map(async (group) => {
+    const order = await buildOrderInputForTaxCalculation(cart, group, context);
+    return context.mutations.getFulfillmentGroupTaxes(context, { order, forceZeroes: false });
   }));
 
+  // Add tax properties to all items in the cart, if taxes were able to be calculated
   const cartItems = cart.items.map((item) => {
     const newItem = { ...item };
-    itemsWithTax.forEach((group) => {
-      const matchingGroupItem = group.find((groupItem) => groupItem._id === item._id);
-      if (matchingGroupItem) {
-        newItem.tax = matchingGroupItem.tax;
-        newItem.taxableAmount = matchingGroupItem.taxableAmount;
-        newItem.taxes = matchingGroupItem.taxes;
+    taxResultsByGroup.forEach((group) => {
+      const matchingGroupTaxes = group.itemTaxes.find((groupItem) => groupItem.itemId === item._id);
+      if (matchingGroupTaxes) {
+        newItem.tax = matchingGroupTaxes.tax;
+        newItem.taxableAmount = matchingGroupTaxes.taxableAmount;
+        newItem.taxes = matchingGroupTaxes.taxes;
       }
     });
     return newItem;
   });
 
-  // Reduce all group tax summaries to a single one
-  const taxSummary = taxSummaries.reduce((combinedSummary, groupSummary) => {
+  // Merge all group tax summaries to a single one for the whole cart
+  let combinedSummary = { tax: 0, taxableAmount: 0, taxes: [] };
+  for (const { taxSummary } of taxResultsByGroup) {
     // groupSummary will be null if there wasn't enough info to calc taxes
-    if (!combinedSummary || !groupSummary) return null;
+    if (!taxSummary) {
+      combinedSummary = null;
+      break;
+    }
 
-    combinedSummary.calculatedAt = groupSummary.calculatedAt;
-    combinedSummary.tax += groupSummary.tax;
-    combinedSummary.taxableAmount += groupSummary.taxableAmount;
-    combinedSummary.taxes = combinedSummary.taxes.concat(groupSummary.taxes);
+    combinedSummary.calculatedAt = taxSummary.calculatedAt;
+    combinedSummary.tax += taxSummary.tax;
+    combinedSummary.taxableAmount += taxSummary.taxableAmount;
+    combinedSummary.taxes = combinedSummary.taxes.concat(taxSummary.taxes);
+  }
 
-    return combinedSummary;
-  }, { tax: 0, taxableAmount: 0, taxes: [] });
-
-  return { cartItems, taxSummary };
+  return { cartItems, taxSummary: combinedSummary };
 }
 
 const EMITTED_BY_NAME = "TAXES_CORE_PLUGIN";

--- a/imports/plugins/core/taxes/server/no-meteor/startup.js
+++ b/imports/plugins/core/taxes/server/no-meteor/startup.js
@@ -93,6 +93,7 @@ async function getUpdatedCartItems(cart, context) {
     }
 
     combinedSummary.calculatedAt = taxSummary.calculatedAt;
+    combinedSummary.calculatedByTaxServiceName = taxSummary.calculatedByTaxServiceName;
     combinedSummary.tax += taxSummary.tax;
     combinedSummary.taxableAmount += taxSummary.taxableAmount;
     combinedSummary.taxes = combinedSummary.taxes.concat(taxSummary.taxes);

--- a/imports/plugins/core/versions/server/migrations/46_cart_item_props.js
+++ b/imports/plugins/core/versions/server/migrations/46_cart_item_props.js
@@ -1,0 +1,90 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Cart, Catalog } from "/lib/collections";
+import findAndConvertInBatches from "../util/findAndConvertInBatches";
+import findVariantInCatalogProduct from "../util/findVariantInCatalogProduct";
+
+/**
+ * @summary Migrate up one cart
+ * @param {Object} cart The cart to convert
+ * @returns {Object} The converted cart
+ */
+function convertCartUp(cart) {
+  const firstCartItem = cart.items[0];
+  if (!firstCartItem) return cart; // already converted
+  if ({}.hasOwnProperty.call(firstCartItem, "price")) return cart; // already converted
+
+  const { currencyCode } = cart;
+
+  cart.items = cart.items.map((item) => {
+    const catalogItem = Catalog.findOne({ "product.productId": item.productId });
+    if (!catalogItem) {
+      throw new Error(`CatalogProduct with product ID ${item.productId} not found`);
+    }
+
+    const catalogProduct = catalogItem.product;
+    const { variant } = findVariantInCatalogProduct(catalogProduct, item.variantId);
+    if (!variant) {
+      throw new Error(`Product with ID ${item.productId} has no variant with ID ${item.variantId}`);
+    }
+
+    const variantPriceInfo = variant.pricing[currencyCode];
+    if (!variantPriceInfo) {
+      throw new Error(`This product variant does not have a price for ${currencyCode}`);
+    }
+
+    item.price = {
+      amount: variantPriceInfo.price,
+      currencyCode
+    };
+    item.subtotal = {
+      amount: variantPriceInfo.price * item.quantity,
+      currencyCode
+    };
+    if (variantPriceInfo.compareAtPrice || variantPriceInfo.compareAtPrice === 0) {
+      item.compareAtPrice = {
+        amount: variantPriceInfo.compareAtPrice,
+        currencyCode
+      };
+    } else {
+      item.compareAtPrice = null;
+    }
+    return item;
+  });
+
+  return cart;
+}
+
+/**
+ * @summary Migrate down one cart
+ * @param {Object} cart The cart to convert
+ * @returns {Object} The converted cart
+ */
+function convertCartDown(cart) {
+  cart.items = cart.items.map((item) => {
+    delete item.price;
+    delete item.compareAtPrice;
+    return item;
+  });
+
+  return cart;
+}
+
+Migrations.add({
+  version: 46,
+
+  up() {
+    // Carts
+    findAndConvertInBatches({
+      collection: Cart,
+      converter: (cart) => convertCartUp(cart)
+    });
+  },
+
+  down() {
+    // Carts
+    findAndConvertInBatches({
+      collection: Cart,
+      converter: (cart) => convertCartDown(cart)
+    });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -43,3 +43,4 @@ import "./42_payment_methods";
 import "./43_stripe_marketplace_pkg";
 import "./44_tax_rates_pkg";
 import "./45_tax_schema_changes";
+import "./46_cart_item_props";

--- a/imports/plugins/core/versions/server/util/findVariantInCatalogProduct.js
+++ b/imports/plugins/core/versions/server/util/findVariantInCatalogProduct.js
@@ -1,0 +1,47 @@
+/**
+ * @param {Object} catalogProduct - The `product` property of a Catalog Item
+ * @param {String} variantId - The variantId to look for
+ * @returns {Object} Object with `variant` and `parentVariant` props.
+ *   `variant` is the variant or option object with the requested variantId. It will
+ *   also have a `parcel` object added to it, with inheritance from parent variant for options.
+ *   If `variant` is an option, `parentVariant` will be set to the parent variant.
+ */
+export default function findVariantInCatalogProduct(catalogProduct, variantId) {
+  let foundVariant = null;
+  let parentVariant = null;
+
+  catalogProduct.variants.forEach((variant) => {
+    if (variant.options && variant.options.length) {
+      variant.options.forEach((option) => {
+        if (option.variantId === variantId) {
+          // Build the `parcel` object, which should inherit (as a whole) from the parent variant
+          let parcel;
+          if (option.weight || option.height || option.width || option.length) {
+            parcel = { weight: option.weight, height: option.height, width: option.width, length: option.length };
+          } else if (variant.weight || variant.height || variant.width || variant.length) {
+            parcel = { weight: variant.weight, height: variant.height, width: variant.width, length: variant.length };
+          }
+          foundVariant = {
+            ...option,
+            parcel
+          };
+          parentVariant = {
+            ...variant
+          };
+          delete parentVariant.options;
+        }
+      });
+    } else if (variant.variantId === variantId) {
+      let parcel;
+      if (variant.weight || variant.height || variant.width || variant.length) {
+        parcel = { weight: variant.weight, height: variant.height, width: variant.width, length: variant.length };
+      }
+      foundVariant = {
+        ...variant,
+        parcel
+      };
+    }
+  });
+
+  return { parentVariant, variant: foundVariant };
+}

--- a/imports/plugins/included/discount-codes/server/no-meteor/util/getItemPriceDiscount.js
+++ b/imports/plugins/included/discount-codes/server/no-meteor/util/getItemPriceDiscount.js
@@ -26,10 +26,9 @@ export default async function getItemPriceDiscount(cartId, discountId, collectio
   // TODO add item specific conditions to sale calculations.
   let discount = 0;
   for (const item of cart.items) {
-    const preDiscountItemTotal = item.quantity * item.priceWhenAdded.amount;
     const salePriceItemTotal = item.quantity * discountAmount;
     // we if the sale is below 0, we won't discount at all. that's invalid.
-    discount += Math.max(0, preDiscountItemTotal - salePriceItemTotal);
+    discount += Math.max(0, item.subtotal.amount - salePriceItemTotal);
   }
 
   return discount;

--- a/imports/plugins/included/discount-codes/server/no-meteor/util/getPercentageOffDiscount.js
+++ b/imports/plugins/included/discount-codes/server/no-meteor/util/getPercentageOffDiscount.js
@@ -25,8 +25,7 @@ export default async function getPercentageOffDiscount(cartId, discountId, colle
 
   let discount = 0;
   for (const item of cart.items) {
-    const preDiscount = item.quantity * item.priceWhenAdded.amount;
-    discount += preDiscount * discountAmount / 100;
+    discount += item.subtotal.amount * discountAmount / 100;
   }
 
   return discount;

--- a/imports/plugins/included/marketplace/server/no-meteor/mutations/placeMarketplaceOrderWithStripeCardPayment.js
+++ b/imports/plugins/included/marketplace/server/no-meteor/mutations/placeMarketplaceOrderWithStripeCardPayment.js
@@ -122,6 +122,7 @@ export default async function placeMarketplaceOrderWithStripeCardPayment(context
   let stripeCustomerId;
   const stripeIdsByShopId = {};
   return mutations.createOrder(context, {
+    billingAddress,
     order: orderInput,
     async afterValidate() {
       const result = await getStripeInstanceForShop(context, shopId);

--- a/imports/plugins/included/payments-example/server/no-meteor/mutations/placeOrderWithExampleIOUPayment.js
+++ b/imports/plugins/included/payments-example/server/no-meteor/mutations/placeOrderWithExampleIOUPayment.js
@@ -93,6 +93,7 @@ export default async function placeOrderWithExampleIOUPayment(context, input) {
   billingAddress._id = billingAddressId || Random.id();
 
   return mutations.createOrder(context, {
+    billingAddress,
     order: orderInput,
     async createPaymentForFulfillmentGroup(group) {
       return {

--- a/imports/plugins/included/payments-stripe/server/no-meteor/mutations/placeOrderWithStripeCardPayment.js
+++ b/imports/plugins/included/payments-stripe/server/no-meteor/mutations/placeOrderWithStripeCardPayment.js
@@ -90,6 +90,7 @@ export default async function placeOrderWithStripeCardPayment(context, input) {
   let stripe;
   let stripeCustomerId;
   return mutations.createOrder(context, {
+    billingAddress,
     order: orderInput,
     async afterValidate() {
       stripe = await getStripeInstanceForShop(context, shopId);

--- a/imports/plugins/included/taxes-rates/register.js
+++ b/imports/plugins/included/taxes-rates/register.js
@@ -1,5 +1,5 @@
 import Reaction from "/imports/plugins/core/core/server/Reaction";
-import calculateOrderGroupTaxes from "./server/no-meteor/util/calculateOrderGroupTaxes";
+import calculateOrderTaxes from "./server/no-meteor/util/calculateOrderTaxes";
 import getTaxCodes from "./server/no-meteor/util/getTaxCodes";
 
 Reaction.registerPackage({
@@ -12,7 +12,7 @@ Reaction.registerPackage({
       displayName: "Custom Rates",
       name: "custom-rates",
       functions: {
-        calculateOrderGroupTaxes,
+        calculateOrderTaxes,
         getTaxCodes
       }
     }

--- a/imports/plugins/included/taxes-rates/server/no-meteor/util/calculateOrderTaxes.js
+++ b/imports/plugins/included/taxes-rates/server/no-meteor/util/calculateOrderTaxes.js
@@ -1,5 +1,7 @@
 import Random from "@reactioncommerce/random";
 
+const TAX_SERVICE_NAME = "custom-rates";
+
 /**
  * @summary Gets all applicable tax definitions based on shop ID and shipping address of a fulfillment group
  * @param {Object} collections Map of MongoDB collections
@@ -116,6 +118,7 @@ export default async function calculateOrderTaxes({ context, order }) {
     itemTaxes,
     taxSummary: {
       calculatedAt: new Date(),
+      calculatedByTaxServiceName: TAX_SERVICE_NAME,
       tax: totalTax,
       taxableAmount: totalTaxableAmount,
       taxes: Object.values(groupTaxes)

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -104,7 +104,7 @@ export const cartOrderTransform = {
    * @returns {Number} Total price of goods for the order
    */
   getSubTotal() {
-    const subTotal = getSummary(this.items, ["quantity"], ["priceWhenAdded", "amount"]);
+    const subTotal = getSummary(this.items, ["quantity"], ["price", "amount"]);
     return accounting.toFixed(subTotal, 2);
   },
   /**
@@ -115,7 +115,7 @@ export const cartOrderTransform = {
   getSubtotalByShop() {
     return this.items.reduce((uniqueShopSubTotals, item) => {
       if (!uniqueShopSubTotals[item.shopId]) {
-        const subTotal = getSummary(this.items, ["quantity"], ["priceWhenAdded", "amount"], item.shopId);
+        const subTotal = getSummary(this.items, ["quantity"], ["price", "amount"], item.shopId);
         uniqueShopSubTotals[item.shopId] = accounting.toFixed(subTotal, 2);
         return uniqueShopSubTotals;
       }


### PR DESCRIPTION
Resolves #4807   
Impact: **minor**  
Type: **feature**

## Changes
The order data being passed to tax calculation functions was not consistent due to differences between Cart and Order schemas. This PR introduces a new schema CommonOrder, which represents one actual or potential order for one shop. New transforms allow a cart fulfillment group or an order fulfillment group to be converted to a CommonOrder. Tax calculation functions only need to understand and deal with CommonOrders.

This was implemented in a generic way because we expect to need this same transformation for shipping restrictions, surcharges, and other similar calculations that do not need to care whether they're calculating for a Cart or an Order.

## Breaking changes for custom tax plugins
There are breaking changes only within the current RC7 release, since prior PRs were merged. Custom tax plugins should do the following:
- Change function name from `calculateOrderGroupTaxes` to `calculateOrderTaxes`
- Expect that `calculateOrderTaxes` will be called with `{ context, order }` rather than `{ context, group }`, where `order` is similar to what `group` was, but is guaranteed to be in the new `CommonOrder` schema, whether being called for a Cart or an Order. Among other things, a common order has `originAddress` and `currencyCode` properties, and the items are guaranteed to have `price` property set.
- Expect `calculateOrderTaxes` to now be called even when `shippingAddress` is `null`. Return `null` if you cannot calculate taxes. In most cases, tax plugins will immediately check whether `shippingAddress` is `null` and if so, return `null`.
- A `calculateOrderTaxes` function may now set `calculatedByTaxServiceName` property in the `taxSummary` that is returned. Set this to the name of your tax service (same as in `taxServices` array in `registerPackage`). One good reason to set this is to determine whether tax was calculated by your tax service after the order is placed. Depending on the type of tax integration, you may need to inform the third-party tax service that the order was placed. Use `referenceId` to store the corresponding calculation ID from the third-party system if necessary.

## Testing
- Test all aspects of taxation. Primarily, test adding taxable items to your cart and checking them 
out.
- To test the specific bug fix, you can log in `calculateOrderTaxes` function for the included "custom rates" service and verify that the `order` argument is the same whether being called for a cart (such as when adding items) or for an order (such as when completing checkout).