### PR TITLE
feature: adds optional flag to filter out sold-out products

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/queries/catalogItems.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/catalogItems.js
@@ -11,7 +11,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @param {String[]} [params.tags] - Tag IDs to include (OR)
  * @return {Promise<MongoCursor>} - A MongoDB cursor for the proper query
  */
-export default async function catalogItems(context, { shopIds, tagIds } = {}) {
+export default async function catalogItems(context, { isSoldOut, shopIds, tagIds } = {}) {
   const { collections } = context;
   const { Catalog } = collections;
 
@@ -19,8 +19,15 @@ export default async function catalogItems(context, { shopIds, tagIds } = {}) {
     throw new ReactionError("invalid-param", "You must provide tagIds or shopIds or both");
   }
 
+  // If isSoldOut filter is provided, add it to the query
+  let isSoldOutFilter = {};
+  if (isSoldOut === true || isSoldOut === false) {
+    isSoldOutFilter = { "product.isSoldOut": { $eq: isSoldOut } };
+  }
+
   const query = {
     "product.isDeleted": { $ne: true },
+    ...isSoldOutFilter,
     "product.isVisible": true
   };
 

--- a/imports/plugins/core/catalog/server/no-meteor/queries/catalogItems.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/catalogItems.js
@@ -21,7 +21,7 @@ export default async function catalogItems(context, { isSoldOut, shopIds, tagIds
 
   // If isSoldOut filter is provided, add it to the query
   let isSoldOutFilter = {};
-  if (isSoldOut === true || isSoldOut === false) {
+  if (typeof isSoldOut === "boolean") {
     isSoldOutFilter = { "product.isSoldOut": { $eq: isSoldOut } };
   }
 

--- a/imports/plugins/core/catalog/server/no-meteor/queries/catalogItemsAggregate.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/catalogItemsAggregate.js
@@ -21,7 +21,7 @@ export default async function catalogItemsAggregate(context, { isSoldOut, shopId
 
   // If isSoldOut filter is provided, add it to the query
   let isSoldOutFilter = {};
-  if (isSoldOut === true || isSoldOut === false) {
+  if (typeof isSoldOut === "boolean") {
     isSoldOutFilter = { "product.isSoldOut": { $eq: isSoldOut } };
   }
 

--- a/imports/plugins/core/catalog/server/no-meteor/queries/catalogItemsAggregate.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/catalogItemsAggregate.js
@@ -11,12 +11,18 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @param {String} tagId - Tag ID
  * @return {Promise<MongoCursor>} - A MongoDB cursor for the proper query
  */
-export default async function catalogItemsAggregate(context, { shopIds, tagId } = {}) {
+export default async function catalogItemsAggregate(context, { isSoldOut, shopIds, tagId } = {}) {
   const { collections } = context;
   const { Catalog, Tags } = collections;
 
   if ((!shopIds || shopIds.length === 0) && (!tagId)) {
     throw new ReactionError("invalid-param", "You must provide a tagId or shopIds or both");
+  }
+
+  // If isSoldOut filter is provided, add it to the query
+  let isSoldOutFilter = {};
+  if (isSoldOut === true || isSoldOut === false) {
+    isSoldOutFilter = { "product.isSoldOut": { $eq: isSoldOut } };
   }
 
   // Match all products that belong to a single tag
@@ -25,6 +31,7 @@ export default async function catalogItemsAggregate(context, { shopIds, tagId } 
       "shopId": { $in: shopIds },
       "product.tagIds": tagId,
       "product.isDeleted": { $ne: true },
+      ...isSoldOutFilter,
       "product.isVisible": true
     }
   };

--- a/imports/plugins/core/catalog/server/no-meteor/resolvers/Query/catalogItems.js
+++ b/imports/plugins/core/catalog/server/no-meteor/resolvers/Query/catalogItems.js
@@ -16,7 +16,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @return {Promise<Object>} A CatalogItemConnection object
  */
 export default async function catalogItems(_, args, context) {
-  const { shopIds: opaqueShopIds, tagIds: opaqueTagIds, ...connectionArgs } = args;
+  const { shopIds: opaqueShopIds, tagIds: opaqueTagIds, isSoldOut, ...connectionArgs } = args;
 
   const shopIds = opaqueShopIds && opaqueShopIds.map(decodeShopOpaqueId);
   const tagIds = opaqueTagIds && opaqueTagIds.map(decodeTagOpaqueId);
@@ -30,6 +30,7 @@ export default async function catalogItems(_, args, context) {
     }
     const tagId = tagIds[0];
     const aggregationParams = await context.queries.catalogItemsAggregate(context, {
+      isSoldOut,
       shopIds,
       tagId
     });
@@ -44,6 +45,7 @@ export default async function catalogItems(_, args, context) {
   }
 
   const query = await context.queries.catalogItems(context, {
+    isSoldOut,
     shopIds,
     tagIds
   });

--- a/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
@@ -451,6 +451,9 @@ extend type Query {
     "Optionally provide a list of tag IDs to further filter the item list"
     tagIds: [ID],
 
+    "Optionally provide a flag to filter out sold out products"
+    isSoldOut: Boolean,
+
     after: ConnectionCursor,
     before: ConnectionCursor,
     first: ConnectionLimitInt,


### PR DESCRIPTION
Impact: minor
Type: feature

## Feature
Adds optional flag to filter out sold out products in `catalogItems` query

## Testing
1. In the storefront, add a boolean param named `isSoldOut` to the `catalogItems` query and set it to either `true` or `false`
2. Visit tag page, if `isSoldOut=false`, confirm that sold out products are not returned.

