### PR TITLE
feat: Make Sitemap data available via GraphQL query

### DIFF
--- a/imports/plugins/included/sitemap-generator/register.js
+++ b/imports/plugins/included/sitemap-generator/register.js
@@ -2,6 +2,7 @@ import Reaction from "/imports/plugins/core/core/server/Reaction";
 import mutations from "./server/no-meteor/mutations";
 import resolvers from "./server/no-meteor/resolvers";
 import schemas from "./server/no-meteor/schemas";
+import startup from "./server/no-meteor/startup";
 
 Reaction.registerPackage({
   label: "Sitemap Generator",
@@ -11,6 +12,9 @@ Reaction.registerPackage({
   graphQL: {
     resolvers,
     schemas
+  },
+  functionsByType: {
+    startup: [startup]
   },
   mutations
 });

--- a/imports/plugins/included/sitemap-generator/server/middleware/handle-sitemap-routes.js
+++ b/imports/plugins/included/sitemap-generator/server/middleware/handle-sitemap-routes.js
@@ -6,7 +6,7 @@ import getSitemapXML from "../lib/get-sitemap-xml";
  * @summary Route handler/middleware for generated sitemap XML files
  * @param {Object} req - Node.js IncomingMessage object
  * @param {Object} res - Node.js ServerResponse object
- * @param {Function} next - Passes handling of request to next relevant middlewhere
+ * @param {Function} next - Passes handling of request to next relevant middleware
  * @returns {undefined} - Sends XML to response, or triggers 404
  */
 export default function handleSitemapRoutes(req, res, next) {

--- a/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/Query/index.js
+++ b/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/Query/index.js
@@ -1,0 +1,5 @@
+import sitemap from "./sitemap";
+
+export default {
+  sitemap
+};

--- a/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/Query/sitemap.js
+++ b/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/Query/sitemap.js
@@ -7,7 +7,7 @@ import url from "url";
  * @param {Object} params - an object of all arguments that were sent by the client
  * @param {String} params.handle - Sitemap's handle, as set in Sitemaps collection
  * @param {String} params.shopUrl - URL of the shop the sitemap belongs to. The URL is used to find the shop with the domain of the URL
- * @param {Object} context -  an object containing the per-request state
+ * @param {Object} context - an object containing the per-request state
  * @returns {String} - Sitemap object containing XML with placeholders replaced (BASE_URL, LAST_MOD)
  */
 export default async function sitemapQuery(_, params, context) {

--- a/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/Query/sitemap.js
+++ b/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/Query/sitemap.js
@@ -1,0 +1,31 @@
+import url from "url";
+
+/**
+ * @name sitemapQuery
+ * @method
+ * @param {Object} _ - unused
+ * @param {Object} params - an object of all arguments that were sent by the client
+ * @param {String} params.handle - Sitemap's handle, as set in Sitemaps collection
+ * @param {String} params.shopUrl - URL of the shop the sitemap belongs to. The URL is used to find the shop with the domain of the URL
+ * @param {Object} context -  an object containing the per-request state
+ * @returns {String} - Sitemap object containing XML with placeholders replaced (BASE_URL, LAST_MOD)
+ */
+export default async function sitemapQuery(_, params, context) {
+  const { Sitemaps, Shops } = context.collections;
+  const { handle, shopUrl } = params;
+
+  const domain = url.parse(shopUrl).hostname;
+
+  // ensure the domain requested is for a known shop domain
+  const { _id: shopId } = await Shops.findOne({ domains: domain }) || {};
+
+  if (!shopId) return null;
+
+  const sitemap = await Sitemaps.findOne({ shopId, handle });
+
+  if (!sitemap) return null;
+
+  sitemap.xml = sitemap.xml.replace(/BASE_URL/g, shopUrl);
+
+  return sitemap;
+}

--- a/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/Sitemap/index.js
+++ b/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/Sitemap/index.js
@@ -1,0 +1,5 @@
+import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+
+export default {
+  shopId: (node) => encodeShopOpaqueId(node.shopId)
+};

--- a/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/index.js
+++ b/imports/plugins/included/sitemap-generator/server/no-meteor/resolvers/index.js
@@ -1,5 +1,9 @@
 import Mutation from "./Mutation";
+import Query from "./Query";
+import Sitemap from "./Sitemap";
 
 export default {
-  Mutation
+  Mutation,
+  Query,
+  Sitemap
 };

--- a/imports/plugins/included/sitemap-generator/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/included/sitemap-generator/server/no-meteor/schemas/schema.graphql
@@ -28,10 +28,10 @@ type Sitemap {
   shopId: String!
 
   "The Sitemap handle, as set in Sitemaps collection"
-  handle: String
+  handle: String!
 
   "The Sitemap XML content"
-  xml: String
+  xml: String!
 
   "Date created"
   createdAt: Date!

--- a/imports/plugins/included/sitemap-generator/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/included/sitemap-generator/server/no-meteor/schemas/schema.graphql
@@ -13,7 +13,26 @@ input GenerateSitemapsInput {
 type GenerateSitemapsPayload {
   "The same string you sent with the mutation params, for matching mutation calls with their responses"
   clientMutationId: String
-  
+
   "Whether the sitemap generation job was successfully scheduled"
   wasJobScheduled: Boolean!
+}
+
+extend type Query {
+  "Returns Sitemap object for a shop based on the handle param"
+  sitemap(handle: String!, shopUrl: String!): Sitemap
+}
+
+type Sitemap {
+  "The shop ID"
+  shopId: String!
+
+  "The Sitemap handle, as set in Sitemaps collection"
+  handle: String
+
+  "The Sitemap XML content"
+  xml: String
+
+  "Date created"
+  createdAt: Date!
 }

--- a/imports/plugins/included/sitemap-generator/server/no-meteor/startup.js
+++ b/imports/plugins/included/sitemap-generator/server/no-meteor/startup.js
@@ -1,0 +1,8 @@
+/**
+ * @summary Called on startup
+ * @param {Object} context Startup context
+ * @returns {undefined}
+ */
+export default function startup(context) {
+  context.collections.Sitemaps = context.app.db.collection("Sitemaps");
+}


### PR DESCRIPTION
Resolves #4796  
Impact: **major**  
Type: **feature**

To be tested along with https://github.com/reactioncommerce/reaction-next-starterkit/pull/488
## Issue
#4796
The sitemaps are generated in the core API app (ie. the `reaction` service), and currently available on the API domain/url. We need to make the sitemap information available through GraphQL so standalone storefronts can use it.

## Solution
- Setup a GQL query for retrieving sitemap data
- Update the starterkit to use the expose data interface (PR -> https://github.com/reactioncommerce/reaction-next-starterkit/pull/488)

**Details**
- The query takes 2 params: `handle` and `shopUrl`. The handle is a string used when the sitemap was created. It can have values like `sitemap.xml`, `sitemap-tags-1.xml`. 
- Sitemaps are saved with the shopId they belong to. Storefront apps like starkerkit get shopId value later on in the rendering process. To get sitemap information without depending on the rendering process, the shopUrl is passed as param.
- The shopUrl is confirmed in the GQL implementation to ensure the domain requested is for a known shop domain `Shops.findOne({ domains: domain })`
- The shopUrl param is also used to replace the xml placeholder: `sitemap.xml.replace(/BASE_URL/g, shopUrl)`


## Testing
- Start reaction on this branch
- Generate Sitemaps by going to the "Shop" admin panel. Under "Options" tab, click "Refresh Sitemap"
- Start the starterkit app with this branch ([feat-4796-impactmass-sitemap-endpoint](https://github.com/reactioncommerce/reaction-next-starterkit/tree/feat-4796-impactmass-sitemap-endpoint)).
- Visit `{starterkitdomain}/sitemap.xml` e.g http://localhost:4000/sitemap.xml 
- You should see the sitemap xml on the page


[ @kieckhafer as the primary reviewer. @dancastellon I added you to take a pass based on the fact that you worked previously on sitemap. ]