### PR TITLE
Feat: Allow plugins to register functions to handle GraphQL transformation of catalog product media items

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProduct/index.js
+++ b/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProduct/index.js
@@ -12,12 +12,8 @@ export default {
   pricing,
   tagIds,
   tags,
-  media: (node, args, context) => {
-    return node.media && node.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context))
-  },
-  primaryImage: (node, args, context) => {
-    return xformCatalogProductMedia(node.primaryImage, context)
-  },
+  media: (node, args, context) => node.media && node.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context)),
+  primaryImage: (node, args, context) => xformCatalogProductMedia(node.primaryImage, context),
   variants: (node, args, context) => node.variants && node.variants.map((variant) => {
     variant.media = variant.media && variant.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context));
     variant.primaryImage = xformCatalogProductMedia(variant.primaryImage, context);

--- a/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProduct/index.js
+++ b/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProduct/index.js
@@ -1,4 +1,4 @@
-import { encodeCatalogProductOpaqueId, xformProductMedia } from "@reactioncommerce/reaction-graphql-xforms/catalogProduct";
+import { encodeCatalogProductOpaqueId, xformCatalogProductMedia } from "@reactioncommerce/reaction-graphql-xforms/catalogProduct";
 import { encodeProductOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/product";
 import { resolveShopFromShopId } from "@reactioncommerce/reaction-graphql-utils";
 import pricing from "./pricing";
@@ -12,16 +12,20 @@ export default {
   pricing,
   tagIds,
   tags,
-  media: (node, args, context) => node.media && node.media.map((mediaItem) => xformProductMedia(mediaItem, context)),
-  primaryImage: (node, args, context) => xformProductMedia(node.primaryImage, context),
+  media: (node, args, context) => {
+    return node.media && node.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context))
+  },
+  primaryImage: (node, args, context) => {
+    return xformCatalogProductMedia(node.primaryImage, context)
+  },
   variants: (node, args, context) => node.variants && node.variants.map((variant) => {
-    variant.media = variant.media && variant.media.map((mediaItem) => xformProductMedia(mediaItem, context));
-    variant.primaryImage = xformProductMedia(variant.primaryImage, context);
+    variant.media = variant.media && variant.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context));
+    variant.primaryImage = xformCatalogProductMedia(variant.primaryImage, context);
 
     if (variant.options) {
       variant.options = variant.options.map((option) => {
-        option.media = option.media && option.media.map((mediaItem) => xformProductMedia(mediaItem, context));
-        option.primaryImage = xformProductMedia(option.primaryImage, context);
+        option.media = option.media && option.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context));
+        option.primaryImage = xformCatalogProductMedia(option.primaryImage, context);
         return option;
       });
     }

--- a/imports/plugins/core/files/register.js
+++ b/imports/plugins/core/files/register.js
@@ -1,0 +1,15 @@
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import xformFileCollectionsProductMedia from "./server/no-meteor/xforms/xformFileCollectionsProductMedia";
+
+Reaction.registerPackage({
+  label: "File Collections",
+  name: "reaction-file-collections",
+  icon: "fa fa-files-o",
+  autoEnable: true,
+  settings: {
+    name: "File Collections"
+  },
+  functionsByType: {
+    xformCatalogProductMedia: [xformFileCollectionsProductMedia]
+  }
+});

--- a/imports/plugins/core/files/server/no-meteor/xforms/xformFileCollectionsProductMedia.js
+++ b/imports/plugins/core/files/server/no-meteor/xforms/xformFileCollectionsProductMedia.js
@@ -1,0 +1,27 @@
+/**
+ * @name xformFileCollectionsProductMedia
+ * @method
+ * @memberof GraphQL/Transforms
+ * @param {Object} mediaItem object from a catalog product
+ * @param {Object} context - an object containing the per-request state
+ * @return {Object} transformed product media item
+ */
+export default function xformFileCollectionsProductMedia(mediaItem, context) {
+  if (!(mediaItem && mediaItem.URLs)) return null;
+
+  const { priority, toGrid, productId, variantId, URLs: { large, medium, original, small, thumbnail } } = mediaItem;
+
+  return {
+    priority,
+    toGrid,
+    productId,
+    variantId,
+    URLs: {
+      large: context.getAbsoluteUrl(large),
+      medium: context.getAbsoluteUrl(medium),
+      original: context.getAbsoluteUrl(original),
+      small: context.getAbsoluteUrl(small),
+      thumbnail: context.getAbsoluteUrl(thumbnail)
+    }
+  };
+}

--- a/imports/plugins/core/files/server/no-meteor/xforms/xformFileCollectionsProductMedia.test.js
+++ b/imports/plugins/core/files/server/no-meteor/xforms/xformFileCollectionsProductMedia.test.js
@@ -1,4 +1,4 @@
-import { xformProductMedia } from "./catalogProduct";
+import xformFileCollectionsProductMedia from "./xformFileCollectionsProductMedia";
 
 const ROOT_URL = "https://example.com";
 const context = {
@@ -19,7 +19,7 @@ test("catalogProduct works in base case", () => {
       thumbnail: `${ROOT_URL}/thumbnail.jpg`
     }
   };
-  const result = xformProductMedia(
+  const result = xformFileCollectionsProductMedia(
     {
       priority: "unit-test-priority",
       toGrid: "unit-test-to-grid",
@@ -39,11 +39,11 @@ test("catalogProduct works in base case", () => {
 });
 
 test("catalogProduct works in null case", () => {
-  const result = xformProductMedia(null, context);
+  const result = xformFileCollectionsProductMedia(null, context);
   expect(result).toBeNull();
 });
 
 test("catalogProduct works in {URLs: null} case", () => {
-  const result = xformProductMedia({ URLs: null }, context);
+  const result = xformFileCollectionsProductMedia({ URLs: null }, context);
   expect(result).toBeNull();
 });

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/catalogProduct.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/catalogProduct.js
@@ -7,29 +7,23 @@ export const decodeCatalogProductOpaqueId = decodeOpaqueIdForNamespace(namespace
 export const encodeCatalogProductOpaqueId = encodeOpaqueId(namespaces.CatalogProduct);
 
 /**
- * @name xformProductMedia
+ * @name xformCatalogProductMedia
  * @method
  * @memberof GraphQL/Transforms
- * @param {Object} mediaItem object from a catalog product
- * @param {Object} context - an object containing the per-request state
- * @return {Object} transformed product media item
+ * @summary Transforms DB media object to final GraphQL result. Calls functions plugins have registered for type
+ *  "xformCatalogProductMedia". First to return an object is returned here
+ * @param {Object} mediaItem Media item object. See ImageInfo SimpleSchema
+ * @param {Object} context Request context
+ * @return {Object|null} Transformed media item or null
  */
-export function xformProductMedia(mediaItem, context) {
-  if (!(mediaItem && mediaItem.URLs)) return null;
-
-  const { priority, toGrid, productId, variantId, URLs: { large, medium, original, small, thumbnail } } = mediaItem;
-
-  return {
-    priority,
-    toGrid,
-    productId,
-    variantId,
-    URLs: {
-      large: context.getAbsoluteUrl(large),
-      medium: context.getAbsoluteUrl(medium),
-      original: context.getAbsoluteUrl(original),
-      small: context.getAbsoluteUrl(small),
-      thumbnail: context.getAbsoluteUrl(thumbnail)
+export async function xformCatalogProductMedia(mediaItem, context) {
+  const xformCatalogProductMediaFuncs = context.getFunctionsOfType("xformCatalogProductMedia");
+  for (const func of xformCatalogProductMediaFuncs) {
+    const xformedMediaItem = await func(mediaItem, context);
+    if (xformedMediaItem) {
+      return xformedMediaItem;
     }
-  };
+  }
+
+  return null;
 }

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/catalogProduct.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/catalogProduct.js
@@ -19,7 +19,7 @@ export const encodeCatalogProductOpaqueId = encodeOpaqueId(namespaces.CatalogPro
 export async function xformCatalogProductMedia(mediaItem, context) {
   const xformCatalogProductMediaFuncs = context.getFunctionsOfType("xformCatalogProductMedia");
   for (const func of xformCatalogProductMediaFuncs) {
-    const xformedMediaItem = await func(mediaItem, context);
+    const xformedMediaItem = await func(mediaItem, context); // eslint-disable-line no-await-in-loop
     if (xformedMediaItem) {
       return xformedMediaItem;
     }

--- a/tests/TestApp.js
+++ b/tests/TestApp.js
@@ -9,6 +9,7 @@ import defineCollections from "../imports/node-app/core/util/defineCollections";
 import Factory from "../imports/test-utils/helpers/factory";
 import hashLoginToken from "../imports/node-app/core/util/hashLoginToken";
 import setUpFileCollections from "../imports/plugins/core/files/server/no-meteor/setUpFileCollections";
+import coreMediaXform from "../imports/plugins/core/files/server/no-meteor/xforms/xformFileCollectionsProductMedia";
 import mutations from "../imports/node-app/devserver/mutations";
 import queries from "../imports/node-app/devserver/queries";
 import schemas from "../imports/node-app/devserver/schemas";
@@ -20,7 +21,17 @@ class TestApp {
     this.context = {
       appEvents,
       collections: this.collections,
-      getFunctionsOfType: () => [],
+      getFunctionsOfType: (type) => {
+        let funcs;
+        switch (type) {
+          case "xformCatalogProductMedia":
+            funcs = [coreMediaXform];
+            break;
+          default:
+            funcs = [];
+        }
+        return funcs;
+      },
       mutations,
       queries
     };


### PR DESCRIPTION
Resolves #4987 
Impact: **minor**  
Type: **feature**

## Issue
Currently, all media is assumed to be hosted within Reaction's database. There is a core transformation function - `xformProductMedia` - that is called from within several GraphQL resolvers - `Cart.items`, `OrderFulfillmentGroup.items`, `CatalogProduct.media`, `CatalogProduct.primaryImage`, and `CatalogProduct.variants`. Because this function is hard-coded within the resolvers, it makes it difficult to override with a custom media transformation function, which is the case when media is hosted elsewhere (Cloudinary for example).

## Solution
This PR replaces direct calls to `xformProductMedia` in GraphQL resolvers with `getFunctionsOfType("xformCatalogProductMedia")`. This allows any plugin to register a function that can transform a media object for a catalog product. It also renames `xformProductMedia` to `xformFileCollectionsProductMedia`, moves it to the core `files` plugin, and registers it via a new register.js file in that plugin.

## Breaking changes
None


## Testing
1. Clone the latest SDI Cloudinary plugin (or PR) into `/imports/plugins/custom`
2. Reset Reaction and run upload an image for the default product that is created on first startup.
3. Confirm you see the image in the grid, PDP, cart, checkout, and order confirmation screens.
4. Visit Reaction's dashboard and configure the Cloudinary plugin.
5. Insert this product into the Catalog collection:
```
{
    "_id" : "kEcAvh3xxQvuRGuK9",
    "product" : {
        "_id" : "2051342",
        "createdAt" : ISODate("2019-01-24T10:39:13.192Z"),
        "description" : "...",
        "inventoryAvailableToSell" : 20,
        "inventoryInStock" : 20,
        "isBackorder" : false,
        "isDeleted" : false,
        "isLowQuantity" : false,
        "isSoldOut" : false,
        "isVisible" : true,
        "media" : [],
        "price" : {
            "range" : "0.00 - 0.00",
            "min" : 1,
            "max" : 1
        },
        "pricing" : {
            "USD" : {
                "compareAtPrice" : null,
                "displayPrice" : "$0.00",
                "maxPrice" : 1,
                "minPrice" : 1,
                "price" : null
            }
        },
        "primaryImage" : {
            "filename" : "2051342_001_main.jpg",
            "alt" : "NIKE Women's Tapered Double Dry Pants - BLACK/DESRTSAND-010",
            "title" : "NIKE Women's Tapered Double Dry Pants - BLACK/DESRTSAND-010",
            "productId" : "2051342",
            "type" : "hi-res",
            "priority" : 0,
            "toGrid" : 0,
            "variantId" : "2051342-BLACK/DESRTSAND-010"
        },
        "productId" : "2051342",
        "shopId" : "J8Bhq3uTtdgwZx3rz",
        "slug" : "nike-women-s-tapered-double-dry-pants",
        "supportedFulfillmentTypes" : [ 
            "shipping"
        ],
        "title" : "NIKE Women's Tapered Double Dry Pants",
        "type" : "product-simple",
        "tagIds" : [],
        "updatedAt" : ISODate("2019-02-11T21:39:07.560Z"),
        "variants" : [ 
            {
                "_id" : "2051342-BLACK/DESRTSAND-010",
                "canBackorder" : false,
                "createdAt" : ISODate("2019-01-24T10:39:13.192Z"),
                "index" : 0,
                "inventoryAvailableToSell" : 20,
                "inventoryInStock" : 20,
                "inventoryManagement" : false,
                "inventoryPolicy" : false,
                "isBackorder" : false,
                "isLowQuantity" : false,
                "isSoldOut" : false,
                "media" : [ 
                    {
                        "filename" : "2051342_001_main.jpg",
                        "alt" : "NIKE Women's Tapered Double Dry Pants - BLACK/DESRTSAND-010",
                        "title" : "NIKE Women's Tapered Double Dry Pants - BLACK/DESRTSAND-010",
                        "productId" : "2051342",
                        "type" : "hi-res",
                        "priority" : 0,
                        "toGrid" : 0,
                        "variantId" : "2051342-BLACK/DESRTSAND-010"
                    }, 
                    {
                        "filename" : "2051342_001_alt1.jpg",
                        "alt" : "NIKE Women's Tapered Double Dry Pants - BLACK/DESRTSAND-010",
                        "title" : "NIKE Women's Tapered Double Dry Pants - BLACK/DESRTSAND-010",
                        "productId" : "2051342",
                        "type" : "hi-res",
                        "priority" : 0,
                        "toGrid" : 0,
                        "variantId" : "2051342-BLACK/DESRTSAND-010"
                    }, 
                    {
                        "filename" : "2051342_001_sw_25x25.jpg",
                        "alt" : "BLACK/DESRTSAND-010",
                        "title" : "BLACK/DESRTSAND-010",
                        "productId" : "2051342",
                        "type" : "swatch",
                        "priority" : 0,
                        "toGrid" : 0,
                        "variantId" : "2051342-BLACK/DESRTSAND-010"
                    }
                ],
                "optionTitle" : "BLACK/DESRTSAND-010",
                "price" : 1,
                "pricing" : {
                    "USD" : {
                        "compareAtPrice" : null,
                        "displayPrice" : "$0.00",
                        "maxPrice" : 1,
                        "minPrice" : 1,
                        "price" : 1
                    }
                },
                "primaryImage" : null,
                "shopId" : "J8Bhq3uTtdgwZx3rz",
                "title" : "BLACK/DESRTSAND-010",
                "updatedAt" : ISODate("2019-01-24T10:39:13.192Z"),
                "variantId" : "2051342-BLACK/DESRTSAND-010",
                "options" : [ 
                    {
                        "_id" : "33135100016",
                        "canBackorder" : false,
                        "createdAt" : ISODate("2019-01-24T10:39:13.192Z"),
                        "index" : 0,
                        "inventoryAvailableToSell" : 20,
                        "inventoryInStock" : 20,
                        "inventoryManagement" : false,
                        "inventoryPolicy" : false,
                        "isBackorder" : false,
                        "isLowQuantity" : false,
                        "isSoldOut" : false,
                        "media" : [],
                        "optionTitle" : "M",
                        "price" : 1,
                        "pricing" : {
                            "USD" : {
                                "compareAtPrice" : null,
                                "displayPrice" : "$0.00",
                                "maxPrice" : 1,
                                "minPrice" : 1,
                                "price" : 1
                            }
                        },
                        "primaryImage" : null,
                        "shopId" : "J8Bhq3uTtdgwZx3rz",
                        "title" : "M",
                        "updatedAt" : ISODate("2019-01-24T10:39:13.192Z"),
                        "variantId" : "33135100016",
                        "isTaxable" : false
                    }, 
                    {
                        "_id" : "33135100018",
                        "canBackorder" : false,
                        "createdAt" : ISODate("2019-01-24T10:39:13.192Z"),
                        "index" : 0,
                        "inventoryAvailableToSell" : 20,
                        "inventoryInStock" : 20,
                        "inventoryManagement" : false,
                        "inventoryPolicy" : false,
                        "isBackorder" : false,
                        "isLowQuantity" : false,
                        "isSoldOut" : false,
                        "media" : [],
                        "optionTitle" : "XL",
                        "price" : 1,
                        "pricing" : {
                            "USD" : {
                                "compareAtPrice" : null,
                                "displayPrice" : "$0.00",
                                "maxPrice" : 1,
                                "minPrice" : 1,
                                "price" : 1
                            }
                        },
                        "primaryImage" : null,
                        "shopId" : "J8Bhq3uTtdgwZx3rz",
                        "title" : "XL",
                        "updatedAt" : ISODate("2019-01-24T10:39:13.192Z"),
                        "variantId" : "33135100018",
                        "isTaxable" : false
                    }, 
                    {
                        "_id" : "33135100017",
                        "canBackorder" : false,
                        "createdAt" : ISODate("2019-01-24T10:39:13.192Z"),
                        "index" : 0,
                        "inventoryAvailableToSell" : 20,
                        "inventoryInStock" : 20,
                        "inventoryManagement" : false,
                        "inventoryPolicy" : false,
                        "isBackorder" : false,
                        "isLowQuantity" : false,
                        "isSoldOut" : false,
                        "media" : [],
                        "optionTitle" : "L",
                        "price" : 1,
                        "pricing" : {
                            "USD" : {
                                "compareAtPrice" : null,
                                "displayPrice" : "$0.00",
                                "maxPrice" : 1,
                                "minPrice" : 1,
                                "price" : 1
                            }
                        },
                        "primaryImage" : null,
                        "shopId" : "J8Bhq3uTtdgwZx3rz",
                        "title" : "L",
                        "updatedAt" : ISODate("2019-01-24T10:39:13.192Z"),
                        "variantId" : "33135100017",
                        "isTaxable" : false
                    }, 
                    {
                        "_id" : "33135100015",
                        "canBackorder" : false,
                        "createdAt" : ISODate("2019-01-24T10:39:13.192Z"),
                        "index" : 0,
                        "inventoryAvailableToSell" : 20,
                        "inventoryInStock" : 20,
                        "inventoryManagement" : false,
                        "inventoryPolicy" : false,
                        "isBackorder" : false,
                        "isLowQuantity" : false,
                        "isSoldOut" : false,
                        "media" : [],
                        "optionTitle" : "S",
                        "price" : 1,
                        "pricing" : {
                            "USD" : {
                                "compareAtPrice" : null,
                                "displayPrice" : "$0.00",
                                "maxPrice" : 1,
                                "minPrice" : 1,
                                "price" : 1
                            }
                        },
                        "primaryImage" : null,
                        "shopId" : "J8Bhq3uTtdgwZx3rz",
                        "title" : "S",
                        "updatedAt" : ISODate("2019-01-24T10:39:13.192Z"),
                        "variantId" : "33135100015",
                        "isTaxable" : false
                    }
                ],
                "isTaxable" : false
            }
        ],
        "vendor" : "NIKE"
    },
    "shopId" : "J8Bhq3uTtdgwZx3rz",
    "createdAt" : ISODate("2019-01-23T05:51:07.140Z"),
    "updatedAt" : ISODate("2019-02-11T21:40:50.163Z")
}
```
6. Visit storefront and confirm you see the Cloudinary image in the grid, PDP, cart, checkout, and order confirmation screens.