### PR TITLE
perf: Tag subscription

### DIFF
--- a/client/modules/core/subscriptions.js
+++ b/client/modules/core/subscriptions.js
@@ -35,8 +35,6 @@ Subscriptions.Packages = Subscriptions.Manager.subscribe("Packages");
 // TODO: Consider how to handle routes for several shops which are all active at once
 Subscriptions.PrimaryShopPackages = Subscriptions.Manager.subscribe("Packages");
 
-Subscriptions.Tags = Subscriptions.Manager.subscribe("Tags");
-
 Subscriptions.Groups = Subscriptions.Manager.subscribe("Groups");
 
 Subscriptions.BrandAssets = Subscriptions.Manager.subscribe("BrandAssets");

--- a/imports/plugins/core/core/server/publications/collections/tags.js
+++ b/imports/plugins/core/core/server/publications/collections/tags.js
@@ -9,15 +9,15 @@ import Reaction from "/imports/plugins/core/core/server/Reaction";
 Meteor.publish("Tags", function (tagIds) {
   check(tagIds, Match.OneOf(undefined, Array));
 
+  // Prevent subscribing to all tags
+  if (!Array.isArray(tagIds)) {
+    return this.ready();
+  }
+
   const shopId = Reaction.getShopId();
 
   // Only let users what have createProduct permissions see the tags
   if (!Reaction.hasPermission(["createProduct"], this.userId)) {
-    return this.ready();
-  }
-
-  // Prevent subscribing to all tags
-  if (!Array.isArray(tagIds)) {
     return this.ready();
   }
 

--- a/imports/plugins/core/core/server/publications/collections/tags.js
+++ b/imports/plugins/core/core/server/publications/collections/tags.js
@@ -1,24 +1,39 @@
 import { Meteor } from "meteor/meteor";
+import { check, Match } from "meteor/check";
 import { Tags } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 /**
  * tags
  */
-Meteor.publish("Tags", function () {
-  const selector = {};
+Meteor.publish("Tags", function (tagIds) {
+  check(tagIds, Match.OneOf(undefined, Array));
 
   const shopId = Reaction.getShopId();
+
+  // Only let users what have createProduct permissions see the tags
+  if (!Reaction.hasPermission(["createProduct"], this.userId)) {
+    return this.ready();
+  }
+
+  // Prevent subscribing to all tags
+  if (!Array.isArray(tagIds)) {
+    return this.ready();
+  }
 
   if (!shopId) {
     return this.ready();
   }
 
+  const selector = {
+    _id: {
+      $in: tagIds
+    }
+  };
+
   if (!Reaction.isShopPrimary()) {
     selector.shopId = shopId;
   }
 
-  // TODO: filter tag results based on permissions and isVisible or some other
-  // publication quality
   return Tags.find(selector);
 });

--- a/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/toolbarContainer.js
@@ -4,23 +4,17 @@ import { Session } from "meteor/session";
 import { composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Reaction, i18next } from "/client/api";
 import ReactionError from "@reactioncommerce/reaction-error";
-import { Tags, Shops } from "/lib/collections";
+import { Shops } from "/lib/collections";
 import { AdminContextProvider } from "/imports/plugins/core/ui/client/providers";
 
 const handleAddProduct = () => {
   Meteor.call("products/createProduct", (error, productId) => {
     if (Meteor.isClient) {
-      let currentTag;
-      let currentTagId;
-
       if (error) {
         throw new ReactionError("create-product-error", error);
-      } else if (productId) {
-        currentTagId = Session.get("currentTag");
-        currentTag = Tags.findOne(currentTagId);
-        if (currentTag) {
-          Meteor.call("products/updateProductTags", productId, currentTag.name, currentTagId);
-        }
+      }
+
+      if (productId) {
         Session.set("productGrid/selectedProducts", [productId]);
         // go to new product
         Reaction.Router.go("product", {

--- a/imports/plugins/core/layout/client/templates/layout/createContentMenu/createContentMenu.js
+++ b/imports/plugins/core/layout/client/templates/layout/createContentMenu/createContentMenu.js
@@ -1,8 +1,6 @@
 import { Reaction } from "/client/api";
 import ReactionError from "@reactioncommerce/reaction-error";
-import { Tags } from "/lib/collections";
 import { Meteor } from "meteor/meteor";
-import { Session } from "meteor/session";
 import { Template } from "meteor/templating";
 
 Template.createContentMenu.helpers({
@@ -16,17 +14,11 @@ Template.createContentMenu.helpers({
         if (item.route === "/products/createProduct") {
           Meteor.call("products/createProduct", (error, productId) => {
             if (Meteor.isClient) {
-              let currentTag;
-              let currentTagId;
-
               if (error) {
                 throw new ReactionError("create-product-error", error);
-              } else if (productId) {
-                currentTagId = Session.get("currentTag");
-                currentTag = Tags.findOne(currentTagId);
-                if (currentTag) {
-                  Meteor.call("products/updateProductTags", productId, currentTag.name, currentTagId);
-                }
+              }
+
+              if (productId) {
                 // go to new product
                 Reaction.Router.go("product", {
                   handle: productId

--- a/imports/plugins/core/tags/server/index.js
+++ b/imports/plugins/core/tags/server/index.js
@@ -1,1 +1,2 @@
 import "./i18n";
+import "./methods";

--- a/imports/plugins/core/tags/server/methods.js
+++ b/imports/plugins/core/tags/server/methods.js
@@ -1,0 +1,34 @@
+import { Meteor } from "meteor/meteor";
+import { check, Match } from "meteor/check";
+import { Reaction } from "/lib/api";
+import { Tags } from "/lib/collections";
+
+Meteor.methods({
+  "tags/getBySlug": async (term, excludedTagIds) => {
+    check(term, String);
+    check(excludedTagIds, Match.OneOf(undefined, Array));
+
+    // Return a blank result set for non admins
+    if (!Reaction.hasPermission(["admin", "owner", "createProduct"], this.userId)) {
+      return [];
+    }
+
+    const slug = await Reaction.getSlug(term);
+
+    const selector = {
+      slug: new RegExp(slug, "i")
+    };
+
+    if (Array.isArray(excludedTagIds)) {
+      selector._id = {
+        $nin: excludedTagIds
+      };
+    }
+
+    const tags = Tags.find(selector, { limit: 4 }).map((tag) => ({
+      label: tag.name
+    }));
+
+    return tags;
+  }
+});

--- a/imports/plugins/core/ui-tagnav/client/util/getTagSuggestions.js
+++ b/imports/plugins/core/ui-tagnav/client/util/getTagSuggestions.js
@@ -1,5 +1,4 @@
-import { Reaction } from "/client/api";
-import { Tags } from "/lib/collections";
+import { Meteor } from "meteor/meteor";
 
 /**
  * @name getTagSuggestions
@@ -10,21 +9,17 @@ import { Tags } from "/lib/collections";
  * @return {Promise<Array>} matching tags
  */
 export default async function getTagSuggestions(term, { excludeTags }) {
-  const slug = await Reaction.getSlug(term);
-
-  const selector = {
-    slug: new RegExp(slug, "i")
-  };
-
-  if (Array.isArray(excludeTags)) {
-    selector._id = {
-      $nin: excludeTags
-    };
+  try {
+    return new Promise((resolve, reject) => {
+      Meteor.call("tags/getBySlug", term, excludeTags, (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  } catch (error) {
+    return [];
   }
-
-  const tags = Tags.find(selector).map((tag) => ({
-    label: tag.name
-  }));
-
-  return tags;
 }

--- a/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/ProductTagForm.js
@@ -15,7 +15,7 @@ function ProductTagForm(props) {
   const { editable, product } = props;
 
   return (
-    <Card>
+    <Card style={{ overflow: "visible" }}>
       <CardHeader title={i18next.t("productDetail.tags")} />
       <CardContent>
         <Components.TagList

--- a/imports/plugins/included/product-admin/client/hocs/withProduct.js
+++ b/imports/plugins/included/product-admin/client/hocs/withProduct.js
@@ -216,6 +216,7 @@ function composer(props, onData) {
 
   if (productSub && productSub.ready()) {
     product = ReactionProduct.setProduct(productId, variantId);
+    product && Meteor.subscribe("Tags", product.hashtags);
 
     if (variantId) {
       ReactionProduct.setCurrentVariant(variantId);

--- a/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/productDetail.js
@@ -81,7 +81,6 @@ const wrapComponent = (Comp) =>
  * @returns {undefined}
  */
 function composer(props, onData) {
-  const tagSub = Meteor.subscribe("Tags");
   const shopIdOrSlug = Reaction.Router.getParam("shopSlug");
   const productId = props.match.params.handle;
   const variantId = ReactionProduct.selectedVariantId();
@@ -91,7 +90,7 @@ function composer(props, onData) {
   if (productId) {
     productSub = Meteor.subscribe("Product", productId, shopIdOrSlug);
   }
-  if (productSub && productSub.ready() && tagSub.ready() && Reaction.Subscriptions.Cart && Reaction.Subscriptions.Cart.ready()) {
+  if (productSub && productSub.ready() && Reaction.Subscriptions.Cart && Reaction.Subscriptions.Cart.ready()) {
     const product = ReactionProduct.setProduct(productId, variantId);
     if (Reaction.hasPermission("createProduct")) {
       if (!Reaction.getActionView() && Reaction.isActionViewOpen() === true) {
@@ -107,6 +106,7 @@ function composer(props, onData) {
       let tags;
       const hashTags = product.hashtags || product.tagIds;
       if (_.isArray(hashTags)) {
+        Meteor.subscribe("Tags", hashTags);
         tags = Tags.find({ _id: { $in: hashTags } }).fetch();
       }
 


### PR DESCRIPTION
Resolves #5101   
Impact: **critical**  
Type: **performance**

## Issue

All tags were published and subscribed to all users.

## Solution

- Make the subscription admin only
- Limit published tags to a specified list
- Use a Meteor method to get a small list of autocomplete suggestion for the product editor

## Breaking changes

Tags are no longer subscribed to at a global level. Subscribe to tags when you need them using `Meteor.subscribe("Tags", [tagIds]);`

## Testing
1. Ensure all tags are not loaded. Meteor dev tools may help with this.
2. Ensure that the product editor shows all tags for a product
3. When adding a new tag to a product, ensure the auto-suggestion choices appear if there are any
