### PR TITLE
fix: tag bulk actions copy

### DIFF
--- a/imports/plugins/core/tags/client/pages/TagSettingsPageWithData.js
+++ b/imports/plugins/core/tags/client/pages/TagSettingsPageWithData.js
@@ -31,8 +31,8 @@ class TagSettings extends Component {
     super(props);
 
     this.bulkActions = [
-      { value: "hidden", label: i18next.t("admin.tags.hidden") },
-      { value: "visible", label: i18next.t("admin.tags.visible") },
+      { value: "hidden", label: i18next.t("admin.tags.makeHidden") },
+      { value: "visible", label: i18next.t("admin.tags.makeVisible") },
       { value: "delete", label: i18next.t("admin.tags.delete") }
     ];
 

--- a/imports/plugins/core/tags/server/i18n/en.json
+++ b/imports/plugins/core/tags/server/i18n/en.json
@@ -14,6 +14,8 @@
             "disable": "Disable",
             "delete": "Delete",
             "visible": "Visible",
+            "makeVisible": "Make visible",
+            "makeHidden": "Make hidden",
             "hidden": "Hidden",
             "visibleAction": "Make {{count}} tag visible to customers",
             "visibleAction_plural": "Make {{count}} tags visible to customers",


### PR DESCRIPTION
Impact: **minor**  
Type: **style**

## Issue

Forgot to commit and push some copy changes for PR: https://github.com/reactioncommerce/reaction/pull/4933

## Solution

Make the necessary copy changes

## Breaking changes

none

## Testing

1. Open the tag manager UI
1. Select tags in the table
1. see the bulk actions say "Make hidden" and "Make visible"
1. Use each action in two separate bulk operations and ensure they indeed, "make visible" and "make hidden" the tags you selected.
