### PR TITLE
Restore CORS for 401s

### DIFF
--- a/imports/node-app/core/createApolloServer.js
+++ b/imports/node-app/core/createApolloServer.js
@@ -1,3 +1,4 @@
+import cors from "cors";
 import express from "express";
 import { makeExecutableSchema, mergeSchemas } from "apollo-server";
 import { ApolloServer } from "apollo-server-express";
@@ -58,6 +59,12 @@ export default function createApolloServer(options = {}) {
   // GraphQL endpoint, enhanced with JSON body parser
   app.use(
     path,
+    // Enable `cors` to set HTTP response header: Access-Control-Allow-Origin: *
+    // Although the `cors: true` option to `applyMiddleware` below does this already
+    // for successful requests, we need it to be set here, before tokenMiddleware,
+    // so that the header is set on 401 responses, too. Otherwise it breaks our 401
+    // refresh handling on the clients.
+    cors(),
     tokenMiddleware(contextFromOptions)
   );
 


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
When I updated to Apollo Server 2.0, I switched to using their built-in CORS middleware. Unfortunately, I've now discovered that this only adds the CORS header for requests that make it past our auth middleware. This could be OK, but it turns out that Apollo Client behavior changes when the 401 response doesn't allow CORS, and this prevents the starterkit auto-token-refresh logic from working properly.

## Solution
Add back explicit CORS middleware, prior to the auth middleware.

## Breaking changes
None

## Testing
Try a GraphQL request with an expired or invalid token, and examine the headers of the 401 response. Verify that you see `Access-Control-Allow-Origin: *` header.