### PR TITLE
fix: make Accounts.createdAt optional in schema

### DIFF
--- a/imports/collections/schemas/accounts.js
+++ b/imports/collections/schemas/accounts.js
@@ -205,7 +205,8 @@ export const Accounts = new SimpleSchema({
   },
   "createdAt": {
     type: Date,
-    autoValue: createdAtAutoValue
+    autoValue: createdAtAutoValue,
+    optional: true
   },
   "updatedAt": {
     type: Date,


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
The `createdAt` field of the Accounts schema is currently required. This makes it impossible to validate against the schema when performing updates.

## Solution
This PR simply adds `optional: true` to the `createdAt` field.

## Breaking changes
None

## Testing
1. Add the following piece of test code in `/imports/plugins/core/accounts/server/index.js`:
```
async function testAccountUpdate() {
  import { Accounts } from "/imports/collections/schemas";

  const testDoc = {
    userId: "mZv3WqQTC8MshuAHc",
    shopId: "J8Bhq3uTtdgwZx3rz",
    name: "Dan"
  }
  
  Accounts.validate(testDoc);

  console.log("Validation passed.");
}

testAccountUpdate();
```
2. Confirm you see "Validation passed." in console
3. Remove line 209 (`optional: true`) in /imports/collections/schemas/accounts.js
4. When the console restarts, confirm you see `ERROR Reaction: Created at is required` in console.
