### PR TITLE
feat: allow 10 levels of navigation tree

### DIFF
--- a/imports/collections/schemas/navigationTrees.js
+++ b/imports/collections/schemas/navigationTrees.js
@@ -35,11 +35,61 @@ export const NavigationTreeItem = new SimpleSchema({
       items,
       "items.$": {
         type: new SimpleSchema({
+          expanded,
           navigationItemId,
           items,
           "items.$": {
             type: new SimpleSchema({
-              navigationItemId
+              expanded,
+              navigationItemId,
+              items,
+              "items.$": {
+                type: new SimpleSchema({
+                  expanded,
+                  navigationItemId,
+                  items,
+                  "items.$": {
+                    type: new SimpleSchema({
+                      expanded,
+                      navigationItemId,
+                      items,
+                      "items.$": {
+                        type: new SimpleSchema({
+                          expanded,
+                          navigationItemId,
+                          items,
+                          "items.$": {
+                            type: new SimpleSchema({
+                              expanded,
+                              navigationItemId,
+                              items,
+                              "items.$": {
+                                type: new SimpleSchema({
+                                  expanded,
+                                  navigationItemId,
+                                  items,
+                                  "items.$": {
+                                    type: new SimpleSchema({
+                                      expanded,
+                                      navigationItemId,
+                                      items,
+                                      "items.$": {
+                                        type: new SimpleSchema({
+                                          navigationItemId
+                                        })
+                                      }
+                                    })
+                                  }
+                                })
+                              }
+                            })
+                          }
+                        })
+                      }
+                    })
+                  }
+                })
+              }
             })
           }
         })

--- a/imports/plugins/core/navigation/client/components/NavigationTreeContainer.js
+++ b/imports/plugins/core/navigation/client/components/NavigationTreeContainer.js
@@ -84,7 +84,7 @@ class NavigationTreeContainer extends Component {
           }}
           generateNodeProps={this.generateNodeProps}
           treeData={sortableNavigationTree || []}
-          maxDepth={3}
+          maxDepth={10}
           onChange={onSetSortableNavigationTree}
           theme={SortableTheme}
           dndType={"CARD"}

--- a/imports/plugins/core/navigation/client/hocs/defaultNavigationTreeQuery.js
+++ b/imports/plugins/core/navigation/client/hocs/defaultNavigationTreeQuery.js
@@ -1,28 +1,12 @@
 import gql from "graphql-tag";
-import { navigationItemFragment } from "./fragments";
+import { navigationTreeWith10LevelsFragment } from "./fragments";
 
 export default gql`
   query defaultNavigationTreeQuery($id: ID!, $language: String!) {
     navigationTreeById(id: $id, language: $language) {
-      name
-      draftItems {
-        expanded
-        navigationItem {
-          ...NavigationItemCommon
-        }
-        items {
-          expanded
-          navigationItem {
-            ...NavigationItemCommon
-          }
-          items {
-            navigationItem {
-              ...NavigationItemCommon
-            }
-          }
-        }
-      }
+      ...NavigationTreeWith10Levels
     }
   }
-  ${navigationItemFragment.navigationItem}
+
+  ${navigationTreeWith10LevelsFragment}
 `;

--- a/imports/plugins/core/navigation/client/hocs/fragments.js
+++ b/imports/plugins/core/navigation/client/hocs/fragments.js
@@ -1,20 +1,69 @@
 import gql from "graphql-tag";
 
-export const navigationItemFragment = {
-  navigationItem: gql`
-    fragment NavigationItemCommon on NavigationItem {
-      _id
-      draftData {
-        content {
-          language
-          value
-        }
-        url
-        isUrlRelative
-        shouldOpenInNewWindow
-        classNames
+
+export const navigationItemFragment = gql`
+  fragment NavigationItem on NavigationItem {
+    _id
+    draftData {
+      content {
+        language
+        value
       }
-      metadata
+      url
+      isUrlRelative
+      shouldOpenInNewWindow
+      classNames
     }
-  `
-};
+    metadata
+  }
+`;
+
+export const navigationTreeItemFragment = gql`
+  fragment NavigationTreeItem on NavigationTreeItem {
+    expanded
+    navigationItem {
+      ...NavigationItem
+    }
+  }
+  ${navigationItemFragment}
+`;
+
+export const navigationTreeWith10LevelsFragment = gql`
+  fragment NavigationTreeWith10Levels on NavigationTree {
+    name
+    draftItems {
+      ...NavigationTreeItem
+      items {
+        ...NavigationTreeItem
+        items {
+          ...NavigationTreeItem
+          items {
+            ...NavigationTreeItem
+            items {
+              ...NavigationTreeItem
+              items {
+                ...NavigationTreeItem
+                items {
+                  ...NavigationTreeItem
+                  items {
+                    ...NavigationTreeItem
+                    items {
+                      ...NavigationTreeItem
+                      items {
+                        navigationItem {
+                          ...NavigationItem
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  ${navigationItemFragment}
+  ${navigationTreeItemFragment}
+`;

--- a/imports/plugins/core/navigation/client/hocs/navigationItemsQuery.js
+++ b/imports/plugins/core/navigation/client/hocs/navigationItemsQuery.js
@@ -6,9 +6,9 @@ export default gql`
     navigationItemsByShopId(shopId: $shopId, first: $first, after: $after) {
       totalCount
       nodes {
-        ...NavigationItemCommon
+        ...NavigationItem
       }
     }
   }
-  ${navigationItemFragment.navigationItem}
+  ${navigationItemFragment}
 `;

--- a/imports/plugins/core/navigation/client/hocs/withCreateNavigationItem.js
+++ b/imports/plugins/core/navigation/client/hocs/withCreateNavigationItem.js
@@ -8,11 +8,11 @@ const createNavigationItemMutation = gql`
   mutation createNavigationItemMutation($input: CreateNavigationItemInput!) {
     createNavigationItem(input: $input) {
       navigationItem {
-        ...NavigationItemCommon
+        ...NavigationItem
       }
     }
   }
-  ${navigationItemFragment.navigationItem}
+  ${navigationItemFragment}
 `;
 
 export default (Component) => (

--- a/imports/plugins/core/navigation/client/hocs/withUpdateNavigationItem.js
+++ b/imports/plugins/core/navigation/client/hocs/withUpdateNavigationItem.js
@@ -28,7 +28,7 @@ const deleteNavigationItemMutation = gql`
 
 const publishNavigationChangesMutation = gql`
   mutation publishNavigationChangesMutation($input: PublishNavigationChangesInput!) {
-    publishNavigationChanges(input: $input) {mon
+    publishNavigationChanges(input: $input) {
       navigationTree {
         ...NavigationTreeWith10Levels
       }

--- a/imports/plugins/core/navigation/client/hocs/withUpdateNavigationItem.js
+++ b/imports/plugins/core/navigation/client/hocs/withUpdateNavigationItem.js
@@ -2,56 +2,39 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 import { Mutation, withApollo } from "react-apollo";
-import { navigationItemFragment } from "./fragments";
+import { navigationItemFragment, navigationTreeWith10LevelsFragment } from "./fragments";
 
 const updateNavigationItemMutation = gql`
   mutation updateNavigationItemMutation($input: UpdateNavigationItemInput!) {
     updateNavigationItem(input: $input) {
       navigationItem {
-        ...NavigationItemCommon
+        ...NavigationItem
       }
     }
   }
-  ${navigationItemFragment.navigationItem}
+  ${navigationItemFragment}
 `;
 
 const deleteNavigationItemMutation = gql`
   mutation deleteNavigationItemMutation($input: DeleteNavigationItemInput!) {
     deleteNavigationItem(input: $input) {
       navigationItem {
-        ...NavigationItemCommon
+        ...NavigationItem
       }
     }
   }
-  ${navigationItemFragment.navigationItem}
+  ${navigationItemFragment}
 `;
 
 const publishNavigationChangesMutation = gql`
   mutation publishNavigationChangesMutation($input: PublishNavigationChangesInput!) {
-    publishNavigationChanges(input: $input) {
+    publishNavigationChanges(input: $input) {mon
       navigationTree {
-        name
-        draftItems {
-          expanded
-          navigationItem {
-            ...NavigationItemCommon
-          }
-          items {
-            expanded
-            navigationItem {
-              ...NavigationItemCommon
-            }
-            items {
-              navigationItem {
-                ...NavigationItemCommon
-              }
-            }
-          }
-        }
+        ...NavigationTreeWith10Levels
       }
     }
   }
-  ${navigationItemFragment.navigationItem}
+  ${navigationTreeWith10LevelsFragment}
 `;
 
 export default (Component) => {

--- a/imports/plugins/core/navigation/client/hocs/withUpdateNavigationTree.js
+++ b/imports/plugins/core/navigation/client/hocs/withUpdateNavigationTree.js
@@ -7,7 +7,9 @@ import { navigationTreeWith10LevelsFragment } from "./fragments";
 const updateNavigationTreeMutation = gql`
   mutation updateNavigationTreeMutation($input: UpdateNavigationTreeInput!) {
     updateNavigationTree(input: $input) {
-      ...NavigationTreeWith10Levels
+      navigationTree {
+        ...NavigationTreeWith10Levels
+      }
     }
   }
   ${navigationTreeWith10LevelsFragment}

--- a/imports/plugins/core/navigation/client/hocs/withUpdateNavigationTree.js
+++ b/imports/plugins/core/navigation/client/hocs/withUpdateNavigationTree.js
@@ -2,36 +2,15 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 import { Mutation } from "react-apollo";
-import { navigationItemFragment } from "./fragments";
+import { navigationTreeWith10LevelsFragment } from "./fragments";
 
 const updateNavigationTreeMutation = gql`
   mutation updateNavigationTreeMutation($input: UpdateNavigationTreeInput!) {
     updateNavigationTree(input: $input) {
-      navigationTree {
-
-        name
-        draftItems {
-          expanded
-          navigationItem {
-            ...NavigationItemCommon
-          }
-          items {
-            expanded
-            navigationItem {
-              ...NavigationItemCommon
-            }
-            items {
-              navigationItem {
-                ...NavigationItemCommon
-              }
-            }
-          }
-        }
-
-      }
+      ...NavigationTreeWith10Levels
     }
   }
-  ${navigationItemFragment.navigationItem}
+  ${navigationTreeWith10LevelsFragment}
 `;
 
 export default (Component) => (


### PR DESCRIPTION
Resolves #5117   
Impact: **minor**  
Type: **feature**

## Issue

Navigation tree of 3 levels is not enough.

## Solution

Made it 10 levels. Good Luck.

**Note 1: The UI will be compressed the more levels you expand. This PR will not be addressing that.**

**Note 2: I could have made a function to make it configurable. For the sake of time, this PR will not be addressing the navigation depth configuration.**

## Breaking changes

None.

## Testing
1. In the navigation editor, add 10 levels of navigation and save
2. Refresh and verify if those 10 levels were saved.
