### PR TITLE
Add cart referenceId in graphql schema

### DIFF
--- a/imports/plugins/core/cart/server/no-meteor/schemas/cart.graphql
+++ b/imports/plugins/core/cart/server/no-meteor/schemas/cart.graphql
@@ -18,6 +18,9 @@ type Cart implements Node {
   "An email address that has been associated with the cart"
   email: String
 
+  "A string to reference the cart"
+  referenceId: String
+
   "The items that have been added to the cart. A cart is not created until the first item is added. Items can be removed from a cart, and a cart is not deleted if all items are removed from it. Because all items may have been removed, this may be an empty array."
   items(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = desc, sortBy: CartItemsSortByField = addedAt): CartItemConnection
 

--- a/imports/plugins/core/cart/server/no-meteor/schemas/cart.graphql
+++ b/imports/plugins/core/cart/server/no-meteor/schemas/cart.graphql
@@ -21,10 +21,12 @@ type Cart implements Node {
   "The items that have been added to the cart. A cart is not created until the first item is added. Items can be removed from a cart, and a cart is not deleted if all items are removed from it. Because all items may have been removed, this may be an empty array."
   items(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = desc, sortBy: CartItemsSortByField = addedAt): CartItemConnection
 
-  "If you integrate with third-party systems that require you to send the same ID for order
+  """
+  If you integrate with third-party systems that require you to send the same ID for order
   calculations as for cart calculations, you may use this ID, which is the same on a `cart` as on
   the `order` placed from that cart. This ID can also be customized by plugins and is the best
-  ID to use if it is necessary to show a cart ID in the user interface."
+  ID to use if it is necessary to show a cart ID in the user interface.
+  """
   referenceId: String
 
   "The shop that owns the cart."

--- a/imports/plugins/core/cart/server/no-meteor/schemas/cart.graphql
+++ b/imports/plugins/core/cart/server/no-meteor/schemas/cart.graphql
@@ -18,11 +18,14 @@ type Cart implements Node {
   "An email address that has been associated with the cart"
   email: String
 
-  "A string to reference the cart"
-  referenceId: String
-
   "The items that have been added to the cart. A cart is not created until the first item is added. Items can be removed from a cart, and a cart is not deleted if all items are removed from it. Because all items may have been removed, this may be an empty array."
   items(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = desc, sortBy: CartItemsSortByField = addedAt): CartItemConnection
+
+  "If you integrate with third-party systems that require you to send the same ID for order
+  calculations as for cart calculations, you may use this ID, which is the same on a `cart` as on
+  the `order` placed from that cart. This ID can also be customized by plugins and is the best
+  ID to use if it is necessary to show a cart ID in the user interface."
+  referenceId: String
 
   "The shop that owns the cart."
   shop: Shop!


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
Cart's referenceId, introduced here https://github.com/reactioncommerce/reaction/pull/5054, needs to be passed to the client.

## Solution
Add `referenceId` to cart's graphql schema.

## Breaking changes
None