### PR TITLE
chore: remove unused dispatch:run-as-user package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -52,7 +52,6 @@ aldeed:collection2@3.0.1
 aldeed:schema-index@3.0.0
 aldeed:template-extension
 bozhao:accounts-instagram
-dispatch:run-as-user
 meteorhacks:ssr
 meteorhacks:subs-manager
 ongoworks:security

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -38,7 +38,6 @@ ddp-rate-limiter@1.0.7
 ddp-server@2.2.0
 deps@1.0.12
 diff-sequence@1.1.0
-dispatch:run-as-user@1.1.1
 dynamic-import@0.5.0
 ecmascript@0.12.1
 ecmascript-runtime@0.7.0


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
Based on a code search for the APIs that are added by the `dispatch:run-as-user` Meteor package, I don't believe it is necessary anymore.

## Solution
Remove the package

## Breaking changes
Custom plugins that rely on the `dispatch:run-as-user` Meteor package will need to find a different solution and remove the dependent code.

## Testing
Verify the app starts up and perform basic smoke tests