### PR TITLE
fix: extendCommonOrder items data was over-written by itself

### DIFF
--- a/imports/plugins/core/shipping/server/no-meteor/util/extendCommonOrder.js
+++ b/imports/plugins/core/shipping/server/no-meteor/util/extendCommonOrder.js
@@ -50,7 +50,7 @@ export default async function extendCommonOrder(context, commonOrder) {
   }
 
   return {
-    items: products,
-    ...commonOrder
+    ...commonOrder,
+    items: products
   };
 }


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
Inside the `extendCommonOrder` function, which is used for `surcharges` and `shippingRestrictions`, we add `customAttributes` onto each item of an order to check against. We then pass this new `items` object back into `commonOrder`. We were accidently over writing the new `items` data with the original data, because of the order we were returning it in.

## Solution
Swap the order, stop the over write.

## Breaking changes
None
