### PR TITLE
feat: Migrations & related checks can be disabled

### DIFF
--- a/imports/node-app/core/config.js
+++ b/imports/node-app/core/config.js
@@ -3,6 +3,10 @@ import envalid, { bool, str } from "envalid";
 export default envalid.cleanEnv(process.env, {
   GRAPHQL_INTROSPECTION_ENABLED: bool({ default: false }),
   GRAPHQL_PLAYGROUND_ENABLED: bool({ default: false }),
+  MIGRATION_BYPASS_ENABLED: bool({
+    default: false,
+    desc: "Bypasses migration version checks and migration runs. Enables startup if migration state is not compatible. This can be dangerous enough to cause data inconsistencies. Use at your own risk!"
+  }),
   // This is necessary to override the envalid default
   // validation for NODE_ENV, which uses
   // str({ choices: ['development', 'test', 'production'] })

--- a/imports/plugins/core/versions/server/startup.js
+++ b/imports/plugins/core/versions/server/startup.js
@@ -2,6 +2,8 @@ import Logger from "@reactioncommerce/logger";
 import { Meteor } from "meteor/meteor";
 import { Migrations } from "meteor/percolate:migrations";
 import appEvents from "/imports/node-app/core/util/appEvents";
+import config from "/imports/node-app/core/config";
+
 
 function reactionLogger(opts) {
   if (["warn", "info", "error"].includes(opts.level)) {
@@ -20,20 +22,31 @@ appEvents.on("afterCoreInit", () => {
   const currentMigrationVersion = Migrations._getControl().version;
   const highestAvailableVersion = Migrations._list[Migrations._list.length - 1].version;
 
-  // Checks to ensure the app is running against a DB at the right migration state. Running the app
-  // with a wrong DB state will cause the app to malfunction
-  if (currentMigrationVersion > highestAvailableVersion) {
-    Logger.fatal(`You are running a Reaction install with migration version (${highestAvailableVersion}) below your current DB migration state (${currentMigrationVersion})`);
-    Logger.fatal(`Upgrade to a version of Reaction containing migration ${currentMigrationVersion} or higher.`);
-    Logger.fatal("If you really want to downgrade to this version, you should restore your DB to a previous state from your backup.");
-    process.exit(0);
-  } else if (!Meteor.isAppTest) {
-    try {
-      Migrations.migrateTo("latest");
-    } catch (error) {
-      Logger.error("Error while migrating", error);
-      // Make sure the migration control record is unlocked so they can attempt to run again next time
-      Migrations.unlock();
+  if (config.MIGRATION_BYPASS_ENABLED) {
+    Logger.warn("DANGER: MIGRATION_BYPASS_ENABLED is true and all migration activity is bypassed. This is a dangerous mode and may result in data corruption.");
+    if (currentMigrationVersion > highestAvailableVersion) {
+      Logger.warn(`You are running a Reaction install with migration version (${highestAvailableVersion}) below your current DB migration state (${currentMigrationVersion})`);
+      Logger.warn(`Upgrade to a version of Reaction containing migration ${currentMigrationVersion} or higher.`);
+      Logger.warn("If you really want to downgrade to this version, you should restore your DB to a previous state from your backup.");
+    }
+  } else {
+    // Checks to ensure the app is running against a DB at the right migration state. Running the app
+    // with a wrong DB state will cause the app to malfunction
+    if (currentMigrationVersion > highestAvailableVersion) {
+      Logger.fatal(`You are running a Reaction install with migration version (${highestAvailableVersion}) below your current DB migration state (${currentMigrationVersion})`);
+      Logger.fatal(`Upgrade to a version of Reaction containing migration ${currentMigrationVersion} or higher.`);
+      Logger.fatal("If you really want to downgrade to this version, you should restore your DB to a previous state from your backup.");
+      process.exit(0);
+    }
+
+    if (!Meteor.isAppTest) {
+      try {
+        Migrations.migrateTo("latest");
+      } catch (error) {
+        Logger.error("Error while migrating", error);
+        // Make sure the migration control record is unlocked so they can attempt to run again next time
+        Migrations.unlock();
+      }
     }
   }
 });


### PR DESCRIPTION
Resolves N/A
Impact: **minor**  
Type: **feature**

## Issue
The checks that verify the migration state are important to run the application in a safe and sane way. However, in some emergency circumstances it can be necessary to disable checks so that the application may be started when the migration versions don't line up.

An example scenario might be an emergency release rollback.

## Solution
Adds new environment variables to flag the migration feature. 

- `MIGRATION_BYPASS_ENABLED`, boolean, not required, default: false

Code changes disable migrations and checks when the flag is true.

:warning: **Running in such a mode is inherently unsafe!** It is the operator's responsibility to decide if it is OK to run in this mode. The difference between the target and existing migration state should be examined carefully.

## Breaking changes
None.

## Testing

### Flag disabled
#### Migrations are Enabled
1. Ensure `MIGRATION_BYPASS_ENABLED` flag is false
2. Add a migration.
3. Migrations should run on startup.

#### Migration Checks are Enabled
1. Ensure `MIGRATION_BYPASS_ENABLED` flag is false
2. Add a migration.
3. Run migration.
4. Rollback code to older version.
5. Migration check should run at startup. App should not start.


### Flag enabled
#### Migrations are Disabled
1. Ensure `MIGRATION_BYPASS_ENABLED` flag is true
2. Add a migration.
3. Migrations should not run at startup.
4. Warning should appear in logs, `"DANGER: MIGRATION_BYPASS_ENABLED is true and all migration activity is bypassed. This is a dangerous mode and may result in data corruption."`

#### Migration Checks are Disabled
1. Ensure `MIGRATION_BYPASS_ENABLED` flag is true
2. Add a migration.
3. Run migration.
4. Rollback code to older version.
4. Migration check should not run at startup. App should start.
