### PR TITLE
fix: catalog items performance

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProduct/index.js
+++ b/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProduct/index.js
@@ -13,19 +13,5 @@ export default {
   tagIds,
   tags,
   media: (node, args, context) => node.media && node.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context)),
-  primaryImage: (node, args, context) => xformCatalogProductMedia(node.primaryImage, context),
-  variants: (node, args, context) => node.variants && node.variants.map((variant) => {
-    variant.media = variant.media && variant.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context));
-    variant.primaryImage = xformCatalogProductMedia(variant.primaryImage, context);
-
-    if (variant.options) {
-      variant.options = variant.options.map((option) => {
-        option.media = option.media && option.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context));
-        option.primaryImage = xformCatalogProductMedia(option.primaryImage, context);
-        return option;
-      });
-    }
-
-    return variant;
-  })
+  primaryImage: (node, args, context) => xformCatalogProductMedia(node.primaryImage, context)
 };

--- a/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProductVariant/index.js
+++ b/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProductVariant/index.js
@@ -1,10 +1,13 @@
 import { encodeCatalogProductVariantOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/catalogProductVariant";
 import { encodeProductOpaqueId, xformPricingArray } from "@reactioncommerce/reaction-graphql-xforms/product";
 import { resolveShopFromShopId } from "@reactioncommerce/reaction-graphql-utils";
+import { xformCatalogProductMedia } from "@reactioncommerce/reaction-graphql-xforms/catalogProduct";
 
 export default {
   _id: (node) => encodeCatalogProductVariantOpaqueId(node._id),
   variantId: (node) => encodeProductOpaqueId(node.variantId),
   shop: resolveShopFromShopId,
-  pricing: (node) => xformPricingArray(node.pricing)
+  pricing: (node) => xformPricingArray(node.pricing),
+  media: (node, args, context) => node.media && node.media.map((mediaItem) => xformCatalogProductMedia(mediaItem, context)),
+  primaryImage: (node, args, context) => xformCatalogProductMedia(node.primaryImage, context)
 };


### PR DESCRIPTION
Resolves N/A  
Impact: **major**  
Type: **performance**

## Issue

Catalog items query runs poorly with lots of media on variants and options.

## Solution

Refactor resolver to ensure the `primaryImage` and `media` resolvers only run if requested.

## Breaking changes

None.

## Testing

1. Add lots of products with lots of images using a special set of data. (you know the one)
2. Run the `catalogItems` query with all variants and options
3. See the query fast without the `primaryImage` and `media`
4. Add the `primaryImage` and `media` and see the query slow down

```
{
  primaryShopId
  catalogItems(
    shopIds: ["cmVhY3Rpb24vc2hvcDpKOEJocTN1VHRkZ3daeDNyeg=="]
    tagIds:["cmVhY3Rpb24vdGFnOnRMc003SDVKSGRzWXlYZndE"]
    sortBy: createdAt,
    first: 20
  ) {
    edges {
      cursor
      node {
        _id
        ... on CatalogItemProduct {
          product {
            _id
            
            variants {
              _id
              primaryImage {
                URLs {
                  large
                  medium
                  small
                  thumbnail
                }
              }
              options {
                _id
                primaryImage {
                URLs {
                  large
                  medium
                  small
                  thumbnail
                }
            }
              }
                
          }
        }
      }
    } 
  }
}
```
