### PR TITLE
Fix 404 from invite email link

### DIFF
--- a/imports/plugins/core/accounts/client/containers/updatePassword.js
+++ b/imports/plugins/core/accounts/client/containers/updatePassword.js
@@ -15,6 +15,7 @@ const wrapComponent = (Comp) => (
       callback: PropTypes.func,
       formMessages: PropTypes.object,
       isOpen: PropTypes.bool,
+      onCompleteRoute: PropTypes.string,
       type: PropTypes.string,
       uniqueId: PropTypes.string
     }
@@ -75,7 +76,7 @@ const wrapComponent = (Comp) => (
         } else {
           // Now that Meteor.users is verified, we should do the same with the Accounts collection
           Meteor.call("accounts/verifyAccount");
-          Router.go(`${Router.current().route.fullPath}/completed`);
+          Router.go(this.props.onCompleteRoute);
         }
       });
     }

--- a/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
+++ b/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
@@ -2,25 +2,11 @@ import Random from "@reactioncommerce/random";
 import { Accounts } from "meteor/accounts-base";
 import { Template } from "meteor/templating";
 import { $ } from "meteor/jquery";
-import { Blaze } from "meteor/blaze";
 import { ReactiveVar } from "meteor/reactive-var";
-import { i18next } from "/client/api";
+import { Reaction, i18next } from "/client/api";
 import { LoginFormSharedHelpers } from "../../helpers";
 import { getComponent } from "/imports/plugins/core/components/lib";
 import { LoginFormValidation } from "/lib/api";
-
-/**
- * Accounts Event: onEnrollmentLink When a user uses an enrollment link
- */
-Accounts.onEnrollmentLink((token, done) => {
-  Blaze.renderWithData(Template.loginFormUpdatePasswordOverlay, {
-    token,
-    callback: done,
-    isOpen: true,
-    type: "setPassword"
-  }, $("body").get(0));
-});
-
 
 // ----------------------------------------------------------------------------
 // /**
@@ -28,10 +14,25 @@ Accounts.onEnrollmentLink((token, done) => {
 //  */
 Template.loginFormUpdatePassword.helpers({
   component() {
+    const routeName = Reaction.Router.current().route.name;
+    const formTypeProps = {
+      "account/enroll": {
+        type: "setPassword",
+        onCompleteRoute: "/"
+      },
+      "reset-password": {
+        type: "updatePassword",
+        onCompleteRoute: `${Reaction.Router.current().route.fullPath}/completed`
+      }
+    };
+
+    const { type, onCompleteRoute } = formTypeProps[routeName];
+
     return {
       component: getComponent("UpdatePassword"),
       isOpen: true,
-      type: "updatePassword"
+      type,
+      onCompleteRoute
     };
   }
 });

--- a/imports/plugins/core/accounts/register.js
+++ b/imports/plugins/core/accounts/register.js
@@ -3,6 +3,7 @@ import mutations from "./server/no-meteor/mutations";
 import queries from "./server/no-meteor/queries";
 import resolvers from "./server/no-meteor/resolvers";
 import schemas from "./server/no-meteor/schemas";
+import { ENROLL_URI_BASE } from "./server/util/getDataForEmail";
 
 /**
  * @file Accounts core plugin: Manage how members sign into your shop
@@ -72,6 +73,13 @@ Reaction.registerPackage({
     meta: { noAdminControls: true },
     name: "reset-password",
     label: "reset-password"
+  }, {
+    route: `/${ENROLL_URI_BASE}/:token/:status?`,
+    template: "loginFormUpdatePassword",
+    workflow: "none",
+    meta: { noAdminControls: true },
+    name: ENROLL_URI_BASE,
+    label: "Account Enroll"
   }],
   layout: [{
     layout: "coreLayout",

--- a/imports/plugins/core/accounts/server/init.js
+++ b/imports/plugins/core/accounts/server/init.js
@@ -1,6 +1,7 @@
 import Hooks from "@reactioncommerce/hooks";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import { Accounts, Groups } from "/lib/collections";
+import { ENROLL_URI_BASE } from "./util/getDataForEmail";
 
 // set default admin user's account as "owner"
 Hooks.Events.add("afterCreateDefaultAdminUser", (user) => {
@@ -16,6 +17,6 @@ Hooks.Events.add("afterCoreInit", () => {
   Reaction.addRolesToGroups({
     allShops: true,
     groups: ["guest", "customer"],
-    roles: ["account/verify", "reset-password"]
+    roles: ["account/verify", "reset-password", ENROLL_URI_BASE]
   });
 });

--- a/imports/plugins/core/accounts/server/util/getDataForEmail.js
+++ b/imports/plugins/core/accounts/server/util/getDataForEmail.js
@@ -4,6 +4,12 @@ import { Accounts as MeteorAccounts } from "meteor/accounts-base";
 import { Shops } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 
+export const ENROLL_URI_BASE = "account/enroll";
+
+MeteorAccounts.urls.enrollAccount = function (token) {
+  return Reaction.absoluteUrl(`${ENROLL_URI_BASE}/${token}`);
+};
+
 /**
  * @name getDataForEmail
  * @memberof Accounts/Methods


### PR DESCRIPTION
Resolves #4892  
Impact: **major**  
Type: **bugfix**

## Issue
#4892
Following the enroll email link results in a blank page with errors in the console.

## Solution
- In previous release (#4637), the template that should be rendered when the enroll email link is followed was renamed and updated. So this PR updates to the correct template name.
- The updates made to the above template requires changes to the way props are passed when rendering the template when the enroll link is clicked.

## Breaking changes
N/A

## Testing
1. As an admin, enable and configure email settings (([docs](https://docs.reactioncommerce.com/docs/email-admin#docsNav)).
2. Go to the Accounts dashboard, use the "Add Admin User" form to send invitation email to a new user to join Shop Manager group
3. Go to email, and click the "Get Started" button.
4. Confirm that you see a form to set your password. After settings password, you are redirected to the home page
