### PR TITLE
(fix) Make Publish All work correctly

### DIFF
--- a/imports/plugins/core/catalog/client/components/publishControls.js
+++ b/imports/plugins/core/catalog/client/components/publishControls.js
@@ -21,6 +21,7 @@ class PublishControls extends Component {
     isPreview: PropTypes.bool,
     onAction: PropTypes.func,
     onAddProduct: PropTypes.func,
+    onPublishAllClick: PropTypes.func,
     onPublishClick: PropTypes.func,
     onViewContextChange: PropTypes.func,
     onVisibilityChange: PropTypes.func,
@@ -37,9 +38,9 @@ class PublishControls extends Component {
 
   constructor(props) {
     super(props);
-
     this.handleToggleShowChanges = this.handleToggleShowChanges.bind(this);
     this.handlePublishClick = this.handlePublishClick.bind(this);
+    this.handlePublishAllClick = this.handlePublishAllClick.bind(this);
   }
 
   state = {
@@ -62,6 +63,16 @@ class PublishControls extends Component {
   handlePublishClick() {
     if (this.props.onPublishClick) {
       this.props.onPublishClick(this.props.revisions);
+
+      this.setState({
+        isHashUpdating: true
+      });
+    }
+  }
+
+  handlePublishAllClick() {
+    if (this.props.onPublishAllClick) {
+      this.props.onPublishAllClick();
 
       this.setState({
         isHashUpdating: true
@@ -158,7 +169,8 @@ class PublishControls extends Component {
   renderPublishButton() {
     const buttonProps = {};
 
-    if (Array.isArray(this.props.documentIds) && this.props.documentIds.length > 1) {
+    const multiProduct = Array.isArray(this.props.documentIds) && this.props.documentIds.length > 1;
+    if (multiProduct) {
       buttonProps.label = "Publish All";
       buttonProps.i18nKeyLabel = "toolbar.publishAll";
     }
@@ -171,8 +183,8 @@ class PublishControls extends Component {
         <Button
           bezelStyle="solid"
           disabled={isDisabled}
-          label="Publish"
-          onClick={this.handlePublishClick}
+          label={ multiProduct ? "Publish All" : "Publish" }
+          onClick={ multiProduct ? this.handlePublishAllClick : this.handlePublishClick}
           status="success"
           i18nKeyLabel="productDetailEdit.publish"
           {...buttonProps}

--- a/imports/plugins/core/catalog/client/containers/publishContainer.js
+++ b/imports/plugins/core/catalog/client/containers/publishContainer.js
@@ -20,13 +20,27 @@ class PublishContainer extends Component {
     });
   }
 
+  publishAllToCatalog(collection) {
+    Meteor.call(`catalog/publishAll/${collection}`, (error, result) => {
+      if (result) {
+        Alerts.toast(i18next.t("admin.catalogProductPublishSuccess", { defaultValue: "Products published to catalog" }), "success");
+      } else if (error) {
+        Alerts.toast(error.message, "error");
+      }
+    });
+  }
+
   handlePublishClick = () => {
     const productIds = this.props.documents
       .filter((doc) => doc.type === "simple")
       .map((doc) => doc._id);
 
     this.publishToCatalog("products", productIds);
-  }
+  };
+
+  handlePublishAllClick = () => {
+    this.publishAllToCatalog("products");
+  };
 
   handlePublishActions = (event, action) => {
     if (action === "archive" && this.props.onAction) {
@@ -42,6 +56,7 @@ class PublishContainer extends Component {
           documents={this.props.documents}
           isEnabled={this.props.isEnabled}
           onPublishClick={this.handlePublishClick}
+          onPublishAllClick={this.handlePublishAllClick}
           onAction={this.handlePublishActions}
           onVisibilityChange={this.props.onVisibilityChange}
           isPreview={this.props.isPreview}

--- a/imports/plugins/core/catalog/server/methods/publishProducts.js
+++ b/imports/plugins/core/catalog/server/methods/publishProducts.js
@@ -2,11 +2,16 @@ import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
 import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
 import publishProductsMutation from "../no-meteor/mutations/publishProducts";
+import publishAllProducts from "../no-meteor/mutations/publishAllProducts";
 
 Meteor.methods({
   "catalog/publish/products"(productIds) {
     check(productIds, [String]);
     const context = Promise.await(getGraphQLContextInMeteorMethod(this.userId));
     return publishProductsMutation(context, productIds);
+  },
+  "catalog/publishAll/products"() {
+    const context = Promise.await(getGraphQLContextInMeteorMethod(this.userId));
+    return publishAllProducts(context);
   }
 });

--- a/imports/plugins/core/catalog/server/no-meteor/mutations/index.js
+++ b/imports/plugins/core/catalog/server/no-meteor/mutations/index.js
@@ -1,5 +1,7 @@
 import publishProducts from "./publishProducts";
+import publishAllProducts from "./publishAllProducts";
 
 export default {
-  publishProducts
+  publishProducts,
+  publishAllProducts
 };

--- a/imports/plugins/core/catalog/server/no-meteor/mutations/publishAllProducts.js
+++ b/imports/plugins/core/catalog/server/no-meteor/mutations/publishAllProducts.js
@@ -1,0 +1,10 @@
+import publishProducts from "./publishProducts";
+
+
+export default async function publishAllProducts(context) {
+  const { collections } = context;
+  const { Products } = collections;
+  const allProducts = await Products.find({ type: "simple" }, { _id: 1 }).toArray();
+  const allProductIds = allProducts.map((product) => product._id);
+  return publishProducts(context, allProductIds);
+}

--- a/imports/plugins/core/catalog/server/no-meteor/mutations/publishProducts.js
+++ b/imports/plugins/core/catalog/server/no-meteor/mutations/publishProducts.js
@@ -12,8 +12,9 @@ import publishProductsToCatalog from "../utils/publishProductsToCatalog";
  * @return {Promise<Object[]>} Array of CatalogItemProduct objects
  */
 export default async function publishProducts(context, productIds) {
-  const { collections, shopId: primaryShopId, userHasPermission } = context;
+  const { collections, shopId: primaryShopId, userHasPermission, appEvents } = context;
   const { Catalog, Products } = collections;
+  appEvents.emit("userIntentToPublish", productIds);
 
   // Find all products
   const products = await Products.find(
@@ -44,5 +45,6 @@ export default async function publishProducts(context, productIds) {
     Logger.error("Some Products could not be published to the Catalog.");
     throw new ReactionError("server-error", "Some Products could not be published to the Catalog. Make sure your variants are visible.");
   }
+  appEvents.emit("afterProductsPublished", productIds);
   return Catalog.find({ "product.productId": { $in: productIds } }).toArray();
 }


### PR DESCRIPTION
Resolves #4823 
Impact: **major**  
Type: **bugfix**

## Issue
Currently the "Publish All" button only publishes the visible products. This makes it so all products are published.

## Solution
Create a `publishAllToCatalog` method and call that when there is more than one product in the scope.

## Testing
1. Create multiple products with unpublished changes (> 100)
1. Hit "Publish All"
1. Verify that all products all now in the Catalog

