### PR TITLE
ShopId can be any string

### DIFF
--- a/imports/collections/schemas/accounts.js
+++ b/imports/collections/schemas/accounts.js
@@ -144,8 +144,7 @@ export const Accounts = new SimpleSchema({
     type: String
   },
   "shopId": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Id
+    type: String
   },
   "name": {
     type: String,

--- a/imports/collections/schemas/groups.js
+++ b/imports/collections/schemas/groups.js
@@ -34,8 +34,7 @@ export const Groups = new SimpleSchema({
     type: String
   },
   "shopId": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Id
+    type: String
   },
   "createdBy": {
     type: String,


### PR DESCRIPTION
Since clients would demand shopId based on their need, we should have flexibility in the type of string that can be a shopId.