### PR TITLE
feat: use shop logo for login pages

### DIFF
--- a/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js
+++ b/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js
@@ -11,7 +11,7 @@ const getShop = gql`
     shop(id: $id) {
       brandAssets {
         navbarBrandImage {
-          thumbnail
+          large
         }
       }
       name
@@ -32,7 +32,7 @@ function ShopLogoWithData({ shopId, linkTo, size }) {
       {({ loading, data }) => {
         if (loading) return null;
         const { shop } = data;
-        const customLogo = shop.brandAssets && shop.brandAssets.navbarBrandImage && shop.brandAssets.navbarBrandImage.thumbnail;
+        const customLogo = shop.brandAssets && shop.brandAssets.navbarBrandImage && shop.brandAssets.navbarBrandImage.large;
         const defaultLogo = "/resources/reaction-logo-circular.svg";
 
         return (

--- a/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js
+++ b/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js
@@ -24,24 +24,23 @@ const getShop = gql`
  * @params {Object} props Component props
  * @returns {Node} React component
  */
-function ShopLogoWithData({ shopId }) {
+function ShopLogoWithData({ shopId, linkTo, size }) {
   if (!shopId) return null;
 
   return (
     <Query query={getShop} variables={{ id: shopId }}>
       {({ loading, data }) => {
         if (loading) return null;
-
         const { shop } = data;
         const customLogo = shop.brandAssets && shop.brandAssets.navbarBrandImage && shop.brandAssets.navbarBrandImage.thumbnail;
         const defaultLogo = "/resources/reaction-logo-circular.svg";
 
         return (
-          <Link to="/operator">
+          <Link to={linkTo}>
             <img
               alt={shop.name}
               src={customLogo || defaultLogo}
-              width={60}
+              width={size}
             />
           </Link>
         );
@@ -51,7 +50,16 @@ function ShopLogoWithData({ shopId }) {
 }
 
 ShopLogoWithData.propTypes = {
-  shopId: PropTypes.string
+  linkTo: PropTypes.string,
+  shopId: PropTypes.string.length,
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
+
+
+ShopLogoWithData.defaultProps = {
+  linkTo: "/operator",
+  size: 60
+};
+
 
 export default withPrimaryShopId(withComponents(ShopLogoWithData));

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/shopBrandImageOption.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/shopBrandImageOption.js
@@ -4,6 +4,8 @@ import { Meteor } from "meteor/meteor";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 import { Media } from "/imports/plugins/core/files/client";
 import { i18next, Logger } from "/client/api";
+import Radio from "@material-ui/core/Radio";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
 
 class ShopBrandImageOption extends Component {
   static propTypes = {
@@ -41,16 +43,29 @@ class ShopBrandImageOption extends Component {
   };
 
   render() {
-    const { media } = this.props;
+    const { isSelected, media } = this.props;
 
     return (
-      <Components.MediaItem
-        editable
-        onClick={this.handleClick}
-        onRemoveMedia={this.handleRemoveClick}
-        size="small"
-        source={media}
-      />
+      <div>
+        <Components.MediaItem
+          editable
+          onClick={this.handleClick}
+          onRemoveMedia={this.handleRemoveClick}
+          size="small"
+          source={media}
+        />
+
+        <FormControlLabel
+          control={
+            <Radio
+              checked={isSelected}
+              onClick={this.handleClick}
+            />
+          }
+          label="Use as shop logo"
+        />
+      </div>
+
     );
   }
 }

--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -5,6 +5,7 @@ import { Reaction } from "/client/api";
 import { Meteor } from "meteor/meteor";
 import Button from "@material-ui/core/Button";
 import withStyles from "@material-ui/core/styles/withStyles";
+import ShopLogo from "/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js";
 
 const styles = (theme) => ({
   root: {
@@ -67,13 +68,11 @@ function CoreLayout({ classes, location }) {
       <div className={classes.root}>
         <div className={classes.content}>
           <div className={classes.logo}>
-            <img
-              alt="Reaction"
-              src="/resources/reaction-logo-circular.svg"
-              width={200}
+            <ShopLogo
+              linkTo="/"
+              size={200}
             />
           </div>
-
           {content}
         </div>
       </div>

--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -5,7 +5,7 @@ import { Reaction } from "/client/api";
 import { Meteor } from "meteor/meteor";
 import Button from "@material-ui/core/Button";
 import withStyles from "@material-ui/core/styles/withStyles";
-import ShopLogo from "/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js";
+import ShopLogo from "/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData";
 
 const styles = (theme) => ({
   root: {


### PR DESCRIPTION
Resolves #5046  
Impact: **minor**  
Type: **feature**

## Issue

Logo on login pages always defaulted to the built-in Reaction logo.

## Solution

- Use the `ShopLogoWithData` component for the login page
- Make it clearer in the shop admin which logo is selected for use as the shop logo. This confused me when I was trying to determine how to make an image the shop logo, so I fixed it as well.
- Use the `large` image size to get a better quality image since the bigger logo on the login page is blurry when using `thumbnail`.

## Breaking changes

none

## Testing
1. Open shop settings
2. Upload an image
3. Set it as the shop logo
4. Refresh

![shop](https://user-images.githubusercontent.com/42217/55762135-a5dcc480-5a16-11e9-83d6-0374f573b9d4.png)

5. log-out or go incognito and see the login page. You should see your logo
6. Use login from the starterkit, you should also see your logo