### PR TITLE
Add node_modules/.bin to PATH in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM reactioncommerce/base:v1.8-meteor as meteor-dev
 
 LABEL maintainer="Reaction Commerce <architecture@reactioncommerce.com>"
 
-ENV PATH $PATH:/home/node/.meteor
+ENV PATH $PATH:/home/node/.meteor:$APP_SOURCE_DIR/node_modules/.bin
 
 COPY --chown=node package-lock.json $APP_SOURCE_DIR/
 COPY --chown=node package.json $APP_SOURCE_DIR/


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
In the docker container I can't just run npm tools with CLIs like `eslint` outside of the defined npm scripts from `package.json`. Adding this directory to the PATH allows running such programs normally.

Just a developer convenience.