### PR TITLE
Feat env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
 REACTION_EMAIL=me@example.com
 REACTION_AUTH=somepassword
 REACTION_USER=ReactionAdmin
+
+ROOT_URL=http://localhost:3000
+
 MONGO_URL=mongodb://mongo:27017/reaction
 MONGO_OPLOG_URL=mongodb://mongo:27017/local
-ROOT_URL=http://localhost:3000
+
 HYDRA_ADMIN_URL=http://hydra:4445
 HYDRA_TOKEN_URL=http://hydra:4444/oauth2/token
 HYDRA_OAUTH2_INTROSPECT_URL=http://hydra:4445/oauth2/introspect
 OAUTH2_CLIENT_DOMAINS=http://localhost:4000
+
 SKIP_FIXTURES=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     command: bash -c "meteor npm install && node ./.reaction/waitForMongo.js && reaction"
     depends_on:
       - mongo
+    env_file: .env
     environment:
       MONGO_URL: "mongodb://mongo:27017/reaction"
       MONGO_OPLOG_URL: "mongodb://mongo:27017/local"


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Description
Added support for a `.env` file.

## Breaking changes
None. All this does is add additional support for a `.env` file. I did not move the existing variables from `docker-compose` over to it. I would like to and think we should, but this would mean all users would need to worry about copying/symlinking/creating a `.env` file so I chose not to make this change here or now.