### PR TITLE
fix: properly save all customFields from tax service result

### DIFF
--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -470,7 +470,7 @@ export default async function placeOrder(context, input) {
     await addShipmentMethodToGroup(context, finalGroup, cleanedInput, groupInput, discountTotal, orderId);
 
     // Apply Taxes
-    await addTaxesToGroup(context, finalGroup, cleanedInput, groupInput, discountTotal, orderId);
+    await addTaxesToGroup(context, finalGroup, orderInput, discountTotal, orderId);
 
     // Add some more properties for convenience
     finalGroup.itemIds = finalGroup.items.map((item) => item._id);

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -9,6 +9,7 @@ import { Address as AddressSchema, Order as OrderSchema, Payment as PaymentSchem
 import getDiscountsTotalForCart from "/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart";
 import xformOrderGroupToCommonOrder from "/imports/plugins/core/orders/server/util/xformOrderGroupToCommonOrder";
 import { getPaymentMethodConfigByName } from "/imports/plugins/core/payments/server/no-meteor/registration";
+import addTaxesToGroup from "../../util/addTaxesToGroup";
 import verifyPaymentsMatchOrderTotal from "../../util/verifyPaymentsMatchOrderTotal";
 
 const orderItemsSchema = new SimpleSchema({
@@ -292,45 +293,6 @@ async function addShipmentMethodToGroup(context, finalGroup, cleanedInput, group
     handling: selectedFulfillmentMethod.handlingPrice,
     rate: selectedFulfillmentMethod.shippingPrice
   };
-}
-
-/**
- * @summary Adds taxes to the final fulfillment group
- * @param {Object} context - an object containing the per-request state
- * @param {Object} finalGroup Fulfillment group object pre shipment method addition
- * @param {Object} cleanedInput - Necessary orderInput. See SimpleSchema
- * @param {Object} groupInput - Original fulfillment group that we compose finalGroup from. See SimpleSchema
- * @param {String} discountTotal - Calculated discount total
- * @param {String} orderId - Randomized new orderId
- * @returns {Object} Fulfillment group object post tax addition
- */
-async function addTaxesToGroup(context, finalGroup, cleanedInput, groupInput, discountTotal, orderId) {
-  const { collections } = context;
-  const { order: orderInput } = cleanedInput;
-  const { billingAddress, cartId, currencyCode } = orderInput;
-
-  const commonOrder = await xformOrderGroupToCommonOrder({
-    billingAddress,
-    cartId,
-    collections,
-    currencyCode,
-    group: finalGroup,
-    orderId,
-    discountTotal
-  });
-
-  const { itemTaxes, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, { order: commonOrder, forceZeroes: true });
-  finalGroup.items = finalGroup.items.map((item) => {
-    const itemTax = itemTaxes.find((entry) => entry.itemId === item._id) || {};
-
-    return {
-      ...item,
-      tax: itemTax.tax,
-      taxableAmount: itemTax.taxableAmount,
-      taxes: itemTax.taxes
-    };
-  });
-  finalGroup.taxSummary = taxSummary;
 }
 
 /**

--- a/imports/plugins/core/orders/server/util/addTaxesToGroup.js
+++ b/imports/plugins/core/orders/server/util/addTaxesToGroup.js
@@ -27,12 +27,19 @@ export default async function addTaxesToGroup(context, group, orderInput, discou
   group.items = group.items.map((item) => {
     const itemTax = itemTaxes.find((entry) => entry.itemId === item._id) || {};
 
-    return {
+    const updatedItem = {
       ...item,
       tax: itemTax.tax,
       taxableAmount: itemTax.taxableAmount,
       taxes: itemTax.taxes
     };
+
+    if (itemTax.customFields) {
+      updatedItem.customTaxFields = itemTax.customFields;
+    }
+
+    return updatedItem;
   });
+
   group.taxSummary = taxSummary;
 }

--- a/imports/plugins/core/orders/server/util/addTaxesToGroup.js
+++ b/imports/plugins/core/orders/server/util/addTaxesToGroup.js
@@ -3,16 +3,14 @@ import xformOrderGroupToCommonOrder from "/imports/plugins/core/orders/server/ut
 /**
  * @summary Adds taxes to the final fulfillment group
  * @param {Object} context - an object containing the per-request state
- * @param {Object} finalGroup Fulfillment group object pre shipment method addition
- * @param {Object} cleanedInput - Necessary orderInput. See SimpleSchema
- * @param {Object} groupInput - Original fulfillment group that we compose finalGroup from. See SimpleSchema
+ * @param {Object} group Fulfillment group object
+ * @param {Object} orderInput - Necessary orderInput. See SimpleSchema
  * @param {String} discountTotal - Calculated discount total
  * @param {String} orderId - Randomized new orderId
  * @returns {Object} Fulfillment group object post tax addition
  */
-export default async function addTaxesToGroup(context, finalGroup, cleanedInput, groupInput, discountTotal, orderId) {
+export default async function addTaxesToGroup(context, group, orderInput, discountTotal, orderId) {
   const { collections } = context;
-  const { order: orderInput } = cleanedInput;
   const { billingAddress, cartId, currencyCode } = orderInput;
 
   const commonOrder = await xformOrderGroupToCommonOrder({
@@ -20,13 +18,13 @@ export default async function addTaxesToGroup(context, finalGroup, cleanedInput,
     cartId,
     collections,
     currencyCode,
-    group: finalGroup,
+    group,
     orderId,
     discountTotal
   });
 
   const { itemTaxes, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, { order: commonOrder, forceZeroes: true });
-  finalGroup.items = finalGroup.items.map((item) => {
+  group.items = group.items.map((item) => {
     const itemTax = itemTaxes.find((entry) => entry.itemId === item._id) || {};
 
     return {
@@ -36,5 +34,5 @@ export default async function addTaxesToGroup(context, finalGroup, cleanedInput,
       taxes: itemTax.taxes
     };
   });
-  finalGroup.taxSummary = taxSummary;
+  group.taxSummary = taxSummary;
 }

--- a/imports/plugins/core/orders/server/util/addTaxesToGroup.js
+++ b/imports/plugins/core/orders/server/util/addTaxesToGroup.js
@@ -1,0 +1,40 @@
+import xformOrderGroupToCommonOrder from "/imports/plugins/core/orders/server/util/xformOrderGroupToCommonOrder";
+
+/**
+ * @summary Adds taxes to the final fulfillment group
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} finalGroup Fulfillment group object pre shipment method addition
+ * @param {Object} cleanedInput - Necessary orderInput. See SimpleSchema
+ * @param {Object} groupInput - Original fulfillment group that we compose finalGroup from. See SimpleSchema
+ * @param {String} discountTotal - Calculated discount total
+ * @param {String} orderId - Randomized new orderId
+ * @returns {Object} Fulfillment group object post tax addition
+ */
+export default async function addTaxesToGroup(context, finalGroup, cleanedInput, groupInput, discountTotal, orderId) {
+  const { collections } = context;
+  const { order: orderInput } = cleanedInput;
+  const { billingAddress, cartId, currencyCode } = orderInput;
+
+  const commonOrder = await xformOrderGroupToCommonOrder({
+    billingAddress,
+    cartId,
+    collections,
+    currencyCode,
+    group: finalGroup,
+    orderId,
+    discountTotal
+  });
+
+  const { itemTaxes, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, { order: commonOrder, forceZeroes: true });
+  finalGroup.items = finalGroup.items.map((item) => {
+    const itemTax = itemTaxes.find((entry) => entry.itemId === item._id) || {};
+
+    return {
+      ...item,
+      tax: itemTax.tax,
+      taxableAmount: itemTax.taxableAmount,
+      taxes: itemTax.taxes
+    };
+  });
+  finalGroup.taxSummary = taxSummary;
+}

--- a/imports/plugins/core/orders/server/util/addTaxesToGroup.test.js
+++ b/imports/plugins/core/orders/server/util/addTaxesToGroup.test.js
@@ -1,0 +1,87 @@
+import Factory from "/imports/test-utils/helpers/factory";
+import mockContext from "/imports/test-utils/helpers/mockContext";
+import addTaxesToGroup from "./addTaxesToGroup";
+
+const address = Factory.Address.makeOne({ _id: undefined });
+
+if (!mockContext.mutations) mockContext.mutations = {};
+mockContext.mutations.getFulfillmentGroupTaxes = jest.fn().mockName("getFulfillmentGroupTaxes");
+
+test("mutates group.items and group.taxSummary", async () => {
+  const group = {
+    address,
+    items: [
+      {
+        _id: "1",
+        attributes: [],
+        isTaxable: true,
+        price: {
+          amount: 10.99,
+          currencyCode: "USD"
+        },
+        productId: "productId1",
+        productVendor: "productVendor",
+        quantity: 1,
+        shopId: "shopId1",
+        taxCode: "123",
+        title: "Title",
+        variantId: "variantId1",
+        variantTitle: "Variant Title"
+      }
+    ],
+    shopId: "shopId1",
+    type: "shipping"
+  };
+
+  const orderInput = {
+    billingAddress: address,
+    currencyCode: "USD"
+  };
+
+  mockContext.collections.Shops.findOne.mockReturnValueOnce(Promise.resolve({ _id: "shopId1" }));
+
+  const taxSummary = {
+    calculatedAt: new Date("2019-01-01T10:00:00"),
+    calculatedByTaxServiceName: "mockService",
+    tax: 0.5,
+    taxableAmount: 10.99,
+    taxes: [
+      {
+        sourcing: "destination",
+        tax: 0.5,
+        taxableAmount: 10.99,
+        taxName: "City tax",
+        taxRate: 0.01
+      }
+    ]
+  };
+
+  const itemTaxes = [
+    {
+      sourcing: "destination",
+      tax: 0.5,
+      taxableAmount: 10.99,
+      taxName: "City tax",
+      taxRate: 0.01
+    }
+  ];
+
+  mockContext.mutations.getFulfillmentGroupTaxes.mockReturnValueOnce(Promise.resolve({
+    itemTaxes: [
+      {
+        itemId: "1",
+        tax: 0.5,
+        taxableAmount: 10.99,
+        taxes: itemTaxes
+      }
+    ],
+    taxSummary
+  }));
+
+  await addTaxesToGroup(mockContext, group, orderInput);
+
+  expect(group.items[0].tax).toBe(0.5);
+  expect(group.items[0].taxableAmount).toBe(10.99);
+  expect(group.items[0].taxes).toEqual(itemTaxes);
+  expect(group.taxSummary).toEqual(taxSummary);
+});

--- a/imports/plugins/core/taxes/lib/extendCoreSchemas.js
+++ b/imports/plugins/core/taxes/lib/extendCoreSchemas.js
@@ -21,6 +21,16 @@ OrderFulfillmentGroup.extend({
 });
 
 CartItem.extend({
+  /**
+   * Custom key/value data that you need to store.
+   * You'll need to extend GraphQL schemas if you
+   * want to expose any of this data through the API.
+   */
+  "customTaxFields": {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
   "isTaxable": Boolean,
   // For a cart item, `tax` will be `null` until there is enough information to calculate it,
   // or whenever no tax service is active for the shop.
@@ -46,6 +56,16 @@ CartItem.extend({
 });
 
 OrderItem.extend({
+  /**
+   * Custom key/value data that you need to store.
+   * You'll need to extend GraphQL schemas if you
+   * want to expose any of this data through the API.
+   */
+  "customTaxFields": {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
   "isTaxable": Boolean,
   "tax": Number,
   "taxableAmount": Number,

--- a/imports/plugins/core/taxes/server/no-meteor/startup.js
+++ b/imports/plugins/core/taxes/server/no-meteor/startup.js
@@ -1,50 +1,5 @@
 import { isEqual } from "lodash";
-import xformCartGroupToCommonOrder from "/imports/plugins/core/cart/server/no-meteor/util/xformCartGroupToCommonOrder";
-
-/**
- * @summary Returns `cart.items` with tax-related props updated on them
- * @param {Object} cart The cart
- * @param {Object} context App context
- * @returns {Object[]} Updated items array
- */
-async function getUpdatedCartItems(cart, context) {
-  const taxResultsByGroup = await Promise.all((cart.shipping || []).map(async (group) => {
-    const order = await xformCartGroupToCommonOrder(cart, group, context);
-    return context.mutations.getFulfillmentGroupTaxes(context, { order, forceZeroes: false });
-  }));
-
-  // Add tax properties to all items in the cart, if taxes were able to be calculated
-  const cartItems = (cart.items || []).map((item) => {
-    const newItem = { ...item };
-    taxResultsByGroup.forEach((group) => {
-      const matchingGroupTaxes = group.itemTaxes.find((groupItem) => groupItem.itemId === item._id);
-      if (matchingGroupTaxes) {
-        newItem.tax = matchingGroupTaxes.tax;
-        newItem.taxableAmount = matchingGroupTaxes.taxableAmount;
-        newItem.taxes = matchingGroupTaxes.taxes;
-      }
-    });
-    return newItem;
-  });
-
-  // Merge all group tax summaries to a single one for the whole cart
-  let combinedSummary = { tax: 0, taxableAmount: 0, taxes: [] };
-  for (const { taxSummary } of taxResultsByGroup) {
-    // groupSummary will be null if there wasn't enough info to calc taxes
-    if (!taxSummary) {
-      combinedSummary = null;
-      break;
-    }
-
-    combinedSummary.calculatedAt = taxSummary.calculatedAt;
-    combinedSummary.calculatedByTaxServiceName = taxSummary.calculatedByTaxServiceName;
-    combinedSummary.tax += taxSummary.tax;
-    combinedSummary.taxableAmount += taxSummary.taxableAmount;
-    combinedSummary.taxes = combinedSummary.taxes.concat(taxSummary.taxes);
-  }
-
-  return { cartItems, taxSummary: combinedSummary };
-}
+import getUpdatedCartItems from "./util/getUpdatedCartItems";
 
 const EMITTED_BY_NAME = "TAXES_CORE_PLUGIN";
 
@@ -64,7 +19,7 @@ export default function startup(context) {
   appEvents.on("afterCartUpdate", async ({ cart }, { emittedBy } = {}) => {
     if (emittedBy === EMITTED_BY_NAME) return; // short circuit infinite loops
 
-    const { cartItems, taxSummary } = await getUpdatedCartItems(cart, context);
+    const { cartItems, taxSummary } = await getUpdatedCartItems(context, cart);
 
     if (isEqual(cartItems, cart.items) && isEqual(taxSummary, cart.taxSummary)) return;
 

--- a/imports/plugins/core/taxes/server/no-meteor/util/getUpdatedCartItems.js
+++ b/imports/plugins/core/taxes/server/no-meteor/util/getUpdatedCartItems.js
@@ -21,6 +21,9 @@ export default async function getUpdatedCartItems(context, cart) {
         newItem.tax = matchingGroupTaxes.tax;
         newItem.taxableAmount = matchingGroupTaxes.taxableAmount;
         newItem.taxes = matchingGroupTaxes.taxes;
+        if (matchingGroupTaxes.customFields) {
+          newItem.customTaxFields = matchingGroupTaxes.customFields;
+        }
       }
     });
     return newItem;
@@ -40,6 +43,11 @@ export default async function getUpdatedCartItems(context, cart) {
     combinedSummary.tax += taxSummary.tax;
     combinedSummary.taxableAmount += taxSummary.taxableAmount;
     combinedSummary.taxes = combinedSummary.taxes.concat(taxSummary.taxes);
+
+    if (taxSummary.customFields) {
+      if (!combinedSummary.customFields) combinedSummary.customFields = {};
+      Object.assign(combinedSummary.customFields, taxSummary.customFields);
+    }
   }
 
   return { cartItems, taxSummary: combinedSummary };

--- a/imports/plugins/core/taxes/server/no-meteor/util/getUpdatedCartItems.js
+++ b/imports/plugins/core/taxes/server/no-meteor/util/getUpdatedCartItems.js
@@ -1,0 +1,46 @@
+import xformCartGroupToCommonOrder from "/imports/plugins/core/cart/server/no-meteor/util/xformCartGroupToCommonOrder";
+
+/**
+ * @summary Returns `cart.items` with tax-related props updated on them
+ * @param {Object} context App context
+ * @param {Object} cart The cart
+ * @returns {Object[]} Updated items array
+ */
+export default async function getUpdatedCartItems(context, cart) {
+  const taxResultsByGroup = await Promise.all((cart.shipping || []).map(async (group) => {
+    const order = await xformCartGroupToCommonOrder(cart, group, context);
+    return context.mutations.getFulfillmentGroupTaxes(context, { order, forceZeroes: false });
+  }));
+
+  // Add tax properties to all items in the cart, if taxes were able to be calculated
+  const cartItems = (cart.items || []).map((item) => {
+    const newItem = { ...item };
+    taxResultsByGroup.forEach((group) => {
+      const matchingGroupTaxes = group.itemTaxes.find((groupItem) => groupItem.itemId === item._id);
+      if (matchingGroupTaxes) {
+        newItem.tax = matchingGroupTaxes.tax;
+        newItem.taxableAmount = matchingGroupTaxes.taxableAmount;
+        newItem.taxes = matchingGroupTaxes.taxes;
+      }
+    });
+    return newItem;
+  });
+
+  // Merge all group tax summaries to a single one for the whole cart
+  let combinedSummary = { tax: 0, taxableAmount: 0, taxes: [] };
+  for (const { taxSummary } of taxResultsByGroup) {
+    // groupSummary will be null if there wasn't enough info to calc taxes
+    if (!taxSummary) {
+      combinedSummary = null;
+      break;
+    }
+
+    combinedSummary.calculatedAt = taxSummary.calculatedAt;
+    combinedSummary.calculatedByTaxServiceName = taxSummary.calculatedByTaxServiceName;
+    combinedSummary.tax += taxSummary.tax;
+    combinedSummary.taxableAmount += taxSummary.taxableAmount;
+    combinedSummary.taxes = combinedSummary.taxes.concat(taxSummary.taxes);
+  }
+
+  return { cartItems, taxSummary: combinedSummary };
+}

--- a/imports/plugins/core/taxes/server/no-meteor/util/getUpdatedCartItems.test.js
+++ b/imports/plugins/core/taxes/server/no-meteor/util/getUpdatedCartItems.test.js
@@ -1,11 +1,17 @@
 import Factory from "/imports/test-utils/helpers/factory";
 import mockContext from "/imports/test-utils/helpers/mockContext";
-import addTaxesToGroup from "./addTaxesToGroup";
+import getUpdatedCartItems from "./getUpdatedCartItems";
 
 const address = Factory.Address.makeOne({ _id: undefined });
 
 const group = {
   address,
+  itemIds: ["1"],
+  shopId: "shopId1",
+  type: "shipping"
+};
+
+const cart = {
   items: [
     {
       _id: "1",
@@ -25,13 +31,9 @@ const group = {
       variantTitle: "Variant Title"
     }
   ],
-  shopId: "shopId1",
-  type: "shipping"
-};
-
-const orderInput = {
-  billingAddress: address,
-  currencyCode: "USD"
+  shipping: [
+    group
+  ]
 };
 
 const taxSummary = {
@@ -78,12 +80,12 @@ test("mutates group.items and group.taxSummary", async () => {
     taxSummary
   }));
 
-  await addTaxesToGroup(mockContext, group, orderInput);
+  const { cartItems, taxSummary: taxSummaryResult } = await getUpdatedCartItems(mockContext, cart);
 
-  expect(group.items[0].tax).toBe(0.5);
-  expect(group.items[0].taxableAmount).toBe(10.99);
-  expect(group.items[0].taxes).toEqual(itemTaxes);
-  expect(group.taxSummary).toEqual(taxSummary);
+  expect(cartItems[0].tax).toBe(0.5);
+  expect(cartItems[0].taxableAmount).toBe(10.99);
+  expect(cartItems[0].taxes).toEqual(itemTaxes);
+  expect(taxSummaryResult).toEqual(taxSummary);
 });
 
 test("customFields are properly saved", async () => {
@@ -114,9 +116,9 @@ test("customFields are properly saved", async () => {
     }
   }));
 
-  await addTaxesToGroup(mockContext, group, orderInput);
+  const { cartItems, taxSummary: taxSummaryResult } = await getUpdatedCartItems(mockContext, cart);
 
-  expect(group.items[0].taxes[0].customFields).toEqual({ foo: "bar3" });
-  expect(group.items[0].customTaxFields).toEqual({ foo: "bar2" });
-  expect(group.taxSummary.customFields).toEqual({ foo: "bar1" });
+  expect(cartItems[0].taxes[0].customFields).toEqual({ foo: "bar3" });
+  expect(cartItems[0].customTaxFields).toEqual({ foo: "bar2" });
+  expect(taxSummaryResult.customFields).toEqual({ foo: "bar1" });
 });


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
https://github.com/reactioncommerce/reaction/pull/4955 and https://github.com/reactioncommerce/reaction/pull/4965 added the ability for tax services to return `customFields` in the response. A couple bugs were found after merging.
- When calculating for a `cart`, `customFields` on cart items and on `taxSummary` were not saved to the database
- When calculating for an `order`, `customFields` on cart items were not saved to the database

## Solution
All `customFields` returned by a tax service at any level are now saved in the database, for both cart and order.

On cart and order items, the field name in the database is `customTaxFields` as opposed to `customFields` because otherwise it would be unclear that they're related to taxes since they're saved directly on the item object. The tax service should still return them as `customFields`; the field name change is only in the database.

## Breaking changes
None

## Testing
1. Temporarily update the `calculateOrderTaxes` function in the `taxes-rates` plugin to include `customFields` objects in the `taxSummary`, in one of the `itemTaxes` objects, and in one of the `taxes` objects.
2. Add items to a cart and begin checking out, using a destination address for which the shop collects taxes.
3. Once you see a tax amount on the checkout page, look in MongoDB to verify that all three expected `customFields` objects were saved in the `Cart` document.
4. Finish checking out. Look in MongoDB to verify that all three expected `customFields` objects were saved in the `Order` document.