### PR TITLE
perf: create index for Jobs queries

### DIFF
--- a/imports/utils/jobs.js
+++ b/imports/utils/jobs.js
@@ -1,7 +1,8 @@
 import { check, Match } from "meteor/check";
 import { Meteor } from "meteor/meteor";
-import { Mongo } from "meteor/mongo";
+import { Mongo, MongoInternals } from "meteor/mongo";
 import createJobCollection from "@reactioncommerce/job-queue";
+import collectionIndex from "./collectionIndex";
 
 const later = Meteor.isServer && require("later");
 
@@ -10,5 +11,9 @@ const { Job, JobCollection } = createJobCollection({ Mongo, Meteor, check, Match
 const Jobs = new JobCollection("Jobs", {
   noCollectionSuffix: true
 });
+
+// Add an index to support the `status: "running"` lookups it does
+const { db } = MongoInternals.defaultRemoteCollectionDriver().mongo;
+collectionIndex(db.collection("Jobs"), { status: 1 });
 
 export { Jobs, Job };


### PR DESCRIPTION
Impact: **minor**  
Type: **performance**

## Issue
In profiling DB ops locally, I noticed that the job-queue package does periodic queries of the `Jobs` collection with only `status` and `expiresAfter` as query fields. These queries do a `COLLSCAN`, which can be very slow as the number of jobs increases.

## Solution
Added a `{ status: 1 }` index on `Jobs` collection.

## Breaking changes
None

## Testing
Check out `develop` branch.

First run `db.setProfilingLevel(2)` in your local DB Mongo shell. This will tell it to log all queries.

Now start the app, wait a minute, and run this query:

```
db.system.profile.find({ 
    "command.find" : "Jobs", 
    "command.filter.status" : "running"
}).sort({ 
    "ts" : -1.0
});
```

You should see `planSummary` field is `COLLSCAN` on these queries.

Now check out this PR branch, start the app, wait a minute, and run the above query again. You should see `planSummary` field is "IXSCAN { status: 1 }" on the most recent one.

Finally, run `db.setProfilingLevel(0)` to turn off profiling since it will slow down your local DB.