### PR TITLE
fix: item subtotal is incorrect when additional quantities of same item are added to cart

### DIFF
--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -160,6 +160,8 @@ export default async function addCartItems(context, currentItems, inputItems, op
       updatedItemList.push(cartItem);
     } else {
       const currentCartItem = updatedItemList[currentMatchingItemIndex];
+      const updatedQuantity = currentCartItem.quantity + cartItem.quantity;
+      const updatedSubtotalAmount = updatedQuantity * cartItem.price.amount;
       updatedItemList[currentMatchingItemIndex] = {
         ...currentCartItem,
         ...cartItem,
@@ -167,7 +169,11 @@ export default async function addCartItems(context, currentItems, inputItems, op
         // chances that someone is adding the same item to the same cart in two different
         // browsers at the same time? Doing it this way allows for more functional and
         // testable code.
-        quantity: currentCartItem.quantity + cartItem.quantity
+        quantity: updatedQuantity,
+        subtotal: {
+          amount: updatedSubtotalAmount,
+          currencyCode: price.currencyCode
+        }
       };
     }
   });

--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -160,15 +160,16 @@ export default async function addCartItems(context, currentItems, inputItems, op
       updatedItemList.push(cartItem);
     } else {
       const currentCartItem = updatedItemList[currentMatchingItemIndex];
+      // Combine quantities. This is not atomic like $inc would be, but what are the
+      // chances that someone is adding the same item to the same cart in two different
+      // browsers at the same time? Doing it this way allows for more functional and
+      // testable code.
       const updatedQuantity = currentCartItem.quantity + cartItem.quantity;
+      // Recalculate subtotal with new quantity number
       const updatedSubtotalAmount = updatedQuantity * cartItem.price.amount;
       updatedItemList[currentMatchingItemIndex] = {
         ...currentCartItem,
         ...cartItem,
-        // Combine quantities. This is not atomic like $inc would be, but what are the
-        // chances that someone is adding the same item to the same cart in two different
-        // browsers at the same time? Doing it this way allows for more functional and
-        // testable code.
         quantity: updatedQuantity,
         subtotal: {
           amount: updatedSubtotalAmount,


### PR DESCRIPTION
Resolves https://github.com/reactioncommerce/reaction-next-starterkit/issues/462
Impact: **major**  
Type: **bugfix**

## Issue
Adding additional quantities of an item that is already in your cart does not trigger a subtotal recalculation, leaving the numbers in the cart preview incorrect. For example, the following image, 1 item was added, then as a second action, another item was added to the cart. The subtotal should be $39.98 ($19.99*2), but it still displays $19.99.
![image](https://user-images.githubusercontent.com/4482263/53860584-5843e680-3f96-11e9-9d8a-4987c5882290.png)

## Solution
Add a recalculation of the `subtotal` inside `addItemsToCart` util.

## Testing
1. Start `reaction-platform`
1. Add any quantity of items to a cart
1. See the subtotal is correct in the mini-cart dropdown
1. Add any number of *the same* items to the cart
1. See that the subtotal has updated and the calculation is correct
1. Also see that subtotal is correctly calculated when using `+`, `-` and `remove` buttons inside the cart itself
![price updates mov](https://user-images.githubusercontent.com/4482263/53860968-8970e680-3f97-11e9-8bfa-9ddfbba8f946.gif)
