### PR TITLE
Update collectionIndex util function to take options

### DIFF
--- a/imports/utils/collectionIndex.js
+++ b/imports/utils/collectionIndex.js
@@ -1,15 +1,14 @@
 /**
  * @name collectionIndex
- * @private
+ * @summary Sets up necessary indexes on a collection. A wrapper around `createIndex`
  * @param {RawMongoCollection} collection the collection
- * @param {Object} index field to index
-* @returns {undefined}
- *
- * Sets up necessary indexes on the Catalog collection
+ * @param {Object} index field or fields to index
+ * @param {Object} [options] createIndex options. `background: true` is added automatically
+ * @returns {Promise<undefined>} Promise that resolves with undefined
  */
-export default async function collectionIndex(collection, index) {
+export default async function collectionIndex(collection, index, options = {}) {
   try {
-    await collection.createIndex(index, { background: true });
+    await collection.createIndex(index, { background: true, ...options });
   } catch (error) {
     console.error(error); // eslint-disable-line no-console
   }


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
It was not possible to pass indexing options such as `unique: true` when using the `collectionIndex` util function to create indexes on a MongoDB collection.

## Solution
Added optional `options` argument and passed it through to `createIndex`

## Breaking changes
Nope

## Testing
Verify that the server starts up without errors.