### PR TITLE
fix: Inventory is set to `NaN` in rare circumstances based on Migrations

### DIFF
--- a/imports/plugins/core/versions/server/migrations/57_confirm_inventory_is_not_NaN.js
+++ b/imports/plugins/core/versions/server/migrations/57_confirm_inventory_is_not_NaN.js
@@ -1,0 +1,21 @@
+import { Migrations } from "meteor/percolate:migrations";
+import * as collections from "/lib/collections";
+
+Migrations.add({
+  version: 57,
+  up() {
+    collections.Products.update(
+      {
+        type: { $in: ["simple", "variant"] },
+        inventoryAvailableToSell: NaN
+      },
+      {
+        $set: { inventoryAvailableToSell: 0 }
+      },
+      {
+        bypassCollection2: true,
+        multi: true
+      }
+    );
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/57_confirm_inventory_is_not_NaN.js
+++ b/imports/plugins/core/versions/server/migrations/57_confirm_inventory_is_not_NaN.js
@@ -1,13 +1,15 @@
+
 import { Migrations } from "meteor/percolate:migrations";
 import * as collections from "/lib/collections";
+import { convertCatalogItemVariants } from "../util/convert57";
+import findAndConvertInBatches from "../util/findAndConvertInBatches";
 
 Migrations.add({
   version: 57,
   up() {
     collections.Products.update(
       {
-        type: { $in: ["simple", "variant"] },
-        inventoryAvailableToSell: NaN
+        inventoryAvailableToSell: { $in: [NaN, null] }
       },
       {
         $set: { inventoryAvailableToSell: 0 }
@@ -20,8 +22,7 @@ Migrations.add({
 
     collections.Products.update(
       {
-        type: { $in: ["simple", "variant"] },
-        inventoryInStock: NaN
+        inventoryInStock: { $in: [NaN, null] }
       },
       {
         $set: { inventoryInStock: 0 }
@@ -31,5 +32,10 @@ Migrations.add({
         multi: true
       }
     );
+
+    findAndConvertInBatches({
+      collection: collections.Catalog,
+      converter: (catalogItem) => convertCatalogItemVariants(catalogItem, collections)
+    });
   }
 });

--- a/imports/plugins/core/versions/server/migrations/57_confirm_inventory_is_not_NaN.js
+++ b/imports/plugins/core/versions/server/migrations/57_confirm_inventory_is_not_NaN.js
@@ -17,5 +17,19 @@ Migrations.add({
         multi: true
       }
     );
+
+    collections.Products.update(
+      {
+        type: { $in: ["simple", "variant"] },
+        inventoryInStock: NaN
+      },
+      {
+        $set: { inventoryInStock: 0 }
+      },
+      {
+        bypassCollection2: true,
+        multi: true
+      }
+    );
   }
 });

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -55,3 +55,4 @@ import "./53_update_password_registry_route_name";
 import "./54_template_name_updates";
 import "./55_order_payments";
 import "./56_change_inventoryQuantity_to_inventoryInStock";
+import "./57_confirm_inventory_is_not_NaN.js";

--- a/imports/plugins/core/versions/server/util/convert57.js
+++ b/imports/plugins/core/versions/server/util/convert57.js
@@ -1,0 +1,175 @@
+import _ from "lodash";
+
+/**
+ * @method canBackorder
+ * @summary If all the products variants have inventory policy disabled and inventory management enabled
+ * @memberof Catalog
+ * @param {Object[]} variants - Array with product variant objects
+ * @return {boolean} is backorder allowed or not for a product
+ */
+function canBackorder(variants) {
+  const results = variants.map((variant) => !variant.inventoryPolicy && variant.inventoryManagement);
+  return results.every((result) => result);
+}
+
+
+/**
+ * @method isBackorder
+ * @summary If all the products variants have inventory policy disabled, inventory management enabled and a quantity of zero return `true`
+ * @memberof Catalog
+ * @param {Object[]} variants - Array with product variant objects
+ * @return {boolean} is backorder currently active or not for a product
+ */
+function isBackorder(variants) {
+  const results = variants.map((variant) => !variant.inventoryPolicy && variant.inventoryManagement && variant.inventoryAvailableToSell === 0);
+  return results.every((result) => result);
+}
+
+/**
+ * @method isSoldOut
+ * @summary If all the product variants have a quantity of 0 return `true`.
+ * @memberof Catalog
+ * @param {Object[]} variants - Array with top-level variants
+ * @return {Boolean} true if quantity is zero.
+ */
+function isSoldOut(variants) {
+  const results = variants.map((variant) => variant.inventoryManagement && variant.inventoryAvailableToSell <= 0);
+  return results.every((result) => result);
+}
+
+
+/**
+ * @method isLowQuantity
+ * @summary If at least one of the product variants quantity is less than the low inventory threshold return `true`.
+ * @memberof Catalog
+ * @param {Object[]} variants - Array of child variants
+ * @return {boolean} low quantity or not
+ */
+function isLowQuantity(variants) {
+  const threshold = variants && variants.length && variants[0].lowInventoryWarningThreshold;
+  const results = variants.map((variant) => {
+    if (variant.inventoryManagement && variant.inventoryAvailableToSell) {
+      return variant.inventoryAvailableToSell <= threshold;
+    }
+    return false;
+  });
+  return results.some((result) => result);
+}
+
+/**
+ * @param {Object} item The catalog item to transform
+ * @param {Object} collections The catalog item to transform
+ * @returns {Object} The converted item document
+ */
+export function convertCatalogItemVariants(item, collections) {
+  const { Products } = collections;
+
+  // Get all variants of the product.
+  // All variants are needed as we need to match the currently published variants with
+  // their counterparts from the products collection. We don't want to the inventory numbers
+  // to be invalid just because a product has been set to not visible while that change has
+  // not yet been published to the catalog.
+  // The catalog will be used as the source of truth for the variants and options.
+  const product = Products.findOne({
+    _id: item.product._id
+  });
+
+  const variants = Products.find({
+    ancestors: item.product._id
+  }).fetch();
+
+  const topVariants = new Map();
+  const options = new Map();
+
+  variants.forEach((variant) => {
+    if (variant.ancestors.length === 2) {
+      const parentId = variant.ancestors[1];
+      if (options.has(parentId)) {
+        options.get(parentId).push(variant);
+      } else {
+        options.set(parentId, [variant]);
+      }
+    } else {
+      topVariants.set(variant._id, variant);
+    }
+  });
+
+  const catalogProductVariants = item.product.variants.map((variant) => {
+    const catalogVariantOptions = variant.options || [];
+    const topVariantFromProductsCollection = topVariants.get(variant._id);
+    const variantOptionsFromProductsCollection = options.get(variant._id);
+    const catalogVariantOptionsMap = new Map();
+
+    catalogVariantOptions.forEach((catalogVariantOption) => {
+      catalogVariantOptionsMap.set(catalogVariantOption._id, catalogVariantOption);
+    });
+
+    // We only want the variant options that are currently published to the catalog.
+    // We need to be careful, not to publish variant or options to the catalog
+    // that an operator may not wish to be published yet.
+    const variantOptions = _.intersectionWith(
+      variantOptionsFromProductsCollection, // array to filter
+      catalogVariantOptions, // Items to exclude
+      ({ _id: productVariantId }, { _id: catalogItemVariantOptionId }) => (
+        // Exclude options from the products collection that aren't in the catalog collection
+        productVariantId === catalogItemVariantOptionId
+      )
+    );
+
+    let updatedVariantFields;
+    if (variantOptions) {
+      // For variants with options, update the inventory flags for the top-level variant and options
+      updatedVariantFields = {
+        canBackorder: canBackorder(variantOptions),
+        inventoryAvailableToSell: topVariantFromProductsCollection.inventoryAvailableToSell,
+        inventoryInStock: topVariantFromProductsCollection.inventoryQuantity || topVariantFromProductsCollection.inventoryInStock,
+        isBackorder: isBackorder(variantOptions),
+        isLowQuantity: isLowQuantity(variantOptions),
+        isSoldOut: isSoldOut(variantOptions),
+        options: variantOptions.map((option) => ({
+          ...catalogVariantOptionsMap.get(option._id),
+          canBackorder: canBackorder([option]),
+          inventoryAvailableToSell: option.inventoryAvailableToSell,
+          inventoryInStock: option.inventoryQuantity || option.inventoryInStock,
+          isBackorder: isBackorder([option]),
+          isLowQuantity: isLowQuantity([option]),
+          isSoldOut: isSoldOut([option])
+        }))
+      };
+    } else {
+      // For variants WITHOUT options, update the inventory flags for the top-level variant only
+      updatedVariantFields = {
+        canBackorder: canBackorder([topVariantFromProductsCollection]),
+        inventoryAvailableToSell: topVariantFromProductsCollection.inventoryAvailableToSell,
+        inventoryInStock: topVariantFromProductsCollection.inventoryQuantity || topVariantFromProductsCollection.inventoryInStock,
+        isBackorder: isBackorder([topVariantFromProductsCollection]),
+        isLowQuantity: isLowQuantity([topVariantFromProductsCollection]),
+        isSoldOut: isSoldOut([topVariantFromProductsCollection])
+      };
+    }
+
+    return {
+      ...variant,
+      ...updatedVariantFields
+    };
+  });
+
+  const catalogProduct = {
+    ...item.product,
+    inventoryAvailableToSell: product.inventoryAvailableToSell,
+    inventoryInStock: product.inventoryQuantity || product.inventoryInStock,
+    isBackorder: isBackorder(variants),
+    isLowQuantity: isLowQuantity(variants),
+    isSoldOut: isSoldOut(variants),
+    variants: catalogProductVariants
+  };
+
+  const doc = {
+    _id: item._id,
+    product: catalogProduct,
+    shopId: item.shopId,
+    createdAt: item.createdAt
+  };
+
+  return doc;
+}

--- a/imports/plugins/core/versions/server/util/findAndConvertInBatches.js
+++ b/imports/plugins/core/versions/server/util/findAndConvertInBatches.js
@@ -10,12 +10,12 @@ const LIMIT = 200;
  * @param {Function} options.converter Conversion function for a single doc
  * @returns {undefined}
  */
-export default function findAndConvertInBatches({ collection, converter }) {
+export default function findAndConvertInBatches({ collection, converter, query = {} }) {
   let docs;
   let skip = 0;
 
   do {
-    docs = collection.find({}, {
+    docs = collection.find(query, {
       limit: LIMIT,
       skip,
       sort: {

--- a/private/data/Products.json
+++ b/private/data/Products.json
@@ -15,7 +15,7 @@
   "price.min": 12.99,
   "price.max": 19.99,
   "inventoryAvailableToSell": 35,
-  "inventoryQuantity": 35,
+  "inventoryInStock": 35,
   "isVisible": true,
   "isLowQuantity": false,
   "isSoldOut": false,
@@ -44,7 +44,7 @@
   "inventoryManagement": true,
   "inventoryPolicy": true,
   "inventoryAvailableToSell": 35,
-  "inventoryQuantity": 35,
+  "inventoryInStock": 35,
   "isVisible": true,
   "updatedAt": {
     "$date": "2014-04-03T13:46:52.411-0700"
@@ -72,7 +72,7 @@
   "inventoryManagement": true,
   "inventoryPolicy": true,
   "inventoryAvailableToSell": 20,
-  "inventoryQuantity": 20,
+  "inventoryInStock": 20,
   "isVisible": true,
   "updatedAt": {
     "$date": "2014-04-03T13:46:52.411-0700"
@@ -103,7 +103,7 @@
   "inventoryManagement": true,
   "inventoryPolicy": true,
   "inventoryAvailableToSell": 35,
-  "inventoryQuantity": 35,
+  "inventoryInStock": 35,
   "isVisible": true,
   "updatedAt": {
     "$date": "2014-04-03T13:46:52.411-0700"

--- a/private/data/Products.json
+++ b/private/data/Products.json
@@ -14,6 +14,8 @@
   "price.range": "12.99 - 19.99",
   "price.min": 12.99,
   "price.max": 19.99,
+  "inventoryAvailableToSell": 35,
+  "inventoryQuantity": 35,
   "isVisible": true,
   "isLowQuantity": false,
   "isSoldOut": false,
@@ -41,7 +43,8 @@
   "price": 19.99,
   "inventoryManagement": true,
   "inventoryPolicy": true,
-  "inventoryInStock": 15,
+  "inventoryAvailableToSell": 35,
+  "inventoryQuantity": 35,
   "isVisible": true,
   "updatedAt": {
     "$date": "2014-04-03T13:46:52.411-0700"
@@ -68,7 +71,8 @@
   "price": 19.99,
   "inventoryManagement": true,
   "inventoryPolicy": true,
-  "inventoryInStock": 19,
+  "inventoryAvailableToSell": 20,
+  "inventoryQuantity": 20,
   "isVisible": true,
   "updatedAt": {
     "$date": "2014-04-03T13:46:52.411-0700"
@@ -98,7 +102,8 @@
   "price": 12.99,
   "inventoryManagement": true,
   "inventoryPolicy": true,
-  "inventoryInStock": 42,
+  "inventoryAvailableToSell": 35,
+  "inventoryQuantity": 35,
   "isVisible": true,
   "updatedAt": {
     "$date": "2014-04-03T13:46:52.411-0700"

--- a/private/data/Products.json
+++ b/private/data/Products.json
@@ -102,8 +102,8 @@
   "price": 12.99,
   "inventoryManagement": true,
   "inventoryPolicy": true,
-  "inventoryAvailableToSell": 35,
-  "inventoryInStock": 35,
+  "inventoryAvailableToSell": 10,
+  "inventoryInStock": 10,
   "isVisible": true,
   "updatedAt": {
     "$date": "2014-04-03T13:46:52.411-0700"


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
While not confirmed to be the only way this happens, it seems that if a user has not run `Migration 51` yet, when they pull in the changes that come along with `Migration 56`, `inventoryQuantity` / `inventoryInStock` gets set to `NaN`.

If a codebase is already past `Migration 51` when the changes that include `Migration 56` are pulled in, everything is OK.

## Solution
Create a new migration, `Migration 57`, to make sure inventory in never set to `NaN` when a user has already run `Migration 51`. Also, go back and fix `Migration 51` to address this issue for users who haven't run it yet.

## Breaking changes
None

## Testing
1. Start an app from scratch
1. Make sure all 57 migrations run
1. See that neither `inventoryInStock` or `inventoryAvailableToSell` is set to `NaN` in the `Products` or `Catalog` collection