### PR TITLE
feat(tags): A Tag can be active or inactive.

### DIFF
--- a/imports/collections/schemas/tags.js
+++ b/imports/collections/schemas/tags.js
@@ -91,7 +91,7 @@ export const Tag = new SimpleSchema({
   },
   "isActive": {
     type: Boolean,
-    optional: true
+    optional: false
   }
 });
 

--- a/imports/collections/schemas/tags.js
+++ b/imports/collections/schemas/tags.js
@@ -89,7 +89,7 @@ export const Tag = new SimpleSchema({
     type: String,
     optional: true
   },
-  "active": {
+  "isActive": {
     type: Boolean,
     optional: true
   }

--- a/imports/collections/schemas/tags.js
+++ b/imports/collections/schemas/tags.js
@@ -88,6 +88,10 @@ export const Tag = new SimpleSchema({
   "displayTitle": {
     type: String,
     optional: true
+  },
+  "active": {
+    type: Boolean,
+    optional: true
   }
 });
 

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -1087,7 +1087,8 @@ Meteor.methods({
 
     const newTag = {
       slug: Reaction.getSlug(tagName),
-      name: tagName
+      name: tagName,
+      isActive: true
     };
 
     const existingTag = Tags.findOne({

--- a/imports/plugins/core/core/server/fixtures/products.js
+++ b/imports/plugins/core/core/server/fixtures/products.js
@@ -156,6 +156,7 @@ export default function () {
    * @property {String} name - `"Tag"`
    * @property {String} slug - `"tag"`
    * @property {Number} position - `_.random(0, 100000)`
+   * @property {Boolean} isActive - `true`
    * @property {Boolean} isTopLevel - `true`
    * @property {String} shopId - `getShop()._id`
    * @property {Date} createdAt - `faker.date.past()`
@@ -166,6 +167,7 @@ export default function () {
     slug: "tag",
     position: _.random(0, 100000),
     //  relatedTagIds: [],
+    isActive: true,
     isTopLevel: true,
     shopId: getShop()._id,
     createdAt: faker.date.past(),

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -44,6 +44,9 @@ type Tag implements Node & Deletable {
 
   "A string of the title to be displayed on a tag listing page"
   displayTitle: String
+
+  "If `true`, the tag's tag listing page will be available to be viewed by the public"
+  active: Boolean
 }
 
 "The fields by which you are allowed to sort any query that returns a `TagConnection`"

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -46,7 +46,7 @@ type Tag implements Node & Deletable {
   displayTitle: String
 
   "If `true`, the tag's tag listing page will be available to be viewed by the public"
-  active: Boolean
+  isActive: Boolean
 }
 
 "The fields by which you are allowed to sort any query that returns a `TagConnection`"

--- a/imports/plugins/core/versions/server/migrations/50_set_tags_isactive_to_true.js
+++ b/imports/plugins/core/versions/server/migrations/50_set_tags_isactive_to_true.js
@@ -14,7 +14,7 @@ Migrations.add({
         isActive: true
       }
     }, {
-      multi: true 
+      multi: true
     });
   },
   down() {
@@ -23,7 +23,7 @@ Migrations.add({
         isActive: ""
       }
     }, {
-      multi: true 
+      multi: true
     });
   }
 });

--- a/imports/plugins/core/versions/server/migrations/50_set_tags_isactive_to_true.js
+++ b/imports/plugins/core/versions/server/migrations/50_set_tags_isactive_to_true.js
@@ -1,0 +1,30 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Tags } from "/lib/collections";
+
+/**
+ * @file
+ * Sets isActive on all existing Tags to true
+ */
+
+Migrations.add({
+  version: 50,
+  up() {
+    Tags.rawCollection().update({}, {
+      $set: {
+        isActive: true
+      }
+    }, {
+      multi: true 
+    });
+  },
+  down() {
+    Tags.rawCollection().update({}, {
+      $set: {
+        isActive: ""
+      }
+    }, {
+      multi: true 
+    });
+  }
+});
+

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -48,3 +48,4 @@ import "./46_cart_item_props";
 import "./47_order_ref";
 import "./48_catalog_variant_inventory";
 import "./49_update_idp_route_name_to_match_pattern";
+import "./50_set_tags_isactive_to_true";


### PR DESCRIPTION
Resolves #4848   
Impact: **minor**  
Type: **feature**

## Issue
An admin needs a way to make a Tag's Tag Listing Page hidden from the public. A Tag's `isActive` boolean field will allow an admin to mark a Tag Listing Page (TLP) as active, to be viewable to the public, or inactive, hidden from the public.

## Solution
- Adds a new `isActive` field: A Tag's `active` boolean field will allow an admin to mark a Tag as `true` or `false`:
- `isActive = true` - _active_
- `isActive = false` - _hidden_

Currently, the Tag's `isActive` field is not used in any logic. 

After this PR is merged, the Storefront Starter-Kit will be modified to only display TLP if the Tag's `isActive` field is set to `true`, and if a Tag has `isActive` set to `false`, the TLP will be removed from the site map and will not render.

## Database changes

- Migration: All legacy Tags will be migrated to have `isActive` set to `true`.

I've tested the migration locally:
<img width="1159" alt="screen shot 2018-12-12 at 3 15 20 pm" src="https://user-images.githubusercontent.com/3673236/49904992-fc4b4500-fe20-11e8-88ab-841f7fd6eb84.png">
<img width="1185" alt="screen shot 2018-12-12 at 3 15 15 pm" src="https://user-images.githubusercontent.com/3673236/49904994-fce3db80-fe20-11e8-8afd-d4114decc91f.png">

## Breaking changes / Questions
* How does this affect Tag Listing Pages (TLP) that are part of the Navigation? Or should it not be related at all to NavBuilder logic? @dancastellon 

## Testing
1. Test the migration: Test that all Tags have `isActive` set
2. Test that a Tag can be set to `isActive`