### PR TITLE
feat: Use .env.example files from custom plugins

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,29 +2,37 @@
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 env_file=${__dir}/../.env
-env_example_file=${__dir}/../.env.example
 
-function main {
+function main() {
   set -e
 
   add_new_env_vars
 }
 
-function add_new_env_vars {
+function add_new_env_vars() {
   # create .env and set perms if it does not exist
-  [ ! -f "${env_file}" ] && { touch "${env_file}" ; chmod 0600 "${env_file}" ; }
+  [[ ! -f "${env_file}" ]] && {
+    touch "${env_file}"
+    chmod 0600 "${env_file}"
+  }
 
-  export IFS=$'\n'
-  for var in $(cat "${env_example_file}"); do
-    key="${var%%=*}"     # get var key
-    var=$(eval echo "$var") # generate dynamic values
+  find . imports/plugins/custom -name .env.example -type f -print0 |
+    xargs -0 grep -Ehv '^\s*#' |
+    {
+      while IFS= read -r var; do
+        if [[ -z "${var}" ]]; then
+          continue
+        fi
+        key="${var%%=*}"        # get var key
+        var=$(eval echo "$var") # generate dynamic values
 
-    # If .env doesn't contain this env key, add it
-    if ! $(grep -qLE "^$key=" "${env_file}"); then
-      echo "Adding $key to .env"
-      echo "$var" >> "${env_file}"
-    fi
-  done
+        # If .env doesn't contain this env key, add it
+        if ! grep -qLE "^$key=" "${env_file}"; then
+          echo "Adding $key to .env"
+          echo "$var" >>"${env_file}"
+        fi
+      done
+    }
 }
 
 main


### PR DESCRIPTION
- Combine the main .env.example file with any .env.example
  files from custom plugins during setup
- Also support ignoring commented-out lines in `.env.example` files
- Also ignore blank lines
- also format with shfmt
- also fix one shellcheck lint error

Impact: **minor**  
Type: **feature**

## Issue

Sometimes reaction custom plugins need environment variable settings, and need to provide examples. Previously only the main reaction `.env.example` file was used to initially populate the user's `.env` file. Any settings from custom plugins would require a documented manual process to initially setup.

## Solution

Search the `imports/plugins/custom` directory for any files named `.env.example` and incorporate those into the main `.env`.

## Breaking changes

The script has always avoided overwriting any values that already exist in the file, and that behavior is retained.

## Testing

I locally tested a few scenarios

- no extra `.env.example` files
- several custom plugins with `.env.example` files
- a custom plugin with an `.env.example`in a `docs` subdire

**How to test this yourself**
- check out this feature branch
- put a bunch of varying `.env.example` files in your directory tree including the reaction project directory and anywhere under `imports/plugins/custom`
- Populate those files with a mix of `KEY=value` vars and commented out lines
- Run `bin/setup`
- Examine your project root `.env` file and make sure it has the values you expect