### PR TITLE
feat: allow tax services to add custom data to taxes

### DIFF
--- a/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
+++ b/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
@@ -9,7 +9,7 @@ const Money = new SimpleSchema({
   }
 });
 
-const CommonOrderItem = new SimpleSchema({
+export const CommonOrderItem = new SimpleSchema({
   _id: String,
   isTaxable: {
     type: Boolean,

--- a/imports/plugins/core/taxes/lib/simpleSchemas.js
+++ b/imports/plugins/core/taxes/lib/simpleSchemas.js
@@ -2,6 +2,16 @@ import SimpleSchema from "simpl-schema";
 
 export const Taxes = new SimpleSchema({
   _id: String,
+  /**
+   * Custom key/value data that you need to store.
+   * You'll need to extend GraphQL schemas if you
+   * want to expose any of this data through the API.
+   */
+  customData: {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
   jurisdictionId: {
     type: String,
     optional: true
@@ -46,18 +56,20 @@ export const TaxSummary = new SimpleSchema({
   taxes: [Taxes]
 });
 
+export const TaxServiceItemTax = new SimpleSchema({
+  itemId: String,
+  tax: {
+    type: Number,
+    min: 0
+  },
+  taxableAmount: {
+    type: Number,
+    min: 0
+  },
+  taxes: [Taxes]
+});
+
 export const TaxServiceResult = new SimpleSchema({
-  "itemTaxes": Array,
-  "itemTaxes.$": Object,
-  "itemTaxes.$.itemId": String,
-  "itemTaxes.$.tax": {
-    type: Number,
-    min: 0
-  },
-  "itemTaxes.$.taxableAmount": {
-    type: Number,
-    min: 0
-  },
-  "itemTaxes.$.taxes": [Taxes],
-  "taxSummary": TaxSummary
+  itemTaxes: [TaxServiceItemTax],
+  taxSummary: TaxSummary
 });

--- a/imports/plugins/core/taxes/server/no-meteor/mutations/__snapshots__/getFulfillmentGroupTaxes.test.js.snap
+++ b/imports/plugins/core/taxes/server/no-meteor/mutations/__snapshots__/getFulfillmentGroupTaxes.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throws if the calculation function throws 1`] = `"Error while calculating taxes"`;
+
+exports[`throws if the result doesn't match the schema 1`] = `"Error while calculating taxes"`;

--- a/imports/plugins/core/taxes/server/no-meteor/mutations/getFulfillmentGroupTaxes.test.js
+++ b/imports/plugins/core/taxes/server/no-meteor/mutations/getFulfillmentGroupTaxes.test.js
@@ -1,0 +1,363 @@
+import Factory from "/imports/test-utils/helpers/factory";
+import mockContext from "/imports/test-utils/helpers/mockContext";
+import getFulfillmentGroupTaxes from "./getFulfillmentGroupTaxes";
+import { rewire$getTaxServicesForShop, restore as restoreRegistration } from "../registration";
+
+const orderItem = Factory.CommonOrderItem.makeOne();
+
+const order = Factory.CommonOrder.makeOne({
+  items: [orderItem]
+});
+delete order._id; // There is a bug where Factory package adds _id even if it isn't in the schema
+
+const getTaxServicesForShopMock = jest.fn().mockName("getTaxServicesForShop");
+
+beforeAll(() => {
+  rewire$getTaxServicesForShop(getTaxServicesForShopMock);
+});
+
+afterAll(() => {
+  restoreRegistration();
+});
+
+test("no registered tax services, do not force zeroes", async () => {
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({}));
+
+  const result = await getFulfillmentGroupTaxes(mockContext, {
+    forceZeroes: false,
+    order
+  });
+
+  expect(result).toEqual({ itemTaxes: [], taxSummary: null });
+});
+
+test("no registered tax services, force zeroes", async () => {
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({}));
+
+  const result = await getFulfillmentGroupTaxes(mockContext, {
+    forceZeroes: true,
+    order
+  });
+
+  expect(result).toEqual({
+    taxSummary: {
+      calculatedAt: jasmine.any(Date),
+      tax: 0,
+      taxableAmount: 0,
+      taxes: []
+    },
+    itemTaxes: [
+      { itemId: orderItem._id, tax: 0, taxableAmount: 0, taxes: [] }
+    ]
+  });
+});
+
+test("null result from primary tax service, no fallback, do not force zeroes", async () => {
+  const calculateOrderTaxes = jest.fn().mockName("calculateOrderTaxes").mockReturnValueOnce(Promise.resolve(null));
+
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({
+    primaryTaxService: {
+      displayName: "Primary Tax Service",
+      name: "primary-tax-service-mock",
+      functions: {
+        calculateOrderTaxes
+      }
+    }
+  }));
+
+  const result = await getFulfillmentGroupTaxes(mockContext, {
+    forceZeroes: false,
+    order
+  });
+
+  expect(result).toEqual({ itemTaxes: [], taxSummary: null });
+});
+
+test("null result from primary tax service, no fallback, force zeroes", async () => {
+  const calculateOrderTaxes = jest.fn().mockName("calculateOrderTaxes").mockReturnValueOnce(Promise.resolve(null));
+
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({
+    primaryTaxService: {
+      displayName: "Primary Tax Service",
+      name: "primary-tax-service-mock",
+      functions: {
+        calculateOrderTaxes
+      }
+    }
+  }));
+
+  const result = await getFulfillmentGroupTaxes(mockContext, {
+    forceZeroes: true,
+    order
+  });
+
+  expect(result).toEqual({
+    taxSummary: {
+      calculatedAt: jasmine.any(Date),
+      tax: 0,
+      taxableAmount: 0,
+      taxes: []
+    },
+    itemTaxes: [
+      { itemId: orderItem._id, tax: 0, taxableAmount: 0, taxes: [] }
+    ]
+  });
+});
+
+test("null result from both tax services, do not force zeroes", async () => {
+  const calculateOrderTaxes = jest.fn().mockName("calculateOrderTaxes").mockReturnValueOnce(Promise.resolve(null));
+  const fallbackCalculateOrderTaxes = jest.fn().mockName("fallbackCalculateOrderTaxes").mockReturnValueOnce(Promise.resolve(null));
+
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({
+    fallbackTaxService: {
+      displayName: "Fallback Tax Service",
+      name: "fallback-tax-service-mock",
+      functions: {
+        calculateOrderTaxes: fallbackCalculateOrderTaxes
+      }
+    },
+    primaryTaxService: {
+      displayName: "Primary Tax Service",
+      name: "primary-tax-service-mock",
+      functions: {
+        calculateOrderTaxes
+      }
+    }
+  }));
+
+  const result = await getFulfillmentGroupTaxes(mockContext, {
+    forceZeroes: false,
+    order
+  });
+
+  expect(result).toEqual({ itemTaxes: [], taxSummary: null });
+});
+
+test("null result from both tax services, force zeroes", async () => {
+  const calculateOrderTaxes = jest.fn().mockName("calculateOrderTaxes").mockReturnValueOnce(Promise.resolve(null));
+  const fallbackCalculateOrderTaxes = jest.fn().mockName("fallbackCalculateOrderTaxes").mockReturnValueOnce(Promise.resolve(null));
+
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({
+    fallbackTaxService: {
+      displayName: "Fallback Tax Service",
+      name: "fallback-tax-service-mock",
+      functions: {
+        calculateOrderTaxes: fallbackCalculateOrderTaxes
+      }
+    },
+    primaryTaxService: {
+      displayName: "Primary Tax Service",
+      name: "primary-tax-service-mock",
+      functions: {
+        calculateOrderTaxes
+      }
+    }
+  }));
+
+  const result = await getFulfillmentGroupTaxes(mockContext, {
+    forceZeroes: true,
+    order
+  });
+
+  expect(result).toEqual({
+    taxSummary: {
+      calculatedAt: jasmine.any(Date),
+      tax: 0,
+      taxableAmount: 0,
+      taxes: []
+    },
+    itemTaxes: [
+      { itemId: orderItem._id, tax: 0, taxableAmount: 0, taxes: [] }
+    ]
+  });
+});
+
+test("minimal result from primary tax service", async () => {
+  const taxes = [
+    {
+      _id: "mockTax",
+      customData: {
+        foo: "bar"
+      },
+      sourcing: "destination",
+      tax: 15,
+      taxName: "mockTaxName",
+      taxRate: 0.05,
+      taxableAmount: 90
+    }
+  ];
+
+  const itemTax = {
+    itemId: orderItem._id,
+    tax: 15,
+    taxableAmount: 90,
+    taxes
+  };
+
+  const taxSummary = {
+    calculatedAt: new Date(),
+    calculatedByTaxServiceName: "primary-tax-service-mock",
+    tax: 15,
+    taxableAmount: 90,
+    taxes
+  };
+
+  const mockResult = Factory.TaxServiceResult.makeOne({
+    itemTaxes: [itemTax],
+    taxSummary
+  });
+  delete mockResult._id; // There is a bug where Factory package adds _id even if it isn't in the schema
+
+  const calculateOrderTaxes = jest.fn().mockName("calculateOrderTaxes").mockReturnValueOnce(Promise.resolve(mockResult));
+
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({
+    primaryTaxService: {
+      displayName: "Primary Tax Service",
+      name: "primary-tax-service-mock",
+      functions: {
+        calculateOrderTaxes
+      }
+    }
+  }));
+
+  const result = await getFulfillmentGroupTaxes(mockContext, {
+    forceZeroes: false,
+    order
+  });
+
+  expect(result).toEqual({
+    itemTaxes: [itemTax],
+    taxSummary
+  });
+});
+
+test("null result from primary tax service, minimal result from fallback tax service", async () => {
+  const taxes = [
+    {
+      _id: "mockTax",
+      sourcing: "destination",
+      tax: 15,
+      taxName: "mockTaxName",
+      taxRate: 0.05,
+      taxableAmount: 90
+    }
+  ];
+
+  const itemTax = {
+    itemId: orderItem._id,
+    tax: 15,
+    taxableAmount: 90,
+    taxes
+  };
+
+  const taxSummary = {
+    calculatedAt: new Date(),
+    calculatedByTaxServiceName: "primary-tax-service-mock",
+    tax: 15,
+    taxableAmount: 90,
+    taxes
+  };
+
+  const mockResult = Factory.TaxServiceResult.makeOne({
+    itemTaxes: [itemTax],
+    taxSummary
+  });
+  delete mockResult._id; // There is a bug where Factory package adds _id even if it isn't in the schema
+
+  const calculateOrderTaxes = jest.fn().mockName("calculateOrderTaxes").mockReturnValueOnce(Promise.resolve(null));
+  const fallbackCalculateOrderTaxes = jest.fn().mockName("fallbackCalculateOrderTaxes").mockReturnValueOnce(Promise.resolve(mockResult));
+
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({
+    fallbackTaxService: {
+      displayName: "Fallback Tax Service",
+      name: "fallback-tax-service-mock",
+      functions: {
+        calculateOrderTaxes: fallbackCalculateOrderTaxes
+      }
+    },
+    primaryTaxService: {
+      displayName: "Primary Tax Service",
+      name: "primary-tax-service-mock",
+      functions: {
+        calculateOrderTaxes
+      }
+    }
+  }));
+
+  const result = await getFulfillmentGroupTaxes(mockContext, {
+    forceZeroes: false,
+    order
+  });
+
+  expect(result).toEqual({
+    itemTaxes: [itemTax],
+    taxSummary
+  });
+});
+
+test("throws if the result doesn't match the schema", async () => {
+  const taxes = [
+    {
+      _id: "mockTax",
+      tax: 15,
+      taxName: "mockTaxName",
+      taxRate: 0.05,
+      taxableAmount: 90
+    }
+  ];
+
+  const itemTax = {
+    itemId: orderItem._id,
+    tax: 15,
+    taxableAmount: 90,
+    taxes
+  };
+
+  const taxSummary = {
+    calculatedAt: new Date(),
+    calculatedByTaxServiceName: "primary-tax-service-mock",
+    tax: 15,
+    taxableAmount: 90,
+    taxes
+  };
+
+  const mockResult = Factory.TaxServiceResult.makeOne({
+    itemTaxes: [itemTax],
+    taxSummary
+  });
+  delete mockResult._id; // There is a bug where Factory package adds _id even if it isn't in the schema
+
+  const calculateOrderTaxes = jest.fn().mockName("calculateOrderTaxes").mockReturnValueOnce(Promise.resolve(mockResult));
+
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({
+    primaryTaxService: {
+      displayName: "Primary Tax Service",
+      name: "primary-tax-service-mock",
+      functions: {
+        calculateOrderTaxes
+      }
+    }
+  }));
+
+  const result = getFulfillmentGroupTaxes(mockContext, { forceZeroes: false, order });
+  expect(result).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("throws if the calculation function throws", async () => {
+  const calculateOrderTaxes = jest.fn().mockName("calculateOrderTaxes").mockImplementationOnce(async () => {
+    throw new Error("Internal problem");
+  });
+
+  getTaxServicesForShopMock.mockReturnValueOnce(Promise.resolve({
+    primaryTaxService: {
+      displayName: "Primary Tax Service",
+      name: "primary-tax-service-mock",
+      functions: {
+        calculateOrderTaxes
+      }
+    }
+  }));
+
+  const result = getFulfillmentGroupTaxes(mockContext, { forceZeroes: false, order });
+  expect(result).rejects.toThrowErrorMatchingSnapshot();
+});

--- a/imports/test-utils/helpers/factory.js
+++ b/imports/test-utils/helpers/factory.js
@@ -1,8 +1,16 @@
 import { createFactoryForSchema, Factory } from "@reactioncommerce/data-factory";
-import * as schemas from "imports/collections/schemas";
+import * as coreSchemas from "/imports/collections/schemas";
+import * as ordersSchemas from "/imports/plugins/core/orders/server/no-meteor/simpleSchemas";
+import * as taxSchemas from "/imports/plugins/core/taxes/lib/simpleSchemas";
 
-Object.keys(schemas).forEach((key) => {
-  createFactoryForSchema(key, schemas[key]);
+[
+  coreSchemas,
+  ordersSchemas,
+  taxSchemas
+].forEach((schemas) => {
+  Object.keys(schemas).forEach((key) => {
+    createFactoryForSchema(key, schemas[key]);
+  });
 });
 
 export default Factory;


### PR DESCRIPTION
Resolves #4945   
Impact: **minor**  
Type: **feature**

## Changes
A tax service's `calculateOrderTaxes` function may now return a black box `customData` object on each item in the `taxes` arrays.

This is not exposed through GraphQL. If you need any of the fields, you can create a custom plugin to `extend type CalculatedTax` with your properly typed custom fields and add resolvers as necessary.

Primarily, though, this is intended to be used to store extra data that the third-party tax integrations need for later API calls.

## Breaking changes
None

## Testing
This isn't currently used in the built-in tax service. You'd have to modify that `calculateOrderTaxes` function to include `customData` in its return, and then verify that it's stored in the database.