### PR TITLE
Being able to set Tax inclusive on Tax settings

### DIFF
--- a/imports/plugins/included/taxes-rates/client/settings/custom.html
+++ b/imports/plugins/included/taxes-rates/client/settings/custom.html
@@ -34,6 +34,7 @@
           {{> afQuickField name='postal' class='form-control' placeholder="Postal Code"}}
           {{> afQuickField name='taxCode' class='form-control' placeholder="Tax only products with this tax code (optional)"}}
           {{> afQuickField name='rate' class='form-control' placeholder="Rate as a percentage"}}
+          {{> afQuickField name='rateIsTaxInclusive' placeholder="Rate is tax inclusive"}}
         </div>
         {{> taxSettingsSubmitButton instance=instance}}
       {{/autoForm}}
@@ -64,6 +65,7 @@
 
           {{> afQuickField name='postal' class='form-control' placeholder="Postal Code"}}
           {{> afQuickField name='rate' class='form-control' placeholder="Rate as a percentage"}}
+          {{> afQuickField name='rateIsTaxInclusive' placeholder="Rate is tax inclusive"}}
         </div>
         {{> taxSettingsSubmitButton instance=instance}}
       {{/autoForm}}

--- a/imports/plugins/included/taxes-rates/lib/collections/schemas.js
+++ b/imports/plugins/included/taxes-rates/lib/collections/schemas.js
@@ -43,6 +43,10 @@ export const Taxes = new SimpleSchema({
     optional: true,
     index: 1
   },
+  rateIsTaxInclusive: {
+    type: Boolean,
+    defaultValue: false
+  },
   rate: Number
 }, { check, tracker: Tracker });
 

--- a/imports/plugins/included/taxes-rates/server/no-meteor/util/calculateOrderTaxes.js
+++ b/imports/plugins/included/taxes-rates/server/no-meteor/util/calculateOrderTaxes.js
@@ -60,15 +60,23 @@ export default async function calculateOrderTaxes({ context, order }) {
 
     return allTaxes
       .filter((taxDef) => !taxDef.taxCode || taxDef.taxCode === item.taxCode)
-      .map((taxDef) => ({
-        _id: Random.id(),
-        jurisdictionId: taxDef._id,
-        sourcing: taxDef.taxLocale,
-        tax: item.subtotal.amount * taxDef.rate,
-        taxableAmount: item.subtotal.amount,
-        taxName: taxDef.name,
-        taxRate: taxDef.rate
-      }));
+      .map((taxDef) => {
+        let tax = 0;
+        if (taxDef.rateIsTaxInclusive) {
+          tax = item.subtotal.amount * taxDef.rate / (1 - taxDef.rate);
+        } else {
+          tax = item.subtotal.amount * taxDef.rate;
+        }
+        return {
+          _id: Random.id(),
+          jurisdictionId: taxDef._id,
+          sourcing: taxDef.taxLocale,
+          tax,
+          taxableAmount: item.subtotal.amount,
+          taxName: taxDef.name,
+          taxRate: taxDef.rate
+        };
+      });
   }
 
   // calculate line item taxes


### PR DESCRIPTION
Resolves #3342 
Impact: **minor**  
Type: **feature**

## Issue
Tax rates were expressed as a percentage of the net price. This feature allows tax rates to be expressed as a percentage of the total price including tax.

## Solution
I added a checkbox to the `"customTaxRates-update-form"`. If checked, the tax rate is treated as tax inclusive.

## Breaking changes
None


## Testing
1. Open the Taxes section in operator ui
2. Add a custom rate and check "Rate is tax inclusive" (e.g. 10%)
3. Make sure the tax rate is applicable to an item in your catalog
4. Add one of these items to your basket and check out
5. Note that the tax is 10% of the total (excluding shipping and surcharges), not 10% of the items total
