### PR TITLE
#4890 Use Request Origin to determine rootURL #multishop

### DIFF
--- a/imports/node-app/core/util/buildContext.js
+++ b/imports/node-app/core/util/buildContext.js
@@ -11,7 +11,7 @@ import getAbsoluteUrl from "/imports/plugins/core/core/server/util/getAbsoluteUr
  *   `userHasPermission` properties.
  * @param {Object} context - A context object on which to set additional context properties
  * @param {Object} request - Request object
- * @param {String} request.hostname - Hostname derived from Host or X-Forwarded-Host heaer
+ * @param {String} request.hostname - Hostname derived from Host or X-Forwarded-Host header
  * @param {Object} request.protocol - Either http or https
  * @param {Object} [request.user] - The user who authenticated this request, if applicable
  * @returns {undefined} No return
@@ -29,12 +29,16 @@ export default async function buildContext(context, request) {
     context.accountId = (account && account._id) || null;
   }
 
-  // Add the shopId for this request, either from the authenticated user's preferences or based on the ROOT_URL domain name
+  context.rootUrl = getRootUrl(request);
+  context.getAbsoluteUrl = (path) => getAbsoluteUrl(context.rootUrl, path);
+
+  // Add the shopId for this request, either from the authenticated user's
+  // preferences or based on the rootUrl domain name.
+  // *** important ***
+  //   context.rootUrl must be set
   context.shopId = await getShopIdForContext(context);
+  // TODO: fallback to primaryShopId if shopId is null
 
   // Add a curried hasPermission tied to the current user (or to no user)
   context.userHasPermission = getHasPermissionFunctionForUser(context.user);
-
-  context.rootUrl = getRootUrl(request);
-  context.getAbsoluteUrl = (path) => getAbsoluteUrl(context.rootUrl, path);
 }

--- a/imports/node-app/core/util/buildContext.test.js
+++ b/imports/node-app/core/util/buildContext.test.js
@@ -1,49 +1,158 @@
-import mockContext from "/imports/test-utils/helpers/mockContext";
+import mockContext, { resetContext } from "/imports/test-utils/helpers/mockContext";
 import buildContext from "./buildContext";
 
-const fakeUser = {
-  _id: "FAKE_BUILD_CONTEXT_USER_ID"
-};
+describe("#buildContext", () => {
+  let mockAccount;
+  let fakeUser;
 
-test("properly mutates the context object without user", async () => {
-  process.env.ROOT_URL = "http://localhost:3000";
-  const context = { collections: mockContext.collections };
-  await buildContext(context, { user: undefined });
-  expect(context).toEqual({
-    collections: mockContext.collections,
-    shopId: null,
-    user: null,
-    userHasPermission: jasmine.any(Function),
-    userId: null,
-    rootUrl: "http://localhost:3000/",
-    getAbsoluteUrl: jasmine.any(Function)
-  });
-});
+  beforeEach(() => {
+    fakeUser = {
+      _id: "FAKE_BUILD_CONTEXT_USER_ID"
+    };
+    mockAccount = { _id: "accountId", userId: fakeUser._id };
 
-test("properly mutates the context object with user", async () => {
-  process.env.ROOT_URL = "https://localhost:3000";
-  const mockAccount = { _id: "accountId", userId: fakeUser._id };
-  mockContext.collections.Accounts.findOne.mockReturnValueOnce(Promise.resolve(mockAccount));
-
-  const context = { collections: mockContext.collections };
-  await buildContext(context, { user: fakeUser });
-  expect(context).toEqual({
-    account: mockAccount,
-    accountId: mockAccount._id,
-    collections: mockContext.collections,
-    shopId: null,
-    user: fakeUser,
-    userHasPermission: jasmine.any(Function),
-    userId: fakeUser._id,
-    rootUrl: "https://localhost:3000/",
-    getAbsoluteUrl: jasmine.any(Function)
+    resetContext();
   });
 
-  // Make sure the hasPermission currying works with one arg
-  const result1 = await context.userHasPermission(["foo"]);
-  expect(result1).toBe(false);
+  test("properly mutates the context object without user", async () => {
+    process.env.ROOT_URL = "http://localhost:3000";
+    const context = { collections: mockContext.collections };
+    await buildContext(context, { user: undefined });
+    expect(context).toEqual({
+      collections: mockContext.collections,
+      shopId: null,
+      user: null,
+      userHasPermission: jasmine.any(Function),
+      userId: null,
+      rootUrl: "http://localhost:3000/",
+      getAbsoluteUrl: jasmine.any(Function)
+    });
+  });
 
-  // Make sure the hasPermission currying works with two args
-  const result2 = await context.userHasPermission(["foo"], "scope");
-  expect(result2).toBe(false);
+  test("properly mutates the context object with user", async () => {
+    process.env.ROOT_URL = "https://localhost:3000";
+    mockContext.collections.Accounts.findOne.mockReturnValueOnce(Promise.resolve(mockAccount));
+
+    const context = { collections: mockContext.collections };
+    await buildContext(context, { user: fakeUser });
+    expect(context).toEqual({
+      account: mockAccount,
+      accountId: mockAccount._id,
+      collections: mockContext.collections,
+      shopId: null,
+      user: fakeUser,
+      userHasPermission: jasmine.any(Function),
+      userId: fakeUser._id,
+      rootUrl: "https://localhost:3000/",
+      getAbsoluteUrl: jasmine.any(Function)
+    });
+
+    // Make sure the hasPermission currying works with one arg
+    const result1 = await context.userHasPermission(["foo"]);
+    expect(result1).toBe(false);
+
+    // Make sure the hasPermission currying works with two args
+    const result2 = await context.userHasPermission(["foo"], "scope");
+    expect(result2).toBe(false);
+  });
+
+  describe("setting shopId", () => {
+    let domain;
+    let mockShopId;
+    let mockShop;
+    let previousRootUrl;
+
+    beforeEach(() => {
+      domain = `${randomString()}.reactioncommerce.com`;
+
+      mockAccount = {
+        _id: "accountId",
+        userId: fakeUser._id
+      };
+      mockShopId = randomString();
+      mockShop = {
+        _id: mockShopId
+      };
+
+      mockContext.collections.Accounts.findOne
+        .mockReturnValueOnce(Promise.resolve(mockAccount));
+
+      previousRootUrl = process.env.ROOT_URL;
+    });
+
+    afterEach(() => {
+      process.env.ROOT_URL = previousRootUrl;
+    });
+
+    test("with User Preference", async () => {
+      fakeUser.profile = {
+        preferences: {
+          reaction: {
+            activeShopId: mockShopId
+          }
+        }
+      };
+
+      await buildContext(mockContext, { user: fakeUser });
+
+      expect(mockContext.collections.Shops.findOne).not.toHaveBeenCalled();
+
+      expect(mockContext)
+        .toEqual(expect.objectContaining({ shopId: mockShopId }));
+    });
+
+    test("with Origin header when present", async () => {
+      mockContext.collections.Shops.findOne.mockReturnValueOnce(Promise.resolve(mockShop));
+
+      await buildContext(mockContext, {
+        user: fakeUser,
+        headers: { origin: `https://${domain}/` }
+      });
+
+      expect(mockContext.collections.Shops.findOne).toHaveBeenCalledWith({
+        domains: domain
+      }, expect.anything());
+
+      expect(mockContext)
+        .toEqual(expect.objectContaining({ shopId: mockShopId }));
+    });
+
+    test("with ROOT_URL when Origin is not present", async () => {
+      process.env.ROOT_URL = `https://${domain}/`;
+
+      mockContext.collections.Shops.findOne.mockReturnValueOnce(Promise.resolve(mockShop));
+
+      await buildContext(mockContext, { user: fakeUser });
+
+      expect(mockContext.collections.Shops.findOne).toHaveBeenCalledWith({
+        domains: domain
+      }, expect.anything());
+
+      expect(mockContext)
+        .toEqual(expect.objectContaining({ shopId: mockShopId }));
+    });
+
+    test("with request hostname (i.e., the API's domain) when ROOT_URL and Origin are not present", async () => {
+      delete process.env.ROOT_URL;
+
+      mockContext.collections.Shops.findOne.mockReturnValueOnce(Promise.resolve(mockShop));
+
+      await buildContext(mockContext, {
+        user: fakeUser,
+        hostname: domain,
+        protocol: "https"
+      });
+
+      expect(mockContext.collections.Shops.findOne).toHaveBeenCalledWith({
+        domains: domain
+      }, expect.anything());
+
+      expect(mockContext)
+        .toEqual(expect.objectContaining({ shopId: mockShopId }));
+    });
+  });
+
+  function randomString() {
+    return Math.random().toString(36);
+  }
 });

--- a/imports/plugins/core/accounts/server/no-meteor/getShopIdByDomain.js
+++ b/imports/plugins/core/accounts/server/no-meteor/getShopIdByDomain.js
@@ -1,12 +1,12 @@
 import url from "url";
 
-export default async function getShopIdByDomain(collections) {
+export default async function getShopIdByDomain(context) {
+  const { collections, rootUrl } = context;
   const { Shops } = collections;
 
-  const { ROOT_URL } = process.env;
-  if (typeof ROOT_URL !== "string") return null;
+  if (typeof rootUrl !== "string") return null;
 
-  const domain = url.parse(ROOT_URL).hostname;
+  const domain = url.parse(rootUrl).hostname;
 
   const shop = await Shops.findOne({
     domains: domain

--- a/imports/plugins/core/accounts/server/no-meteor/getShopIdForContext.js
+++ b/imports/plugins/core/accounts/server/no-meteor/getShopIdForContext.js
@@ -2,7 +2,7 @@ import { get } from "lodash";
 import getShopIdByDomain from "./getShopIdByDomain";
 
 export default async function getShopIdForContext(context) {
-  const { collections, user } = context;
+  const { user } = context;
 
   let shopId;
 
@@ -12,8 +12,15 @@ export default async function getShopIdForContext(context) {
 
   // if still not found, look up the shop by domain
   if (!shopId) {
-    shopId = await getShopIdByDomain(collections);
+    shopId = await getShopIdByDomain(context);
   }
+
+  // if (shopId) {
+  //   // TODO: set user preference such that a user returning to the Primary Shop
+  //   // will already be in their preferred shop
+
+  //   Reaction.setUserPreferences("reaction", "activeShopId", shopId);
+  // }
 
   return shopId || null;
 }

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShopId.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/primaryShopId.js
@@ -11,6 +11,6 @@ import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
  * @return {Promise<String>} The shop ID based on the domain in ROOT_URL
  */
 export default async function primaryShopId(_, __, context) {
-  const shopId = await context.queries.primaryShopId(context.collections);
+  const shopId = await context.queries.primaryShopId(context);
   return encodeShopOpaqueId(shopId);
 }

--- a/imports/plugins/core/core/server/util/getRootUrl.js
+++ b/imports/plugins/core/core/server/util/getRootUrl.js
@@ -3,19 +3,52 @@
  * @summary Returns the root URL, returning process.env.ROOT_URL if set,
  *  otherwise using the request's protocol & hostname
  * @param {Object} request Express request object
- * @param {Object} request.hostname Hostname derived from Host or X-Forwarded-Host heaer
+ * @param {Object} request.headers the Set of HTTP headers
+ * @param {String} request.headers.origin Origin of the request (aka, client URL)
+ * @param {String} request.hostname Hostname derived from Host or X-Forwarded-Host header
  * @param {String} request.protocol Either http or https
  * @returns {String} URL
  */
 export default function getRootURL(request) {
-  const { ROOT_URL } = process.env;
-  if (ROOT_URL) {
-    if (ROOT_URL.endsWith("/")) {
-      return ROOT_URL;
-    }
-    return `${ROOT_URL}/`;
+  let rootUrl = getOriginUrl(request);
+
+  if (!rootUrl) {
+    rootUrl = getDefaultUrl();
   }
 
+  if (!rootUrl) {
+    rootUrl = getHostUrl(request);
+  }
+
+  return rootUrl;
+}
+
+function getOriginUrl(request) {
+  const { headers: { origin } = {} } = request;
+
+  if (!origin) { return; }
+
+  if (origin.endsWith("/")) {
+    return origin;
+  }
+
+  return `${origin}/`;
+}
+
+function getHostUrl(request) {
   const { hostname, protocol } = request;
+
   return `${protocol}://${hostname}/`;
+}
+
+function getDefaultUrl() {
+  const { ROOT_URL } = process.env;
+
+  if (!ROOT_URL) { return; }
+
+  if (ROOT_URL.endsWith("/")) {
+    return ROOT_URL;
+  }
+
+  return `${ROOT_URL}/`;
 }

--- a/imports/plugins/core/core/server/util/getRootUrl.test.js
+++ b/imports/plugins/core/core/server/util/getRootUrl.test.js
@@ -1,5 +1,18 @@
 import getRootUrl from "./getRootUrl";
 
+test("returns the origin url when set", () => {
+  process.env.ROOT_URL = "http://localhost:3000";
+  const request = {
+    protocol: "https",
+    hostname: "api.reaction.localhost",
+    headers: {
+      origin: "https://merchant.reactioncommerce.com"
+    }
+  };
+
+  expect(getRootUrl(request)).toBe("https://merchant.reactioncommerce.com/");
+});
+
 test("returns process.env.ROOT_URL with trailing slash if set", () => {
   process.env.ROOT_URL = "http://localhost:3000";
   const request = {

--- a/imports/test-utils/helpers/mockContext.js
+++ b/imports/test-utils/helpers/mockContext.js
@@ -6,6 +6,7 @@ const mockContext = {
   },
   collections: {},
   getFunctionsOfType: jest.fn().mockName("getFunctionsOfType").mockReturnValue([]),
+  rootUrl: "http://localhost/",
   shopId: "FAKE_SHOP_ID",
   userHasPermission: jest.fn().mockName("userHasPermission"),
   userId: "FAKE_USER_ID"
@@ -76,3 +77,32 @@ mockContext.collections.Media = {
 };
 
 export default mockContext;
+
+// use this method to reset any mocked functions when checking call counts
+export function resetContext() {
+  mockContext.accountId = "FAKE_ACCOUNT_ID";
+  mockContext.rootUrl = "http://localhost/";
+  mockContext.shopId = "FAKE_SHOP_ID";
+  mockContext.userId = "FAKE_USER_ID";
+
+  Object.keys(mockContext.collections).forEach((collection) => {
+    [
+      "deleteOne",
+      "deleteMany",
+      "find",
+      "findLocal",
+      "findOne",
+      "findOneLocal",
+      "insertOne",
+      "insertMany",
+      "toArray",
+      "updateOne",
+      "updateMany"
+    ].filter((method) => (
+      (method in mockContext.collections[collection]) &&
+        mockContext.collections[collection][method].mockReset
+    )).forEach((method) => {
+      mockContext.collections[collection][method].mockReset();
+    });
+  });
+}


### PR DESCRIPTION
Resolves #4890
Impact: **minor|major**  
Type: **feature|bugfix**

## Issue
Shops have a feature which allows them to be associated with a domain. Given the new API/client relationship of Reaction v2, the API only inspects `process.env.ROOT_URL` and `request.hostname` which both refer to the API's domain, not the client's. Superceeding those values is a User preference for activeShop, but it is unclear how that would be set on the initial visit to a marketplace shop on its own domain.

## Solution
Inspect the request's `"Origin"` header if no user preference is set (although it is debatable whether that User preference should take precedence... that is, if my active shop is Marketplace Shop #1 and I visit Marketplace Shop #2, I should see Marketplace Shop #2's products).

I see that there is already [a PR](https://github.com/reactioncommerce/reaction/pull/4862/files) for falling back to the primary shop Id, so I'm sure we will have some merge-conflicts. Once approved, I will rebase against that commit


## Testing
1. Create a Marketplace Shop.
2. give this shop a named domain (requires a manually write to the DB)
3. Run your NextJS server on that named domain (suggestion on how to do that below)
4. visit named domain

expected: Marketplace Shop data
actual: Primary Shop data
