### PR TITLE
feat: add name related data to viewer Account query

### DIFF
--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/index.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/index.js
@@ -9,6 +9,9 @@ export default {
   addressBook,
   currency: (account) => getXformedCurrencyByCode(account.profile && account.profile.currency),
   emailRecords: (account) => account.emails,
+  firstName: (account) => account.profile.firstName,
+  lastName: (account) => account.profile.lastName,
+  name: (account) => account.profile.name,
   preferences: (account) => get(account, "profile.preferences"),
   primaryEmailAddress: (account) => {
     const primaryRecord = (account.emails || []).find((record) => record.provides === "default");

--- a/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
+++ b/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
@@ -130,6 +130,12 @@ type Account implements Node {
   "A paged list of the permission groups in which this account is listed"
   groups(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: GroupSortByField = createdAt): GroupConnection
 
+  "The first name of the person this account represents, if known"
+  firstName: String
+
+  "The last name of the person this account represents, if known"
+  lastName: String
+
   "Arbitrary additional metadata about this account"
   metafields: [Metafield]
 


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
The API does not provide all data needed for display on the account profile page.

## Solution
Add new `firstName`, `lastName`, and `name` fields to resolver.

## Breaking changes
None

## Testing
1. Create an account with `firstName`, `lastName`, and `name` fields inside the `profile`. There is no UI inside core reaction or starterkit to do this, you'll need to do it via Mongo.
1. use the `viewer` GQL query and see that these fields are returned when requested:

```
query {
  viewer {
    name
    firstName
    lastName
  }
}
```

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
