### PR TITLE
FIX: Unable to checkout with taxes

### DIFF
--- a/imports/collections/schemas/payments.js
+++ b/imports/collections/schemas/payments.js
@@ -45,6 +45,11 @@ export const Invoice = new SimpleSchema({
     type: Number,
     min: 0
   },
+  taxData: {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
   total: {
     type: Number,
     min: 0

--- a/imports/plugins/core/orders/server/no-meteor/util/updateGroupTotals.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/updateGroupTotals.js
@@ -54,7 +54,7 @@ export default async function updateGroupTotals(context, {
   });
 
   // Calculate and set taxes. Mutates group object in addition to returning the totals.
-  const { taxTotal, taxableAmount } = await addTaxesToGroup(context, {
+  const { taxTotal, taxableAmount, taxData, itemTaxes } = await addTaxesToGroup(context, {
     billingAddress,
     cartId,
     currencyCode,
@@ -69,8 +69,10 @@ export default async function updateGroupTotals(context, {
     group,
     groupDiscountTotal: discountTotal,
     groupSurchargeTotal,
+    itemTaxes,
     taxableAmount,
-    taxTotal
+    taxTotal,
+    taxData
   });
 
   if (expectedGroupTotal) {

--- a/imports/plugins/core/taxes/lib/extendCoreSchemas.js
+++ b/imports/plugins/core/taxes/lib/extendCoreSchemas.js
@@ -16,10 +16,6 @@ Cart.extend({
   }
 });
 
-OrderFulfillmentGroup.extend({
-  taxSummary: TaxSummary
-});
-
 CartItem.extend({
   /**
    * Custom key/value data that you need to store.
@@ -66,9 +62,18 @@ OrderItem.extend({
     blackbox: true,
     optional: true
   },
-  "isTaxable": Boolean,
-  "tax": Number,
-  "taxableAmount": Number,
+  "isTaxable": {
+    type: Boolean,
+    optional: true
+  },
+  "tax": {
+    type: Number,
+    optional: true
+  },
+  "taxableAmount": {
+    type: Number,
+    optional: true
+  },
   "taxCode": {
     type: String,
     optional: true

--- a/imports/plugins/core/taxes/lib/extendCoreSchemas.js
+++ b/imports/plugins/core/taxes/lib/extendCoreSchemas.js
@@ -2,7 +2,6 @@ import {
   Cart,
   CartItem,
   CatalogVariantSchema,
-  OrderFulfillmentGroup,
   OrderItem,
   ProductVariant,
   VariantBaseSchema

--- a/imports/plugins/core/taxes/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/taxes/server/no-meteor/schemas/schema.graphql
@@ -72,19 +72,19 @@ extend type CartItem {
 
 extend type OrderItem {
   "Is this a taxable item?"
-  isTaxable: Boolean!
+  isTaxable: Boolean
 
   "Total tax calculated for this item"
-  tax: Money!
+  tax: Money
 
   "The tax code for this item"
   taxCode: String
 
   "Amount of subtotal that is taxable"
-  taxableAmount: Money!
+  taxableAmount: Money
 
   "List of calculated taxes due for this item"
-  taxes: [CalculatedTax]!
+  taxes: [CalculatedTax]
 }
 
 enum TaxSource {


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issue
It is currently impossible to checkout because of schema validation issue here:

https://github.com/reactioncommerce/reaction/blob/b7c6c207a431e511857f66beec64755a59bc4409/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js#L577

This validation always fails because the required fields here are not provided:

https://github.com/reactioncommerce/reaction/blob/b7c6c207a431e511857f66beec64755a59bc4409/imports/plugins/core/taxes/lib/extendCoreSchemas.js#L58-L81

 since the following lines were removed:

https://github.com/reactioncommerce/reaction/blob/b7c6c207a431e511857f66beec64755a59bc4409/imports/plugins/core/orders/server/util/addTaxesToGroup.js#L30-L35

Also, some fields needed by SE Team to be saved in an order were removed.

## Solution

I put back tax data per item and added a blackbox `taxData` field to invoice schema to allow saving of custom fields returned by tax service in a fulfillment group..


## Testing
You should be able to checkout.
