### PR TITLE
fix: migration 56 throwing an error

### DIFF
--- a/imports/plugins/core/versions/server/migrations/56_change_inventoryQuantity_to_inventoryInStock.js
+++ b/imports/plugins/core/versions/server/migrations/56_change_inventoryQuantity_to_inventoryInStock.js
@@ -6,23 +6,13 @@ Migrations.add({
   up() {
     collections.Products.update(
       {
-        type: "simple"
+        type: { $in: ["simple", "variant"] }
       },
       {
         $rename: { inventoryQuantity: "inventoryInStock" }
       },
       {
-        multi: true
-      }
-    );
-    collections.Products.update(
-      {
-        type: "variant"
-      },
-      {
-        $rename: { inventoryQuantity: "inventoryInStock" }
-      },
-      {
+        bypassCollection2: true,
         multi: true
       }
     );
@@ -30,24 +20,13 @@ Migrations.add({
   down() {
     collections.Products.update(
       {
-        type: "simple"
+        type: { $in: ["simple", "variant"] }
       },
       {
         $rename: { inventoryInStock: "inventoryQuantity" }
       },
       {
-        multi: true
-      }
-    );
-
-    collections.Products.update(
-      {
-        type: "variant"
-      },
-      {
-        $rename: { inventoryInStock: "inventoryQuantity" }
-      },
-      {
+        bypassCollection2: true,
         multi: true
       }
     );

--- a/imports/plugins/core/versions/server/migrations/56_change_inventoryQuantity_to_inventoryInStock.js
+++ b/imports/plugins/core/versions/server/migrations/56_change_inventoryQuantity_to_inventoryInStock.js
@@ -6,7 +6,18 @@ Migrations.add({
   up() {
     collections.Products.update(
       {
-        type: { $in: ["simple", "variant"] }
+        type: "simple"
+      },
+      {
+        $rename: { inventoryQuantity: "inventoryInStock" }
+      },
+      {
+        multi: true
+      }
+    );
+    collections.Products.update(
+      {
+        type: "variant"
       },
       {
         $rename: { inventoryQuantity: "inventoryInStock" }
@@ -19,7 +30,19 @@ Migrations.add({
   down() {
     collections.Products.update(
       {
-        type: { $in: ["simple", "variant"] }
+        type: "simple"
+      },
+      {
+        $rename: { inventoryInStock: "inventoryQuantity" }
+      },
+      {
+        multi: true
+      }
+    );
+
+    collections.Products.update(
+      {
+        type: "variant"
       },
       {
         $rename: { inventoryInStock: "inventoryQuantity" }


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
Migration 56 is throwing an error, `Error while migrating TypeError: Cannot read property 'namedContext' of null`. It seems this error stems from the issue of having two different schemas for `variant` and `simple`, causing the issue with the update.

There are various cases of this same error reported in github issues:
https://github.com/aldeed/meteor-collection2/issues/310
https://github.com/aldeed/meteor-collection2-core/issues/12

## Solution
Split the update into two different database calls.

## Breaking changes
None

## Testing
1. Start reaction from a fresh install
1. See all migrations worked