### PR TITLE
[WIP] - Use base image directly in dev docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM reactioncommerce/base:v1.8-meteor as builder
 
 COPY --chown=node . $APP_SOURCE_DIR
 
+RUN meteor npm install
+
 RUN printf "\\n[-] Running Reaction plugin loader...\\n" \
  && reaction plugins load
 RUN printf "\\n[-] Building Meteor application...\\n" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,9 @@
 ##############################################################################
-# meteor-dev stage - builds image for dev and used with docker-compose.yml
-##############################################################################
-FROM reactioncommerce/base:v1.8-meteor as meteor-dev
-
-LABEL maintainer="Reaction Commerce <architecture@reactioncommerce.com>"
-
-ENV PATH $PATH:/home/node/.meteor:$APP_SOURCE_DIR/node_modules/.bin
-
-COPY --chown=node package-lock.json $APP_SOURCE_DIR/
-COPY --chown=node package.json $APP_SOURCE_DIR/
-
-# Because Docker Compose uses a named volume for node_modules and named volumes are owned
-# by root by default, we have to initially create node_modules here with correct owner.
-# Without this NPM cannot write packages into node_modules later, when running in a container.
-RUN mkdir "$APP_SOURCE_DIR/node_modules" && chown node "$APP_SOURCE_DIR/node_modules"
-
-RUN meteor npm install
-
-COPY --chown=node . $APP_SOURCE_DIR
-
-
-##############################################################################
 # builder stage - builds the production bundle
 ##############################################################################
-FROM meteor-dev as builder
+FROM reactioncommerce/base:v1.8-meteor as builder
+
+COPY --chown=node . $APP_SOURCE_DIR
 
 RUN printf "\\n[-] Running Reaction plugin loader...\\n" \
  && reaction plugins load

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,7 @@ networks:
 services:
 
   reaction:
-    build:
-      context: .
-      target: meteor-dev
+    image: reactioncommerce/base:v1.8-meteor-dev
     command: bash -c "meteor npm install && node ./.reaction/waitForMongo.js && reaction"
     depends_on:
       - mongo


### PR DESCRIPTION
Resolves #4770  
Impact: **minor**  
Type: **chore**

## Issue
#4770 

## Solution
- Update reactionbase/base reactioncommerce/base#38
- Use new image in docker-compose.yml

## Breaking changes
N/A


## Testing
- Confirm that starting the app in docker works in dev
- Confirm that building an image from the Dockerfile works (this is already confirmed in the CI step https://circleci.com/gh/reactioncommerce/reaction/33891).
