### PR TITLE
test: Fix sitemaps test timeouts

### DIFF
--- a/imports/plugins/included/sitemap-generator/server/lib/generate-sitemaps.app-test.js
+++ b/imports/plugins/included/sitemap-generator/server/lib/generate-sitemaps.app-test.js
@@ -11,7 +11,8 @@ describe("generateSitemaps", () => {
   let sandbox;
   let primaryShop;
 
-  beforeEach(() => {
+  beforeEach(function () {
+    this.timeout(10000);
     sandbox = sinon.sandbox.create();
     primaryShop = Factory.create("shop");
     sandbox.stub(Reaction, "getPrimaryShopId", () => primaryShop._id);


### PR DESCRIPTION
Impact: **minor**  
Type: **test**
Related: #4909 

## Issue
The `generateSitemaps` Meteor app tests often fail with a timeout error on CI.

## Solution
Increase timeout.

## Breaking changes
None

## Testing
Verify the `app-test` build phase succeeds on CI.