### PR TITLE
fix: add contentForLanguage resolver for nav item content

### DIFF
--- a/imports/plugins/core/navigation/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/navigation/server/no-meteor/schemas/schema.graphql
@@ -67,6 +67,9 @@ type NavigationItemData {
   "The content for the navigation item, in one or more languages"
   content: [NavigationItemContent]
 
+  "The translated content for a navigation item"
+  contentForLanguage: String
+
   "CSS class names to add to the menu item for display"
   classNames: String
 

--- a/imports/plugins/core/navigation/server/no-meteor/util/getNavigationItemContentForLanguage.js
+++ b/imports/plugins/core/navigation/server/no-meteor/util/getNavigationItemContentForLanguage.js
@@ -1,15 +1,15 @@
 /**
  * @name getNavigationItemContentForLanguage
- * @summary Filters a navigation item's content array down to a single language. If not found,
- *  defaults to first element in content array.
+ * @summary Returns translated navigation item content
  * @param {Array} content Navigation item's data or draftData content
- * @param {String} language Language to filter by
- * @return {Array} Array containing a single content translation object
+ * @param {String} language Language
+ * @return {String} Translated navigation item content, or first navigation item content if translation in
+ *  provided language is not available.
  */
 export default function getNavigationItemContentForLanguage(content, language) {
   const translatedContent = content.find((contentItem) => contentItem.language === language);
   if (translatedContent) {
-    return [translatedContent];
+    return translatedContent.value;
   }
-  return [content[0]];
+  return content[0].value || "";
 }

--- a/imports/plugins/core/navigation/server/no-meteor/xforms/xformNavigationTreeItem.js
+++ b/imports/plugins/core/navigation/server/no-meteor/xforms/xformNavigationTreeItem.js
@@ -16,15 +16,15 @@ export default async function xformNavigationTreeItem(context, language, item) {
 
   const navigationItem = await NavigationItems.findOne({ _id: navigationItemId });
 
-  // Filter navigation content by language
+  // Add translated content value
   const { draftData, data } = navigationItem;
   const { content: draftContent } = draftData || {};
   const { content } = data;
   if (draftContent) {
-    navigationItem.draftData.content = getNavigationItemContentForLanguage(draftContent, language);
+    navigationItem.draftData.contentForLanguage = getNavigationItemContentForLanguage(draftContent, language);
   }
   if (content) {
-    navigationItem.data.content = getNavigationItemContentForLanguage(content, language);
+    navigationItem.data.contentForLanguage = getNavigationItemContentForLanguage(content, language);
   }
 
   if (items.length) {


### PR DESCRIPTION
Resolves #4912   
Impact: **minor**  
Type: **bugfix**

## Issue
The `NavigationItemData.content` resolver currently filters down the content array by the language argument provided to the `navigationTreeById` GraphQL query. Instead, it should return the array without filtering for the operator UI, and have a separate resolver that storefront can use to load the translated content string.

## Solution
This PR removes the filtering from the `content` resolver and adds a `contentForLanguage` resolver that returns the content string in the correct language. If a translation for that language is not available, it defaults to the first content provided.

## Breaking changes
None

## Testing
1. Edit a navigation item in the database. Under `draftData` and `data`, add a translation to the array:
```
{
  "language" : "es",
  "value" : "Camisas"
}
```
2. Run this query in Graphiql:
```
{
  primaryShop {
    defaultNavigationTree(language: "es") {
      items {
        navigationItem {
          data {
          	content {
              value
            }
            contentForLanguage
            classNames
            url
            isUrlRelative
            shouldOpenInNewWindow
        	}
          draftData {
          	content {
              value
            }
            contentForLanguage
            classNames
            url
            isUrlRelative
            shouldOpenInNewWindow
        	}
        }
      }
    }
  }
}
```
3. Confirm `contentForLanguage` returns the Spanish content.