### PR TITLE
[WIP] fix: Fix critical performance issue caused by catalog items query for `featured` products

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/queries/catalogItemsAggregate.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/catalogItemsAggregate.js
@@ -36,13 +36,6 @@ export default async function catalogItemsAggregate(context, { isSoldOut, shopId
     }
   };
 
-  // defaultSort by id
-  const defaultSort = {
-    $sort: {
-      "product._id": 1
-    }
-  };
-
   const tag = await Tags.findOne({
     _id: tagId
   });
@@ -102,6 +95,6 @@ export default async function catalogItemsAggregate(context, { isSoldOut, shopId
 
   return {
     collection: Catalog,
-    pipeline: [match, defaultSort, addFields, projection, sort]
+    pipeline: [match, addFields, projection, sort]
   };
 }

--- a/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
@@ -537,6 +537,12 @@ extend type Query {
     last: ConnectionLimitInt,
     sortOrder: SortOrder = desc,
 
+    "Page"
+    page: Int,
+
+    "Limit per page"
+    limit: Int,
+
     "Provide a Currency code if sortBy is minPrice"
     sortByPriceCurrencyCode: String
 

--- a/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
@@ -541,7 +541,7 @@ extend type Query {
     page: Int,
 
     "Limit per page"
-    limit: Int,
+    limit: ConnectionLimitInt,
 
     "Provide a Currency code if sortBy is minPrice"
     sortByPriceCurrencyCode: String

--- a/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponse.js
+++ b/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponse.js
@@ -1,0 +1,46 @@
+/**
+ * @name getOffsetBasedPaginatedResponse
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Given a MongoDB cursor, adds skip, limit, sort, and other filters as necessary
+ *   based on GraphQL resolver arguments.
+ * @param {Cursor} mongoCursor Node MongoDB Cursor instance. Will be mutated.
+ * @param {Object} args Connection arguments from GraphQL query
+ * @return {Promise<Object>} `{ nodes, pageInfo, totalCount }`
+ */
+export default async function getOffsetBasedPaginatedResponse(mongoCursor, args) {
+  const { sortOrder } = args;
+  const totalCount = await mongoCursor.clone().count();
+  const nodes = await mongoCursor.toArray();
+  const limit = args.limit || 20;
+  const page = args.page || 0;
+  const skip = page * limit;
+  let sortBy;
+
+  if (sortBy === "minPrice") {
+    if (typeof args.sortByPriceCurrencyCode !== "string") {
+      throw new Error("sortByPriceCurrencyCode is required when sorting by minPrice");
+    }
+    sortBy = `product.pricing.${args.sortByPriceCurrencyCode}.minPrice`;
+  } else {
+    sortBy = args.sortBy; // eslint-disable-line prefer-destructuring
+  }
+
+  mongoCursor
+    .limit(limit)
+    .skip(skip)
+    .sort({
+      [sortBy]: sortOrder === "desc" ? -1 : 1
+    });
+
+  return {
+    nodes,
+    pageInfo: {
+      hasNextPage: (page + 1) * limit < totalCount,
+      hasPreviousPage: page > 0 && totalCount,
+      startCursor: (nodes.length && nodes[0]._id) || null,
+      endCursor: (nodes.length && nodes[nodes.length - 1]._id) || null
+    },
+    totalCount
+  };
+}

--- a/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponse.js
+++ b/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponse.js
@@ -10,8 +10,6 @@
  */
 export default async function getOffsetBasedPaginatedResponse(mongoCursor, args) {
   const { sortOrder } = args;
-  const totalCount = await mongoCursor.clone().count();
-  const nodes = await mongoCursor.toArray();
   const limit = args.limit || 20;
   const page = args.page || 0;
   const skip = page * limit;
@@ -32,6 +30,9 @@ export default async function getOffsetBasedPaginatedResponse(mongoCursor, args)
     .sort({
       [sortBy]: sortOrder === "desc" ? -1 : 1
     });
+
+  const totalCount = await mongoCursor.clone().count();
+  const nodes = await mongoCursor.toArray();
 
   return {
     nodes,

--- a/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponseFromAggregation.js
+++ b/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponseFromAggregation.js
@@ -33,7 +33,8 @@ export default async function getOffsetBasedPaginatedResponseFromAggregation(agg
   // Run the aggregation
   const aggregationResult = await collection.aggregate([...pipeline, facet]).toArray();
 
-  const { nodes, pageInfo: { totalCount } } = aggregationResult[0];
+  const { nodes, pageInfo } = aggregationResult[0];
+  const { totalCount } = pageInfo[0];
   const nodeCount = (Array.isArray(nodes) && nodes.length) || 0;
 
   return {

--- a/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponseFromAggregation.js
+++ b/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponseFromAggregation.js
@@ -1,0 +1,49 @@
+
+/**
+ * @name getOffsetBasedPaginatedFromAggregation
+ * @method
+ * @memberof GraphQL/ResolverUtilities
+ * @summary Given an object with a collection and aggregation pipeline array, run a Mongo aggregation applying
+ *   limit, and skip based on GraphQL resolver arguments.
+ * @param {Object} aggregationOptions an object containing a collection and aggregation pipeline array
+ * @param {MongoCollection} aggregationOptions.collection Mongo collection
+ * @param {Array} aggregationOptions.pipeline Array of aggregation pipeline stages
+ * @param {Object} args Connection arguments from GraphQL query
+ * @return {Promise<Object>} `{ nodes, pageInfo, totalCount }`
+ */
+export default async function getOffsetBasedPaginatedResponseFromAggregation(aggregationOptions, args) {
+  const { collection, pipeline } = aggregationOptions;
+  const limit = args.limit || 20;
+  const page = args.page || 0;
+  const skip = page * limit;
+
+  // Apply limit and skip
+  const facet = {
+    $facet: {
+      nodes: [
+        { $skip: skip },
+        { $limit: limit }
+      ],
+      pageInfo: [
+        { $count: "totalCount" }
+      ]
+    }
+  };
+
+  // Run the aggregation
+  const aggregationResult = await collection.aggregate([...pipeline, facet]).toArray();
+
+  const { nodes, pageInfo: { totalCount } } = aggregationResult[0];
+  const nodeCount = (Array.isArray(nodes) && nodes.length) || 0;
+
+  return {
+    nodes,
+    pageInfo: {
+      hasNextPage: (page + 1) * limit < totalCount,
+      hasPreviousPage: page > 0 && nodeCount,
+      startCursor: (nodes.length && nodes[0]._id) || null,
+      endCursor: (nodes.length && nodes[nodes.length - 1]._id) || null
+    },
+    totalCount
+  };
+}

--- a/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponseFromAggregation.js
+++ b/imports/plugins/core/graphql/server/no-meteor/util/getOffsetBasedPaginatedResponseFromAggregation.js
@@ -1,3 +1,4 @@
+const DEFAULT_LIMIT = 20;
 
 /**
  * @name getOffsetBasedPaginatedFromAggregation
@@ -13,8 +14,8 @@
  */
 export default async function getOffsetBasedPaginatedResponseFromAggregation(aggregationOptions, args) {
   const { collection, pipeline } = aggregationOptions;
-  const limit = args.limit || 20;
-  const page = args.page || 0;
+  const limit = args.limit || DEFAULT_LIMIT;
+  const page = Math.max(args.page, 0);
   const skip = page * limit;
 
   // Apply limit and skip
@@ -35,13 +36,13 @@ export default async function getOffsetBasedPaginatedResponseFromAggregation(agg
 
   const { nodes, pageInfo } = aggregationResult[0];
   const { totalCount } = pageInfo[0];
-  const nodeCount = (Array.isArray(nodes) && nodes.length) || 0;
+  const totalPageCount = Math.ceil(totalCount / limit);
 
   return {
     nodes,
     pageInfo: {
-      hasNextPage: (page + 1) * limit < totalCount,
-      hasPreviousPage: page > 0 && nodeCount,
+      hasNextPage: page >= 0 && (page + 1) < totalPageCount,
+      hasPreviousPage: page > 0 && page < totalPageCount,
       startCursor: (nodes.length && nodes[0]._id) || null,
       endCursor: (nodes.length && nodes[nodes.length - 1]._id) || null
     },

--- a/imports/plugins/core/graphql/server/no-meteor/util/index.js
+++ b/imports/plugins/core/graphql/server/no-meteor/util/index.js
@@ -6,6 +6,8 @@
 export { default as applyPaginationToMongoCursor } from "./applyPaginationToMongoCursor";
 export { default as applyPaginationToMongoAggregation } from "./applyPaginationToMongoAggregation";
 export { default as getConnectionTypeResolvers } from "./getConnectionTypeResolvers";
+export { default as getOffsetBasedPaginatedResponse } from "./getOffsetBasedPaginatedResponse";
+export { default as getOffsetBasedPaginatedResponseFromAggregation } from "./getOffsetBasedPaginatedResponseFromAggregation";
 export { default as getPaginatedAggregateResponse } from "./getPaginatedAggregateResponse";
 export { default as getPaginatedResponse } from "./getPaginatedResponse";
 export { default as namespaces } from "./namespaces";

--- a/imports/plugins/core/tags/client/components/TagProductTable.js
+++ b/imports/plugins/core/tags/client/components/TagProductTable.js
@@ -3,17 +3,14 @@ import PropTypes from "prop-types";
 import { Query } from "react-apollo";
 import { i18next } from "/client/api";
 import TextInput from "@reactioncommerce/components/TextInput/v1";
-import Button from "@material-ui/core/Button";
-import ExpansionPanelActions from "@material-ui/core/ExpansionPanelActions";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
+import TablePagination from "@material-ui/core/TablePagination";
 import TableRow from "@material-ui/core/TableRow";
-import ChevronRightIcon from "mdi-material-ui/ChevronRight";
-import ChevronLeftIcon from "mdi-material-ui/ChevronLeft";
 import { tagProductsQuery } from "../../lib/queries";
-import { pagination } from "./util/pagination";
+import paginationByPageNumber from "/imports/utils/paginationByPageNumber";
 
 class TagProductTable extends Component {
   static propTypes = {
@@ -27,19 +24,25 @@ class TagProductTable extends Component {
     onProductPriorityChange() {}
   }
 
+  state = {
+    page: 0,
+    limit: 10
+  }
+
   handlePriorityChange = (productId, priority) => {
     this.props.onProductPriorityChange(productId, priority);
   }
 
   render() {
     const { tagId, shopId } = this.props;
+    const { limit, page } = this.state;
 
     if (!tagId) {
       return null;
     }
 
     return (
-      <Query query={tagProductsQuery} variables={{ tagId, shopId, first: 20 }} fetchPolicy="network-only">
+      <Query query={tagProductsQuery} variables={{ tagId, shopId, limit }} fetchPolicy="network-only">
         {({ data, fetchMore }) => {
           const productsByTagId = data && data.productsByTagId;
           let products;
@@ -47,14 +50,12 @@ class TagProductTable extends Component {
             products = productsByTagId.nodes;
           }
 
-          const pageInfo = pagination({
+          const { totalCount, loadPage } = paginationByPageNumber({
             fetchMore,
             data,
             queryName: "productsByTagId",
-            limit: 20
+            limit
           });
-
-          const { hasNextPage, hasPreviousPage, loadNextPage, loadPreviousPage } = pageInfo;
 
           return (
             <Fragment>
@@ -87,24 +88,26 @@ class TagProductTable extends Component {
                   })}
                 </TableBody>
               </Table>
-              <ExpansionPanelActions>
-                <Button
-                  color="primary"
-                  disabled={!hasPreviousPage}
-                  onClick={loadPreviousPage}
-                >
-                  <ChevronLeftIcon />
-                  {i18next.t("admin.routing.tableText.previousText")}
-                </Button>
-                <Button
-                  color="primary"
-                  disabled={!hasNextPage}
-                  onClick={loadNextPage}
-                >
-                  {i18next.t("admin.routing.tableText.nextText")}
-                  <ChevronRightIcon />
-                </Button>
-              </ExpansionPanelActions>
+              <TablePagination
+                count={totalCount}
+                component="div"
+                page={page}
+                rowsPerPage={limit}
+                rowsPerPageOptions={[10, 25, 50, 100]}
+                backIconButtonProps={{
+                  "aria-label": "Previous Page"
+                }}
+                nextIconButtonProps={{
+                  "aria-label": "Next Page"
+                }}
+                onChangePage={(event, index) => {
+                  this.setState({ page: index });
+                  loadPage(index);
+                }}
+                onChangeRowsPerPage={(event) => {
+                  this.setState({ limit: event.target.value });
+                }}
+              />
             </Fragment>
           );
         }}

--- a/imports/plugins/core/tags/lib/queries.js
+++ b/imports/plugins/core/tags/lib/queries.js
@@ -26,14 +26,15 @@ export const getTag = gql`
 `;
 
 export const tagProductsQueryString = `
-  query getTagProducts($shopId: ID!, $first: ConnectionLimitInt, $tagId: ID!, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor) {
-    productsByTagId(shopId: $shopId, tagId: $tagId, first: $first, last: $last, before: $before, after: $after) {
+  query getTagProducts($shopId: ID!, $limit: ConnectionLimitInt, $tagId: ID!, $page: Int) {
+    productsByTagId(shopId: $shopId, tagId: $tagId, limit: $limit, page: $page) {
       pageInfo {
         endCursor
         startCursor
         hasNextPage
         hasPreviousPage
       }
+      totalCount
       nodes {
         _id
         title

--- a/imports/plugins/core/tags/server/no-meteor/resolvers/Query/productsByTagId.js
+++ b/imports/plugins/core/tags/server/no-meteor/resolvers/Query/productsByTagId.js
@@ -1,6 +1,6 @@
-import { getPaginatedAggregateResponse } from "@reactioncommerce/reaction-graphql-utils";
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 import { decodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag";
+import { getOffsetBasedPaginatedResponseFromAggregation } from "@reactioncommerce/reaction-graphql-utils";
 
 /**
  * @name Query.productsByTagId
@@ -8,27 +8,20 @@ import { decodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag
  * @memberof Tags/GraphQL
  * @summary get a list of products by tag id
  * @param {Object} _ - unused
- * @param {Object} [params] - an object of all arguments that were sent by the client
- * @param {String} [params.shopId] - Shop id
- * @param {String} [params.tagId] - Tag id
+ * @param {Object} [args] - an object of all arguments that were sent by the client
+ * @param {String} [args.shopId] - Shop id
+ * @param {String} [args.tagId] - Tag id
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<Array<Object>>} TagProducts Connection
  */
-export default async function productsByTagId(_, params, context) {
-  const shopId = decodeShopOpaqueId(params.shopId);
-  const tagId = decodeTagOpaqueId(params.tagId);
+export default async function productsByTagId(_, args, context) {
+  const shopId = decodeShopOpaqueId(args.shopId);
+  const tagId = decodeTagOpaqueId(args.tagId);
 
-  const query = await context.queries.productsByTagId(context, {
+  const aggregationOptions = await context.queries.productsByTagId(context, {
     shopId,
     tagId
   });
 
-  const connectionArgs = {
-    after: params.after,
-    before: params.before,
-    first: params.first,
-    last: params.last
-  };
-
-  return getPaginatedAggregateResponse(query, connectionArgs);
+  return getOffsetBasedPaginatedResponseFromAggregation(aggregationOptions, args);
 }

--- a/imports/plugins/core/tags/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/tags/server/no-meteor/schemas/schema.graphql
@@ -172,10 +172,12 @@ extend type Query {
   productsByTagId(
     shopId: ID!
     tagId: ID!
-    after: ConnectionCursor
-    before: ConnectionCursor
-    first: ConnectionLimitInt
-    last: ConnectionLimitInt
+
+    "Page"
+    page: Int,
+
+    "Limit per page"
+    limit: ConnectionLimitInt
   ): TagProductConnection!
 }
 

--- a/imports/utils/paginationByPageNumber.js
+++ b/imports/utils/paginationByPageNumber.js
@@ -1,0 +1,54 @@
+/**
+ * Load page generator
+ * @name loadPage
+ * @param {Object} args Args for pagination
+ * @param {String} args.queryName Name of the GraphQL whose result will be used to paginate
+ * @param {Object} args.limit Limit
+ * @param {Object} args.fetchMore fetchMore function
+ * @returns {Function} load page function
+ */
+const loadPage = ({ queryName, limit, fetchMore }) => (page) => {
+  if (!queryName) throw new Error("queryName is required");
+
+  fetchMore({
+    variables: {
+      limit,
+      page
+    },
+    updateQuery: (previousResult, { fetchMoreResult }) => {
+      const { [queryName]: items } = fetchMoreResult;
+
+      if (items.nodes && items.nodes.length) {
+        return fetchMoreResult;
+      }
+
+      // Send the previous result if the new result contains no additional data
+      return previousResult;
+    }
+  });
+};
+
+/**
+ * Pagination helpers including pageInfo, totalCount and a loadPage function
+ * @name pagination
+ * @param {Object} args Args for pagination
+ * @param {String} args.queryName Name of the GraphQL whose result will be used to paginate
+ * @param {Object} args.data Full result from GraphQl
+ * @param {Object} args.limit Limit
+ * @param {Object} args.fetchMore fetchMore function
+ * @returns {Function} load page function
+ */
+export default function paginationByPageNumber(args) {
+  const { queryName, data } = args;
+
+  if (!queryName) throw new Error("queryName is required");
+
+  const pageInfo = (data && data[queryName] && data[queryName].pageInfo) || {};
+  const totalCount = (data && data[queryName] && data[queryName].totalCount) || 0;
+
+  return {
+    ...pageInfo,
+    totalCount,
+    loadPage: loadPage(args)
+  };
+}

--- a/tests/catalog/catalogItemsByTagWithOffset.test.js
+++ b/tests/catalog/catalogItemsByTagWithOffset.test.js
@@ -1,0 +1,282 @@
+import { encodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag";
+import { encodeCatalogProductOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/catalogProduct";
+import TestApp from "../TestApp";
+import Factory from "/imports/test-utils/helpers/factory";
+import CatalogItemQuery from "./CatalogItemQuery.graphql";
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM=";
+const shopName = "Test Shop";
+
+const mockTagWithFeatured = Factory.Tag.makeOne({
+  featuredProductIds: ["110", "111", "112", "113", "114"],
+  shopId: internalShopId
+});
+
+const mockTagWithoutFeatured = Factory.Tag.makeOne({
+  shopId: internalShopId
+});
+
+const mockTagWithNoProducts = Factory.Tag.makeOne();
+
+const mockCatalogItemsWithFeatured = Factory.Catalog.makeMany(30, {
+  product: (iterator) => Factory.CatalogProduct.makeOne({
+    _id: (iterator + 100).toString(),
+    isDeleted: false,
+    isVisible: true,
+    tagIds: [mockTagWithFeatured._id],
+    shopId: internalShopId
+  }),
+  shopId: internalShopId
+});
+
+const mockCatalogItemsWithoutFeatured = Factory.Catalog.makeMany(50, {
+  product: Factory.CatalogProduct.makeOne({
+    isDeleted: false,
+    isVisible: true,
+    tagIds: [mockTagWithoutFeatured._id],
+    shopId: internalShopId
+  }),
+  shopId: internalShopId
+});
+
+jest.setTimeout(300000);
+
+let testApp;
+let query;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  query = testApp.query(CatalogItemQuery);
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+  await testApp.collections.Tags.insertOne(mockTagWithFeatured);
+  await testApp.collections.Tags.insertOne(mockTagWithoutFeatured);
+  await testApp.collections.Tags.insertOne(mockTagWithNoProducts);
+  await Promise.all(mockCatalogItemsWithFeatured.map((mockItem) => testApp.collections.Catalog.insertOne(mockItem)));
+  await Promise.all(mockCatalogItemsWithoutFeatured.map((mockItem) => testApp.collections.Catalog.insertOne(mockItem)));
+});
+
+afterAll(async () => {
+  await testApp.collections.Shops.deleteOne({ _id: internalShopId });
+  await testApp.collections.Tags.deleteOne({ _id: mockTagWithFeatured._id });
+  await testApp.collections.Tags.deleteOne({ _id: mockTagWithoutFeatured._id });
+  await testApp.collections.Tags.deleteOne({ _id: mockTagWithNoProducts._id });
+  await Promise.all(mockCatalogItemsWithFeatured.map((mockItem) => testApp.collections.Catalog.deleteOne({ _id: mockItem._id })));
+  await Promise.all(mockCatalogItemsWithoutFeatured.map((mockItem) => testApp.collections.Catalog.deleteOne({ _id: mockItem._id })));
+  testApp.stop();
+});
+
+test("get all items for on tag without sort", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)] });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.totalCount).toEqual(30);
+  expect(result.catalogItems.pageInfo.hasNextPage).toEqual(true);
+  expect(result.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+  expect(result.catalogItems.edges.length).toEqual(20);
+});
+
+test("get items for a tag sorted by featured - in order of featuredProductIds", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)], sortBy: "featured" });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.totalCount).toEqual(30);
+  expect(result.catalogItems.pageInfo.hasNextPage).toEqual(true);
+  expect(result.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+  expect(result.catalogItems.edges[0].node.product._id).toEqual(encodeCatalogProductOpaqueId("110"));
+  expect(result.catalogItems.edges[1].node.product._id).toEqual(encodeCatalogProductOpaqueId("111"));
+  expect(result.catalogItems.edges[2].node.product._id).toEqual(encodeCatalogProductOpaqueId("112"));
+  expect(result.catalogItems.edges[3].node.product._id).toEqual(encodeCatalogProductOpaqueId("113"));
+  expect(result.catalogItems.edges[4].node.product._id).toEqual(encodeCatalogProductOpaqueId("114"));
+});
+
+test("get items for a tag sorted by featured - return 20 items by default if no limit provided", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)], sortBy: "featured" });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.edges.length).toEqual(20);
+});
+
+test("get items for a tag sorted by featured - return number of items specified by limit", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)], sortBy: "featured", limit: 12 });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.edges.length).toEqual(12);
+});
+
+test("get items for a tag sorted by featured - with correct pagination counts", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)], sortBy: "featured" });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.totalCount).toEqual(30);
+  expect(result.catalogItems.pageInfo.hasNextPage).toEqual(true);
+  expect(result.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+});
+
+test("get all items for a tag sorted by featured, even without any featuredProductIds", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId(mockTagWithoutFeatured._id)] });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.totalCount).toEqual(50);
+  expect(result.catalogItems.pageInfo.hasNextPage).toEqual(true);
+  expect(result.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+  expect(result.catalogItems.edges.length).toEqual(20);
+});
+
+test("get no items for a tag that does not exist", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId("12455623")] });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.totalCount).toEqual(0);
+});
+
+test("get empty array of items for a tag sorted by featured, that doesn't have any products", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId(mockTagWithNoProducts._id)] });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.totalCount).toEqual(0);
+  expect(result.catalogItems.pageInfo.hasNextPage).toEqual(false);
+  expect(result.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+  expect(result.catalogItems.edges.length).toEqual(0);
+});
+
+test("get correct start and end cursors for a sort query", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)], sortBy: "featured" });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.catalogItems.pageInfo.startCursor).toBeTruthy();
+  expect(result.catalogItems.pageInfo.endCursor).toBeTruthy();
+  expect(result.catalogItems.pageInfo.startCursor).toEqual(result.catalogItems.edges[0].cursor);
+  expect(result.catalogItems.pageInfo.endCursor).toEqual(result.catalogItems.edges[result.catalogItems.edges.length - 1].cursor);
+});
+
+test("paginate forwards, using cursors from a previous query", async () => {
+  let defaultQuery;
+  let firstQuery;
+  let secondQuery;
+  try {
+    defaultQuery = await query({
+      shopId: opaqueShopId,
+      tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)],
+      sortBy: "featured",
+      first: 30
+    });
+    firstQuery = await query({
+      shopId: opaqueShopId,
+      tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)],
+      sortBy: "featured",
+      first: 20
+    });
+    secondQuery = await query({
+      shopId: opaqueShopId,
+      tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)],
+      sortBy: "featured",
+      after: firstQuery.catalogItems.pageInfo.endCursor,
+      first: 20
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  // defaultQuery gets all items at once, so hasNext and hasPrevious are false
+  expect(defaultQuery.catalogItems.pageInfo.hasNextPage).toEqual(false);
+  expect(defaultQuery.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+  // firstQuery gets the first 20, so hasNext is true and hasPrevious is false
+  expect(firstQuery.catalogItems.pageInfo.hasNextPage).toEqual(true);
+  expect(firstQuery.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+  // secondQuery gets the last 10, so hasNext is false and hasPrevious is true
+  expect(secondQuery.catalogItems.pageInfo.hasNextPage).toEqual(false);
+  expect(secondQuery.catalogItems.pageInfo.hasPreviousPage).toEqual(true);
+  expect(secondQuery.catalogItems.pageInfo).toBeTruthy();
+  expect(secondQuery.catalogItems.totalCount).toEqual(30);
+  // totalCount is 30, and the first 20 after the first 20 were queried.
+  expect(secondQuery.catalogItems.edges.length).toEqual(10);
+  // totalCount is 30, and the first 20 after the first 20 were queried, so there are only 10 left.
+  expect(secondQuery.catalogItems.edges[0].node._id).toEqual(defaultQuery.catalogItems.edges[20].node._id);
+  // get the 21st item
+  // eslint-disable-next-line max-len
+  expect(secondQuery.catalogItems.edges[secondQuery.catalogItems.edges.length - 1].node._id).toEqual(defaultQuery.catalogItems.edges[defaultQuery.catalogItems.edges.length - 1].node._id);
+});
+
+test("paginate forwards, by pages of 15, using cursors from a previous query", async () => {
+  let defaultQuery;
+  let firstQuery;
+  let secondQuery;
+  try {
+    defaultQuery = await query({
+      shopId: opaqueShopId,
+      tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)],
+      sortBy: "featured",
+      first: 30
+    });
+    firstQuery = await query({
+      shopId: opaqueShopId,
+      tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)],
+      sortBy: "featured",
+      first: 15
+    });
+    secondQuery = await query({
+      shopId: opaqueShopId,
+      tagIds: [encodeTagOpaqueId(mockTagWithFeatured._id)],
+      sortBy: "featured",
+      after: firstQuery.catalogItems.pageInfo.endCursor,
+      first: 15
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  // defaultQuery gets all items at once, so hasNext and hasPrevious are false
+  expect(defaultQuery.catalogItems.pageInfo.hasNextPage).toEqual(false);
+  expect(defaultQuery.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+  // firstQuery gets the first 15, so hasNext is true and hasPrevious is false
+  expect(firstQuery.catalogItems.pageInfo.hasNextPage).toEqual(true);
+  expect(firstQuery.catalogItems.pageInfo.hasPreviousPage).toEqual(false);
+  expect(firstQuery.catalogItems.edges.length).toEqual(15);
+  // secondQuery gets the last 15, so hasNext is false and hasPrevious is true
+  expect(secondQuery.catalogItems.edges.length).toEqual(15);
+  // expect(secondQuery.catalogItems.pageInfo.hasNextPage).toEqual(false);
+  // expect(secondQuery.catalogItems.pageInfo.hasPreviousPage).toEqual(true);
+  // totalCount is 30, and the first 15 after the first 15 were queried, so there are only 10 left.
+  expect(secondQuery.catalogItems.edges[0].node._id).toEqual(defaultQuery.catalogItems.edges[15].node._id);
+  // get the last item
+  // eslint-disable-next-line max-len
+  expect(secondQuery.catalogItems.edges[secondQuery.catalogItems.edges.length - 1].node._id).toEqual(defaultQuery.catalogItems.edges[defaultQuery.catalogItems.edges.length - 1].node._id);
+});

--- a/tests/products/productsByTagIdWithOffset.test.js
+++ b/tests/products/productsByTagIdWithOffset.test.js
@@ -1,0 +1,194 @@
+import { encodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag";
+import { tagProductsQueryString } from "/imports/plugins/core/tags/lib/queries";
+import TestApp from "../TestApp";
+import Factory from "/imports/test-utils/helpers/factory";
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM=";
+const shopName = "Test Shop";
+const internalAdminAccountId = "456";
+
+const mockTagWithFeatured = Factory.Tag.makeOne({
+  featuredProductIds: ["110", "111", "112", "113", "114"],
+  shopId: internalShopId
+});
+
+const mockProductsWithTagAndFeaturedProducts = Factory.Product.makeMany(77, {
+  _id: (iterator) => (iterator + 100).toString(),
+  isDeleted: false,
+  isVisible: true,
+  hashtags: [mockTagWithFeatured._id],
+  shopId: internalShopId
+});
+
+const mockAdminAccount = Factory.Accounts.makeOne({
+  _id: internalAdminAccountId
+});
+
+jest.setTimeout(300000);
+
+let testApp;
+let query;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  query = testApp.query(tagProductsQueryString);
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+  await testApp.createUserAndAccount(mockAdminAccount, ["owner"]);
+  await testApp.setLoggedInUser(mockAdminAccount);
+  await testApp.collections.Tags.insertOne(mockTagWithFeatured);
+  await Promise.all(mockProductsWithTagAndFeaturedProducts.map((mockProduct) => testApp.collections.Products.insertOne(mockProduct)));
+});
+
+afterAll(async () => {
+  await testApp.collections.Shops.deleteOne({ _id: internalShopId });
+  await testApp.collections.Tags.deleteOne({ _id: mockTagWithFeatured._id });
+  await Promise.all(mockProductsWithTagAndFeaturedProducts.map((mockProduct) => testApp.collections.Products.deleteOne({ _id: mockProduct._id })));
+  await testApp.clearLoggedInUser();
+  testApp.stop();
+});
+
+test("get all 77 products with a certain tag", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagId: encodeTagOpaqueId(mockTagWithFeatured._id), limit: 77 });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.productsByTagId.pageInfo.hasNextPage).toEqual(false);
+  expect(result.productsByTagId.pageInfo.hasPreviousPage).toEqual(false);
+  expect(result.productsByTagId.nodes.length).toEqual(77);
+});
+
+test("get all products with a certain tag", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagId: encodeTagOpaqueId(mockTagWithFeatured._id) });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.productsByTagId.pageInfo.hasNextPage).toEqual(true);
+  expect(result.productsByTagId.pageInfo.hasPreviousPage).toEqual(false);
+  expect(result.productsByTagId.nodes.length).toEqual(20);
+});
+
+test("get all products with a certain tag, sorted by Featured", async () => {
+  let result;
+  try {
+    result = await query({ shopId: opaqueShopId, tagId: encodeTagOpaqueId(mockTagWithFeatured._id) });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.productsByTagId.nodes[0]._id).toEqual("110");
+  expect(result.productsByTagId.nodes[1]._id).toEqual("111");
+  expect(result.productsByTagId.nodes[2]._id).toEqual("112");
+  expect(result.productsByTagId.nodes[3]._id).toEqual("113");
+  expect(result.productsByTagId.nodes[4]._id).toEqual("114");
+  expect(result.productsByTagId.nodes[0].position).toEqual(0);
+  expect(result.productsByTagId.nodes[1].position).toEqual(1);
+  expect(result.productsByTagId.nodes[2].position).toEqual(2);
+  expect(result.productsByTagId.nodes[3].position).toEqual(3);
+  expect(result.productsByTagId.nodes[4].position).toEqual(4);
+  expect(result.productsByTagId.nodes[5].position).toEqual(-1);
+  expect(result.productsByTagId.nodes[10].position).toEqual(-1);
+});
+
+test("get products with a certain tag, on the first page", async () => {
+  let result;
+  try {
+    result = await query({
+      shopId: opaqueShopId,
+      tagId: encodeTagOpaqueId(mockTagWithFeatured._id),
+      page: 0
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.productsByTagId.nodes.length).toEqual(20);
+  expect(result.productsByTagId.pageInfo.hasNextPage).toEqual(true);
+  expect(result.productsByTagId.pageInfo.hasPreviousPage).toEqual(false);
+});
+
+test("get products with a certain tag, on the second page", async () => {
+  let result;
+  try {
+    result = await query({
+      shopId: opaqueShopId,
+      tagId: encodeTagOpaqueId(mockTagWithFeatured._id),
+      page: 1
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.productsByTagId.nodes.length).toEqual(20);
+  expect(result.productsByTagId.pageInfo.hasNextPage).toEqual(true);
+  expect(result.productsByTagId.pageInfo.hasPreviousPage).toEqual(true);
+});
+
+test("get products with a certain tag, on the second to last page", async () => {
+  let result;
+  try {
+    result = await query({
+      shopId: opaqueShopId,
+      tagId: encodeTagOpaqueId(mockTagWithFeatured._id),
+      page: 6,
+      limit: 10
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(result.productsByTagId.nodes.length).toEqual(10);
+  expect(result.productsByTagId.pageInfo.hasNextPage).toEqual(true);
+  expect(result.productsByTagId.pageInfo.hasPreviousPage).toEqual(true);
+});
+
+test("gets products on the last page", async () => {
+  let totalQuery;
+  let result;
+  try {
+    totalQuery = await query({ shopId: opaqueShopId, tagId: encodeTagOpaqueId(mockTagWithFeatured._id), limit: 77 });
+    result = await query({
+      shopId: opaqueShopId,
+      tagId: encodeTagOpaqueId(mockTagWithFeatured._id),
+      // after: firstQuery.productsByTagId.pageInfo.endCursor,
+      page: 7,
+      limit: 10
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(totalQuery.productsByTagId.nodes.length).toEqual(77);
+  expect(result.productsByTagId.nodes.length).toEqual(7);
+  expect(result.productsByTagId.pageInfo.hasPreviousPage).toEqual(true);
+  expect(result.productsByTagId.pageInfo.hasNextPage).toEqual(false);
+});
+
+test("gets products beyond the last page", async () => {
+  let totalQuery;
+  let result;
+  try {
+    totalQuery = await query({ shopId: opaqueShopId, tagId: encodeTagOpaqueId(mockTagWithFeatured._id), limit: 77 });
+    // Go beyond the final page
+    result = await query({
+      shopId: opaqueShopId,
+      tagId: encodeTagOpaqueId(mockTagWithFeatured._id),
+      page: 8,
+      limit: 10
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  expect(totalQuery.productsByTagId.nodes.length).toEqual(77);
+  expect(result.productsByTagId.nodes.length).toEqual(0);
+  expect(result.productsByTagId.pageInfo.hasPreviousPage).toEqual(false);
+  expect(result.productsByTagId.pageInfo.hasNextPage).toEqual(false);
+});


### PR DESCRIPTION
Resolves #5116   
Impact: **breaking,critical**  
Type: **feature,bugfix,performance,refactor**

## Issue

Querying `catalogItems` for `featured` products can cause Mongo/Reaction to become unresponsive as it tries to load and process every document in the `Catalog` collection.

## Solution

Cursor-based pagination with (first, last, before, and after) does not seem to work well with Mongo Aggregations as we have implemented it.

Cursor-based pagination has been thrown out for Mongo Aggregations for the time being. Instead, it's been replaced with offset based pagination (limit, and page).

The GQL query `catalogItems()` now supports `limit, page` as parameters for more traditional pagination for all `sortBy` types. This is in addition to the cursor based pagination parameters.

Sort by featured `sortBy: featured` **ONLY** supports offset based pagination.

If you use any combination of (first, last, before, after) and (limit, skip) together in the same query, an error will be thrown.

## Breaking changes

query `catalogItems(sortBy: featured, ...)` now only supports offset-based pagination. This means that pagination of featured products must be done with limit and page, like so... `catalogItems(sortBy: featured, limit: 20, page: 1, tagIds: [...] shopIds: [...])` 

## Testing

**Admin (offset-based-pagination-aggregation)**
This test is to ensure the productsByTagId, which has been updated to be exclusively offset-based pagination for a mongo aggregation works as intended.

1. Using a super-duper large dataset that caused this issue in the first place ;) ...
2. Open the operator UI to http://localhost:3000/operator/tags
3. Load a tag that has a lot of products. ( you might also get some from this link if your data set has it, http://localhost:3000/operator/tags/edit/cmVhY3Rpb24vdGFnOjJNWWdtU2NkZGdvb0tvTGpn )
3. Use the pagination controls and ensure you can go next, back, and increase the limits per page.

**Starterkit, (cursor-based-pagination)**
This is a backward compatibility check.

1. Ensure the product grids load and paginate properly.
2. Ensure the URL has some combination of `first, last, before, or after`
