### PR TITLE
fix: shipping restrictions not correctly denying methods

### DIFF
--- a/imports/collections/schemas/address.js
+++ b/imports/collections/schemas/address.js
@@ -17,7 +17,7 @@ const withoutCodeCountries = ["AO", "AG", "AW", "BS", "BZ", "BJ", "BW",
  * @type {SimpleSchema}
  * @property {String} _id
  * @property {String} fullName required
- * @property {String} fistName
+ * @property {String} firstName
  * @property {String} lastName
  * @property {String} address1 required
  * @property {String} address2

--- a/imports/plugins/included/shipping-rates/server/no-meteor/util/filterShippingMethods.test.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/util/filterShippingMethods.test.js
@@ -535,6 +535,7 @@ test("deny method - country on deny list, no item restrictions", async () => {
 
   expect(allowedMethods).toEqual([]);
 });
+
 test("deny method - region on deny list, no item restrictions", async () => {
   // Shipping Location: US, CA, 90405
 
@@ -597,6 +598,55 @@ test("deny method - postal on deny list, no item restrictions", async () => {
       destination: {
         postal: [
           "90405"
+        ]
+      }
+    }
+  ];
+
+  mockContext.collections.FlatRateFulfillmentRestrictions.toArray.mockReturnValue(Promise.resolve(mockMethodRestrictions));
+
+  const allowedMethods = await filterShippingMethods(mockContext, mockShippingMethod, mockHydratedOrder);
+
+  expect(allowedMethods).toEqual([]);
+});
+
+test("deny method - region on one deny list, but also is not on other deny lists", async () => {
+  // Shipping Location: US, CA, 90405
+
+  const mockMethodRestrictions = [
+    {
+      _id: "allow001",
+      methodIds: [
+        "stviZaLdqRvTKW6J5"
+      ],
+      type: "allow",
+      destination: {
+        country: [
+          "US"
+        ]
+      }
+    },
+    {
+      _id: "deny001",
+      methodIds: [
+        "stviZaLdqRvTKW6J5"
+      ],
+      type: "deny",
+      destination: {
+        region: [
+          "CA"
+        ]
+      }
+    },
+    {
+      _id: "deny002",
+      methodIds: [
+        "nUjYh7hYtbUh0Ojht7"
+      ],
+      type: "deny",
+      destination: {
+        region: [
+          "NY"
         ]
       }
     }

--- a/imports/plugins/included/shipping-rates/server/no-meteor/util/locationDenyCheck.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/util/locationDenyCheck.js
@@ -15,7 +15,7 @@ export async function locationDenyCheck(methodRestrictions, method, hydratedOrde
 
   // Loop over each deny restriction and determine if this method is valid
   // If any levels of destination match, this method is invalid at this point
-  const isAllowed = denyRestrictions.some((methodRestriction) => {
+  const isAllowed = denyRestrictions.every((methodRestriction) => {
     const { destination } = methodRestriction;
 
     // If there is no destination restriction on this method, it is valid at this point


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issue
`FlatRateFulfillmentRestrictions` are not correctly filtering `restrictions` using the `deny` method. This is due to using a `some` check instead of an `every` check on the array of `restrictions`. 

For example, let's say we have a Hawaii shipping address, and we have shipping methods A & B, and only B should go to Hawaii. So we add a `restriction` on A to say it can't go to Hawaii. But then we also add two other `restrictions` on A to say it can't go to Alaska, and can't go to Guam. So method A has 3 `deny` `restrictions` attached to it.

Now we could add Alaska and Guam to the same `restriction` as Hawaii, but there will definitely be cases where we have separate `restrictions` for the same method, and this needs to be addressed.

When checking against the `restrictions`, Method A will see the first `restriction` for Hawaii, and return `false` when it checks against the Hawaii address). But then it continues to loop through the other restrictions, and it returns `true` when checking against Guam and Alaska, because a Hawaii address doesn't match either of those. Because we were using `some`, the whole function would return `true`, and the method would then show for Hawaii.

## Solution
Switch the `some` to `every`, so that if any restriction returns a false, the method is removed. 

## Breaking changes
None

## Testing
1. Add multiple shipping methods, and then add multiple shipping restrictions for at least one of them. The restrictions must ensure that at least one of them will match your shipping address, and at least one of them will not. (I can provide a data dump with some restrictions if needed)
1. See that the correct methods are restricted.