### PR TITLE
feat(#4848) - Return only isVisible Tags, unless admin

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/queries/tag.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tag.js
@@ -14,23 +14,23 @@ export default async function tag(context, slugOrId, { shouldIncludeInvisible = 
   let query = {
     $and: [
       { isVisible: true },
-      { $or: [{ _id: slugOrId }, { slug: slugOrId } ]}
+      { $or: [{ _id: slugOrId }, { slug: slugOrId }] }
     ]
-  }
+  };
 
   if (userHasPermission(["owner", "admin"], contextShopId)) {
-    if (shouldIncludeInvisible == true) {
-      query = { 
+    if (shouldIncludeInvisible === true) {
+      query = {
         $and: [
           { isVisible: { $in: [false, true] } },
-          { $or: [{ _id: slugOrId }, { slug: slugOrId } ]}
+          { $or: [{ _id: slugOrId }, { slug: slugOrId }] }
         ]
       };
     } else {
-      query
+      query;
     }
   } else {
-    query
+    query;
   }
 
   return Tags.findOne(query);

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tag.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tag.js
@@ -5,18 +5,33 @@
  * @summary query the Tags collection and return a tag by tag ID or slug
  * @param {Object} context - an object containing the per-request state
  * @param {String} slugOrId - ID or slug of tag to query
+ * @param {Boolean} [params.shouldIncludeInvisible] - Whether or not to include `isVisible=true` tags. Default is `false`
  * @return {Object} - A Tag document if one was found
  */
-export default async function tag(context, slugOrId) {
-  const { collections } = context;
-
+export default async function tag(context, slugOrId, { shouldIncludeInvisible = false } = {}) {
+  const { collections, shopId: contextShopId, userHasPermission } = context;
   const { Tags } = collections;
-  const query = {
-    $or: [
-      { _id: slugOrId },
-      { slug: slugOrId }
+  let query = {
+    $and: [
+      { isVisible: true },
+      { $or: [{ _id: slugOrId }, { slug: slugOrId } ]}
     ]
-  };
+  }
+
+  if (userHasPermission(["owner", "admin"], contextShopId)) {
+    if (shouldIncludeInvisible == true) {
+      query = { 
+        $and: [
+          { isVisible: { $in: [false, true] } },
+          { $or: [{ _id: slugOrId }, { slug: slugOrId } ]}
+        ]
+      };
+    } else {
+      query
+    }
+  } else {
+    query
+  }
 
   return Tags.findOne(query);
 }

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -8,9 +8,10 @@
  * @param {Object} [params] - Additional options for the query
  * @param {Boolean} [params.isTopLevel] - If set, look for `isTopLevel` matching this value
  * @param {Boolean} [params.shouldIncludeDeleted] - Whether or not to include `isDeleted=true` tags. Default is `false`
+ * @param {Boolean} [params.shouldIncludeInvisible] - Whether or not to include `isVisible=false` tags.  Default is `false`.
  * @return {Promise<MongoCursor>} - A MongoDB cursor for the proper query
  */
-export default async function tags(context, shopId, { shouldIncludeDeleted = false, isTopLevel } = {}) {
+export default async function tags(context, shopId, { shouldIncludeDeleted = false, isTopLevel, shouldIncludeInvisible = false } = {}) {
   const { collections } = context;
 
   const { Tags } = collections;
@@ -18,6 +19,7 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
 
   if (isTopLevel === false || isTopLevel === true) query.isTopLevel = isTopLevel;
   if (shouldIncludeDeleted !== true) query.isDeleted = { $ne: true };
+  if (shouldIncludeInvisible !== true) query.isVisible = { $ne: false};
 
   return Tags.find(query);
 }

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -20,21 +20,21 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
   if (isTopLevel === false || isTopLevel === true) query.isTopLevel = isTopLevel;
 
   if (context.userHasPermission(["owner", "admin"], shopId)) {
-    if (shouldIncludeDeleted == true) {
-      query.isDeleted = { $in: [false, true] }
+    if (shouldIncludeDeleted === true) {
+      query.isDeleted = { $in: [false, true] };
     } else {
-      query.isDeleted = { $ne: true }
+      query.isDeleted = { $ne: true };
     }
-    if (shouldIncludeInvisible == true) {
-      query.isVisible = { $in: [false, true] }
+    if (shouldIncludeInvisible === true) {
+      query.isVisible = { $in: [false, true] };
     } else {
-      query.isVisible = { $ne: false }
+      query.isVisible = { $ne: false };
     }
   } else {
     query = {
       isDeleted: false,
       isVisible: true
-    }
+    };
   }
 
   return Tags.find(query);

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -18,11 +18,24 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
   const query = { shopId };
 
   if (isTopLevel === false || isTopLevel === true) query.isTopLevel = isTopLevel;
-  if (shouldIncludeDeleted !== true) query.isDeleted = { $ne: true };
-  if (shouldIncludeInvisible !== true) {
-    query.isVisible = { $ne: false };
-  } else if (shouldIncludeInvisible === true && context.userHasPermission(["owner", "admin"], shopId)) {
-    query.isVisible = { $in: [false, true] };
+
+  if (context.userHasPermission(["owner", "admin"], shopId)) {
+    if (shouldIncludeDeleted == true) {
+      query.isDeleted = { $in: [false, true] }
+    } else {
+      query.isDeleted = { $ne: true }
+    }
+    if (shouldIncludeInvisible == true) {
+      query.isVisible = { $in: [false, true] }
+    } else {
+      query.isVisible = { $ne: false }
+    }
+  } else {
+    query = {
+      isDeleted: false,
+      isVisible: true
+    }
   }
+
   return Tags.find(query);
 }

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -8,7 +8,7 @@
  * @param {Object} [params] - Additional options for the query
  * @param {Boolean} [params.isTopLevel] - If set, look for `isTopLevel` matching this value
  * @param {Boolean} [params.shouldIncludeDeleted] - Whether or not to include `isDeleted=true` tags. Default is `false`
- * @param {Boolean} [params.shouldIncludeInvisible] - Whether or not to include `isVisible=false` tags.  Default is `false`.
+ * @param {Boolean} [params.shouldIncludeInvisible] - Admin only. Whether or not to include `isVisible=false` tags.  Default is `false`.
  * @return {Promise<MongoCursor>} - A MongoDB cursor for the proper query
  */
 export default async function tags(context, shopId, { shouldIncludeDeleted = false, isTopLevel, shouldIncludeInvisible = false } = {}) {
@@ -19,7 +19,10 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
 
   if (isTopLevel === false || isTopLevel === true) query.isTopLevel = isTopLevel;
   if (shouldIncludeDeleted !== true) query.isDeleted = { $ne: true };
-  if (shouldIncludeInvisible !== true) query.isVisible = { $ne: false};
-
+  if (shouldIncludeInvisible !== true) {
+    query.isVisible = { $ne: false };
+  } else if (shouldIncludeInvisible == true && context.userHasPermission(["owner", "admin"], shopId)) {
+    query.isVisible = { $in: [false, true]};
+  };
   return Tags.find(query);
 }

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -15,7 +15,7 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
   const { collections } = context;
 
   const { Tags } = collections;
-  const query = { shopId };
+  let query = { shopId };
 
   if (isTopLevel === false || isTopLevel === true) query.isTopLevel = isTopLevel;
 

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -15,7 +15,7 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
   const { collections } = context;
 
   const { Tags } = collections;
-  let query = { shopId };
+  const query = { shopId };
 
   if (isTopLevel === false || isTopLevel === true) query.isTopLevel = isTopLevel;
 

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -21,8 +21,8 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
   if (shouldIncludeDeleted !== true) query.isDeleted = { $ne: true };
   if (shouldIncludeInvisible !== true) {
     query.isVisible = { $ne: false };
-  } else if (shouldIncludeInvisible == true && context.userHasPermission(["owner", "admin"], shopId)) {
-    query.isVisible = { $in: [false, true]};
-  };
+  } else if (shouldIncludeInvisible === true && context.userHasPermission(["owner", "admin"], shopId)) {
+    query.isVisible = { $in: [false, true] };
+  }
   return Tags.find(query);
 }

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -23,18 +23,16 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
     if (shouldIncludeDeleted === true) {
       query.isDeleted = { $in: [false, true] };
     } else {
-      query.isDeleted = { $ne: true };
+      query.isDeleted = false;
     }
     if (shouldIncludeInvisible === true) {
       query.isVisible = { $in: [false, true] };
     } else {
-      query.isVisible = { $ne: false };
+      query.isVisible = true;
     }
   } else {
-    query = {
-      isDeleted: false,
-      isVisible: true
-    };
+    query.isDeleted = false;
+    query.isVisible = true;
   }
 
   return Tags.find(query);

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -7,7 +7,7 @@
  * @param {String} shopId - ID of shop to query
  * @param {Object} [params] - Additional options for the query
  * @param {Boolean} [params.isTopLevel] - If set, look for `isTopLevel` matching this value
- * @param {Boolean} [params.shouldIncludeDeleted] - Whether or not to include `isDeleted=true` tags. Default is `false`
+ * @param {Boolean} [params.shouldIncludeDeleted] - Admin only. Whether or not to include `isDeleted=true` tags. Default is `false`
  * @param {Boolean} [params.shouldIncludeInvisible] - Admin only. Whether or not to include `isVisible=false` tags.  Default is `false`.
  * @return {Promise<MongoCursor>} - A MongoDB cursor for the proper query
  */

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -28,17 +28,10 @@ test("explicit - isVisible only, excludes isDeleted", async () => {
   expect(result).toBe("CURSOR");
 });
 
-test("explicit - isVisible only, excludes isDeleted", async () => {
+test("explicit - isVisible only, excludes isDeleted and not isVisible", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: false, shouldIncludeDeleted: false });
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
-  expect(result).toBe("CURSOR");
-});
-
-test("include isDeleted", async () => {
-  mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
-  const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: true, isVisible: true });
   expect(result).toBe("CURSOR");
 });
 
@@ -56,9 +49,18 @@ test("non-top-level only", async () => {
   expect(result).toBe("CURSOR");
 });
 
+test("include isDeleted", async () => {
+  mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: true });
+  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isVisible: true });
+  expect(result).toBe("CURSOR");
+});
+
 test("top-level only, include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true, shouldIncludeDeleted: true });
+  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: true, isDeleted: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });
@@ -66,6 +68,7 @@ test("top-level only, include isDeleted", async () => {
 test("non-top-level only, include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false, shouldIncludeDeleted: true });
+  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: true, isDeleted: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });
@@ -73,6 +76,7 @@ test("non-top-level only, include isDeleted", async () => {
 test("include not visible - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true });
+  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });
@@ -80,6 +84,7 @@ test("include not visible - by an admin", async () => {
 test("include not visible and only topLevel - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true, isTopLevel: true });
+  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true, isVisible: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -38,7 +38,7 @@ test("explicit - isVisible only, excludes isDeleted", async () => {
 test("include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: true, isVisible: true});
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: true, isVisible: true });
   expect(result).toBe("CURSOR");
 });
 
@@ -59,27 +59,27 @@ test("non-top-level only", async () => {
 test("top-level only, include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: true, isDeleted: { $in: [false, true] }});
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: true, isDeleted: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });
 
 test("non-top-level only, include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: true , isDeleted: { $in: [false, true] }});
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: true, isDeleted: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });
 
 test("include not visible - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: { $in: [false, true] }});
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });
 
 test("include not visible and only topLevel - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true, isTopLevel: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true, isVisible: { $in: [false, true] }});
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true, isVisible: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -9,6 +9,7 @@ beforeEach(() => {
 
 test("default - isVisible only, excludes isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
   expect(result).toBe("CURSOR");
@@ -16,6 +17,7 @@ test("default - isVisible only, excludes isDeleted", async () => {
 
 test("explicit - isVisible only, excludes not isVisible", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: false });
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
   expect(result).toBe("CURSOR");
@@ -23,6 +25,7 @@ test("explicit - isVisible only, excludes not isVisible", async () => {
 
 test("explicit - isVisible only, excludes isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: false });
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
   expect(result).toBe("CURSOR");
@@ -30,6 +33,7 @@ test("explicit - isVisible only, excludes isDeleted", async () => {
 
 test("explicit - isVisible only, excludes isDeleted and not isVisible", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: false, shouldIncludeDeleted: false });
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
   expect(result).toBe("CURSOR");
@@ -37,6 +41,7 @@ test("explicit - isVisible only, excludes isDeleted and not isVisible", async ()
 
 test("top-level only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { isTopLevel: true });
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true, isVisible: true });
   expect(result).toBe("CURSOR");
@@ -44,6 +49,7 @@ test("top-level only", async () => {
 
 test("non-top-level only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { isTopLevel: false });
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: false, isVisible: true });
   expect(result).toBe("CURSOR");
@@ -51,14 +57,16 @@ test("non-top-level only", async () => {
 
 test("include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: true });
   expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isVisible: true });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isVisible: true, isDeleted: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });
 
 test("top-level only, include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { isTopLevel: true, shouldIncludeDeleted: true });
   expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: true, isDeleted: { $in: [false, true] } });
@@ -67,6 +75,7 @@ test("top-level only, include isDeleted", async () => {
 
 test("non-top-level only, include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { isTopLevel: false, shouldIncludeDeleted: true });
   expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: true, isDeleted: { $in: [false, true] } });
@@ -75,14 +84,16 @@ test("non-top-level only, include isDeleted", async () => {
 
 test("include not visible - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
-  const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true });
-  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: { $in: [false, true] } });
+  mockContext.userHasPermission.mockReturnValueOnce(true);
+  const result = await tags(mockContext, mockContext.shopId, { shouldIncludeInvisible: true });
+  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockContext.shopId);
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockContext.shopId, isDeleted: false, isVisible: { $in: [false, true] } });
   expect(result).toBe("CURSOR");
 });
 
 test("include not visible and only topLevel - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  mockContext.userHasPermission.mockReturnValueOnce(true);
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true, isTopLevel: true });
   expect(mockContext.userHasPermission).toHaveBeenCalledWith(["owner", "admin"], mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true, isVisible: { $in: [false, true] } });

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -10,41 +10,41 @@ beforeEach(() => {
 test("default", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId);
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isActive: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("include deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isActive: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("top-level only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: true });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: true, isActive: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("non-top-level only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: false });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: false, isActive: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("top-level only, including deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isActive: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("non-top-level only, including deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isActive: { $ne: false } });
   expect(result).toBe("CURSOR");
 });

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -10,48 +10,55 @@ beforeEach(() => {
 test("default - is visible only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId);
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isVisible: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
   expect(result).toBe("CURSOR");
 });
 
 test("include deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isVisible: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: true, isVisible: true});
   expect(result).toBe("CURSOR");
 });
 
 test("top-level only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: true, isVisible: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true, isVisible: true });
   expect(result).toBe("CURSOR");
 });
 
 test("non-top-level only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: false, isVisible: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: false, isVisible: true });
   expect(result).toBe("CURSOR");
 });
 
 test("top-level only, including deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: true });
   expect(result).toBe("CURSOR");
 });
 
 test("non-top-level only, including deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: true });
   expect(result).toBe("CURSOR");
 });
 
-test("include not visible - by an admin or not", async () => {
+test("include not visible - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false});
+  expect(result).toBe("CURSOR");
+});
+
+test("include not visible and only topLevel - by an admin", async () => {
+  mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true, isTopLevel: true });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true});
   expect(result).toBe("CURSOR");
 });

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -7,7 +7,7 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-test("default", async () => {
+test("default - is visible only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isActive: { $ne: false } });
@@ -46,5 +46,12 @@ test("non-top-level only, including deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false, shouldIncludeDeleted: true });
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isActive: { $ne: false } });
+  expect(result).toBe("CURSOR");
+});
+
+test("include not visible - by an admin", async () => {
+  mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isActive: { $or: [false, true] } });
   expect(result).toBe("CURSOR");
 });

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -10,48 +10,48 @@ beforeEach(() => {
 test("default - is visible only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId);
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isActive: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isVisible: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("include deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isActive: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isVisible: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("top-level only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: true, isActive: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: true, isVisible: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("non-top-level only", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: false, isActive: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true }, isTopLevel: false, isVisible: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("top-level only, including deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isActive: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("non-top-level only, including deleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isActive: { $ne: false } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: { $ne: false } });
   expect(result).toBe("CURSOR");
 });
 
 test("include not visible - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isActive: { $or: [false, true] } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isVisible: { $or: [false, true] } });
   expect(result).toBe("CURSOR");
 });

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -7,14 +7,35 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-test("default - is visible only", async () => {
+test("default - isVisible only, excludes isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId);
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
   expect(result).toBe("CURSOR");
 });
 
-test("include deleted", async () => {
+test("explicit - isVisible only, excludes not isVisible", async () => {
+  mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: false });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
+  expect(result).toBe("CURSOR");
+});
+
+test("explicit - isVisible only, excludes isDeleted", async () => {
+  mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: false });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
+  expect(result).toBe("CURSOR");
+});
+
+test("explicit - isVisible only, excludes isDeleted", async () => {
+  mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
+  const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: false, shouldIncludeDeleted: false });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: true });
+  expect(result).toBe("CURSOR");
+});
+
+test("include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeDeleted: true });
   expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: true, isVisible: true});
@@ -35,30 +56,30 @@ test("non-top-level only", async () => {
   expect(result).toBe("CURSOR");
 });
 
-test("top-level only, including deleted", async () => {
+test("top-level only, include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: true, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: true });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: true, isVisible: true, isDeleted: { $in: [false, true] }});
   expect(result).toBe("CURSOR");
 });
 
-test("non-top-level only, including deleted", async () => {
+test("non-top-level only, include isDeleted", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { isTopLevel: false, shouldIncludeDeleted: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: true });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isTopLevel: false, isVisible: true , isDeleted: { $in: [false, true] }});
   expect(result).toBe("CURSOR");
 });
 
 test("include not visible - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false});
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isVisible: { $in: [false, true] }});
   expect(result).toBe("CURSOR");
 });
 
 test("include not visible and only topLevel - by an admin", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true, isTopLevel: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true});
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: false, isTopLevel: true, isVisible: { $in: [false, true] }});
   expect(result).toBe("CURSOR");
 });

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.test.js
@@ -49,9 +49,9 @@ test("non-top-level only, including deleted", async () => {
   expect(result).toBe("CURSOR");
 });
 
-test("include not visible - by an admin", async () => {
+test("include not visible - by an admin or not", async () => {
   mockContext.collections.Tags.find.mockReturnValueOnce("CURSOR");
   const result = await tags(mockContext, mockShopId, { shouldIncludeInvisible: true });
-  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isVisible: { $or: [false, true] } });
+  expect(mockContext.collections.Tags.find).toHaveBeenCalledWith({ shopId: mockShopId, isDeleted: { $ne: true } });
   expect(result).toBe("CURSOR");
 });

--- a/imports/plugins/core/core/server/fixtures/products.js
+++ b/imports/plugins/core/core/server/fixtures/products.js
@@ -156,6 +156,7 @@ export default function () {
    * @property {String} name - `"Tag"`
    * @property {String} slug - `"tag"`
    * @property {Number} position - `_.random(0, 100000)`
+   * @property {Boolean} isActive - `true`
    * @property {Boolean} isTopLevel - `true`
    * @property {String} shopId - `getShop()._id`
    * @property {Date} createdAt - `faker.date.past()`
@@ -166,6 +167,7 @@ export default function () {
     slug: "tag",
     position: _.random(0, 100000),
     //  relatedTagIds: [],
+    isActive: true,
     isTopLevel: true,
     shopId: getShop()._id,
     createdAt: faker.date.past(),

--- a/imports/plugins/core/core/server/fixtures/products.js
+++ b/imports/plugins/core/core/server/fixtures/products.js
@@ -156,7 +156,7 @@ export default function () {
    * @property {String} name - `"Tag"`
    * @property {String} slug - `"tag"`
    * @property {Number} position - `_.random(0, 100000)`
-   * @property {Boolean} isActive - `true`
+   * @property {Boolean} isVisible - `true`
    * @property {Boolean} isTopLevel - `true`
    * @property {String} shopId - `getShop()._id`
    * @property {Date} createdAt - `faker.date.past()`
@@ -167,7 +167,7 @@ export default function () {
     slug: "tag",
     position: _.random(0, 100000),
     //  relatedTagIds: [],
-    isActive: true,
+    isVisible: true,
     isTopLevel: true,
     shopId: getShop()._id,
     createdAt: faker.date.past(),

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/tag.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/tag.js
@@ -1,16 +1,27 @@
 import { decodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag";
 
 /**
+ * Arguments passed by the client for a tags query
+ * @typedef {ConnectionArgs} TagConnectionArgs - An object of all arguments that were sent by the client
+ * @memberof Tag/GraphQL
+ * @property {ConnectionArgs} args - An object of all arguments that were sent by the client. {@link ConnectionArgs|See default connection arguments}
+ * @property {String} args.slugOrId - ID or slug of tag to query
+ * @property {Boolean} args.shouldIncludeInvisible - Whether or not to include `isVisible=true` tags. Default is `false`
+ */
+
+/**
  * @name "Query.tag"
  * @method
  * @memberof Tag/GraphQL
  * @summary Returns a tag for a shop, based on tag slug or ID
  * @param {Object} _ - unused
- * @param {Object} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}
+ * @param {Object} connectionArgs - arguments sent by the client {@link ConnectionArgs|See default connection arguments}
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<Object[]>} Promise that resolves with array of Tag objects
  */
-export default async function tag(_, { slugOrId }, context) {
+export default async function tag(_, connectionArgs, context) {
+  const { slugOrId } = connectionArgs;
+
   let dbTagId;
 
   try {
@@ -19,5 +30,5 @@ export default async function tag(_, { slugOrId }, context) {
     dbTagId = slugOrId;
   }
 
-  return context.queries.tag(context, dbTagId);
+  return context.queries.tag(context, dbTagId, connectionArgs);
 }

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/tags.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/tags.js
@@ -7,6 +7,7 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
  * @memberof Tag/GraphQL
  * @property {ConnectionArgs} args - An object of all arguments that were sent by the client. {@link ConnectionArgs|See default connection arguments}
  * @property {Boolean} args.shouldIncludeDeleted - If set to true, include deleted. Default false.
+ * @property {Boolean} ags.shouldIncludeInvisible - If set to true, include invisible. Default false.
  * @property {Boolean} args.isTopLevel - If set to a boolean, filter by this.
  * @property {String} args.shopId - The ID of shop to filter tags by
  * @property {Number} args.sortBy - Sort results by a TagSortByField enum value of `_id`, `name`, `position`, `createdAt`, `updatedAt`

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -87,6 +87,9 @@ extend type Query {
     "Set to true if you want soft deleted tags to be included in the response"
     shouldIncludeDeleted: Boolean = false,
 
+    "Set to true if you want to include tags that have isVisible set to false"
+    shouldIncludeInvisible: Boolean = false,
+
     after: ConnectionCursor,
     before: ConnectionCursor,
     first: ConnectionLimitInt,

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -15,6 +15,9 @@ type Tag implements Node & Deletable {
   "If `true`, this tag should be shown at the top level of the tag hierarchy"
   isTopLevel: Boolean!
 
+  "If `true`, this tag's Tag Listing Page should be visible to the public"
+  isVisible: Boolean!
+
   "Arbitrary additional metadata about this tag"
   metafields: [Metafield]
 
@@ -39,10 +42,10 @@ type Tag implements Node & Deletable {
   "The date and time at which this tag was last updated"
   updatedAt: DateTime!
 
-  "A string containing the hero image url for a tag listing page"
+  "A string containing the hero image url for a Tag Listing Page"
   heroMediaUrl: String
 
-  "A string of the title to be displayed on a tag listing page"
+  "A string of the title to be displayed on a Tag Listing Page"
   displayTitle: String
 }
 

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -47,6 +47,7 @@ type Tag implements Node & Deletable {
 
   "A string of the title to be displayed on a Tag Listing Page"
   displayTitle: String
+  
 }
 
 "The fields by which you are allowed to sort any query that returns a `TagConnection`"
@@ -73,8 +74,17 @@ type TagConnection implements NodeConnection {
 }
 
 extend type Query {
-  "Returns a tag from a provided tag ID or slug"
-  tag(slugOrId: String): Tag
+  "Returns a tag from a provided tag ID or slug. Tags with isVisible set to false are excluded by default."
+  tag(
+    "Only tags associated with this shop will be returned"
+    shopId: ID!,
+  
+    "Slug or ID of Tag"
+    slugOrId: String,
+    
+    "Set to true if you want to include tags that have isVisible set to false"
+    shouldIncludeInvisible: Boolean = false
+  ): Tag
 
   "Returns a paged list of tags for a shop. You must include a shopId when querying."
   tags(

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -76,11 +76,8 @@ type TagConnection implements NodeConnection {
 extend type Query {
   "Returns a tag from a provided tag ID or slug. Tags with isVisible set to false are excluded by default."
   tag(
-    "Only tags associated with this shop will be returned"
-    shopId: ID!,
-  
     "Slug or ID of Tag"
-    slugOrId: String,
+    slugOrId: String!,
     
     "Set to true if you want to include tags that have isVisible set to false"
     shouldIncludeInvisible: Boolean = false

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -77,7 +77,7 @@ extend type Query {
   "Returns a tag from a provided tag ID or slug. Tags with isVisible set to false are excluded by default."
   tag(
     "Slug or ID of Tag"
-    slugOrId: String!,
+    slugOrId: String,
     
     "Set to true if you want to include tags that have isVisible set to false"
     shouldIncludeInvisible: Boolean = false


### PR DESCRIPTION
Resolves #4848   
Impact: **minor**  
Type: **feature**

## Issue
The current Tags query returns all in the collection, even if a tag's `isVisible` is set to false. To make sure the public cannot view the tag listing pages of certain tags, the Tags query should default to only returning `isVisible` tags.

## Solution
- [x] Adds a `shouldIncludeInvisible` parameter to the main query, set to `false` by default
- [x] Add a check for Admin status before `shouldIncludeInvisible` can return all tags
- Unit tests

## Breaking changes
None

## Testing
0. Mark some tags as isVisible == false
1. Test that an Admin can get all Tags, including Invisible tags
2. Test that a non-Admin can only get Visible tags
3. Test  `tag` and `tags` queries
