### PR TITLE
fix: add replace to remove comma from formatting

### DIFF
--- a/client/modules/i18n/currency.js
+++ b/client/modules/i18n/currency.js
@@ -74,11 +74,7 @@ export function formatPriceString(formatPrice, useDefaultShopCurrency) {
   const userCurrency = findCurrency(locale.currency, defaultShopCurrency);
 
   // for the cases then we have only one price. It is a number.
-  const stringCurrentPrice = formatPrice.toString();
-
-  // Remove commas from current price
-  // accounting.formatMoney does not play nice with extra commas
-  const currentPrice = stringCurrentPrice.replace(/,/g, "");
+  const currentPrice = formatPrice.toString();
 
   let price = 0;
   const prices = currentPrice.indexOf(" - ") >= 0 ?

--- a/client/modules/i18n/currency.js
+++ b/client/modules/i18n/currency.js
@@ -75,7 +75,6 @@ export function formatPriceString(formatPrice, useDefaultShopCurrency) {
 
   // for the cases then we have only one price. It is a number.
   const currentPrice = formatPrice.toString();
-
   let price = 0;
   const prices = currentPrice.indexOf(" - ") >= 0 ?
     currentPrice.split(" - ") : [currentPrice];

--- a/client/modules/i18n/currency.js
+++ b/client/modules/i18n/currency.js
@@ -74,7 +74,12 @@ export function formatPriceString(formatPrice, useDefaultShopCurrency) {
   const userCurrency = findCurrency(locale.currency, defaultShopCurrency);
 
   // for the cases then we have only one price. It is a number.
-  const currentPrice = formatPrice.toString();
+  const stringCurrentPrice = formatPrice.toString();
+
+  // Remove commas from current price
+  // accounting.formatMoney does not play nice with extra commas
+  const currentPrice = stringCurrentPrice.replace(/,/g, "");
+
   let price = 0;
   const prices = currentPrice.indexOf(" - ") >= 0 ?
     currentPrice.split(" - ") : [currentPrice];

--- a/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
@@ -5,6 +5,7 @@ import { compose } from "recompose";
 import { registerComponent } from "@reactioncommerce/reaction-components";
 import { Session } from "meteor/session";
 import { Reaction } from "/client/api";
+import { Catalog } from "/lib/api";
 import ProductGridItems from "../components/productGridItems";
 
 const wrapComponent = (Comp) => (
@@ -42,9 +43,8 @@ const wrapComponent = (Comp) => (
     }
 
     displayPrice = () => {
-      if (this.props.product.price && this.props.product.price.range) {
-        return this.props.product.price.range;
-      }
+      const { product } = this.props;
+      return Catalog.getProductPriceRange(product._id).range;
     }
 
     handleCheckboxSelect = (list, product) => {


### PR DESCRIPTION
Resolves #4900   
Impact: **minor**  
Type: **bugfix**

## Issue
Price ranges that included a number above 1000 would show up as NAN in the admin Grid. This is due to the currency being formatted twice, which in turn adds double commas into the string, which breaks the display.

## Solution
Use our "new" `getProductPriceRange` to calculate the price range based off of `min` and `max` `number`s, instead of the price range `string`.

## Breaking changes
None

## Testing
1. Change the price of all of a products variants to anything over $1,000 (anything that will show a comma).
1. See that the price range correctly displays on the Grid when you are logged in as an admin.
1. See that the price is not broken on the Grid AND PDP when not logged in as an admin.