### PR TITLE
#5039 - Register ProductAdminForm component to allow override

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductDetail.js
+++ b/imports/plugins/included/product-admin/client/components/ProductDetail.js
@@ -4,7 +4,6 @@ import { Components } from "@reactioncommerce/reaction-components";
 import Grid from "@material-ui/core/Grid";
 import withProduct from "../hocs/withProduct";
 import ProductList from "./ProductList";
-import ProductAdminForm from "./productAdmin";
 import ProductHeader from "./ProductHeader";
 import VariantTable from "./VariantTable";
 
@@ -43,7 +42,7 @@ function ProductDetail(props) {
           />
         </Grid>
         <Grid item sm={8}>
-          <ProductAdminForm {...props} />
+          <Components.ProductAdminForm {...props} />
           <VariantTable
             title="Variants"
             items={props.variants}

--- a/imports/plugins/included/product-admin/client/components/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/components/productAdmin.js
@@ -2,7 +2,7 @@ import { isEqual } from "lodash";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Alert from "sweetalert2";
-import { Components } from "@reactioncommerce/reaction-components";
+import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 import { i18next } from "/client/api";
 import update from "immutability-helper";
 import { highlightInput } from "/imports/plugins/core/ui/client/helpers/animations";
@@ -464,6 +464,10 @@ ProductAdmin.propTypes = {
   viewProps: PropTypes.object
 };
 
+registerComponent("ProductAdminForm", ProductAdmin, [
+  withGenerateSitemaps,
+  withStyles(styles)
+]);
 
 export default compose(
   withGenerateSitemaps,

--- a/imports/plugins/included/product-admin/client/index.js
+++ b/imports/plugins/included/product-admin/client/index.js
@@ -2,7 +2,7 @@ import "./templates/productAdmin.html";
 import "./templates/productAdmin.js";
 
 export { default as ProductAdmin } from "./containers/productAdmin";
-
+export { ProductAdmin as ProductAdminForm } from "./components";
 
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -13,6 +13,7 @@ import ProductTable from "./components/ProductTable";
 import ProductDetail from "./components/ProductDetail";
 import VariantDetail from "./components/VariantDetail";
 import ContentViewExtraWideLayout from "/imports/client/ui/layouts/ContentViewExtraWideLayout";
+import "./components"; // To register the components that need to be
 
 registerOperatorRoute({
   isNavigationLink: false,


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #5039   
Impact: **major**  
Type: **feature**

## Issue
The `ProductAdmin` component (which renders the form to edit top-level products) was imported directly from its file in `/imports/plugins/included/product-admin/client/components/ProductDetail.js`. This prevented developers from overriding `ProductAdmin` and add custom product fields in the new Operator UI.

## Solution
Register the `ProductAdmin`  component as `ProductAdminForm` (which is the name it was previously imported under), and use this registered component instead of the imported one.

## Breaking changes
None.

## Testing
1. Try to use `replaceComponent` on `ProductAdminForm`.
2. Notice that the form changed at http://localhost:3000/operator/products/<product_id>.