### PR TITLE
chore Update to base image 1.8.0.2 to include Kafka binary libs

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -11,11 +11,11 @@ meteor-base@1.4.0             # Packages every Meteor app needs to have
 mobile-experience@1.0.5       # Packages for a great mobile UX
 blaze-html-templates@1.0.4    # Compile .html files into Meteor Blaze views
 es5-shim@4.8.0               # ECMAScript 5 compatibility for older browsers.
-ecmascript@0.12.0              # Enable ECMAScript2015+ syntax in app code
+ecmascript@0.12.4              # Enable ECMAScript2015+ syntax in app code
 audit-argument-checks@1.0.7   # ensure meteor method argument validation
 browser-policy@1.1.0          # security-related policies enforced by newer browsers
 juliancwirko:postcss@1.3.0    # CSS post-processing plugin (replaces standard-minifier-css)
-session@1.1.8                 # ReactiveDict whose contents are preserved across Hot Code Push
+session@1.2.0                 # ReactiveDict whose contents are preserved across Hot Code Push
 tracker@1.2.0                 # Meteor transparent reactive programming library
 mongo@1.6.0
 reactive-var@1.0.11

--- a/.meteor/release
+++ b/.meteor/release
@@ -1,1 +1,1 @@
-METEOR@1.8
+METEOR@1.8.0.2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -12,7 +12,7 @@ aldeed:template-extension@4.1.0
 allow-deny@1.1.0
 audit-argument-checks@1.0.7
 autoupdate@1.5.0
-babel-compiler@7.2.1
+babel-compiler@7.2.4
 babel-runtime@1.3.0
 base64@1.0.11
 binary-heap@1.0.11
@@ -25,7 +25,7 @@ browser-policy@1.1.0
 browser-policy-common@1.0.11
 browser-policy-content@1.1.0
 browser-policy-framing@1.1.0
-caching-compiler@1.2.0
+caching-compiler@1.2.1
 caching-html-compiler@1.1.3
 callback-hook@1.1.0
 check@1.3.1
@@ -37,9 +37,9 @@ ddp-common@1.4.0
 ddp-rate-limiter@1.0.7
 ddp-server@2.2.0
 deps@1.0.12
-diff-sequence@1.1.0
+diff-sequence@1.1.1
 dynamic-import@0.5.0
-ecmascript@0.12.1
+ecmascript@0.12.4
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.8.0
 ecmascript-runtime-server@0.7.1
@@ -76,12 +76,12 @@ meteorhacks:ssr@2.2.0
 meteorhacks:subs-manager@1.6.4
 meteortesting:browser-tests@0.2.0
 meteortesting:mocha@0.6.0
-minifier-css@1.4.0
+minifier-css@1.4.1
 minifier-js@2.4.0
 minimongo@1.4.5
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14
-modern-browsers@0.1.2
+modern-browsers@0.1.3
 modules@0.13.0
 modules-runtime@0.10.3
 momentjs:moment@2.19.4
@@ -91,9 +91,9 @@ mongo-dev-server@1.1.0
 mongo-id@1.0.7
 npm-bcrypt@0.9.3
 npm-mongo@3.1.1
-oauth@1.2.4
+oauth@1.2.6
 oauth-encryption@1.3.1
-oauth1@1.2.1
+oauth1@1.2.2
 oauth2@1.2.1
 observe-sequence@1.0.16
 ongoworks:security@2.1.0
@@ -103,7 +103,7 @@ percolate:migrations@0.9.8
 practicalmeteor:chai@2.1.0_1
 practicalmeteor:mocha-core@1.0.1
 practicalmeteor:sinon@1.14.1_2
-promise@0.11.1
+promise@0.11.2
 raix:eventemitter@0.1.3
 random@1.1.0
 rate-limit@1.0.9
@@ -113,7 +113,7 @@ reload@1.2.0
 retry@1.1.0
 routepolicy@1.1.0
 service-configuration@1.0.11
-session@1.1.8
+session@1.2.0
 sha@1.0.9
 shell-server@0.4.0
 socket-stream-client@0.2.2
@@ -133,5 +133,5 @@ twitter-oauth@1.2.0
 ui@1.0.13
 underscore@1.0.10
 url@1.2.0
-webapp@1.7.0
+webapp@1.7.1
 webapp-hashing@1.0.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##############################################################################
 # meteor-dev stage - builds image for dev and used with docker-compose.yml
 ##############################################################################
-FROM reactioncommerce/base:v1.8-meteor as meteor-dev
+FROM reactioncommerce/base:v1.8.0.2-meteor as meteor-dev
 
 LABEL maintainer="Reaction Commerce <architecture@reactioncommerce.com>"
 


### PR DESCRIPTION
Type: **chore?**

## Changes
- We published an updated base image in order to add new dependencies useful for kakfa development (reactioncommerce/base#39). This update is particularly useful for data import features.
- The base image versioning is currently tied to Meteor versions, hence the new base image for 1.8.0.2
- Meteor 1.8.0.2 only contains a minor bug fix https://github.com/meteor/meteor/pull/10403 
- Meteor's Atmosphere packages also got some patch updates

## Testing
- Run basic tests in the meteor app (guest browsing, add to cart, login, checkout)
- You can merge this into a branch you're using in development and test it out for a few hours
- Confirm that the kafka-related bins (librdkafka-dev, libsasl2-dev) are present (@dancastellon I assume you know how to confirm this, since you use them)