### PR TITLE
(fix): GraphQL cart methods should return variantTitle of parent variant when options present

### DIFF
--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -95,7 +95,9 @@ export default async function addCartItems(context, currentItems, inputItems, op
     // Until we do a more complete attributes revamp, we'll do our best to fudge attributes here.
     // The main issue is we do not have labels.
     const attributes = [];
+    let variantTitle = chosenVariant.title;
     if (parentVariant) {
+      variantTitle = parentVariant.title;
       attributes.push({
         label: null, // Set label to null for now. We expect to use it in the future.
         value: parentVariant.title
@@ -140,7 +142,7 @@ export default async function addCartItems(context, currentItems, inputItems, op
       title: catalogProduct.title,
       updatedAt: currentDateTime,
       variantId: productVariantId,
-      variantTitle: chosenVariant.title
+      variantTitle
     };
 
     if (variantPriceInfo.compareAtPrice || variantPriceInfo.compareAtPrice === 0) {


### PR DESCRIPTION
Resolves issue with storefront not getting proper variantTitle (no issue number)
Impact: critical  
Type: bugfix

## Issue
When items are added to the cart as through createCartMutation or addCartItemsMutation, when options for a variant are present, the variantTitle returned is the title of the option, not the variant.

## Solution
Updated imports/plugins/core/cart/server/no-meteor/util/addCartItems.js to save parentVariant.title when it is present, or to retain chosenVariant.title otherwise, and pass this back as variantTitle in the reply.

## Testing
If RC is staged locally, add an item with variants and options to your cart, with a network inspector running.
Note that in the reply from graphql-alpha, the variantTitle in the reply is a number (ie '6' instead of '0007-DK-INDIGO-MOON') before this is applied, and is set properly (ie to '0007-DK-INDIGO-MOON') after it is applied.
