### PR TITLE
chore: ignore js-yaml vuln for 30 days

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,9 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.13.3
 patch: {}
-ignore: {}
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-JSYAML-174129:
+    - '@reactioncommerce/components > react-select > emotion > babel-plugin-emotion > babel-plugin-macros > cosmiconfig > js-yaml':
+        reason: Updating breaks jest snapshot tests in weird ways
+        expires: '2019-05-08T17:13:00.808Z'


### PR DESCRIPTION

Impact: **minor**  
Type: **chore**

## Issue

We can't find a quick upgrade path for this js-yaml vuln.

## Solution

Ignoring for now so circleci will pass and unrelated work can flow through.


## Breaking changes
None

## Testing

N/A. If circleci passes, this is working.
