### PR TITLE
Fix Password reset page not found

### DIFF
--- a/imports/plugins/core/accounts/register.js
+++ b/imports/plugins/core/accounts/register.js
@@ -70,7 +70,7 @@ Reaction.registerPackage({
     template: "loginFormUpdatePassword",
     workflow: "none",
     meta: { noAdminControls: true },
-    name: "Reset Password",
+    name: "reset-password",
     label: "reset-password"
   }],
   layout: [{

--- a/imports/plugins/core/accounts/server/init.js
+++ b/imports/plugins/core/accounts/server/init.js
@@ -16,6 +16,6 @@ Hooks.Events.add("afterCoreInit", () => {
   Reaction.addRolesToGroups({
     allShops: true,
     groups: ["guest", "customer"],
-    roles: ["account/verify"]
+    roles: ["account/verify", "reset-password"]
   });
 });

--- a/imports/plugins/core/versions/server/migrations/53_update_password_registry_route_name.js
+++ b/imports/plugins/core/versions/server/migrations/53_update_password_registry_route_name.js
@@ -1,0 +1,26 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Packages } from "/lib/collections";
+
+Migrations.add({
+  version: 53,
+  up() {
+    Packages.update({
+      "name": "reaction-accounts",
+      "registry.name": "Reset Password"
+    }, {
+      $set: {
+        "registry.$.name": "reset-password"
+      }
+    }, { multi: true });
+  },
+  down() {
+    Packages.update({
+      "name": "reaction-accounts",
+      "registry.name": "reset-password"
+    }, {
+      $set: {
+        "registry.$.name": "Reset Password"
+      }
+    }, { multi: true });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -51,3 +51,4 @@ import "./49_update_idp_route_name_to_match_pattern";
 import "./50_create_default_navigation_trees";
 import "./51_catalog_variant_inventory";
 import "./52_change_activetaxfield_to_primary";
+import "./53_update_password_registry_route_name";


### PR DESCRIPTION
Resolves #4911  
Impact: **major**  
Type: **bugfix**

## Issue
Clicking on link in email sent when password reset is requested results in a 404.

## Solution
[This previous update](https://github.com/reactioncommerce/reaction/commit/3d3c4cbfb51649e4d46466a0b8e1446c6a202d82) enabled explicit checking for route item permissions. The reset password permission wasn't enabled for guest and customers, hence the 404 happens.

This PR, adds the route permission to users. It also updates the name to follow other defined plugin convention.

## Breaking changes
N/A
A migration is added to update existing name to match this update.


## Testing
1. As an admin, enable and configure email settings ([docs](https://docs.reactioncommerce.com/docs/email-admin#docsNav)). 
2. Logout, then in the login dropdown, do a password reset
3. Follow link in email
4. Confirm that following the link in the email received shows the password reset form

