### PR TITLE
feat: allow viewing of orders by reference id

### DIFF
--- a/imports/plugins/core/core/server/publications/collections/orders.js
+++ b/imports/plugins/core/core/server/publications/collections/orders.js
@@ -172,7 +172,10 @@ Meteor.publish("OrderById", (orderId) => {
 
   if (Reaction.hasPermission("orders", Reaction.getUserId(), shopId)) {
     return Orders.find({
-      _id: orderId
+      $or: [
+        { _id: orderId },
+        { referenceId: orderId }
+      ]
     }, { limit: 1 });
   }
 
@@ -183,7 +186,12 @@ Meteor.publish("OrderImages", (orderId) => {
   check(orderId, Match.Optional(String));
   if (!orderId) return [];
 
-  const order = Orders.findOne({ _id: orderId });
+  const order = Orders.findOne({
+    $or: [
+      { _id: orderId },
+      { referenceId: orderId }
+    ]
+  });
   if (!order) return [];
 
   const orderItems = order.shipping.reduce((list, group) => [...list, ...group.items], []);

--- a/imports/plugins/core/orders/client/components/orderSummary.js
+++ b/imports/plugins/core/orders/client/components/orderSummary.js
@@ -31,7 +31,7 @@ class OrderSummary extends Component {
 
   orderLink() {
     const orderId = this.props.order.referenceId;
-    return orderId;
+    return `${window.location.origin}/operator/orders/${orderId}`;
   }
 
   truncateId() {

--- a/imports/plugins/core/orders/client/containers/invoiceContainer.js
+++ b/imports/plugins/core/orders/client/containers/invoiceContainer.js
@@ -499,7 +499,12 @@ function capturePayments(order, paymentIds) {
 const composer = (props, onData) => {
   const { fulfillment, orderId } = props;
 
-  const order = Orders.findOne({ _id: orderId });
+  const order = Orders.findOne({
+    $or: [
+      { _id: orderId },
+      { referenceId: orderId }
+    ]
+  });
   const shopId = Reaction.getShopId();
 
   if (order) {

--- a/imports/plugins/core/orders/client/containers/orderDetailContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderDetailContainer.js
@@ -26,7 +26,12 @@ function orderDetailComposer(props, onData) {
   const { ready } = Meteor.subscribe("OrderById", orderId);
 
   if (ready()) {
-    const order = Orders.findOne({ _id: orderId });
+    const order = Orders.findOne({
+      $or: [
+        { _id: orderId },
+        { referenceId: orderId }
+      ]
+    });
     onData(null, {
       order
     });

--- a/imports/plugins/core/orders/client/containers/orderSummaryContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderSummaryContainer.js
@@ -121,7 +121,10 @@ const composer = (props, onData) => {
   if (orderSub.ready()) {
     // Find current order
     const order = Orders.findOne({
-      "_id": props.orderId,
+      "$or": [
+        { _id: props.orderId },
+        { referenceId: props.orderId }
+      ],
       "shipping._id": props.fulfillment && props.fulfillment._id
     });
 

--- a/imports/plugins/core/orders/client/templates/list/pdf.js
+++ b/imports/plugins/core/orders/client/templates/list/pdf.js
@@ -34,7 +34,10 @@ Template.completedPDFLayout.onCreated(function () {
     this.subscribe("Orders");
 
     const order = Orders.findOne({
-      _id: currentRoute.params.id
+      $or: [
+        { _id: currentRoute.params.id },
+        { referenceId: currentRoute.params.id }
+      ]
     });
     this.state.set({
       order

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -23,7 +23,10 @@ Template.coreOrderShippingTracking.onCreated(() => {
   function getOrder(orderId, shipmentId) {
     template.orderDep.depend();
     return Orders.findOne({
-      "_id": orderId,
+      "$or": [
+        { _id: orderId },
+        { referenceId: orderId }
+      ],
       "shipping._id": shipmentId
     });
   }

--- a/imports/plugins/core/orders/client/templates/workflow/workflow.js
+++ b/imports/plugins/core/orders/client/templates/workflow/workflow.js
@@ -24,7 +24,12 @@ Template.coreOrderWorkflow.helpers({
   order() {
     const id = this.order ? this.order._id : Reaction.Router.getQueryParam("_id");
     if (id) {
-      return Orders.findOne({ _id: id });
+      return Orders.findOne({
+        $or: [
+          { _id: id },
+          { referenceId: id }
+        ]
+      });
     }
     return false;
   },


### PR DESCRIPTION
Resolves N/A
Impact: **minor**  
Type: **feature**

## Issue

Allows linking to an order using the `order id` or `reference id` like so `http://localhost:3000/operator/orders/<order-id-or-reference-id>`

## Solution

- Order and OrderMedia publication now also check the `reference id` and `order id` for a match
- Various container components have been updated to support both r`eference id` and `order id`
- "copy link" in order summary supplies the full link using the `reference id`

## Breaking changes

None.

## Testing
1. Make an order, or use an existing one
2. Navigate to that order in the control panel
3. Copy the link by clicking on the `Order ID` number in the order summary. (this is actually the reference ID)
4. Paste this URL in a new window
5. See that link takes you to the same order page
6. Fulfill the order
7. Ensure the PDF preview still works