### PR TITLE
test: increase timeout for generateSitemaps tests

### DIFF
--- a/imports/plugins/included/sitemap-generator/server/lib/generate-sitemaps.app-test.js
+++ b/imports/plugins/included/sitemap-generator/server/lib/generate-sitemaps.app-test.js
@@ -26,11 +26,13 @@ describe("generateSitemaps", () => {
     sandbox.restore();
   });
 
-  it("should throw not-found error if invalid shopId is passed", () => {
+  it("should throw not-found error if invalid shopId is passed", function () {
+    this.timeout(30000);
     expect(() => generateSitemaps({ shopIds: ["FAKE_SHOP_ID"] })).to.throw(Meteor.Error, /not-found/);
   });
 
-  it("should generate the correct number of sitemap documents", () => {
+  it("should generate the correct number of sitemap documents", function () {
+    this.timeout(10000);
     const { _id: shopId } = primaryShop;
 
     // Create a visible tag and product for our primary shop
@@ -51,7 +53,8 @@ describe("generateSitemaps", () => {
     expect(sitemapsCount).to.equal(4);
   });
 
-  it("should create sitemaps for primary shop if no shop _id is given", () => {
+  it("should create sitemaps for primary shop if no shop _id is given", function () {
+    this.timeout(10000);
     const { _id: shopId } = primaryShop;
 
     Sitemaps.remove({});
@@ -65,7 +68,8 @@ describe("generateSitemaps", () => {
     expect(sitemap.shopId).to.equal(shopId);
   });
 
-  it("should not include deleted/non-visible products in sitemaps", () => {
+  it("should not include deleted/non-visible products in sitemaps", function () {
+    this.timeout(10000);
     const { _id: shopId } = primaryShop;
 
     Factory.create("tag", { shopId });
@@ -81,7 +85,8 @@ describe("generateSitemaps", () => {
     expect(sitemapsCount).to.equal(4);
   });
 
-  it("should create sitemaps with the correct number of URLs per each", () => {
+  it("should create sitemaps with the correct number of URLs per each", function () {
+    this.timeout(10000);
     const { _id: shopId } = primaryShop;
     const shopFields = { shopId };
 

--- a/imports/plugins/included/sitemap-generator/server/lib/generate-sitemaps.app-test.js
+++ b/imports/plugins/included/sitemap-generator/server/lib/generate-sitemaps.app-test.js
@@ -11,10 +11,11 @@ describe("generateSitemaps", () => {
   let sandbox;
   let primaryShop;
 
-  beforeEach(() => {
+  beforeEach((done) => {
     sandbox = sinon.sandbox.create();
     primaryShop = Factory.create("shop");
     sandbox.stub(Reaction, "getPrimaryShopId", () => primaryShop._id);
+    done();
   });
 
   afterEach(() => {

--- a/imports/plugins/included/sitemap-generator/server/lib/generate-sitemaps.app-test.js
+++ b/imports/plugins/included/sitemap-generator/server/lib/generate-sitemaps.app-test.js
@@ -11,14 +11,15 @@ describe("generateSitemaps", () => {
   let sandbox;
   let primaryShop;
 
-  beforeEach((done) => {
+  beforeEach(function () {
+    this.timeout(10000);
     sandbox = sinon.sandbox.create();
     primaryShop = Factory.create("shop");
     sandbox.stub(Reaction, "getPrimaryShopId", () => primaryShop._id);
-    done();
   });
 
-  afterEach(() => {
+  afterEach(function () {
+    this.timeout(10000);
     const { _id: shopId } = primaryShop;
     Shops.remove({ _id: shopId });
     Sitemaps.remove({ shopId });


### PR DESCRIPTION
Impact: **minor**  
Type: **test**

## Issue
The `generateSitemaps` Meteor app tests often fail with a timeout error on CI.

## Solution
Increase timeout.

## Breaking changes
None

## Testing
Verify the `app-test` build phase succeeds on CI.