### PR TITLE
chore : e2e integration for release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,12 +355,12 @@ workflows:
          #  filters:
          #   branches:
          #     only: /^release-2.*/
-      - deploy-to-ecs-feature-branch:
-          requires:
-            - docker-push
-          filters:
-            branches:
-              only: /^feat.*/
+      # - deploy-to-ecs-feature-branch:
+      #     requires:
+      #       - docker-push
+      #     filters:
+      #       branches:
+      #         only: /^feat.*/
       - deploy-docs:
           requires:
             - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            docker run -t -e URL=https://reaction-core.staging.reactioncommerce.com/ reactioncommerce/reaction-automation-client:latest yarn test
+            docker run -t -e URL=https://reaction-core.staging.reactioncommerce.com/ reactioncommerce/reaction-automation-client:latest npm run-script chrome
 
   dockerfile-lint:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,9 +358,9 @@ workflows:
       - deploy-to-ecs-feature-branch:
           requires:
             - docker-push
-         filters:
-           branches:
-           only: /^feat.*/
+          filters:
+            branches:
+              only: /^feat.*/
       - deploy-docs:
           requires:
             - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,18 @@ jobs:
           name: Run Integration Tests
           command: npm run test:integration
 
+  test-e2e:
+    <<: *defaults
+    docker:
+      - image: reactioncommerce/reaction-automation-client:latest
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Run Tests
+          command: |
+            docker run -d -t -i -e URL=https://reaction-core.staging.reactioncommerce.com/ reactioncommerce/reaction-automation-client:latest yarn test
+
   dockerfile-lint:
     <<: *defaults
     docker:
@@ -265,7 +277,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Dockerfile Lint
-          command: |
+          command: | 
             hadolint Dockerfile
 
   snyk-security:
@@ -323,6 +335,9 @@ workflows:
       - test-integration:
           requires:
             - build
+      - test-e2e:
+	  requires:
+            - deploy-to-ecs-release-branch
       - eslint:
           requires:
             - build
@@ -337,15 +352,15 @@ workflows:
       - deploy-to-ecs-release-branch:
           requires:
             - docker-push
-          filters:
-            branches:
-              only: /^release-2.*/
+         #  filters:
+         #   branches:
+         #     only: /^release-2.*/
       - deploy-to-ecs-feature-branch:
           requires:
             - docker-push
-          filters:
-            branches:
-              only: /^feat.*/
+         # filters:
+         #   branches:
+         #   only: /^feat.*/
       - deploy-docs:
           requires:
             - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            docker run -d -t -i -e URL=https://reaction-core.staging.reactioncommerce.com/ reactioncommerce/reaction-automation-client:latest yarn test
+            docker run -t -e URL=https://reaction-core.staging.reactioncommerce.com/ reactioncommerce/reaction-automation-client:latest yarn test
 
   dockerfile-lint:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,9 +358,9 @@ workflows:
       - deploy-to-ecs-feature-branch:
           requires:
             - docker-push
-         # filters:
-         #   branches:
-         #   only: /^feat.*/
+         filters:
+           branches:
+           only: /^feat.*/
       - deploy-docs:
           requires:
             - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ workflows:
           requires:
             - build
       - test-e2e:
-	  requires:
+          requires:
             - deploy-to-ecs-release-branch
       - eslint:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,9 +352,9 @@ workflows:
       - deploy-to-ecs-release-branch:
           requires:
             - docker-push
-         #  filters:
-         #   branches:
-         #     only: /^release-2.*/
+          filters:
+            branches:
+              only: /^release-2.*/
       # - deploy-to-ecs-feature-branch:
       #     requires:
       #       - docker-push


### PR DESCRIPTION
Resolves : https://github.com/reactioncommerce/automation-reaction-client/issues/28
Impact: **minor**  
Type: **chore**

## Issue
- End to End tests were run locally on a machine for testing purposes, no integration within the CI workflow. 
- Feature branch deployments are not working as they are supposed to, disable until fixed.

## Solution
- Dockerize Reaction Automation Client properly
- Integrate after successful deploy to a release environment at the very end
- Execute tests

## Testing
1. Run through CI process (takes 30~ minutes)

Sample Successful Run: 
https://circleci.com/gh/reactioncommerce/reaction/34548