### PR TITLE
feat: shipping Operator into 2.0

### DIFF
--- a/imports/plugins/core/shipping/client/components/Shipping.js
+++ b/imports/plugins/core/shipping/client/components/Shipping.js
@@ -1,10 +1,12 @@
 import React, { Component } from "react";
+import Blaze from "meteor/gadicc:blaze-react-component";
 
 export default class Shipping extends Component {
   render() {
     return (
       <div>
         <h4>Shipping</h4>
+        <Blaze template="shippingSettings" {...this.props} />
       </div>
     );
   }


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
Shipping operator was not moved into Operator 2.0

## Solution
As a temporary solution, before updating to React / adding more features, simply include the existing Blaze template in Operator 2.0 so that we have something instead of a blank screen

## Breaking changes
None

## Testing
1. Start the app
1. Login as admin
1. Head to `/operator/shipping`
1. See that the existing Shipping operator UI is ported and functional
