### PR TITLE
feat(tag): add Display Title to Tag

### DIFF
--- a/imports/collections/schemas/tags.js
+++ b/imports/collections/schemas/tags.js
@@ -84,6 +84,10 @@ export const Tag = new SimpleSchema({
   "heroMediaUrl": {
     type: String,
     optional: true
+  },
+  "displayTitle": {
+    type: String,
+    optional: true
   }
 });
 

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -39,8 +39,11 @@ type Tag implements Node & Deletable {
   "The date and time at which this tag was last updated"
   updatedAt: DateTime!
 
-  "A string containing the hero image url for a tag landing page"
+  "A string containing the hero image url for a tag listing page"
   heroMediaUrl: String
+
+  "A string of the title to be displayed on a tag listing page"
+  displayTitle: String
 }
 
 "The fields by which you are allowed to sort any query that returns a `TagConnection`"


### PR DESCRIPTION
Resolves #4843 
Impact: **minor**  
Type: **feature**

## Issue
- An admin needs to be able to add a custom Display Title for a Tag, to be displayed on the Tag's Listing Page
- Required for https://github.com/reactioncommerce/reaction-next-starterkit/pull/450 in storefront

## Solution
- Add `displayTitle` to Tag schema, Tag GraphQL query
- A `displayTitle` is an optional string on `Tag`.

## Breaking changes
none

## Testing
1. Add a `displayTitle` to a Tag in the database
2. Check the Tag data GraphiQL

<img width="1062" alt="screen shot 2018-12-06 at 2 50 16 pm" src="https://user-images.githubusercontent.com/3673236/49616654-661da780-f966-11e8-9385-7363b0caf31f.png">

Tested with Starter-Kit: https://github.com/reactioncommerce/reaction-next-starterkit/pull/450

<img width="1440" alt="screen shot 2018-12-06 at 2 50 08 pm" src="https://user-
images.githubusercontent.com/3673236/49616660-67e76b00-f966-11e8-9665-60aa870e5a8d.png">

Test with GraphiQL:
<img width="1089" alt="screen shot 2018-12-06 at 2 56 03 pm" src="https://user-images.githubusercontent.com/3673236/49616872-168bab80-f967-11e8-8538-edc28c46c467.png">

