### PR TITLE
Add custom fields to order schema

### DIFF
--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -375,6 +375,7 @@ export const OrderFulfillmentGroup = new SimpleSchema({
  * @property {String} cartId optional For tracking which cart created this order
  * @property {Date} createdAt required
  * @property {String} currencyCode required
+ * @property {Object[]} customFields optional
  * @property {Document[]} documents optional
  * @property {String} email optional
  * @property {Object[]} exportHistory optional

--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -413,6 +413,11 @@ export const Order = new SimpleSchema({
     type: String,
     optional: true
   },
+  "customFields": {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
   "createdAt": Date,
   "currencyCode": String,
   "discounts": {


### PR DESCRIPTION
Resolves #4978
Impact: **critical**  
Type: **bugfix**

## Issue
`customFields` is not in the order schema causing placing any order to fail.

## Solution
Add `customFields` to order schema.

## Breaking changes
None

## Testing
1. Place an order from the starter kit.
2. The order should be successfully placed.