### PR TITLE
Deploy feature branches to ECS

### DIFF
--- a/.circleci/bin/ecs-deploy-feature-branch.sh
+++ b/.circleci/bin/ecs-deploy-feature-branch.sh
@@ -3,11 +3,12 @@
 sudo apt-get -y install python3-pip wget
 sudo pip3 install awscli
 
-export ENVIRONMENT=feat
+export ENVIRONMENT=staging
 export CLUSTER=core
-export SERVICE_SUFFIX=$CIRCLE_BRANCH
-export SERVICE1=reaction-core
-export CONTAINER1=core
+# remove spaces from branch name
+export SERVICE_FEATURE=`echo $CIRCLE_BRANCH | sed 's/ //g'`
+export SERVICE=reaction-core
+export CONTAINER=core
 export core_CIRCLE_SHA1=$CIRCLE_SHA1
 
 PROPEL_CONFIG_FILE="propel-feat.yaml"
@@ -39,16 +40,24 @@ sudo mv propel /usr/local/bin/propel
 sudo chmod +x /usr/local/bin/propel
 
 RELEASE_DESCRIPTION="CircleCI build URL: ${CIRCLE_BUILD_URL}"
-propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE1 --container $CONTAINER1 --suffix $SERVICE_SUFFIX --overwrite
-propel param set ROOT_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com/ -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE1 --container $CONTAINER1 --suffix $SERVICE_SUFFIX --overwrite
-propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE1 --suffix $SERVICE_SUFFIX
 
-export SERVICE2=storefront
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER --feature $SERVICE_FEATURE --overwrite
+
+propel param set ROOT_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/ -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER --feature $SERVICE_FEATURE --overwrite
+
+propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE --feature $SERVICE_FEATURE
+
+export SERVICE=storefront
+export CONTAINER1=nginx
 export CONTAINER2=storefront
-propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set CANONICAL_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set OAUTH2_REDIRECT_URL=https://${SERVICE2}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com/callback -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set OAUTH2_IDP_HOST_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set EXTERNAL_GRAPHQL_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel param set INTERNAL_GRAPHQL_URL=https://${SERVICE1}-${SERVICE_SUFFIX}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE2 --container $CONTAINER2 --suffix $SERVICE_SUFFIX --overwrite
-propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE2 --suffix $SERVICE_SUFFIX
+
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER1 --feature $SERVICE_FEATURE --overwrite
+propel param copy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+
+propel param set CANONICAL_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set OAUTH2_REDIRECT_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/callback -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set OAUTH2_IDP_HOST_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set EXTERNAL_GRAPHQL_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+propel param set INTERNAL_GRAPHQL_URL=https://${SERVICE_FEATURE}.$ENVIRONMENT.reactioncommerce.com/graphql-alpha -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --service $SERVICE --container $CONTAINER2 --feature $SERVICE_FEATURE --overwrite
+
+propel release create --deploy -f ${PROPEL_CONFIG_FILE} --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --service $SERVICE --feature $SERVICE_FEATURE

--- a/.circleci/bin/ecs-deploy-release-branch.sh
+++ b/.circleci/bin/ecs-deploy-release-branch.sh
@@ -37,5 +37,5 @@ sudo mv propel /usr/local/bin/propel
 sudo chmod +x /usr/local/bin/propel
 
 RELEASE_DESCRIPTION="CircleCI build URL: ${CIRCLE_BUILD_URL}"
-echo Running propel release create --deploy --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --verbose
-propel release create --deploy --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --verbose
+echo Running propel release create --deploy --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}"
+propel release create --deploy --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}"

--- a/.circleci/bin/ecs-deploy-release-branch.sh
+++ b/.circleci/bin/ecs-deploy-release-branch.sh
@@ -6,6 +6,7 @@ sudo pip3 install awscli
 export ENVIRONMENT=staging
 export CLUSTER=core
 export core_CIRCLE_SHA1=$CIRCLE_SHA1
+echo core_CIRCLE_SHA1=${core_CIRCLE_SHA1}
 
 PROPEL_CONFIG_FILE="propel.yaml"
 if [ ! -f ${PROPEL_CONFIG_FILE} ]; then
@@ -36,4 +37,5 @@ sudo mv propel /usr/local/bin/propel
 sudo chmod +x /usr/local/bin/propel
 
 RELEASE_DESCRIPTION="CircleCI build URL: ${CIRCLE_BUILD_URL}"
-propel release create --deploy --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" 
+echo Running propel release create --deploy --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --verbose
+propel release create --deploy --env $ENVIRONMENT --cluster $CLUSTER --descr "${RELEASE_DESCRIPTION}" --verbose

--- a/propel-feat.yaml
+++ b/propel-feat.yaml
@@ -1,6 +1,5 @@
 services:
 - name: reaction-core
-  certificate_arn: arn:aws:acm:us-west-2:773713188930:certificate/c2979a7a-7b84-43ed-b3a7-24b0256a1b9f
   root_domain: staging.reactioncommerce.com
   dns_name: reaction-core
   desired_task_count: 2
@@ -21,7 +20,7 @@ services:
       - container_port: 3000
         host_port: 3000
       image: reactioncommerce/reaction
-      image_tag: release-2.0.0-rc.5
+      image_tag: release-2.0.0-rc.7
       env_params:
       - name: REACTION_AUTH
       - name: REACTION_EMAIL
@@ -31,27 +30,40 @@ services:
       - name: HYDRA_ADMIN_URL
       - name: HYDRA_OAUTH2_INTROSPECT_URL
       - name: SKIP_FIXTURES
-- name: storefront
-  certificate_arn: arn:aws:acm:us-west-2:773713188930:certificate/c2979a7a-7b84-43ed-b3a7-24b0256a1b9f
+      - name: CERTIFICATE_ARN
+- name: storefront-core
   root_domain: staging.reactioncommerce.com
   dns_name: storefront
   desired_task_count: 1
   min_task_count: 0
-  max_task_count: 8
+  max_task_count: 2
   min_healthy_percent: 100
   max_percent: 200
   alb_listener_port: 80
   alb_listener_path: /
-  alb_health_check_path: /
+  alb_health_check_path: /health
   task-definition:
-    name: staging-storefront
+    name: staging-storefront-core
     containers:
+    - name: nginx
+      cpu: 128
+      memory: 256
+      port_mappings:
+      - container_port: 8082
+        host_port: 8082
+      image: sportsdirect/nginx
+      image_tag: latest
+      links:
+      - storefront
+      env_params:
+      - name: PROXY_URL
+      - name: NGINX_LISTEN_PORT
+      - name: CERTIFICATE_ARN
     - name: storefront
       cpu: 500
       memory: 1800
       port_mappings:
       - container_port: 4000
-        host_port: 4000
       image: reactioncommerce/reaction-next-starterkit
       image_tag: develop
       env_params:
@@ -72,5 +84,9 @@ services:
       - name: OAUTH2_CLIENT_ID
       - name: OAUTH2_CLIENT_SECRET
       - name: OAUTH2_REDIRECT_URL
-      - name: PASSPORT_SESSION_SECRET
+      - name: OAUTH2_HOST
+      - name: OAUTH2_ADMIN_PORT
+      - name: HYDRA_ADMIN_URL
+      - name: SESSION_SECRET
+      - name: SESSION_MAX_AGE_MS
       - name: CANONICAL_URL

--- a/propel-feat.yaml
+++ b/propel-feat.yaml
@@ -51,8 +51,8 @@ services:
       port_mappings:
       - container_port: 8082
         host_port: 8082
-      image: sportsdirect/nginx
-      image_tag: latest
+      image: reactioncommerce/reaction-nginx
+      image_tag: storefront
       links:
       - storefront
       env_params:

--- a/propel.yaml
+++ b/propel.yaml
@@ -1,6 +1,5 @@
 services:
 - name: reaction-core
-  certificate_arn: arn:aws:acm:us-west-2:773713188930:certificate/c2979a7a-7b84-43ed-b3a7-24b0256a1b9f
   root_domain: staging.reactioncommerce.com
   dns_name: reaction-core
   desired_task_count: 2
@@ -21,7 +20,7 @@ services:
       - container_port: 3000
         host_port: 3000
       image: reactioncommerce/reaction
-      image_tag: release-2.0.0-rc.5
+      image_tag: release-2.0.0-rc.7
       env_params:
       - name: REACTION_AUTH
       - name: REACTION_EMAIL
@@ -31,3 +30,4 @@ services:
       - name: HYDRA_ADMIN_URL
       - name: HYDRA_OAUTH2_INTROSPECT_URL
       - name: SKIP_FIXTURES
+      - name: CERTIFICATE_ARN


### PR DESCRIPTION
Type: **feature**

## Issue
We would like to deploy feature branches to their own new services in ECS, so that changes can be tested by hitting a specific URL.

## Solution
A new service based on the current code is created and deployed to ECS. The service is called reaction-core-FEATURE-BRANCH-NAME.

A service for the storefront based on the reaction-next-starterkit master branch is also created and deployed to ECS. The service is called storefront-FEATURE-BRANCH-NAME.

## Testing
1. Perform functional testing at https://reaction-core-FEATURE-BRANCH-NAME.feat.reactioncommerce.com and https://storefront-FEATURE-BRANCH-NAME.feat.reactioncommerce.com
