### PR TITLE
Fix ENOSPC error with jest --watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,7 +366,8 @@
     }
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/imports/test-utils/setupJestTests.js"
+    "setupTestFrameworkScriptFile": "<rootDir>/imports/test-utils/setupJestTests.js",
+    "modulePathIgnorePatterns": ["node_modules"]
   },
   "eslintConfig": {
     "extends": "@reactioncommerce",


### PR DESCRIPTION
Impact: **none**  
Type: **test**

## Issue

Trying to run `meteor npm run test:file path/to/my/file.test.js` with linux host OS inside a docker container was crashing with this error:

```
node@b683c6336f32:/opt/reaction/src$ meteor npm run test:file -- $f

fs.js:1384
    throw error;
    ^

Error: watch /opt/reaction/src/node_modules/faker/lib/locales/en_IND/name ENOSPC
```

Spencer found [jest issue 3254](https://github.com/facebook/jest/issues/3254#issuecomment-457027880) which indicates its a problem with filesystem watching.

## Solution

This configuration seems to avoid the problem and allow the command to run properly.

## Testing
1. `meteor npm run test:file path/to/my/file.test.js`
  - If it crashes, the problem still exists, if the test runs and you see the jest watch menu displayed, the problem is solved.