### PR TITLE
adding indexes

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/startup.js
+++ b/imports/plugins/core/catalog/server/no-meteor/startup.js
@@ -1,4 +1,5 @@
 import Logger from "@reactioncommerce/logger";
+import collectionIndex from "/imports/utils/collectionIndex";
 import hashProduct from "./mutations/hashProduct";
 
 /**
@@ -31,6 +32,9 @@ async function hashRelatedProduct(media, collections) {
  */
 export default function startup(context) {
   const { appEvents, collections } = context;
+
+  collectionIndex(collections.Catalog, { "product.productId": 1 }); // Used to update products
+  collectionIndex(collections.Catalog, { "product.variants.options._id": 1 }); // Used while publishing products
 
   appEvents.on("afterMediaInsert", ({ mediaRecord }) => {
     hashRelatedProduct(mediaRecord, collections).catch((error) => {

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -210,6 +210,8 @@ export const MediaRecords = new Mongo.Collection("cfs.Media.filerecord");
 // Index on the props we search on
 if (Meteor.isServer) {
   collectionIndex(Catalog.rawCollection(), { updatedAt: 1 });
+  collectionIndex(Catalog.rawCollection(), { "product.productId": 1 }); // Used to update products
+  collectionIndex(Catalog.rawCollection(), { "product.variants.options._id": 1 }); // Used while publishing products
   collectionIndex(MediaRecords.rawCollection(), { "metadata.productId": 1 });
   collectionIndex(MediaRecords.rawCollection(), { "metadata.variantId": 1 });
   collectionIndex(MediaRecords.rawCollection(), { "metadata.priority": 1 });

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -210,8 +210,6 @@ export const MediaRecords = new Mongo.Collection("cfs.Media.filerecord");
 // Index on the props we search on
 if (Meteor.isServer) {
   collectionIndex(Catalog.rawCollection(), { updatedAt: 1 });
-  collectionIndex(Catalog.rawCollection(), { "product.productId": 1 }); // Used to update products
-  collectionIndex(Catalog.rawCollection(), { "product.variants.options._id": 1 }); // Used while publishing products
   collectionIndex(MediaRecords.rawCollection(), { "metadata.productId": 1 });
   collectionIndex(MediaRecords.rawCollection(), { "metadata.variantId": 1 });
   collectionIndex(MediaRecords.rawCollection(), { "metadata.priority": 1 });


### PR DESCRIPTION
While publishing the product to the database, the following queries are made:
1. ```const result = await Catalog.updateOne({ "product.productId": catalogProduct.productId}, modifier, { upsert: true });```
2. `catalog = await Catalog.findOne({ "product.variants.options._id": optionId });`

This PR adds indexes for these queries.