### PR TITLE
Revert "fix: make Accounts.createdAt optional in schema"

### DIFF
--- a/imports/collections/schemas/accounts.js
+++ b/imports/collections/schemas/accounts.js
@@ -127,7 +127,7 @@ registerSchema("Email", Email);
  * @property {Profile} profile optional
  * @property {String[]} groups optional, Array of groupIds of the groups the user belongs to
  * @property {Metafield[]} metafields optional
- * @property {Date} createdAt optional
+ * @property {Date} createdAt required
  * @property {Date} updatedAt optional
  */
 export const Accounts = new SimpleSchema({
@@ -205,8 +205,7 @@ export const Accounts = new SimpleSchema({
   },
   "createdAt": {
     type: Date,
-    autoValue: createdAtAutoValue,
-    optional: true
+    autoValue: createdAtAutoValue
   },
   "updatedAt": {
     type: Date,


### PR DESCRIPTION
Reverts reactioncommerce/reaction#4899

After discussions with @zenweasel and @aldeed, it was decided that instead of making `createdAt` optional in the schema, `{ modifier: true }` should be passed to `AccountsSchema.validate` as the second argument. Example: `AccountsSchema.validate(update, { modifier: true });`.