### PR TITLE
Speed up the products table publication

### DIFF
--- a/imports/plugins/core/core/server/publications/collections/products.js
+++ b/imports/plugins/core/core/server/publications/collections/products.js
@@ -392,33 +392,17 @@ Meteor.publish("ProductsAdminList", function (page = 0, limit = 24, productFilte
 
   delete selector.isVisible; // in edit mode, you should see all products
 
-  Counts.publish(this, "products-count", Products.find(selector));
+  // noReady and nonReactive are needed for good performance on
+  // large data sets
+  Counts.publish(this, "products-count", Products.find(selector), {
+    noReady: true,
+    nonReactive: true
+  });
 
-  // Get the IDs of the first N (limit) top-level products that match the query
-  const productIds = Products.find(selector, {
+  // Get the first N (limit) top-level products that match the query
+  return Products.find(selector, {
     sort,
     skip: page * limit,
     limit
-  }, {
-    fields: {
-      _id: 1
-    }
-  }).map((product) => product._id);
-
-  // Return a cursor for the matching products plus all their variants
-  return Products.find({
-    $or: [{
-      ancestors: {
-        $in: productIds
-      }
-    }, {
-      _id: {
-        $in: productIds
-      }
-    }]
-  }, {
-    sort
-    // We shouldn't limit here. Otherwise we are limited to 24 total products which
-    // could be far less than 24 top-level products.
   });
 });

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { Products } from "/lib/collections";
 
 /**

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -19,51 +19,8 @@ export default {
    * @return {Object} range, min, max
    */
   getProductPriceRange(productId) {
-    const product = Products.findOne(productId);
-    if (!product) {
-      return {
-        range: "0",
-        min: 0,
-        max: 0
-      };
-    }
-
-    const variants = this.getTopVariants(product._id);
-    // if we have variants we have a price range.
-    // this processing will default on the server
-    const visibileVariant = variants.filter((variant) => variant.isVisible === true);
-
-    if (visibileVariant.length > 0) {
-      const variantPrices = [];
-      variants.forEach((variant) => {
-        if (variant.isVisible === true) {
-          const range = this.getVariantPriceRange(variant._id);
-          if (typeof range === "string") {
-            const firstPrice = parseFloat(range.substr(0, range.indexOf(" ")));
-            const lastPrice = parseFloat(range.substr(range.lastIndexOf(" ") + 1));
-            variantPrices.push(firstPrice, lastPrice);
-          } else {
-            variantPrices.push(range);
-          }
-        } else {
-          variantPrices.push(0, 0);
-        }
-      });
-      const priceMin = _.min(variantPrices);
-      const priceMax = _.max(variantPrices);
-      let priceRange = `${priceMin.toFixed(2)} - ${priceMax.toFixed(2)}`;
-      // if we don't have a range
-      if (priceMin === priceMax) {
-        priceRange = priceMin.toFixed(2);
-      }
-      return {
-        range: priceRange,
-        min: priceMin,
-        max: priceMax
-      };
-    }
-
-    if (!product.price) {
+    const product = Products.findOne({ _id: productId });
+    if (!product || !product.price) {
       return {
         range: "0",
         min: 0,


### PR DESCRIPTION
Impact: **minor**  
Type: **performance**

## Issue
Loading and paging the products table in the operator UI is slow with large Products collection.

## Solution

Results testing Mongo queries directly with 64654 top-level products:

```
Skip 0, no sorting: ~1ms
Skip 24000, no sorting: ~300ms
Skip 0, sort by createdAt: ~15ms
Skip 24000, sort by createdAt: ~1100ms
```

Sorting slows things down a bit as expected, but it is using the index so I don’t think there’s much to be done there. And 15ms query on the first page is respectable.

The query (without any fancy filtering) seems fine.

When I comment out the `Counts.publish` the table is much faster. So I think most of the blame is with publishing the count. We could look into using https://atmospherejs.com/natestrauser/publish-performant-counts package instead. But since we're soon moving this to GraphQL, I'd rather not introduce a new Meteor package.

For now, I'm seeing improvements by adding `noReady` and `nonReactive` options to the counts publication, and removing variants from the result set. We no longer need the variants included due to recent UI changes.

### Other changes
With the variants no longer being published, this exposed an issue with the client side money formatting where there would end up being two currency symbols in the formatted string. I rewrote that function to use code similar to what we use on the server.

## Breaking changes
None really but any custom plugins with operator UI components that are relying on variants being published might need updating.

## Testing
Go to the Products table in operator UI with a large number of top-level products in the database. Verify that it loads in a few seconds and takes only a few seconds to switch between pages.