### PR TITLE
chore: add optional first and last name fields to schemas

### DIFF
--- a/imports/collections/schemas/address.js
+++ b/imports/collections/schemas/address.js
@@ -50,7 +50,7 @@ export const Address = new SimpleSchema({
   },
   "lastName": {
     type: String,
-    label: "Laast name",
+    label: "Last name",
     optional: true
   },
   "address1": {

--- a/imports/collections/schemas/address.js
+++ b/imports/collections/schemas/address.js
@@ -17,6 +17,8 @@ const withoutCodeCountries = ["AO", "AG", "AW", "BS", "BZ", "BJ", "BW",
  * @type {SimpleSchema}
  * @property {String} _id
  * @property {String} fullName required
+ * @property {String} fistName
+ * @property {String} lastName
  * @property {String} address1 required
  * @property {String} address2
  * @property {String} city required
@@ -40,6 +42,16 @@ export const Address = new SimpleSchema({
   "fullName": {
     type: String,
     label: "Full name"
+  },
+  "firstName": {
+    type: String,
+    label: "First name",
+    optional: true
+  },
+  "lastName": {
+    type: String,
+    label: "Laast name",
+    optional: true
   },
   "address1": {
     label: "Address 1",

--- a/imports/plugins/core/address/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/address/server/no-meteor/schemas/schema.graphql
@@ -56,6 +56,20 @@ input AddressInput {
   "The full name of a person at this address"
   fullName: String!
 
+  """
+  The first name of a person at this address
+  This is an optional field to support legacy and third party platforms
+  We use fullName internally, and use first and last name fields to combine into a full name if needed
+  """
+  firstName: String
+
+  """
+  The last name of a person at this address
+  This is an optional field to support legacy and third party platforms
+  We use fullName internally, and use first and last name fields to combine into a full name if needed
+  """
+  lastName: String
+
   "Is this the default address for billing purposes?"
   isBillingDefault: Boolean
 
@@ -100,6 +114,20 @@ type Address {
 
   "The full name of a person at this address"
   fullName: String!
+
+  """
+  The first name of a person at this address
+  This is an optional field to support legacy and third party platforms
+  We use fullName internally, and use first and last name fields to combine into a full name if needed
+  """
+  firstName: String
+
+  """
+  The last name of a person at this address
+  This is an optional field to support legacy and third party platforms
+  We use fullName internally, and use first and last name fields to combine into a full name if needed
+  """
+  lastName: String
 
   "Is this the default address for billing purposes?"
   isBillingDefault: Boolean

--- a/imports/plugins/core/core/server/no-meteor/resolvers/index.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/index.js
@@ -71,6 +71,8 @@ export default {
  * @property {String} country - Country
  * @property {Boolean} [failedValidation] - Mark address as failed validation by address validation service
  * @property {String} fullName - Full name
+ * @property {String} [firstName] - First name
+ * @property {String} [lastName] - Last name
  * @property {Boolean} isBillingDefault - Mark address as default for billing
  * @property {Boolean} isCommercial - Mask address as commercial
  * @property {Boolean} isShippingDefault -  Mark address as default for shipping

--- a/tests/account/AddAccountAddressBookEntryMutation.graphql
+++ b/tests/account/AddAccountAddressBookEntryMutation.graphql
@@ -7,6 +7,8 @@ mutation ($accountId: ID!, $address: AddressInput!) {
       company
       country
       fullName
+      firstName
+      lastName
       isBillingDefault
       isCommercial
       isShippingDefault


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
Some payment integrations require `firstName` and `lastName` fields to be separated, not just a `fullName` as we currently have set up.

## Solution
Add optional `firstName` and `lastName` fields to our meteor simpl schema for `Address`. This schema is also use don payments. Also, add the fields to the GQL schema for `Address` and `AddressInput`, which again is used for payments and all places `fullName` is required.

As per @spencern's comment... since `fullName` is required,  and `firstName` and `lastName` are optional, we leave it up to the client how to send the data, whether thats just using `fullName`, or taking the input from `firstName` and `lastName` and combining them to create a `fullName`.

## Breaking changes
None

## Testing
1. Use GQL to add an address with first name and last name
```
mutation {
  addAccountAddressBookEntry(
    input: {
      accountId: "cmVhY3Rpb24vYWNjb3VudDpvTldwRFdBa3hlcUxQU3hpUw==",
      address: {
        address1: "123 Main Street Street"
        firstName: "Erik"
        lastName: "Kieckhafer"
        city: "Santa Monica"
        region: "CA"
        country: "US"
        postal: "90405"
        phone: "555-666-7890"
        fullName: "Erik Kieckhafer"
      }
    }
  ) {
	address {
          fullName
          firstName
          lastName
  }
  }
}
```
1. See that they are both saved in the database
1. See that you can query `firstName`, `lastName`, and `fullName` wherever you need an address