### PR TITLE
(fix) remove transform for billingAddress in gql resolver for Payment

### DIFF
--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Payment/index.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Payment/index.js
@@ -1,6 +1,5 @@
 import { encodePaymentOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/payment";
 
 export default {
-  _id: (node) => encodePaymentOpaqueId(node._id),
-  billingAddress: (node) => node.address
+  _id: (node) => encodePaymentOpaqueId(node._id)
 };


### PR DESCRIPTION
Currently what is happening is that a customer implementation is using the withOrder/withOrders containers on the client (React) side which is relying on Payment.billingAddress to be populated.

The GraphQL output currently looks like this:
![Screenshot from 2019-04-11 17-31-49](https://user-images.githubusercontent.com/492653/56163019-56a90d80-5f9b-11e9-9436-621b95ee1b82.png)

It looks like the transform that this PR references may not be necessary, as removing it would appear to give the desired results, ie:

![Screenshot from 2019-04-11 17-47-32](https://user-images.githubusercontent.com/492653/56163067-6e809180-5f9b-11e9-9fb2-f663389f203e.png)

Tagging @aldeed for review as you most recently worked on this part of the GQL code in reaction and will be able to dispense swift guidance.