### PR TITLE
fix: naming issue caused taxes to not be calculated

### DIFF
--- a/imports/node-app/devserver/extendSchemas.js
+++ b/imports/node-app/devserver/extendSchemas.js
@@ -1,0 +1,1 @@
+import "/imports/plugins/core/taxes/lib/extendCoreSchemas";

--- a/imports/node-app/devserver/index.js
+++ b/imports/node-app/devserver/index.js
@@ -6,6 +6,7 @@ import queries from "./queries";
 import resolvers from "./resolvers";
 import schemas from "./schemas";
 import filesStartup from "./filesStartup";
+import "./extendSchemas";
 
 const { MONGO_URL, PORT = 3030, ROOT_URL } = process.env;
 if (!MONGO_URL) throw new Error("You must set MONGO_URL");

--- a/imports/plugins/core/orders/server/no-meteor/util/addTaxesToGroup.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/addTaxesToGroup.js
@@ -31,12 +31,12 @@ export default async function addTaxesToGroup(context, {
     discountTotal
   });
 
-  // A taxes plugin is expected to add a mutation named `setTaxesOnFulfillmentGroup`.
+  // A taxes plugin is expected to add a mutation named `setTaxesOnOrderFulfillmentGroup`.
   // If this isn't done, assume 0 tax.
-  if (typeof mutations.setTaxesOnFulfillmentGroup !== "function") {
+  if (typeof mutations.setTaxesOnOrderFulfillmentGroup !== "function") {
     return { taxTotal: 0, taxableAmount: 0 };
   }
 
   // This will mutate `group` to add whatever tax fields the `taxes` plugin has added to the schemas.
-  return mutations.setTaxesOnFulfillmentGroup(context, { group, commonOrder });
+  return mutations.setTaxesOnOrderFulfillmentGroup(context, { group, commonOrder });
 }

--- a/imports/plugins/core/taxes/server/no-meteor/mutations/setTaxesOnOrderFulfillmentGroup.js
+++ b/imports/plugins/core/taxes/server/no-meteor/mutations/setTaxesOnOrderFulfillmentGroup.js
@@ -5,7 +5,7 @@
  * @param {Object} commonOrder The group in CommonOrder schema
  * @returns {Object} An object with `taxableAmount` and `taxTotal` properties. Also mutates `group`.
  */
-export default async function setTaxesOnFulfillmentGroup(context, { group, commonOrder }) {
+export default async function setTaxesOnOrderFulfillmentGroup(context, { group, commonOrder }) {
   const { itemTaxes, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, { order: commonOrder, forceZeroes: true });
   group.items = group.items.map((item) => {
     const itemTax = itemTaxes.find((entry) => entry.itemId === item._id) || {};

--- a/tests/TestApp.js
+++ b/tests/TestApp.js
@@ -14,6 +14,7 @@ import mutations from "../imports/node-app/devserver/mutations";
 import queries from "../imports/node-app/devserver/queries";
 import schemas from "../imports/node-app/devserver/schemas";
 import resolvers from "../imports/node-app/devserver/resolvers";
+import "../imports/node-app/devserver/extendSchemas";
 
 class TestApp {
   constructor(options = {}) {


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issue
Cannot checkout due to total mismatch when there's any tax on an order

## Solution
A function was not being found due to having renamed it in one place but not another. Fix the names.

## Breaking changes
None

## Testing
1. Add items to cart and go through checkout with data that will cause there to be some non-zero charge for taxes.
2. Verify you can place the order successfully without getting a price mismatch error.