### PR TITLE
fix marketplace invitation validation

### DIFF
--- a/imports/plugins/core/orders/lib/extendShopSchema.js
+++ b/imports/plugins/core/orders/lib/extendShopSchema.js
@@ -9,6 +9,7 @@ import { Shop } from "/imports/collections/schemas";
 Shop.extend({
   orderStatusLabels: {
     type: Object,
-    blackbox: true
+    blackbox: true,
+    optional: true
   }
 });


### PR DESCRIPTION
Resolves #5057
Impact: **major**  
Type: **bugfix**

## Issue
When invitation to new markeplace owner is sent. We are getting error: Order status labels is required.

## Solution
Is provided by this pull request.

## Breaking changes
No breaking changes or functional changes

## Testing
Probably this option need's to be added in tests: Inviting new marketplace owner.