### PR TITLE
fix: Navigation editor WSOD when navigation tree is empty

### DIFF
--- a/imports/plugins/core/navigation/client/hocs/withDefaultNavigationTree.js
+++ b/imports/plugins/core/navigation/client/hocs/withDefaultNavigationTree.js
@@ -41,8 +41,9 @@ export default (Component) => (
         >
           {({ data, loading, refetch }) => {
             if (!loading) {
-              const { navigationTreeById: { name } } = data;
-              props.navigationTreeName = name;
+              if (data && data.navigationTreeById && data.navigationTreeById.name) {
+                props.navigationTreeName = data.navigationTreeById.name;
+              }
             }
             return <Component {...props} refetchNavigationTree={refetch} />;
           }}


### PR DESCRIPTION
Resolves #5066  
Impact: **critical**  
Type: **bugfix**

## Issue

Fix white screen in navigation editor when no navigation items exist in the default navigation tree.

## Solution

Add better `null` value handling for `navigationTreeById` query.

## Breaking changes

None.

## Testing
1. On http://localhost:3000/operator/navigation
2. Remove all navigation items in the navigation tree (right column)
3. Save changes
4. Refresh page
5. Ensure that you can add navigation items to the tree by dragging them from the left to the right.

*note* DnD does not work in Firefox. This is known issue with Firefox and has been filed with them some time ago.
