### PR TITLE
Deploy feature branches to ECS

### DIFF
--- a/.circleci/bin/ecs-deploy-feature-branch.sh
+++ b/.circleci/bin/ecs-deploy-feature-branch.sh
@@ -3,11 +3,12 @@
 sudo apt-get -y install python3-pip wget
 sudo pip3 install awscli
 
-export ENVIRONMENT=feat
+export ENVIRONMENT=staging
 export CLUSTER=core
-export SERVICE_SUFFIX=$CIRCLE_BRANCH
-export SERVICE1=reaction-core
-export CONTAINER1=core
+# remove spaces from branch name
+export SERVICE_FEATURE=`echo $CIRCLE_BRANCH | sed 's/ //g'`
+export SERVICE=reaction-core
+export CONTAINER=core
 export core_CIRCLE_SHA1=$CIRCLE_SHA1
 
 PROPEL_CONFIG_FILE="propel-feat.yaml"
@@ -39,16 +40,24 @@ sudo mv propel /usr/local/bin/propel
 sudo chmod +x /usr/local/bin/propel
 
 RELEASE_DESCRIPTION="CircleCI build URL: ${CIRCLE_BUILD_URL}"
-propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE1 --container $CONTAINER1 --suffix $SERVICE_SUFFIX --overwrite
-propel param set ROOT_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com/ -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE1 --container $CONTAINER1 --suffix $SERVICE_SUFFIX --overwrite
-propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE1 --suffix $SERVICE_SUFFIX
 
-export SERVICE2=storefront
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER --feature $SERVICE_FEATURE --overwrite
+
+propel param set ROOT_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/ -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER --feature $SERVICE_FEATURE --overwrite
+
+propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE --feature $SERVICE_FEATURE
+
+export SERVICE=storefront
+export CONTAINER1=nginx
 export CONTAINER2=storefront
-propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set CANONICAL_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set OAUTH2_REDIRECT_URL=https://${SERVICE2}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com/callback -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set OAUTH2_IDP_HOST_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set EXTERNAL_GRAPHQL_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set INTERNAL_GRAPHQL_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE2 --suffix $SERVICE_SUFFIX
+
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER1 --feature $SERVICE_FEATURE --overwrite
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+
+propel param set CANONICAL_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set OAUTH2_REDIRECT_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/callback -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set OAUTH2_IDP_HOST_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set EXTERNAL_GRAPHQL_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set INTERNAL_GRAPHQL_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+
+propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE --feature $SERVICE_FEATURE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v8
+  rc_linter: reactioncommerce/linter@dev:v9
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,14 @@ defaults: &defaults
     - image: circleci/node:8-stretch
 
 jobs:
+  run_linters:
+    <<: *defaults
+    steps:
+      - rc_linter/run_dockerfile_lint
+      - rc_linter/run_eslint:
+          branch: ${CIRCLECI_BRANCH}
+          global_cache_version: ${GLOBAL_CACHE_VERSION}
+  
   build:
     <<: *defaults
     steps:
@@ -200,10 +208,6 @@ jobs:
               exit 1;
             fi
 
-  rc_linter/run_linters:
-    branch: ${CIRCLECI_BRANCH}
-    global_cache_version: ${GLOBAL_CACHE_VERSION}
-
 #  eslint:
 #    <<: *defaults
 #    steps:
@@ -345,7 +349,7 @@ workflows:
 #      - eslint:
 #          requires:
 #            - build
-      - rc_linter/reactioncommerce_linters:
+      - run_linters:
           requires:
             - build
       - docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v16
+  rc_linter: reactioncommerce/linter@dev:v17
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -25,12 +25,12 @@ jobs:
       - run:
           name: Save GLOBAL_CACHE_VERSION variable in file
           command: |
-            echo ${GLOBAL_CACHE_VERSION} > /tmp/GLOBAL_CACHE_VERSION
+            echo ${GLOBAL_CACHE_VERSION} > GLOBAL_CACHE_VERSION
       - setup_remote_docker:
           docker_layer_caching: true
       - restore_cache:
           name: Restoring Meteor cache
-          key: meteor-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}
+          key: meteor-{{ checksum "GLOBAL_CACHE_VERSION" }}
       - run:
           name: Install Meteor
           command: |
@@ -43,7 +43,7 @@ jobs:
             fi
       - save_cache:
           name: Saving Meteor to cache
-          key: meteor-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ epoch }}
+          key: meteor-{{ checksum "GLOBAL_CACHE_VERSION" }}-{{ epoch }}
           paths:
             - ~/.meteor
       - run:
@@ -77,11 +77,11 @@ jobs:
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.
       - save_cache:
-          key: node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: node-modules-{{ checksum "GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ .Branch }}-{{ epoch }}
+          key: node-modules-{{ checksum "GLOBAL_CACHE_VERSION" }}-{{ .Branch }}-{{ epoch }}
           paths:
             - node_modules
       # mongodb-memory-server installs Mongo binary on npm install, which we need
@@ -91,6 +91,10 @@ jobs:
           key: mongodb-memory-server
           paths:
             - ~/.mongodb-binaries
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - GLOBAL_CACHE_VERSION
 
   docker-build:
     <<: *defaults
@@ -362,7 +366,6 @@ workflows:
 #            - build
       - rc_linter/dockerfile_lint
       - rc_linter/eslint:
-          cache_version: ${GLOBAL_CACHE_VERSION}
           requires:
             - build
       - docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v5
+  rc_linter: reactioncommerce/linter@dev:v6
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v15
+  rc_linter: reactioncommerce/linter@dev:v16
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -91,10 +91,6 @@ jobs:
           key: mongodb-memory-server
           paths:
             - ~/.mongodb-binaries
-      - store_artifacts:
-          path: /tmp/GLOBAL_CACHE_VERSION
-          destination: GLOBAL_CACHE_VERSION_artifact
-
 
   docker-build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v12
+  rc_linter: reactioncommerce/linter@dev:v13
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -222,6 +222,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: Save GLOBAL_CACHE_VERSION variable in file
+          command: |
+            echo ${GLOBAL_CACHE_VERSION} > /tmp/GLOBAL_CACHE_VERSION
       - restore_cache:
           name: Restoring Meteor cache
           key: meteor-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}
@@ -248,6 +252,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: Save GLOBAL_CACHE_VERSION variable in file
+          command: |
+            echo ${GLOBAL_CACHE_VERSION} > /tmp/GLOBAL_CACHE_VERSION
       - restore_cache:
           keys:
             - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
@@ -261,6 +269,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: Save GLOBAL_CACHE_VERSION variable in file
+          command: |
+            echo ${GLOBAL_CACHE_VERSION} > /tmp/GLOBAL_CACHE_VERSION
       - restore_cache:
           keys:
             - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
@@ -290,6 +302,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: Save GLOBAL_CACHE_VERSION variable in file
+          command: |
+            echo ${GLOBAL_CACHE_VERSION} > /tmp/GLOBAL_CACHE_VERSION
       - setup_remote_docker:
           docker_layer_caching: true
       - restore_cache:
@@ -347,7 +363,7 @@ workflows:
 #            - build
       - rc_linter/dockerfile_lint
       - rc_linter/eslint:
-          global_cache_version: ${GLOBAL_CACHE_VERSION}
+          cache_version: ${GLOBAL_CACHE_VERSION}
           requires:
             - build
       - docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,10 @@ jobs:
           key: mongodb-memory-server
           paths:
             - ~/.mongodb-binaries
+      - run:
+          name: Create workspace directory
+          command: |
+            mkdir -p /tmp/workspace
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v17
+  rc_linter: reactioncommerce/linter@dev:v18
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -92,11 +92,12 @@ jobs:
           paths:
             - ~/.mongodb-binaries
       - run:
-          name: Create workspace directory
+          name: Create workspace
           command: |
-            mkdir -p /tmp/workspace
+            mkdir -p docker-build-workspace
+            cp GLOBAL_CACHE_VERSION docker-build-workspace
       - persist_to_workspace:
-          root: /tmp/workspace
+          root: docker-build-workspace
           paths:
             - GLOBAL_CACHE_VERSION
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v14
+  rc_linter: reactioncommerce/linter@dev:v15
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -91,6 +91,9 @@ jobs:
           key: mongodb-memory-server
           paths:
             - ~/.mongodb-binaries
+      - store_artifacts:
+          path: /tmp/GLOBAL_CACHE_VERSION
+          destination: GLOBAL_CACHE_VERSION_artifact
 
 
   docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v13
+  rc_linter: reactioncommerce/linter@dev:v14
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,15 +17,7 @@ defaults: &defaults
   docker:
     - image: circleci/node:8-stretch
 
-jobs:
-  run_linters:
-    <<: *defaults
-    steps:
-      - rc_linter/run_dockerfile_lint
-      - rc_linter/run_eslint:
-          branch: ${CIRCLECI_BRANCH}
-          global_cache_version: ${GLOBAL_CACHE_VERSION}
-  
+jobs:  
   build:
     <<: *defaults
     steps:
@@ -349,7 +341,8 @@ workflows:
 #      - eslint:
 #          requires:
 #            - build
-      - run_linters:
+      - rc_linter/run_linters:
+          branch: ${CIRCLECI_BRANCH}
           requires:
             - build
       - docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v6
+  rc_linter: reactioncommerce/linter@dev:v7
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v9
+  rc_linter: reactioncommerce/linter@dev:v10
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -26,7 +26,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           name: Restoring Meteor cache
-          key: meteor
+          key: "${GLOBAL_CACHE_VERSION}-meteor"
       - run:
           name: Install Meteor
           command: |
@@ -39,7 +39,7 @@ jobs:
             fi
       - save_cache:
           name: Saving Meteor to cache
-          key: meteor-{{ epoch }}
+          key: "${GLOBAL_CACHE_VERSION}-meteor-{{ epoch }}"
           paths:
             - ~/.meteor
       - run:
@@ -73,11 +73,11 @@ jobs:
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.
       - save_cache:
-          key: node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}"
           paths:
             - node_modules
       - save_cache:
-          key: node-modules-{{ .Branch }}-{{ epoch }}
+          key: "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}-{{ epoch }}"
           paths:
             - node_modules
       # mongodb-memory-server installs Mongo binary on npm install, which we need
@@ -206,9 +206,9 @@ jobs:
 #      - checkout
 #      - restore_cache:
 #          keys:
-#            - node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-#            - node-modules-{{ .Branch }}
-#            - node-modules-master
+#            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+#            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
+#            - ${GLOBAL_CACHE_VERSION}-node-modules-master
 #      - run:
 #          name: Run Lint
 #          command: |
@@ -220,16 +220,16 @@ jobs:
       - checkout
       - restore_cache:
           name: Restoring Meteor cache
-          key: meteor
+          key: "${GLOBAL_CACHE_VERSION}-meteor"
       - run:
           name: Link Restored Meteor
           command: sudo ln -s ~/.meteor/meteor /usr/local/bin/meteor
       - restore_cache:
           # Fall back to less specific caches
           keys:
-            - node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - node-modules-{{ .Branch }}
-            - node-modules-master
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-master"
       - run:
           name: Install Reaction CLI
           command: sudo npm install -g reaction-cli
@@ -246,9 +246,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - node-modules-{{ .Branch }}
-            - node-modules-master
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-master"
       - run:
           name: Run Unit Tests
           command: npm run test:unit
@@ -290,9 +290,9 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - node-modules-{{ .Branch }}
-            - node-modules-master
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-master"
       - run:
           name: Snyk Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ defaults: &defaults
     - DOCKER_REPOSITORY: "reactioncommerce/reaction"
     - DOCKER_NAMESPACE: "reactioncommerce"
     - DOCKER_NAME: "reaction"
-    - GLOBAL_CACHE_VERSION: "v2"
     - TOOL_NODE_FLAGS: "--max-old-space-size=4096"
   working_directory: ~/reaction-app
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.
       - save_cache:
-          key: "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}"
+          key: "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum \"package.json\" }}-{{ checksum \"package-lock.json\" }}"
           paths:
             - node_modules
       - save_cache:
@@ -227,7 +227,7 @@ jobs:
       - restore_cache:
           # Fall back to less specific caches
           keys:
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum \"package.json\" }}-{{ checksum \"package-lock.json\" }}"
             - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
             - "${GLOBAL_CACHE_VERSION}-node-modules-master"
       - run:
@@ -246,7 +246,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum \"package.json\" }}-{{ checksum \"package-lock.json\" }}"
             - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
             - "${GLOBAL_CACHE_VERSION}-node-modules-master"
       - run:
@@ -290,7 +290,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}"
+            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum \"package.json\" }}-{{ checksum \"package-lock.json\" }}"
             - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
             - "${GLOBAL_CACHE_VERSION}-node-modules-master"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v7
+  rc_linter: reactioncommerce/linter@dev:v8
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -26,7 +26,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           name: Restoring Meteor cache
-          key: ${GLOBAL_CACHE_VERSION}-meteor
+          key: meteor
       - run:
           name: Install Meteor
           command: |
@@ -39,7 +39,7 @@ jobs:
             fi
       - save_cache:
           name: Saving Meteor to cache
-          key: ${GLOBAL_CACHE_VERSION}-meteor-{{ epoch }}
+          key: meteor-{{ epoch }}
           paths:
             - ~/.meteor
       - run:
@@ -73,11 +73,11 @@ jobs:
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.
       - save_cache:
-          key: ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}-{{ epoch }}
+          key: node-modules-{{ .Branch }}-{{ epoch }}
           paths:
             - node_modules
       # mongodb-memory-server installs Mongo binary on npm install, which we need
@@ -206,9 +206,9 @@ jobs:
 #      - checkout
 #      - restore_cache:
 #          keys:
-#            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-#            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-#            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+#            - node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+#            - node-modules-{{ .Branch }}
+#            - node-modules-master
 #      - run:
 #          name: Run Lint
 #          command: |
@@ -220,16 +220,16 @@ jobs:
       - checkout
       - restore_cache:
           name: Restoring Meteor cache
-          key: ${GLOBAL_CACHE_VERSION}-meteor
+          key: meteor
       - run:
           name: Link Restored Meteor
           command: sudo ln -s ~/.meteor/meteor /usr/local/bin/meteor
       - restore_cache:
           # Fall back to less specific caches
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - node-modules-{{ .Branch }}
+            - node-modules-master
       - run:
           name: Install Reaction CLI
           command: sudo npm install -g reaction-cli
@@ -246,9 +246,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - node-modules-{{ .Branch }}
+            - node-modules-master
       - run:
           name: Run Unit Tests
           command: npm run test:unit
@@ -290,9 +290,9 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - node-modules-{{ .Branch }}
+            - node-modules-master
       - run:
           name: Snyk Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v10
+  rc_linter: reactioncommerce/linter@dev:v12
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -11,6 +11,7 @@ defaults: &defaults
     - DOCKER_REPOSITORY: "reactioncommerce/reaction"
     - DOCKER_NAMESPACE: "reactioncommerce"
     - DOCKER_NAME: "reaction"
+    - GLOBAL_CACHE_VERSION: "v2"
     - TOOL_NODE_FLAGS: "--max-old-space-size=4096"
   working_directory: ~/reaction-app
   docker:
@@ -21,11 +22,15 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          name: Save GLOBAL_CACHE_VERSION variable in file
+          command: |
+            echo ${GLOBAL_CACHE_VERSION} > /tmp/GLOBAL_CACHE_VERSION
       - setup_remote_docker:
           docker_layer_caching: true
       - restore_cache:
           name: Restoring Meteor cache
-          key: "${GLOBAL_CACHE_VERSION}-meteor"
+          key: meteor-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}
       - run:
           name: Install Meteor
           command: |
@@ -38,7 +43,7 @@ jobs:
             fi
       - save_cache:
           name: Saving Meteor to cache
-          key: "${GLOBAL_CACHE_VERSION}-meteor-{{ epoch }}"
+          key: meteor-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ epoch }}
           paths:
             - ~/.meteor
       - run:
@@ -72,11 +77,11 @@ jobs:
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.
       - save_cache:
-          key: "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum \"package.json\" }}-{{ checksum \"package-lock.json\" }}"
+          key: node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}-{{ epoch }}"
+          key: node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ .Branch }}-{{ epoch }}
           paths:
             - node_modules
       # mongodb-memory-server installs Mongo binary on npm install, which we need
@@ -219,16 +224,16 @@ jobs:
       - checkout
       - restore_cache:
           name: Restoring Meteor cache
-          key: "${GLOBAL_CACHE_VERSION}-meteor"
+          key: meteor-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}
       - run:
           name: Link Restored Meteor
           command: sudo ln -s ~/.meteor/meteor /usr/local/bin/meteor
       - restore_cache:
           # Fall back to less specific caches
           keys:
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum \"package.json\" }}-{{ checksum \"package-lock.json\" }}"
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
-            - "${GLOBAL_CACHE_VERSION}-node-modules-master"
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ .Branch }}
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-master
       - run:
           name: Install Reaction CLI
           command: sudo npm install -g reaction-cli
@@ -245,9 +250,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum \"package.json\" }}-{{ checksum \"package-lock.json\" }}"
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
-            - "${GLOBAL_CACHE_VERSION}-node-modules-master"
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ .Branch }}
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-master
       - run:
           name: Run Unit Tests
           command: npm run test:unit
@@ -258,9 +263,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - v1-node-modules-{{ .Branch }}
-            - v1-node-modules-master
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ .Branch }}
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-master
       - restore_cache:
           name: Restoring mongodb-memory-server MongoDB cache
           key: mongodb-memory-server
@@ -289,9 +294,9 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum \"package.json\" }}-{{ checksum \"package-lock.json\" }}"
-            - "${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}"
-            - "${GLOBAL_CACHE_VERSION}-node-modules-master"
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-{{ .Branch }}
+            - node-modules-{{ checksum "/tmp/GLOBAL_CACHE_VERSION" }}-master
       - run:
           name: Snyk Test
           command: |
@@ -325,8 +330,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build:
-          context: reaction-build-cache-settings
+      - build
 #      - dockerfile-lint
       - test-app:
           requires:
@@ -343,6 +347,7 @@ workflows:
 #            - build
       - rc_linter/dockerfile_lint
       - rc_linter/eslint:
+          global_cache_version: ${GLOBAL_CACHE_VERSION}
           requires:
             - build
       - docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v3
+  rc_linter: reactioncommerce/linter@dev:v4
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -342,7 +342,6 @@ workflows:
 #          requires:
 #            - build
       - rc_linter/run_linters:
-          branch: ${CIRCLECI_BRANCH}
           requires:
             - build
       - docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  rc_linter: reactioncommerce/linter@dev:v3
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -197,19 +200,23 @@ jobs:
               exit 1;
             fi
 
-  eslint:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
-      - run:
-          name: Run Lint
-          command: |
-            npm run lint -- --quiet
+  rc_linter/run_linters:
+    branch: ${CIRCLECI_BRANCH}
+    global_cache_version: ${GLOBAL_CACHE_VERSION}
+
+#  eslint:
+#    <<: *defaults
+#    steps:
+#      - checkout
+#      - restore_cache:
+#          keys:
+#            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+#            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
+#            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+#      - run:
+#          name: Run Lint
+#          command: |
+#            npm run lint -- --quiet
 
   test-app:
     <<: *defaults
@@ -266,19 +273,19 @@ jobs:
           name: Run Integration Tests
           command: npm run test:integration
 
-  dockerfile-lint:
-    <<: *defaults
-    docker:
-      - image: hadolint/hadolint:v1.6.6-6-g254b4ff
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Dockerfile Lint
-          command: |
-            hadolint Dockerfile
-
+#  dockerfile-lint:
+#    <<: *defaults
+#    docker:
+#      - image: hadolint/hadolint:v1.6.6-6-g254b4ff
+#    steps:
+#      - checkout
+#      - setup_remote_docker:
+#          docker_layer_caching: true
+#      - run:
+#          name: Dockerfile Lint
+#          command: |
+#            hadolint Dockerfile
+#
   snyk-security:
     <<: *defaults
     steps:
@@ -324,7 +331,7 @@ workflows:
   build_and_test:
     jobs:
       - build
-      - dockerfile-lint
+#      - dockerfile-lint
       - test-app:
           requires:
             - build
@@ -335,7 +342,10 @@ workflows:
       # - test-integration:
       #     requires:
       #       - build
-      - eslint:
+#      - eslint:
+#          requires:
+#            - build
+      - rc_linter/reactioncommerce_linters:
           requires:
             - build
       - docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v18
+  rc_linter: reactioncommerce/linter@0.0.1
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rc_linter: reactioncommerce/linter@dev:v4
+  rc_linter: reactioncommerce/linter@dev:v5
 
 # The following stanza defines a map named defaults with a variable that may be
 # inserted using the YAML merge (<<: *) key later in the file to save some
@@ -341,7 +341,8 @@ workflows:
 #      - eslint:
 #          requires:
 #            - build
-      - rc_linter/run_linters:
+      - rc_linter/dockerfile_lint
+      - rc_linter/eslint:
           requires:
             - build
       - docker-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,7 +325,8 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build:
+          context: reaction-build-cache-settings
 #      - dockerfile-lint
       - test-app:
           requires:

--- a/ecs-deploy-feature-branch.sh
+++ b/ecs-deploy-feature-branch.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+export ENVIRONMENT=staging
+export CLUSTER=core
+export CIRCLE_BRANCH=feat-gg-propel-changes
+# remove spaces from branch name
+export SERVICE_FEATURE=`echo $CIRCLE_BRANCH | sed 's/ //g'`
+export SERVICE1=reaction-core
+export CONTAINER1=core
+#export core_CIRCLE_SHA1=$CIRCLE_SHA1
+
+PROPEL_CONFIG_FILE="propel-feat.yaml"
+if [ ! -f ${PROPEL_CONFIG_FILE} ]; then
+	echo "Propel configuration file not found!"
+	exit 1
+fi
+
+if [ -z "${AWS_REGION}" ]; then
+        export AWS_REGION=us-west-2
+fi
+
+ENV_NAME_UPPERCASE=$(echo $ENVIRONMENT | awk '{print toupper($0)}')
+AWS_ACCESS_KEY_ID_VAR_NAME=CLOUDFORMATION_${ENV_NAME_UPPERCASE}_AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY_VAR_NAME=CLOUDFORMATION_${ENV_NAME_UPPERCASE}_AWS_SECRET_ACCESS_KEY
+
+if [ "${!AWS_ACCESS_KEY_ID_VAR_NAME}" ]; then
+	export AWS_ACCESS_KEY_ID=${!AWS_ACCESS_KEY_ID_VAR_NAME}
+fi
+
+if [ "${!AWS_SECRET_ACCESS_KEY_VAR_NAME}" ]; then
+	export AWS_SECRET_ACCESS_KEY=${!AWS_SECRET_ACCESS_KEY_VAR_NAME}
+fi
+
+RELEASE_DESCRIPTION="CircleCI build URL: ${CIRCLE_BUILD_URL}"
+
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE1 --container $CONTAINER1 --feature $SERVICE_FEATURE --overwrite
+
+propel param set ROOT_URL=https://${SERVICE1}-${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/ -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE1 --container $CONTAINER1 --feature $SERVICE_FEATURE --overwrite
+
+propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE1 --feature $SERVICE_FEATURE
+
+export SERVICE2=storefront-core
+export CONTAINER1=nginx
+export CONTAINER2=storefront
+
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER1 --feature $SERVICE_FEATURE --overwrite
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+
+propel param set CANONICAL_URL=https://${SERVICE2}-${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set OAUTH2_REDIRECT_URL=https://${SERVICE2}-${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/callback -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set OAUTH2_IDP_HOST_URL=https://${SERVICE1}-${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set EXTERNAL_GRAPHQL_URL=https://${SERVICE1}-${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set INTERNAL_GRAPHQL_URL=https://${SERVICE1}-${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+
+propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE2 --feature $SERVICE_FEATURE

--- a/propel-feat.yaml
+++ b/propel-feat.yaml
@@ -1,6 +1,5 @@
 services:
 - name: reaction-core
-  certificate_arn: arn:aws:acm:us-west-2:773713188930:certificate/c2979a7a-7b84-43ed-b3a7-24b0256a1b9f
   root_domain: staging.reactioncommerce.com
   dns_name: reaction-core
   desired_task_count: 2
@@ -21,7 +20,7 @@ services:
       - container_port: 3000
         host_port: 3000
       image: reactioncommerce/reaction
-      image_tag: release-2.0.0-rc.5
+      image_tag: release-2.0.0-rc.7
       env_params:
       - name: REACTION_AUTH
       - name: REACTION_EMAIL
@@ -31,27 +30,40 @@ services:
       - name: HYDRA_ADMIN_URL
       - name: HYDRA_OAUTH2_INTROSPECT_URL
       - name: SKIP_FIXTURES
-- name: storefront
-  certificate_arn: arn:aws:acm:us-west-2:773713188930:certificate/c2979a7a-7b84-43ed-b3a7-24b0256a1b9f
+      - name: CERTIFICATE_ARN
+- name: storefront-core
   root_domain: staging.reactioncommerce.com
   dns_name: storefront
   desired_task_count: 1
   min_task_count: 0
-  max_task_count: 8
+  max_task_count: 2
   min_healthy_percent: 100
   max_percent: 200
   alb_listener_port: 80
   alb_listener_path: /
-  alb_health_check_path: /
+  alb_health_check_path: /health
   task-definition:
-    name: staging-storefront
+    name: staging-storefront-core
     containers:
+    - name: nginx
+      cpu: 128
+      memory: 256
+      port_mappings:
+      - container_port: 8082
+        host_port: 8082
+      image: sportsdirect/nginx
+      image_tag: latest
+      links:
+      - storefront
+      env_params:
+      - name: PROXY_URL
+      - name: NGINX_LISTEN_PORT
+      - name: CERTIFICATE_ARN
     - name: storefront
       cpu: 500
       memory: 1800
       port_mappings:
       - container_port: 4000
-        host_port: 4000
       image: reactioncommerce/reaction-next-starterkit
       image_tag: develop
       env_params:
@@ -72,5 +84,9 @@ services:
       - name: OAUTH2_CLIENT_ID
       - name: OAUTH2_CLIENT_SECRET
       - name: OAUTH2_REDIRECT_URL
-      - name: PASSPORT_SESSION_SECRET
+      - name: OAUTH2_HOST
+      - name: OAUTH2_ADMIN_PORT
+      - name: HYDRA_ADMIN_URL
+      - name: SESSION_SECRET
+      - name: SESSION_MAX_AGE_MS
       - name: CANONICAL_URL

--- a/propel-feat.yaml
+++ b/propel-feat.yaml
@@ -14,7 +14,7 @@ services:
     name: staging-core
     containers:
     - name: core
-      cpu: 500
+      cpu: 510
       memory: 1800
       port_mappings:
       - container_port: 3000

--- a/propel.yaml
+++ b/propel.yaml
@@ -1,6 +1,5 @@
 services:
 - name: reaction-core
-  certificate_arn: arn:aws:acm:us-west-2:773713188930:certificate/c2979a7a-7b84-43ed-b3a7-24b0256a1b9f
   root_domain: staging.reactioncommerce.com
   dns_name: reaction-core
   desired_task_count: 2
@@ -21,7 +20,7 @@ services:
       - container_port: 3000
         host_port: 3000
       image: reactioncommerce/reaction
-      image_tag: release-2.0.0-rc.5
+      image_tag: release-2.0.0-rc.7
       env_params:
       - name: REACTION_AUTH
       - name: REACTION_EMAIL
@@ -31,3 +30,4 @@ services:
       - name: HYDRA_ADMIN_URL
       - name: HYDRA_OAUTH2_INTROSPECT_URL
       - name: SKIP_FIXTURES
+      - name: CERTIFICATE_ARN


### PR DESCRIPTION
Type: **feature**

## Issue
We would like to deploy feature branches to their own new services in ECS, so that changes can be tested by hitting a specific URL.

## Solution
A new service based on the current code is created and deployed to ECS. The service is called reaction-core-FEATURE-BRANCH-NAME.

A service for the storefront based on the reaction-next-starterkit master branch is also created and deployed to ECS. The service is called storefront-FEATURE-BRANCH-NAME.

## Testing
1. Perform functional testing at https://reaction-core-FEATURE-BRANCH-NAME.feat.reactioncommerce.com and https://storefront-FEATURE-BRANCH-NAME.feat.reactioncommerce.com
