### PR TITLE
Add a mongodb index on Catalog.updatedAt

### DIFF
--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -28,8 +28,8 @@ import { cartOrderTransform } from "./transform/cartOrder";
 /**
  * @name mediaRecordsIndex
  * @private
- * @param {RawMongoCollection} rawMedia
- *
+ * @param {RawMongoCollection} rawMedia the collection
+ * @returns {undefined}
  * Sets up necessary indexes on the Media FileCollection
  */
 async function mediaRecordsIndex(rawMedia) {

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -132,6 +132,22 @@ Packages.attachSchema(Schemas.PackageConfig);
 export const Catalog = new Mongo.Collection("Catalog");
 
 /**
+ * @name catalogIndex
+ * @private
+ * @param {RawMongoCollection} catalog the collection
+* @returns {undefined}
+ *
+ * Sets up necessary indexes on the Catalog collection
+ */
+async function catalogIndex(catalog) {
+  try {
+    await catalog.createIndex({ updatedAt: 1 }, { background: true });
+  } catch (error) {
+    console.error(error); // eslint-disable-line no-console
+  }
+}
+
+/**
  * @name Products
  * @memberof Collections
  * @type {MongoCollection}
@@ -230,6 +246,7 @@ export const MediaRecords = new Mongo.Collection("cfs.Media.filerecord");
 // Index on the props we search on
 if (Meteor.isServer) {
   mediaRecordsIndex(MediaRecords.rawCollection());
+  catalogIndex(Catalog.rawCollection());
 }
 
 // Might want to do this at some point.


### PR DESCRIPTION
Impact: **minor**  
Type: **performance**

## Issue
For search we will be querying the Catalog collection sorted by the `updatedAt` timestamp field when syncing via kafka-connect. MongoDB requires an index on this field to efficiently process this query.

## Solution

Add the index via the mongo API.

## Breaking changes
N/A

## Notes

Index creation will run in the background, but does require some resources to do. Most installations won't notice this until it's already done, but if you had a very large catalog data set you may notice mongodb using resources to index the data for a brief period.

## Testing
1. Unit tests still pass
2. eslint still passes
3. Verified the index exists with mongo shell `db.Catalog.getIndexes()`