### PR TITLE
[WIP] (feat) Allow disabling search via ENV variable

### DIFF
--- a/imports/plugins/included/search-mongo/server/config.js
+++ b/imports/plugins/included/search-mongo/server/config.js
@@ -1,0 +1,5 @@
+import envalid, { bool } from "envalid";
+
+export const env = envalid.cleanEnv(process.env, {
+  DISABLE_MONGO_SEARCH: bool({ default: false })
+});

--- a/imports/plugins/included/search-mongo/server/jobs/buildSearchCollections.js
+++ b/imports/plugins/included/search-mongo/server/jobs/buildSearchCollections.js
@@ -10,6 +10,7 @@ import {
   buildProductSearch,
   rebuildProductSearchIndex
 } from "../methods/";
+import { env } from "../config";
 
 function addBuildProductSearchCollection() {
   const productSearchCount = ProductSearch.find({}).count();
@@ -70,7 +71,7 @@ function addBuildAccountSearchCollection() {
 }
 
 appEvents.on("afterCoreInit", () => {
-  if (!Meteor.isAppTest) {
+  if (!Meteor.isAppTest && !env.DISABLE_MONGO_SEARCH) {
     buildEmptyProductSearch();
     addBuildProductSearchCollection();
     addBuildOrderSearchCollection();


### PR DESCRIPTION
Resolves #NA
Impact: **minor**  
Type: **feature**

## Issue
Even if you have another method enabled the Mongo search is still listening to events and keeping the Search collections up to date. This could involve a lot of extra disk ops and extra storage space that is not needed

## Solution
Add an env variable called `DISABLE_MONGO_SEARCH` that acts like a feature flag and disables all Mongo Search operations

## Breaking changes
None. Mongo Search remains on by default until you disable it.


## Testing
1. Start app with the env not set, ensure that everything operates as normal.
1. Set `DISABLE_MONGO_SEARCH` to `true` and reset the database.
1. Ensure that the `ProductSearch` collection is not created.
