### PR TITLE
Set variant media correctly when added to cart

### DIFF
--- a/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
@@ -51,20 +51,17 @@ async function xformCartItem(context, catalogItems, products, cartItem) {
   }
 
   const catalogProduct = catalogItem.product;
+
   const { variant } = findVariantInCatalogProduct(catalogProduct, variantId);
   if (!variant) {
     throw new ReactionError("invalid-param", `Product with ID ${productId} has no variant with ID ${variantId}`);
   }
 
-  const variantSourceProduct = products.find((product) => product._id === variantId);
-  const catalogVariantId = variantSourceProduct.ancestors[1];
-  const catalogVariant = catalogProduct.variants.find((cVariant) => cVariant._id === catalogVariantId);
-
   let media;
   // Give media in variants priority over a product's main media.
-  if (catalogVariant.media) {
+  if (variant.media) {
     // Transform variant's main image only
-    media = await xformCatalogProductMedia(catalogVariant.media[0], context);
+    media = await xformCatalogProductMedia(variant.media[0], context);
     // fallback, return media on catalogProduct
   } else if (catalogProduct.media || catalogProduct.primaryImage) {
     media = catalogProduct.media.find((mediaItem) => mediaItem.variantId === variantId);
@@ -74,6 +71,8 @@ async function xformCartItem(context, catalogItems, products, cartItem) {
       media = await xformCatalogProductMedia(media, context);
     }
   }
+
+  const variantSourceProduct = products.find((product) => product._id === variantId);
 
   return {
     ...cartItem,


### PR DESCRIPTION
Resolves: #5062
Impact: **Critical**
Type: **bugfix**

## Issue
Incorrect variant image rendered in mini cart popover and cart page

## Solution
Give priority to media in variant over media stored on the parent product object. 

## Testing
1. Add variant other than the first one to the shopping cart
2. Confirm the correct variant image is rendered in the cart popover
3. Confirm the correct variant images are rendered in the cart page

