### PR TITLE
Fix: addAccountAddressBookEntry mutation - set account updatedAt

### DIFF
--- a/imports/plugins/core/accounts/server/no-meteor/mutations/addressBookAdd.js
+++ b/imports/plugins/core/accounts/server/no-meteor/mutations/addressBookAdd.js
@@ -1,5 +1,4 @@
 import Random from "@reactioncommerce/random";
-import { get } from "lodash";
 import ReactionError from "@reactioncommerce/reaction-error";
 
 /**
@@ -14,7 +13,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  */
 export default async function addressBookAdd(context, address, accountUserId) {
   const { appEvents, collections, userHasPermission, userId: userIdFromContext } = context;
-  const { Accounts, users: Users } = collections;
+  const { Accounts } = collections;
 
   const userId = accountUserId || userIdFromContext;
   const account = await Accounts.findOne({ userId });

--- a/imports/plugins/core/accounts/server/no-meteor/mutations/addressBookAdd.js
+++ b/imports/plugins/core/accounts/server/no-meteor/mutations/addressBookAdd.js
@@ -56,29 +56,16 @@ export default async function addressBookAdd(context, address, accountUserId) {
     }
   }
 
-  const userUpdateQuery = {
-    $set: {
-      "profile.addressBook": address
-    }
-  };
-  const accountsUpdateQuery = {
-    $addToSet: {
-      "profile.addressBook": address
-    }
-  };
-
-  // If there is no `name` field on account or this is the first address we're
-  // adding for this account, set the name from the address.fullName.
-  if (!account.name || get(account, "profile.addressBook.length", 0) === 0) {
-    userUpdateQuery.$set.name = address.fullName;
-    accountsUpdateQuery.$set = { name: address.fullName };
-  }
-
-  await Users.updateOne({ _id: userId }, userUpdateQuery);
-
   const { value: updatedAccount } = await Accounts.findOneAndUpdate(
     { userId },
-    accountsUpdateQuery,
+    {
+      $addToSet: {
+        "profile.addressBook": address
+      },
+      $set: {
+        updatedAt: new Date()
+      }
+    },
     {
       returnOriginal: false
     }


### PR DESCRIPTION
Resolves #4968  
Impact: **minor**  
Type: **bugfix**

## Issue
When updating an address via the `updateAccountAddressBookEntry`, the `Accounts` record's `updatedAt` field is updated. This isn't  happening when adding an address via the `addAccountAddressBookEntry` mutation.

## Solution
The solution is to set `updatedAt` to the current date when adding the address. After discussing with @aldeed, I also removed logic that added the address as the only address in the matching `users` collection record, and logic that set the name on the address as the account's name. From Eric:

> I’d actually prefer to stop storing most things, including addresses, in the `users` collection since we use `Accounts` collection for all of that. We should be gradually reducing `users` to being only IDP data since we hope to eventually stop using Meteor for identity.

> I’d like to get rid of auto-updating the `name`, too. It’s always been weird that we do that since the name they put on the address might not even be their name

## Breaking changes
None

## Testing
1. Add an address to your account. In Starterkit, you can do that with [this PR](https://github.com/reactioncommerce/reaction-next-starterkit/pull/393)
2. Confirm the address is still added to `Accounts.addressBook[]` and `Accounts.updatedAt` is updated
