### PR TITLE
feat: custom tax data part 2

### DIFF
--- a/imports/plugins/core/taxes/lib/simpleSchemas.js
+++ b/imports/plugins/core/taxes/lib/simpleSchemas.js
@@ -7,7 +7,7 @@ export const Taxes = new SimpleSchema({
    * You'll need to extend GraphQL schemas if you
    * want to expose any of this data through the API.
    */
-  customData: {
+  customFields: {
     type: Object,
     blackbox: true,
     optional: true
@@ -41,6 +41,16 @@ export const TaxSummary = new SimpleSchema({
     type: String,
     optional: true
   },
+  /**
+   * Custom key/value data that you need to store.
+   * You'll need to extend GraphQL schemas if you
+   * want to expose any of this data through the API.
+   */
+  customFields: {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
   referenceId: {
     type: String,
     optional: true
@@ -57,6 +67,16 @@ export const TaxSummary = new SimpleSchema({
 });
 
 export const TaxServiceItemTax = new SimpleSchema({
+  /**
+   * Custom key/value data that you need to store.
+   * You'll need to extend GraphQL schemas if you
+   * want to expose any of this data through the API.
+   */
+  customFields: {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
   itemId: String,
   tax: {
     type: Number,

--- a/imports/plugins/core/taxes/server/no-meteor/mutations/getFulfillmentGroupTaxes.test.js
+++ b/imports/plugins/core/taxes/server/no-meteor/mutations/getFulfillmentGroupTaxes.test.js
@@ -176,8 +176,8 @@ test("minimal result from primary tax service", async () => {
   const taxes = [
     {
       _id: "mockTax",
-      customData: {
-        foo: "bar"
+      customFields: {
+        taxesField: "abc123"
       },
       sourcing: "destination",
       tax: 15,
@@ -188,6 +188,9 @@ test("minimal result from primary tax service", async () => {
   ];
 
   const itemTax = {
+    customFields: {
+      taxesField: "abc123"
+    },
     itemId: orderItem._id,
     tax: 15,
     taxableAmount: 90,
@@ -197,6 +200,9 @@ test("minimal result from primary tax service", async () => {
   const taxSummary = {
     calculatedAt: new Date(),
     calculatedByTaxServiceName: "primary-tax-service-mock",
+    customFields: {
+      taxesField: "abc123"
+    },
     tax: 15,
     taxableAmount: 90,
     taxes


### PR DESCRIPTION
Resolves #4945   
Resolves #4964
Impact: **minor**  
Type: **feature**

## Issue
#4955 added ability to store custom fields on `taxes` array items, but there is still a need to store item-level and order-level custom tax data.

## Solution
It now allows `customFields` objects on not only `taxes` array items, but also on each item tax object, and on `taxSummary`. Note also that based on discussions since the first PR, the field name has been changed to `customFields` rather than `customData`.

## Breaking changes
The field name has been changed to `customFields` rather than `customData`. This is only breaking since the previous PR, which has not yet been released.

## Testing
See #4955 testing instructions