### PR TITLE
fix: include submodule bare repos in docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,13 @@
 .build.*
 .npm
 .git
+
+# This is necessary so plugins can use git repos as npm deps.
+# Leave this here unless you understand the implications.
+# See this issue for details: 
+# https://github.com/reactioncommerce/reaction/pull/5118
+!.git/modules/imports/plugins/custom
+
 .build.log
 Dockerfile
 Dockerfile-devserver


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix|chore**

## Issue

OK this one is a pretty long chain to understand, but here goes. If you bundle your custom reaction plugins by adding them as git submodules, and one of your plugins depends on a package directly from github, it seems to cause docker builds to fail during the npm install. For some reason, in this scenario npm wants to access the submodule's gitdir (no idea what for). Given the globs in the `.dockerignore` as is, that directory does not exist in the docker container during the build.

## Solution

Add an exclusion line to `.dockerignore` so the necessary directories are part of the docker build context.

## Breaking changes

None

## Testing

```sh
cd $(mktemp -d /tmp/submod-XXX)
git init repro
cat <<EOF > repro/package.json
{
  "name": "repro",
  "version": "1.0.0",
  "dependencies": {
    "epimetheus": "github:reactioncommerce/node-epimetheus#baseurl-undefined"
  }
}
EOF
cd repro
git add .
git commit -m "1"
cd ..
git clone https://github.com/reactioncommerce/reaction.git
cd reaction
git submodule add -f "${PWD}/../repro" imports/plugins/custom/repro
```
- copy your main reaction `.env` into this test reaction directory
- stop any other reaction containers that may be running

```
docker-compose build
docker run --rm -it reaction_reaction bash
```

OK now you're in the container which is kind of like how it is in some CI environments.

```
cd imports/plugins/custom/repro
npm i
```

You'll get this error:

```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/reactioncommerce/node-epimetheus.git
npm ERR! 
npm ERR! fatal: Not a git repository: ../../../../.git/modules/imports/plugins/custom/repro
npm ERR! 
npm ERR! exited with error code: 128

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/node/.npm/_logs/2019-04-12T02_37_02_115Z-debug.log

```
