### PR TITLE
Configure prettier arrowParens to match our eslint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,6 +394,9 @@
       "jsx-a11y/label-has-for": "off"
     }
   },
+  "prettier": {
+    "arrowParens": "always"
+  },
   "nodemonConfig": {
     "delay": "2000",
     "execMap": {


### PR DESCRIPTION

Impact: **minor**  
Type: **chore**

## Issue
There's one small discrepancy between our defined eslint rules and our (default, it seems) prettier config. eslint wants arrow function arguments always wrapped in parentheses, whereas prettier omits them for single-argument arrow functions.

What this means is if you autoformat your source code with prettier, sometimes it will fail eslint due to this discrepancy.

## Solution
Add prettier config to package.json to always wrap arrow function arguments in parens.

## Breaking changes
None

## Testing
Mostly N/A as this is a tooling issue, but if we start seeing lint errors after running prettier, let me know.