### PR TITLE
Fix bin/setup handling bad env.example

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -30,17 +30,20 @@ function add_new_env_vars() {
   }
 
   find . -name .env.example -type f -print0 |
-    xargs -0 grep -Ehv '^\s*#' || true |
+    (xargs -0 grep -Ehv '^\s*#' || true) |
+    sort |
     {
       while IFS= read -r var; do
         if [[ -z "${var}" ]]; then
           continue
         fi
-        key="${var%%=*}"        # get var key
-        var=$(eval echo "$var") # generate dynamic values
-
+        key="${var%%=*}" # get var key
+        # only eval for dynamic vars if the value has a dollar sign
+        if [[ "${var}" =~ "$" ]]; then
+          var="$(eval echo "${var}")" # generate dynamic values
+        fi
         # If .env doesn't contain this env key, add it
-        if ! grep -qLE "^$key=" "${env_file}"; then
+        if ! grep -qLE "^${key}=" "${env_file}"; then
           echo "Adding $key to .env"
           echo "$var" >>"${env_file}"
         fi


### PR DESCRIPTION
Resolves #5047  
Impact: **minor**  
Type: **bugfix

## Issue

A bunk `.env.example` file can cause the `bin/setup` script to abort without copying all the values into `.env`.


## Solution

- Only eval lines that contain a `$` to handle dynamic env var expansion
- Use a subshell to deal with exit codes and `grep || true` properly
- Also sort the keys for consistency/determinism

## Breaking changes

None

## Testing
1. Create a `.env.example` file anywhere under your `reaction` directory with the following line
  - `EXAMPLE_VAR=docker.for.mac.localhost:<port>, add stuff: in networks: in docker-compose.yml`
2. Run `./bin/setup`
3. Check your `.env` for the `EXAMPLE_VAR` line
