### PR TITLE
Ensure an error message is logged for apollo errors

### DIFF
--- a/imports/node-app/core/util/getErrorFormatter.js
+++ b/imports/node-app/core/util/getErrorFormatter.js
@@ -26,8 +26,6 @@ function getErrorFormatter() {
         ...(originalError.eventData || {})
       };
 
-      Logger.error(eventObj);
-
       if (typeof originalError.error === "string") type = originalError.error;
 
       if (type === "validation-error" && originalError.details && originalError.details.length) {
@@ -37,6 +35,7 @@ function getErrorFormatter() {
       } else {
         err.message = originalError.message;
       }
+      Logger.error(eventObj, err.message || "ApolloServer error with no message");
     }
 
     // Add a `type` prop to our `errors` response object for client parsing


### PR DESCRIPTION
Resolves #5006   
Impact: **minor**  
Type: **bugfix**

## Issue

Some types of apollo server errors were being logged without the `message` field, which is typically crucial to making sense of the error.

## Solution

Use bunyan's API to pass the message as the 2nd argument, after the details object payload.

## Breaking changes

N/A

## Testing

Hit the graphql endpoint with this query to trigger an error:

```graphql
{
  primaryShopIdNOPE
}
```
Watch your reaction server log file for the following line, and confirm the `msg` field has a non-empty and useful value.

```
{"name":"Reaction","hostname":"81db37f382dc","pid":223,"level":50,"errorId":"cjtj2unhn000067pf7okmerzz","msg":"Cannot query field \"primaryShopIdNOPE\" on type \"Query\". Did you mean \"primaryShopId\" or \"primaryShop\"?","time":"2019-03-21T20:17:32.268Z","v":0}
```