### PR TITLE
(feat) Allow extend generate orderId and cartId

### DIFF
--- a/imports/collections/schemas/cart.js
+++ b/imports/collections/schemas/cart.js
@@ -203,6 +203,11 @@ export const Cart = new SimpleSchema({
     index: 1,
     optional: true
   },
+  "referenceId": {
+    type: String,
+    index: 1,
+    optional: true
+  },
   "email": {
     type: String,
     optional: true,

--- a/imports/collections/schemas/cart.js
+++ b/imports/collections/schemas/cart.js
@@ -205,7 +205,6 @@ export const Cart = new SimpleSchema({
   },
   "referenceId": {
     type: String,
-    index: 1,
     optional: true
   },
   "email": {

--- a/imports/collections/schemas/cart.js
+++ b/imports/collections/schemas/cart.js
@@ -206,7 +206,6 @@ export const Cart = new SimpleSchema({
   "referenceId": {
     type: String,
     index: 1,
-    unique: true,
     optional: true
   },
   "email": {

--- a/imports/collections/schemas/cart.js
+++ b/imports/collections/schemas/cart.js
@@ -206,6 +206,7 @@ export const Cart = new SimpleSchema({
   "referenceId": {
     type: String,
     index: 1,
+    unique: true,
     optional: true
   },
   "email": {

--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -467,9 +467,7 @@ export const Order = new SimpleSchema({
   },
   "payments.$": Payment,
   "referenceId": {
-    type: String,
-    index: 1,
-    unique: true
+    type: String
   },
   "shipping": [OrderFulfillmentGroup],
   "shopId": {

--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -466,7 +466,11 @@ export const Order = new SimpleSchema({
     optional: true
   },
   "payments.$": Payment,
-  "referenceId": String,
+  "referenceId": {
+    type: String,
+    index: 1,
+    unique: true
+  },
   "shipping": [OrderFulfillmentGroup],
   "shopId": {
     type: String,

--- a/imports/plugins/core/cart/server/no-meteor/mutations/convertAnonymousCartToNewAccountCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/convertAnonymousCartToNewAccountCart.js
@@ -11,6 +11,7 @@ import appEvents from "/imports/node-app/core/util/appEvents";
  * @param {Object} anonymousCartSelector The MongoDB selector for the anonymous cart
  * @param {MongoDB.Collection} Cart The Cart collection
  * @param {String} shopId The shop ID to associate with the new account cart
+ * @param {String} userId The ID of the user
  * @return {Object} The new account cart
  */
 export default async function convertAnonymousCartToNewAccountCart({
@@ -36,6 +37,10 @@ export default async function convertAnonymousCartToNewAccountCart({
       status: "new"
     }
   };
+
+  if (anonymousCart.referenceId) {
+    newCart.referenceId = anonymousCart.referenceId;
+  }
 
   CartSchema.validate(newCart);
 

--- a/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
@@ -3,6 +3,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
 import hashLoginToken from "/imports/node-app/core/util/hashLoginToken";
 import { Cart as CartSchema } from "/imports/collections/schemas";
 import addCartItems from "../util/addCartItems";
+import Logger from "@reactioncommerce/logger";
 
 /**
  * @method createCart
@@ -22,7 +23,7 @@ import addCartItems from "../util/addCartItems";
  */
 export default async function createCart(context, input) {
   const { items, shopId, shouldCreateWithoutItems = false } = input;
-  const { appEvents, collections, accountId = null, userId = null } = context;
+  const { appEvents, collections, accountId = null, userId = null, getFunctionsOfType } = context;
   const { Cart, Shops } = collections;
 
   if (shouldCreateWithoutItems !== true && (!Array.isArray(items) || !items.length)) {
@@ -57,6 +58,7 @@ export default async function createCart(context, input) {
   const shop = await Shops.findOne({ _id: shopId }, { projection: { currency: 1 } });
   const cartCurrencyCode = (shop && shop.currency) || "USD";
 
+
   const createdAt = new Date();
   const newCart = {
     _id: Random.id(),
@@ -71,6 +73,19 @@ export default async function createCart(context, input) {
       status: "new"
     }
   };
+
+  let referenceId;
+  const createReferenceIdFunctions = getFunctionsOfType("createCartReferenceId");
+  if (!createReferenceIdFunctions || createReferenceIdFunctions.length === 0) {
+    referenceId = Random.id();
+  } else {
+    referenceId = createReferenceIdFunctions[0](newCart);
+    if (createReferenceIdFunctions.length > 1) {
+      Logger.warn("More than one createCartReferenceId function defined. Using first one defined");
+    }
+  }
+
+  newCart.referenceId = referenceId;
 
   CartSchema.validate(newCart);
 

--- a/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
@@ -81,7 +81,7 @@ export default async function createCart(context, input) {
   } else {
     referenceId = await createReferenceIdFunctions[0](newCart);
     if (typeof referenceId !== "string") {
-      throw new ReactionError("invalid-parameter", "createCartReferenceId return a non-string value");
+      throw new ReactionError("invalid-parameter", "createCartReferenceId returned a non-string value");
     }
     if (createReferenceIdFunctions.length > 1) {
       Logger.warn("More than one createCartReferenceId function defined. Using first one defined");

--- a/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
@@ -1,9 +1,9 @@
 import Random from "@reactioncommerce/random";
 import ReactionError from "@reactioncommerce/reaction-error";
+import Logger from "@reactioncommerce/logger";
 import hashLoginToken from "/imports/node-app/core/util/hashLoginToken";
 import { Cart as CartSchema } from "/imports/collections/schemas";
 import addCartItems from "../util/addCartItems";
-import Logger from "@reactioncommerce/logger";
 
 /**
  * @method createCart

--- a/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
@@ -79,7 +79,10 @@ export default async function createCart(context, input) {
   if (!createReferenceIdFunctions || createReferenceIdFunctions.length === 0) {
     referenceId = Random.id();
   } else {
-    referenceId = createReferenceIdFunctions[0](newCart);
+    referenceId = await createReferenceIdFunctions[0](newCart);
+    if (typeof referenceId !== "string") {
+      throw new ReactionError("invalid-parameter", "createCartReferenceId return a non-string value");
+    }
     if (createReferenceIdFunctions.length > 1) {
       Logger.warn("More than one createCartReferenceId function defined. Using first one defined");
     }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/createCart.js
@@ -79,7 +79,7 @@ export default async function createCart(context, input) {
   if (!createReferenceIdFunctions || createReferenceIdFunctions.length === 0) {
     referenceId = Random.id();
   } else {
-    referenceId = await createReferenceIdFunctions[0](newCart);
+    referenceId = await createReferenceIdFunctions[0](context, newCart);
     if (typeof referenceId !== "string") {
       throw new ReactionError("invalid-parameter", "createCartReferenceId returned a non-string value");
     }

--- a/imports/plugins/core/cart/server/no-meteor/mutations/createCart.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/createCart.test.js
@@ -82,6 +82,7 @@ test("creates an anonymous cart if no user is logged in", async () => {
       anonymousAccessToken: jasmine.any(String),
       currencyCode: "USD",
       createdAt: jasmine.any(Date),
+      referenceId: jasmine.any(String),
       items: [
         {
           _id: "CartItemID",

--- a/imports/plugins/core/discounts/server/no-meteor/startup.js
+++ b/imports/plugins/core/discounts/server/no-meteor/startup.js
@@ -17,8 +17,7 @@ export default function startup(context) {
     }
     Logger.debug("Handling afterCartUpdate: discounts");
 
-    const cartId = cart._id;
-    const { total: discount } = await getDiscountsTotalForCart(context, cartId);
+    const { total: discount } = await getDiscountsTotalForCart(context, cart);
     if (discount !== cart.discount) {
       await Cart.update({ _id: cartId }, { $set: { discount } });
     }

--- a/imports/plugins/core/discounts/server/no-meteor/startup.js
+++ b/imports/plugins/core/discounts/server/no-meteor/startup.js
@@ -19,7 +19,7 @@ export default function startup(context) {
 
     const { total: discount } = await getDiscountsTotalForCart(context, cart);
     if (discount !== cart.discount) {
-      await Cart.update({ _id: cartId }, { $set: { discount } });
+      await Cart.update({ _id: cart._id }, { $set: { discount } });
     }
   });
 }

--- a/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart.js
+++ b/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart.js
@@ -4,17 +4,12 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @summary Calculates total discount amount for a cart based on all discounts
  *   that have been applied to it
  * @param {Object} context Context object
- * @param {String} cartId Cart ID
+ * @param {String} cart The cart to get discounts from
  * @returns {Object} Object with `discounts` array and `total`
  */
-export default async function getDiscountsTotalForCart(context, cartId) {
+export default async function getDiscountsTotalForCart(context, cart) {
   const { collections } = context;
-  const { Cart, Discounts } = collections;
-
-  const cart = await Cart.findOne({ _id: cartId });
-  if (!cart) {
-    throw new ReactionError("not-found", "Cart not found");
-  }
+  const { Discounts } = collections;
 
   // Currently, discounts are added as items in the billing array
   let discounts = await Promise.all((cart.billing || []).map(async (billing) => {

--- a/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart.js
+++ b/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart.js
@@ -1,5 +1,3 @@
-import ReactionError from "@reactioncommerce/reaction-error";
-
 /**
  * @summary Calculates total discount amount for a cart based on all discounts
  *   that have been applied to it

--- a/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart.js
+++ b/imports/plugins/core/discounts/server/no-meteor/util/getDiscountsTotalForCart.js
@@ -2,7 +2,7 @@
  * @summary Calculates total discount amount for a cart based on all discounts
  *   that have been applied to it
  * @param {Object} context Context object
- * @param {String} cart The cart to get discounts from
+ * @param {Object} cart The cart to get discounts from
  * @returns {Object} Object with `discounts` array and `total`
  */
 export default async function getDiscountsTotalForCart(context, cart) {

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -174,8 +174,10 @@ export default async function placeOrder(context, input) {
   } = orderInput;
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
   const { Orders, Cart } = collections;
+
+  let cart;
   if (cartId) {
-    const cart = await Cart.findOne({ _id: cartId });
+    cart = await Cart.findOne({ _id: cartId });
     if (!cart) {
       throw new ReactionError("not-found", "Cart not found while trying to place order");
     }
@@ -275,7 +277,7 @@ export default async function placeOrder(context, input) {
   if (!createReferenceIdFunctions || createReferenceIdFunctions.length === 0) {
     // if the cart has a reference Id, and no custom function is created use that
     if (_.get(cart, "referenceId")) { // we want the else to fallthrough if no cart to keep the if/else logic simple
-      referenceId = cart.referenceId;
+      ({ referenceId } = cart);
     } else {
       referenceId = Random.id();
     }

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -282,7 +282,7 @@ export default async function placeOrder(context, input) {
       referenceId = Random.id();
     }
   } else {
-    referenceId = await createReferenceIdFunctions[0](order, cart);
+    referenceId = await createReferenceIdFunctions[0](context, order, cart);
     if (typeof referenceId !== "string") {
       throw new ReactionError("invalid-parameter", "createOrderReferenceId function returned a non-string value");
     }

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import SimpleSchema from "simpl-schema";
 import Logger from "@reactioncommerce/logger";
 import Random from "@reactioncommerce/random";
@@ -68,6 +69,7 @@ async function getCurrencyExchangeObject(collections, cartCurrencyCode, shopId, 
  * @summary Create all authorized payments for a potential order
  * @param {String} [accountId] The ID of the account placing the order
  * @param {Object} [billingAddress] Billing address for the order as a whole
+ * @param {Object} context - The application context
  * @param {String} currencyCode Currency code for interpreting the amount of all payments
  * @param {Object} currencyExchangeInfo Currency exchange info
  * @param {String} email Email address for the order
@@ -171,15 +173,22 @@ export default async function placeOrder(context, input) {
     shopId
   } = orderInput;
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
-  const { Orders } = collections;
+  const { Orders, Cart } = collections;
+  if (cartId) {
+    const cart = await Cart.findOne({ _id: cartId });
+    if (!cart) {
+      throw new ReactionError("not-found", "Cart not found while trying to place order");
+    }
+  }
+
 
   // We are mixing concerns a bit here for now. This is for backwards compatibility with current
   // discount codes feature. We are planning to revamp discounts soon, but until then, we'll look up
   // any discounts on the related cart here.
   let discounts = [];
   let discountTotal = 0;
-  if (cartId) {
-    const discountsResult = await getDiscountsTotalForCart(context, cartId);
+  if (cart) {
+    const discountsResult = await getDiscountsTotalForCart(context, cart);
     ({ discounts } = discountsResult);
     discountTotal = discountsResult.total;
   }
@@ -190,6 +199,7 @@ export default async function placeOrder(context, input) {
 
   // Create orderId
   const orderId = Random.id();
+
 
   // Add more props to each fulfillment group, and validate/build the items in each group
   let orderTotal = 0;
@@ -249,7 +259,6 @@ export default async function placeOrder(context, input) {
     discounts,
     email,
     payments,
-    referenceId: Random.id(),
     shipping: finalFulfillmentGroups,
     shopId,
     surcharges: orderSurcharges,
@@ -260,6 +269,25 @@ export default async function placeOrder(context, input) {
       workflow: ["new"]
     }
   };
+
+  let referenceId;
+  const createReferenceIdFunctions = getFunctionsOfType("createOrderReferenceId");
+  if (!createReferenceIdFunctions || createReferenceIdFunctions.length === 0) {
+    // if the cart has a reference Id, and no custom function is created use that
+    if (_.get(cart, "referenceId")) { // we want the else to fallthrough if no cart to keep the if/else logic simple
+      referenceId = cart.referenceId;
+    } else {
+      referenceId = Random.id();
+    }
+  } else {
+    referenceId = createReferenceIdFunctions[0](cart, order);
+    if (createReferenceIdFunctions.length > 1) {
+      Logger.warn("More than one createOrderReferenceId function defined. Using first one defined");
+    }
+  }
+
+  order.referenceId = referenceId;
+
 
   // Apply custom order data transformations from plugins
   const transformCustomOrderFieldsFuncs = getFunctionsOfType("transformCustomOrderFields");

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -282,7 +282,10 @@ export default async function placeOrder(context, input) {
       referenceId = Random.id();
     }
   } else {
-    referenceId = createReferenceIdFunctions[0](cart, order);
+    referenceId = await createReferenceIdFunctions[0](order, cart);
+    if (typeof referenceId !== "string") {
+      throw new ReactionError("invalid-parameter", "createOrderReferenceId function returned a non-string value");
+    }
     if (createReferenceIdFunctions.length > 1) {
       Logger.warn("More than one createOrderReferenceId function defined. Using first one defined");
     }

--- a/imports/plugins/core/versions/server/migrations/58_add_reference_id_to_order.js
+++ b/imports/plugins/core/versions/server/migrations/58_add_reference_id_to_order.js
@@ -1,0 +1,27 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Cart } from "/lib/collections";
+import findAndConvertInBatches from "../util/findAndConvertInBatches";
+
+Migrations.add({
+  version: 58,
+
+  up() {
+    findAndConvertInBatches({
+      collection: Cart,
+      converter: (cart) => {
+        if (!cart.referenceId) cart.referenceId = cart._id;
+        return cart;
+      }
+    });
+  },
+
+  down() {
+    Cart.update({
+      referenceId: { $exists: true }
+    }, {
+      $unset: {
+        referenceId: ""
+      }
+    }, { bypassCollection2: true });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -56,3 +56,4 @@ import "./54_template_name_updates";
 import "./55_order_payments";
 import "./56_change_inventoryQuantity_to_inventoryInStock";
 import "./57_confirm_inventory_is_not_NaN.js";
+import "./58_add_reference_id_to_order.js";

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -219,7 +219,19 @@ if (Meteor.isServer) {
   collectionIndex(MediaRecords.rawCollection(), { "original.tempStoreId": 1 });
 
   // Add indexes on referenceId since we query on them
-  collectionIndex(Cart.rawCollection(), { referenceId: 1 }, { unique: true });
+  collectionIndex(Cart.rawCollection(), {
+    referenceId: 1
+  }, {
+    unique: true,
+    // referenceId is an optional field for carts, so we want the uniqueness constraint
+    // to apply only to non-null fields or the second document with value `null`
+    // would throw an error.
+    partialFilterExpression: {
+      referenceId: {
+        $type: "string"
+      }
+    }
+  });
   collectionIndex(Orders.rawCollection(), { referenceId: 1 }, { unique: true });
 }
 

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -219,8 +219,8 @@ if (Meteor.isServer) {
   collectionIndex(MediaRecords.rawCollection(), { "original.tempStoreId": 1 });
 
   // Add indexes on referenceId since we query on them
-  collectionIndex(Cart.rawCollection(), { "referenceId": 1 });
-  collectionIndex(Orders.rawCollection(), { "referenceId": 1 });
+  collectionIndex(Cart.rawCollection(), { referenceId: 1 });
+  collectionIndex(Orders.rawCollection(), { referenceId: 1 });
 }
 
 // Might want to do this at some point.

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -219,8 +219,8 @@ if (Meteor.isServer) {
   collectionIndex(MediaRecords.rawCollection(), { "original.tempStoreId": 1 });
 
   // Add indexes on referenceId since we query on them
-  collectionIndex(Cart.rawCollection(), { referenceId: 1 });
-  collectionIndex(Orders.rawCollection(), { referenceId: 1 });
+  collectionIndex(Cart.rawCollection(), { referenceId: 1 }, { unique: true });
+  collectionIndex(Orders.rawCollection(), { referenceId: 1 }, { unique: true });
 }
 
 // Might want to do this at some point.

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -217,6 +217,10 @@ if (Meteor.isServer) {
   // These queries are used by the workers in file-collections package
   collectionIndex(MediaRecords.rawCollection(), { "original.remoteURL": 1 });
   collectionIndex(MediaRecords.rawCollection(), { "original.tempStoreId": 1 });
+
+  // Add indexes on referenceId since we query on them
+  collectionIndex(Cart.rawCollection(), { "referenceId": 1 });
+  collectionIndex(Orders.rawCollection(), { "referenceId": 1 });
 }
 
 // Might want to do this at some point.

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "inspect-docker": "node --experimental-modules  ./.reaction/run/index.mjs --inspect=0.0.0.0:9229",
     "inspect-brk-docker": "node --experimental-modules  ./.reaction/run/index.mjs --inspect-brk=0.0.0.0:9229",
     "lint": "eslint .",
+    "lint:errors": "eslint . --quiet",
     "test": "npm run test:unit && npm run test:integration && npm run test:app",
     "test:app": "MONGO_URL='' TEST_CLIENT=0 meteor test --no-release-check --once --full-app --driver-package meteortesting:mocha",
     "test:app:watch": "MONGO_URL='' TEST_CLIENT=0 TEST_WATCH=1 meteor test --no-release-check --full-app --driver-package meteortesting:mocha",


### PR DESCRIPTION
**Branch Recreated in order to Sign Commits**
** Replaces PR https://github.com/reactioncommerce/reaction/pull/5029 **

Resolves #5052
Impact: **minor**  
Type: **feature**

## Issue
Currently we use the Random id to generate Order Ids. A lot of systems have requirements for IDs to be of a different type or in a specific order (e.g. consecutive integers). This allows a plugin to override this by providing a `createOrderId` function. The default method of using `Random.id()` remains the same.

## Solution
Allow for a `createOrderReferenceId` and `createCartReferenceId` function to be provided by a plugin and use that instead of Random.id

## Breaking changes
None

## Testing
1. Create an order and verify it has an referenceId
1. Create a test plugin in `imports/plugins/custom/fake` with just this file


register.js
```
import Reaction from "/imports/plugins/core/core/server/Reaction";
import _ from "lodash";

function createNumericId() {
  console.log("createdNumericId");
  return _.random(0, 1000).toString();
}

Reaction.registerPackage({
  label: "Fake",
  name: "reaction-fake",
  icon: "fa fa-fake",
  autoEnable: true,
  functionsByType: {
    createCartReferenceId: [createNumericId]
  }
});
```

3. Restart Reaction
4. Add something to cart
5. Verify it was a reference id that is between 0 and 1000
6. Checkout with this cart
7. Verify that `order.referenceId` is the same as the number above
