### PR TITLE
fix: Add migration file for plugin route name change

### DIFF
--- a/imports/plugins/core/versions/server/migrations/49_update_idp_route_name_to_match_pattern.js
+++ b/imports/plugins/core/versions/server/migrations/49_update_idp_route_name_to_match_pattern.js
@@ -1,0 +1,38 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Packages } from "/lib/collections";
+
+/**
+ * Previously, Hydra plugin's first route defined the name field as "OAuth Login", this changed in rc.8
+ * to "account/login to match defined plugin conventions across the app". This migration updates existing document(s) for the route to match the update.
+ */
+Migrations.add({
+  version: 49,
+
+  up() {
+    Packages.update(
+      {
+        name: "reaction-hydra-oauth"
+      },
+      {
+        $set: {
+          "registry.0.name": "account/login"
+        }
+      },
+      { bypassCollection2: true, multi: true }
+    );
+  },
+
+  down() {
+    Packages.update(
+      {
+        name: "reaction-hydra-oauth"
+      },
+      {
+        $set: {
+          "registry.0.name": "OAuth Login"
+        }
+      },
+      { bypassCollection2: true, multi: true }
+    );
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -47,3 +47,4 @@ import "./45_tax_schema_changes";
 import "./46_cart_item_props";
 import "./47_order_ref";
 import "./48_catalog_variant_inventory";
+import "./49_update_idp_route_name_to_match_pattern";


### PR DESCRIPTION
Fixup: #4835    
Impact: **major**
Type: **fix**

## Change
PR #4794 changed Hydra plugin's first route's name field from "OAuth Login" to "account/login to match plugin patterns/conventions across the app". This migration updates existing document(s) for the route to match the update.

## Testing
Testing this requires switching branches and reseting the DB. So test this when about to make coffee or tea . 

- Checkout your local reaction core code to rc-7. The 404 Login issue existed as at that release. You can do this with `git checkout tags/v2.0.0-rc.7`.
- Start with a fresh DB for this checked out tag. You can `docker-compose down -v` to remove existing DB data then `docker-compose up` after that. You can also point this to a new/separate DB if that's better.
- Once the app starts, try a log in from the storefront, you should see the 404 problem (better done in incognito)
- Then switch your reaction core branch to this one `fixup-4794-impactmass-migrate-plugin-name`, and restart the app
- One the app restarts, try a log in from the storefront app, and confirm login is good