### PR TITLE
Fix permission issues with Meteor methods for Accounts plugin

### DIFF
--- a/imports/plugins/core/accounts/server/methods/addressBookRemove.js
+++ b/imports/plugins/core/accounts/server/methods/addressBookRemove.js
@@ -16,16 +16,16 @@ import ReactionError from "@reactioncommerce/reaction-error";
 export default function addressBookRemove(addressId, accountUserId) {
   check(addressId, String);
   check(accountUserId, Match.Optional(String));
-
-  if (typeof accountUserId === "string") {
-    if (Reaction.getUserId() !== accountUserId && !Reaction.hasPermission("reaction-accounts")) {
-      throw new ReactionError("access-denied", "Access denied");
-    }
-  }
   this.unblock();
 
-  const userId = accountUserId || Reaction.getUserId();
+  const authUserId = Reaction.getUserId();
+  const userId = accountUserId || authUserId;
   const account = Accounts.findOne({ userId });
+  if (!account) throw new ReactionError("not-found", "Not Found");
+
+  if (authUserId !== userId && !Reaction.hasPermission("reaction-accounts", authUserId, account.shopId)) {
+    throw new ReactionError("access-denied", "Access denied");
+  }
 
   const updatedAccountResult = Accounts.update({
     userId,

--- a/imports/plugins/core/accounts/server/methods/index.js
+++ b/imports/plugins/core/accounts/server/methods/index.js
@@ -12,7 +12,6 @@ import markAddressValidationBypassed from "./markAddressValidationBypassed";
 import removeEmailAddress from "./removeEmailAddress";
 import removeUserPermissions from "./removeUserPermissions";
 import sendResetPasswordEmail from "./sendResetPasswordEmail";
-import sendWelcomeEmail from "./sendWelcomeEmail";
 import setProfileCurrency from "./setProfileCurrency";
 import setUserPermissions from "./setUserPermissions";
 import updateEmailAddress from "./updateEmailAddress";
@@ -47,7 +46,6 @@ export default {
   "accounts/removeEmailAddress": removeEmailAddress,
   "accounts/removeUserPermissions": removeUserPermissions,
   "accounts/sendResetPasswordEmail": sendResetPasswordEmail,
-  "accounts/sendWelcomeEmail": sendWelcomeEmail,
   "accounts/setProfileCurrency": setProfileCurrency,
   "accounts/setUserPermissions": setUserPermissions,
   "accounts/updateEmailAddress": updateEmailAddress,

--- a/imports/plugins/core/accounts/server/util/sendWelcomeEmail.js
+++ b/imports/plugins/core/accounts/server/util/sendWelcomeEmail.js
@@ -8,9 +8,8 @@ import { Accounts, Shops } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
- * @name accounts/sendWelcomeEmail
+ * @name sendWelcomeEmail
  * @summary Send an email to consumers on sign up
- * @memberof Accounts/Methods
  * @method
  * @param {String} shopId - shopId of new User
  * @param {String} userId - new userId to welcome
@@ -22,15 +21,13 @@ export default function sendWelcomeEmail(shopId, userId, token) {
   check(userId, String);
   check(token, String);
 
-  this.unblock();
-
-  const account = Accounts.findOne(userId);
+  const account = Accounts.findOne({ userId });
   // anonymous users aren't welcome here
   if (!account.emails || !account.emails.length > 0) {
     return false;
   }
 
-  const shop = Shops.findOne(shopId);
+  const shop = Shops.findOne({ _id: shopId });
 
   // Get shop logo, if available. If not, use default logo from file-system
   const emailLogo = Reaction.Email.getShopLogo(shop);

--- a/imports/plugins/core/core/server/startup/accounts.js
+++ b/imports/plugins/core/core/server/startup/accounts.js
@@ -7,6 +7,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
 import { Accounts } from "meteor/accounts-base";
 import * as Collections from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
+import sendWelcomeEmail from "/imports/plugins/core/accounts/server/util/sendWelcomeEmail";
 
 /**
  * @summary Account server startup code
@@ -167,7 +168,7 @@ export default function startup() {
       if (userDetails.emails && userDetails.emails.length > 0
         && (!(Meteor.users.find().count() === 0) && !userDetails.profile.invited)) {
         const token = Random.secret();
-        Meteor.call("accounts/sendWelcomeEmail", shopId, user._id, token);
+        sendWelcomeEmail(shopId, user._id, token);
         const defaultEmail = userDetails.emails.find((email) => email.provides === "default");
         const when = new Date();
         const tokenObj = {


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
- "accounts/addressBookRemove" Meteor method did not correctly check permissions on multi-shop installations. By having "reaction-accounts" permission on any shop, you could update accounts belonging to any other shop.
- "accounts/addressBookUpdate" Meteor method did not correctly check permissions on multi-shop installations. By having "reaction-accounts" permission on any shop, you could update accounts belonging to any other shop.
- "accounts/sendWelcomeEmail" Meteor method did not check permissions. Any user (possibly even someone who isn't logged in) who knows a MongoDB shop ID and account ID could cause a welcome email to be sent to that account's email address.

## Solution
- Added `account.shopId` to permission check in "accounts/addressBookRemove"
- Added `account.shopId` to permission check in "accounts/addressBookUpdate"
- Removed the "accounts/sendWelcomeEmail" Meteor method and instead put the same code in an internal `sendWelcomeEmail` util function that is only callable from server code.

## Breaking changes
Custom code relying on being able to call the "accounts/sendWelcomeEmail" Meteor method will break. Calls from client code must be removed. Calls from server code should be updated to import and call the `util` function.

## Testing
1. Verify that the described permission issues are fixed.
1. Verify that you can still change your own address and remove an address from your address book.
1. Verify that a welcome email is sent when you register a new user.