### PR TITLE
fix: do not emit afterCartUpdate unless surcharges are updated

### DIFF
--- a/imports/plugins/core/discounts/server/no-meteor/startup.js
+++ b/imports/plugins/core/discounts/server/no-meteor/startup.js
@@ -1,3 +1,4 @@
+import Logger from "@reactioncommerce/logger";
 import appEvents from "/imports/node-app/core/util/appEvents";
 import getDiscountsTotalForCart from "/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart";
 
@@ -14,6 +15,7 @@ export default function startup(context) {
     if (!cart) {
       throw new Error("afterCartUpdate hook run with no cart argument");
     }
+    Logger.debug("Handling afterCartUpdate: discounts");
 
     const cartId = cart._id;
     const { total: discount } = await getDiscountsTotalForCart(context, cartId);

--- a/imports/plugins/core/shipping/server/no-meteor/startup.js
+++ b/imports/plugins/core/shipping/server/no-meteor/startup.js
@@ -1,3 +1,4 @@
+import Logger from "@reactioncommerce/logger";
 import Random from "@reactioncommerce/random";
 import ReactionError from "@reactioncommerce/reaction-error";
 
@@ -28,6 +29,7 @@ export default function startup({ appEvents, collections }) {
     if (!updatedCart) {
       throw new Error("afterCartUpdate hook run with no cart argument");
     }
+    Logger.debug("Handling afterCartUpdate: shipping");
 
     // Every time the cart is updated, create any missing fulfillment groups as necessary.
     // We need one group per type per shop, containing only the items from that shop.

--- a/imports/plugins/core/taxes/server/no-meteor/startup.js
+++ b/imports/plugins/core/taxes/server/no-meteor/startup.js
@@ -1,4 +1,5 @@
 import { isEqual } from "lodash";
+import Logger from "@reactioncommerce/logger";
 import getUpdatedCartItems from "./util/getUpdatedCartItems";
 
 const EMITTED_BY_NAME = "TAXES_CORE_PLUGIN";
@@ -18,6 +19,7 @@ export default function startup(context) {
   // have changed.
   appEvents.on("afterCartUpdate", async ({ cart }, { emittedBy } = {}) => {
     if (emittedBy === EMITTED_BY_NAME) return; // short circuit infinite loops
+    Logger.debug("Handling afterCartUpdate: taxes");
 
     const { cartItems, taxSummary } = await getUpdatedCartItems(context, cart);
 

--- a/imports/plugins/included/surcharges/server/no-meteor/startup.js
+++ b/imports/plugins/included/surcharges/server/no-meteor/startup.js
@@ -24,7 +24,7 @@ export default function startup(context) {
     if (emittedBy === EMITTED_BY_NAME) return; // short circuit infinite loops
     Logger.debug("Handling afterCartUpdate: surcharges");
 
-    const { shipping } = cart;
+    const { surcharges, shipping } = cart;
     const cartSurcharges = [];
 
     // Merge surcharges from each shipping group
@@ -41,7 +41,7 @@ export default function startup(context) {
     // To avoid infinite looping among various `afterCartUpdate` handlers that also
     // update cart and emit a subsequent `afterCartUpdate`, we need to be sure we
     // do not do the update or emit the event unless we truly need to update something.
-    const previousSurcharges = cart.surcharges.map((appliedSurcharge) => ({ ...appliedSurcharge, _id: null }));
+    const previousSurcharges = (surcharges || []).map((appliedSurcharge) => ({ ...appliedSurcharge, _id: null }));
     const nextSurcharges = cartSurcharges.map((appliedSurcharge) => ({ ...appliedSurcharge, _id: null }));
     if (isEqual(previousSurcharges, nextSurcharges)) return;
 


### PR DESCRIPTION
Resolves #4995
Impact: **minor**  
Type: **bugfix**

## Issue
The `afterCartUpdate` handler for surcharges was emitting its own `afterCartUpdate` event even when it hadn't changed the surcharges list at all.

## Solution
Check whether the surcharges list has changed before emitting.

## Breaking changes
None

## Testing
See reproduction steps in the linked issue
