### PR TITLE
chore :  use ci env var for staging url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            docker run -t -e URL=https://reaction-core.staging.reactioncommerce.com/ reactioncommerce/reaction-automation-client:latest npm run-script chrome
+            docker run -t -e URL=${STAGING_URL} reactioncommerce/reaction-automation-client:latest npm run-script chrome
 
   dockerfile-lint:
     <<: *defaults


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
Staging URL is hardcoded into CI config.

## Solution
Remove hardcoded declaration and swap to Circle CI env variable.

## Breaking changes
Make sure staging URL is changed accordingly.

## Testing
1. Run e2e steps