### PR TITLE
Add updateOrder mutation

### DIFF
--- a/imports/plugins/core/orders/server/no-meteor/mutations/__snapshots__/updateOrder.test.js.snap
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/__snapshots__/updateOrder.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throws if orderId isn't supplied 1`] = `"Order ID is required"`;
+
+exports[`throws if permission check fails 1`] = `"Access Denied"`;
+
+exports[`throws if the order doesn't exist 1`] = `"Order not found"`;

--- a/imports/plugins/core/orders/server/no-meteor/mutations/index.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/index.js
@@ -1,5 +1,7 @@
 import placeOrder from "./placeOrder";
+import updateOrder from "./updateOrder";
 
 export default {
-  placeOrder
+  placeOrder,
+  updateOrder
 };

--- a/imports/plugins/core/orders/server/no-meteor/mutations/updateOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/updateOrder.js
@@ -44,7 +44,7 @@ export default async function updateOrder(context, input) {
   const order = await Orders.findOne({ _id: orderId });
   if (!order) throw new ReactionError("not-found", "Order not found");
 
-  // Allow move if the account that placed the order is attempting to move
+  // Allow update if the account that placed the order is attempting to update
   // or if the account has "orders" permission. When called internally by another
   // plugin, context.isInternalCall can be set to `true` to disable this check.
   if (!isInternalCall && !userHasPermission(["orders"], order.shopId)) {

--- a/imports/plugins/core/orders/server/no-meteor/mutations/updateOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/updateOrder.js
@@ -21,7 +21,7 @@ const inputSchema = new SimpleSchema({
 
 /**
  * @method updateOrder
- * @summary Use this mutation to move update order status, email, and other
+ * @summary Use this mutation to update order status, email, and other
  *   properties
  * @param {Object} context - an object containing the per-request state
  * @param {Object} input - Necessary input. See SimpleSchema

--- a/imports/plugins/core/orders/server/no-meteor/mutations/updateOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/updateOrder.js
@@ -1,0 +1,89 @@
+import SimpleSchema from "simpl-schema";
+import ReactionError from "@reactioncommerce/reaction-error";
+import { Order as OrderSchema } from "/imports/collections/schemas";
+
+const inputSchema = new SimpleSchema({
+  customFields: {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
+  email: {
+    type: String,
+    optional: true
+  },
+  orderId: String,
+  status: {
+    type: String,
+    optional: true
+  }
+});
+
+/**
+ * @method updateOrder
+ * @summary Use this mutation to move update order status, email, and other
+ *   properties
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} input - Necessary input. See SimpleSchema
+ * @return {Promise<Object>} Object with `order` property containing the updated order
+ */
+export default async function updateOrder(context, input) {
+  inputSchema.validate(input);
+
+  const {
+    customFields,
+    email,
+    orderId,
+    status
+  } = input;
+
+  const { appEvents, collections, isInternalCall, userHasPermission, userId } = context;
+  const { Orders } = collections;
+
+  // First verify that this order actually exists
+  const order = await Orders.findOne({ _id: orderId });
+  if (!order) throw new ReactionError("not-found", "Order not found");
+
+  // Allow move if the account that placed the order is attempting to move
+  // or if the account has "orders" permission. When called internally by another
+  // plugin, context.isInternalCall can be set to `true` to disable this check.
+  if (!isInternalCall && !userHasPermission(["orders"], order.shopId)) {
+    throw new ReactionError("access-denied", "Access Denied");
+  }
+
+  const modifier = {
+    $set: {
+      updatedAt: new Date()
+    }
+  };
+
+  if (email) modifier.$set.email = email;
+
+  if (customFields) modifier.$set.customFields = customFields;
+
+  if (status && order.workflow.status !== status) {
+    modifier.$set["workflow.status"] = status;
+    modifier.$push = {
+      "workflow.workflow": status
+    };
+  }
+
+  // Skip updating if we have no updates to make
+  if (Object.keys(modifier.$set).length === 1) return { order };
+
+  OrderSchema.validate(modifier, { modifier: true });
+
+  const { modifiedCount, value: updatedOrder } = await Orders.findOneAndUpdate(
+    { _id: orderId },
+    modifier,
+    { returnOriginal: false }
+  );
+  if (modifiedCount === 0 || !updatedOrder) throw new ReactionError("server-error", "Unable to update order");
+
+  await appEvents.emit("afterOrderUpdate", {
+    order: updatedOrder,
+    updatedBy: userId
+  });
+
+  return { order: updatedOrder };
+}

--- a/imports/plugins/core/orders/server/no-meteor/mutations/updateOrder.test.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/updateOrder.test.js
@@ -1,0 +1,150 @@
+import updateOrder from "./updateOrder";
+import Factory from "/imports/test-utils/helpers/factory";
+import mockContext from "/imports/test-utils/helpers/mockContext";
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test("throws if orderId isn't supplied", async () => {
+  await expect(updateOrder(mockContext, {})).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("throws if the order doesn't exist", async () => {
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve(null));
+
+  await expect(updateOrder(mockContext, {
+    orderId: "order1"
+  })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("throws if permission check fails", async () => {
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve({
+    shipping: [
+      {
+        items: []
+      }
+    ],
+    shopId: "SHOP_ID"
+  }));
+
+  mockContext.userHasPermission.mockReturnValueOnce(false);
+
+  await expect(updateOrder(mockContext, {
+    orderId: "order1"
+  })).rejects.toThrowErrorMatchingSnapshot();
+
+  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["orders"], "SHOP_ID");
+});
+
+test("skips permission check if context.isInternalCall", async () => {
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve({
+    shipping: [
+      Factory.OrderFulfillmentGroup.makeOne({
+        items: Factory.OrderItem.makeMany(2)
+      }),
+      Factory.OrderFulfillmentGroup.makeOne({
+        items: Factory.OrderItem.makeMany(2)
+      })
+    ],
+    shopId: "SHOP_ID",
+    workflow: {
+      status: "new",
+      workflow: ["new"]
+    }
+  }));
+
+  mockContext.collections.Orders.findOneAndUpdate.mockReturnValueOnce(Promise.resolve({
+    modifiedCount: 1,
+    value: {}
+  }));
+
+  mockContext.isInternalCall = true;
+
+  await updateOrder(mockContext, {
+    orderId: "order1"
+  });
+
+  delete mockContext.isInternalCall;
+
+  expect(mockContext.userHasPermission).not.toHaveBeenCalled();
+});
+
+
+test("skips update if one is not necessary", async () => {
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve({
+    customFields: {
+      foo: "boo"
+    },
+    email: "old@email.com",
+    shipping: [
+      Factory.OrderFulfillmentGroup.makeOne({
+        items: Factory.OrderItem.makeMany(2)
+      })
+    ],
+    shopId: "SHOP_ID",
+    workflow: {
+      status: "new",
+      workflow: ["new"]
+    }
+  }));
+
+  mockContext.userHasPermission.mockReturnValueOnce(true);
+
+  await updateOrder(mockContext, { orderId: "order1" });
+
+  expect(mockContext.collections.Orders.findOneAndUpdate).not.toHaveBeenCalled();
+});
+
+test("updates an order", async () => {
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve({
+    customFields: {
+      foo: "boo"
+    },
+    email: "old@email.com",
+    shipping: [
+      Factory.OrderFulfillmentGroup.makeOne({
+        items: Factory.OrderItem.makeMany(2)
+      })
+    ],
+    shopId: "SHOP_ID",
+    workflow: {
+      status: "new",
+      workflow: ["new"]
+    }
+  }));
+
+  mockContext.userHasPermission.mockReturnValueOnce(true);
+
+  mockContext.collections.Orders.findOneAndUpdate.mockReturnValueOnce(Promise.resolve({
+    modifiedCount: 1,
+    value: {}
+  }));
+
+  await updateOrder(mockContext, {
+    customFields: {
+      foo: "bar"
+    },
+    email: "new@email.com",
+    orderId: "order1",
+    status: "NEW_STATUS"
+  });
+
+  expect(mockContext.collections.Orders.findOneAndUpdate).toHaveBeenCalledWith(
+    { _id: "order1" },
+    {
+      $set: {
+        "customFields": {
+          foo: "bar"
+        },
+        "email": "new@email.com",
+        "updatedAt": jasmine.any(Date),
+        "workflow.status": "NEW_STATUS"
+      },
+      $push: {
+        "workflow.workflow": "NEW_STATUS"
+      }
+    },
+    { returnOriginal: false }
+  );
+});

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/Mutation/index.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/Mutation/index.js
@@ -1,5 +1,7 @@
 import placeOrder from "./placeOrder";
+import updateOrder from "./updateOrder";
 
 export default {
-  placeOrder
+  placeOrder,
+  updateOrder
 };

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/Mutation/updateOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/Mutation/updateOrder.js
@@ -1,0 +1,38 @@
+import { decodeOrderOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/order";
+
+/**
+ * @name Mutation/updateOrder
+ * @method
+ * @memberof Payments/GraphQL
+ * @summary resolver for the updateOrder GraphQL mutation
+ * @param {Object} parentResult - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {Object} [args.input.customFields] - Updated custom fields
+ * @param {String} [args.input.email] - Set this as the order email
+ * @param {String} args.input.orderId - The order ID
+ * @param {String} [args.input.status] - Set this as the current order status
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} UpdateOrderPayload
+ */
+export default async function updateOrder(parentResult, { input }, context) {
+  const {
+    clientMutationId = null,
+    customFields,
+    email,
+    orderId,
+    status
+  } = input;
+
+  const { order } = await context.mutations.updateOrder(context, {
+    customFields,
+    email,
+    orderId: decodeOrderOpaqueId(orderId),
+    status
+  });
+
+  return {
+    clientMutationId,
+    order
+  };
+}

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -28,6 +28,11 @@ extend type Mutation {
   The order will be placed only if authorization is successful for all submitted payments.
   """
   placeOrder(input: PlaceOrderInput!): PlaceOrderPayload!
+
+  """
+  Use this mutation to update order details after the order has been placed.
+  """
+  updateOrder(input: UpdateOrderInput!): UpdateOrderPayload!
 }
 
 enum OrderFulfillmentGroupItemsSortByField {
@@ -399,6 +404,30 @@ input PlaceOrderInput {
   method where the `amount` field is `null` will be charged the remainder due.
   """
   payments: [PaymentInput]
+}
+
+"Input for the updateOrder mutation"
+input UpdateOrderInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "Set the order email to this"
+  email: String
+
+  "ID of the order to update"
+  orderId: ID!
+
+  "Set the current order status to this"
+  status: String
+}
+
+"Response payload for the updateOrder mutation"
+type UpdateOrderPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "The updated order"
+  order: Order!
 }
 
 type PlaceOrderPayload {

--- a/imports/test-utils/helpers/mockContext.js
+++ b/imports/test-utils/helpers/mockContext.js
@@ -11,6 +11,11 @@ const mockContext = {
   userId: "FAKE_USER_ID"
 };
 
+/**
+ * @summary Returns a mock collection instance with the given name
+ * @param {String} collectionName The collection name
+ * @returns {Object} Mock collection instance
+ */
 export function mockCollection(collectionName) {
   return {
     insert() {
@@ -32,6 +37,7 @@ export function mockCollection(collectionName) {
       .mockReturnThis(),
     findOne: jest.fn().mockName(`${collectionName}.findOne`),
     findOneAndDelete: jest.fn().mockName(`${collectionName}.findOneAndDelete`),
+    findOneAndUpdate: jest.fn().mockName(`${collectionName}.findOneAndUpdate`),
     fetch: jest.fn().mockName(`${collectionName}.fetch`),
     insertOne: jest.fn().mockName(`${collectionName}.insertOne`),
     insertMany: jest.fn().mockName(`${collectionName}.insertMany`),

--- a/tests/order/UpdateOrderMutation.graphql
+++ b/tests/order/UpdateOrderMutation.graphql
@@ -1,0 +1,12 @@
+mutation ($email: String, $orderId: ID!, $status: String) {
+  updateOrder(input: {
+    email: $email,
+    orderId: $orderId,
+    status: $status
+  }) {
+    order {
+      email
+      status
+    }
+  }
+}

--- a/tests/order/updateOrder.test.js
+++ b/tests/order/updateOrder.test.js
@@ -1,0 +1,86 @@
+import Factory from "/imports/test-utils/helpers/factory";
+import { encodeOrderOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/order";
+import TestApp from "../TestApp";
+import UpdateOrderMutation from "./UpdateOrderMutation.graphql";
+
+jest.setTimeout(300000);
+
+let testApp;
+let updateOrder;
+let catalogItem;
+let mockOrdersAccount;
+let shopId;
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  shopId = await testApp.insertPrimaryShop();
+
+  mockOrdersAccount = Factory.Accounts.makeOne({
+    roles: {
+      [shopId]: ["orders"]
+    }
+  });
+  await testApp.createUserAndAccount(mockOrdersAccount);
+
+  catalogItem = Factory.Catalog.makeOne({
+    isDeleted: false,
+    product: Factory.CatalogProduct.makeOne({
+      isDeleted: false,
+      isVisible: true,
+      variants: Factory.CatalogVariantSchema.makeMany(1)
+    })
+  });
+  await testApp.collections.Catalog.insertOne(catalogItem);
+
+  updateOrder = testApp.mutate(UpdateOrderMutation);
+});
+
+afterAll(async () => {
+  await testApp.collections.Catalog.remove({});
+  await testApp.collections.Shops.remove({});
+  testApp.stop();
+});
+
+test("user with orders role can update an order", async () => {
+  await testApp.setLoggedInUser(mockOrdersAccount);
+
+  const orderItem = Factory.OrderItem.makeOne({
+    productId: catalogItem.product.productId,
+    quantity: 2,
+    variantId: catalogItem.product.variants[0].variantId,
+    workflow: {
+      status: "new",
+      workflow: ["new"]
+    }
+  });
+
+  const order = Factory.Order.makeOne({
+    accountId: "123",
+    shipping: [
+      Factory.OrderFulfillmentGroup.makeOne({
+        items: [orderItem]
+      })
+    ],
+    shopId,
+    workflow: {
+      status: "new",
+      workflow: ["new"]
+    }
+  });
+  await testApp.collections.Orders.insertOne(order);
+
+  let result;
+  try {
+    result = await updateOrder({
+      email: "new@email.com",
+      orderId: encodeOrderOpaqueId(order._id),
+      status: "NEW_STATUS"
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.updateOrder.order.email).toBe("new@email.com");
+  expect(result.updateOrder.order.status).toBe("NEW_STATUS");
+});


### PR DESCRIPTION
Part of #4999
Impact: **minor**  
Type: **feature**

## Changes
A new `updateOrder` mutation allows you to change the `email`, `status`, or `customFields` of an order after it has been placed. (Saving `customFields` is not enabled by default. See https://docs.reactioncommerce.com/docs/how-to-store-custom-order-fields)

The operator UI does not yet implement this.

- `updateOrder` can be called internally to synchronize from an external system by setting `context.isInternalCall` to `true`
- `updateOrder` can be called through GraphQL by any user with "orders" permission for the shop that owns the order

## Breaking changes
None

## Testing
Note: Do not worry about testing the `customFields` update since it requires customization to opt in.

1. Place an order.
1. Verify that the mutation works as described.
1. Verify that you can update the order when authenticated as a user with "orders" role, but not when authenticated as someone else or when not authenticated.