### PR TITLE
fix: add tagId check to guard against undefined

### DIFF
--- a/imports/plugins/core/shipping/server/no-meteor/util/helpers.js
+++ b/imports/plugins/core/shipping/server/no-meteor/util/helpers.js
@@ -82,17 +82,24 @@ export async function tagsByIds(collections, catalogProducts) {
   const { Tags } = collections;
 
   const tagIds = catalogProducts.reduce((list, item) => {
-    list.push(...item.product.tagIds);
+    if (item.product.tagIds) {
+      list.push(...item.product.tagIds);
+    }
     return list;
   }, []);
 
   const tags = await Tags.find({ _id: { $in: tagIds } }).toArray();
 
-  return catalogProducts.map((item) => ({
-    productId: item.product.productId,
-    tags: item.product.tagIds.map((id) => {
-      const foundTag = tags.find((tag) => tag._id === id);
-      return foundTag ? foundTag.name : null;
-    })
-  }));
+  return catalogProducts.reduce((list, item) => {
+    if (item.product.tagIds) {
+      list.push({
+        productId: item.product.productId,
+        tags: item.product.tagIds.map((id) => {
+          const foundTag = tags.find((tag) => tag._id === id);
+          return foundTag ? foundTag.name : null;
+        })
+      });
+    }
+    return list;
+  }, []);
 }


### PR DESCRIPTION
Resolves https://github.com/reactioncommerce/reaction/issues/5013
Impact: **critical**  
Type: **bugfix**

## Issue
When trying to check out with a product that does not have tagIds attached to it, an error is thrown, and checkout isn't allowed.

## Solution
Add a check to insure tagIds is available before checking against it.


## Breaking changes
None


## Testing
- Try to check out with an item that does not have `tagIds` attached to it. See it works.
