### PR TITLE
Fix: Don't crash when mediaItem.URLs is null

### DIFF
--- a/imports/plugins/core/graphql/server/no-meteor/xforms/catalogProduct.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/catalogProduct.js
@@ -15,7 +15,7 @@ export const encodeCatalogProductOpaqueId = encodeOpaqueId(namespaces.CatalogPro
  * @return {Object} transformed product media item
  */
 export function xformProductMedia(mediaItem, context) {
-  if (!mediaItem) return null;
+  if (!(mediaItem && mediaItem.URLs)) return null;
 
   const { priority, toGrid, productId, variantId, URLs: { large, medium, original, small, thumbnail } } = mediaItem;
 

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/catalogProduct.test.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/catalogProduct.test.js
@@ -1,0 +1,49 @@
+import { xformProductMedia } from "./catalogProduct";
+
+const ROOT_URL = "https://example.com";
+const context = {
+  getAbsoluteUrl: (path) => `${ROOT_URL}${path}`
+};
+
+test("catalogProduct works in base case", () => {
+  const expected = {
+    priority: "unit-test-priority",
+    toGrid: "unit-test-to-grid",
+    productId: "unit-test-product-id",
+    variantId: "unit-test-variant-id",
+    URLs: {
+      small: `${ROOT_URL}/small.jpg`,
+      medium: `${ROOT_URL}/medium.jpg`,
+      large: `${ROOT_URL}/large.jpg`,
+      original: `${ROOT_URL}/original.jpg`,
+      thumbnail: `${ROOT_URL}/thumbnail.jpg`
+    }
+  };
+  const result = xformProductMedia(
+    {
+      priority: "unit-test-priority",
+      toGrid: "unit-test-to-grid",
+      productId: "unit-test-product-id",
+      variantId: "unit-test-variant-id",
+      URLs: {
+        small: "/small.jpg",
+        medium: "/medium.jpg",
+        large: "/large.jpg",
+        original: "/original.jpg",
+        thumbnail: "/thumbnail.jpg"
+      }
+    },
+    context
+  );
+  expect(result).toMatchObject(expected);
+});
+
+test("catalogProduct works in null case", () => {
+  const result = xformProductMedia(null, context);
+  expect(result).toBeNull();
+});
+
+test("catalogProduct works in {URLs: null} case", () => {
+  const result = xformProductMedia({ URLs: null }, context);
+  expect(result).toBeNull();
+});


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
With some imperfect development data we have some catalog products that have a `primaryImage.URLs: null`. This situation causes the destructuring to fail with this error:

```
GraphQL error: Cannot destructure property `large` of 'undefined' or 'null'.
    at new ApolloError (/usr/local/src/node_modules/apollo-client/errors/ApolloError.js:25:1)
```

## Solution
Return null early and avoid the exception.

## Testing

This module was previously barren of unit tests. I added some basic tests that confirm this fix plus the base case behavior.
