### PR TITLE
ref: add home, order, orders, and account profile urls to shop object

### DIFF
--- a/imports/collections/schemas/shops.js
+++ b/imports/collections/schemas/shops.js
@@ -540,9 +540,8 @@ export const Shop = new SimpleSchema({
     type: String,
     optional: true
   },
-  "storeFrontUrls": {
+  "storefrontUrls": {
     type: StorefrontUrls,
-    optional: true,
     defaultValue: {}
   }
 });

--- a/imports/collections/schemas/shops.js
+++ b/imports/collections/schemas/shops.js
@@ -223,6 +223,40 @@ const MerchantShop = new SimpleSchema({
 registerSchema("MerchantShop", MerchantShop);
 
 /**
+ * @name StorefrontUrls
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @property {String[]} storefrontHomeUrlShop optional
+ * @property {String[]} storefrontOrderUrl optional
+ * @property {String[]} storefrontOrdersUrl optional
+ * @property {String[]} storefrontAccountProfileUrl optional
+ */
+const StorefrontUrls = new SimpleSchema({
+  storefrontHomeUrl: {
+    type: String,
+    label: "Storefront Home URL",
+    optional: true
+  },
+  storefrontOrderUrl: {
+    type: String,
+    label: "Storefront single order URL (can include `:orderReferenceId` and `:orderToken` in string)",
+    optional: true
+  },
+  storefrontOrdersUrl: {
+    type: String,
+    label: "Storefront orders URL (can include `:accountId` in string)",
+    optional: true
+  },
+  storefrontAccountProfileUrl: {
+    type: String,
+    label: "Storefront Account Profile URL (can include `:accountId` in string)",
+    optional: true
+  }
+});
+
+registerSchema("StorefrontUrls", StorefrontUrls);
+
+/**
  * @name Shop
  * @memberof Schemas
  * @type {SimpleSchema}
@@ -504,6 +538,11 @@ export const Shop = new SimpleSchema({
   "defaultNavigationTreeId": {
     type: String,
     optional: true
+  },
+  "storeFrontUrls": {
+    type: StorefrontUrls,
+    optional: true,
+    defaultValue: {}
   }
 });
 

--- a/imports/collections/schemas/shops.js
+++ b/imports/collections/schemas/shops.js
@@ -301,7 +301,7 @@ registerSchema("StorefrontUrls", StorefrontUrls);
  * @property {Date} updatedAt optional
  * @property {Object[]} paymentMethods blackbox, default value: `[]`
  * @property {String[]} availablePaymentMethods default value: `[]`
- * @property {Object} storefrontUrls default value: `{}`
+ * @property {Object[]} storefrontUrls optional
  * @property {Workflow} workflow optional
  */
 export const Shop = new SimpleSchema({
@@ -543,6 +543,7 @@ export const Shop = new SimpleSchema({
   },
   "storefrontUrls": {
     type: StorefrontUrls,
+    optional: true,
     defaultValue: {}
   }
 });

--- a/imports/collections/schemas/shops.js
+++ b/imports/collections/schemas/shops.js
@@ -7,40 +7,26 @@ import { Layout } from "./layouts";
 import { Metafield } from "./metafield";
 import { Workflow } from "./workflow";
 
+
 /**
- * @name CustomEmailSettings
+ * @name BrandAsset
  * @memberof Schemas
  * @type {SimpleSchema}
- * @property {String} service optional
- * @property {String} username optional
- * @property {String} password optional
- * @property {String} host optional
- * @property {Number} port optional
+ * @property {String} mediaId optional
+ * @property {String} type optional
  */
-export const CustomEmailSettings = new SimpleSchema({
-  service: {
+export const BrandAsset = new SimpleSchema({
+  mediaId: {
     type: String,
     optional: true
   },
-  username: {
+  type: {
     type: String,
-    optional: true
-  },
-  password: {
-    type: String,
-    optional: true
-  },
-  host: {
-    type: String,
-    optional: true
-  },
-  port: {
-    type: SimpleSchema.Integer,
     optional: true
   }
 });
 
-registerSchema("CustomEmailSettings", CustomEmailSettings);
+registerSchema("BrandAsset", BrandAsset);
 
 /**
  * @name Currency
@@ -86,6 +72,109 @@ export const Currency = new SimpleSchema({
 registerSchema("Currency", Currency);
 
 /**
+ * @name CustomEmailSettings
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @property {String} service optional
+ * @property {String} username optional
+ * @property {String} password optional
+ * @property {String} host optional
+ * @property {Number} port optional
+ */
+export const CustomEmailSettings = new SimpleSchema({
+  service: {
+    type: String,
+    optional: true
+  },
+  username: {
+    type: String,
+    optional: true
+  },
+  password: {
+    type: String,
+    optional: true
+  },
+  host: {
+    type: String,
+    optional: true
+  },
+  port: {
+    type: SimpleSchema.Integer,
+    optional: true
+  }
+});
+
+registerSchema("CustomEmailSettings", CustomEmailSettings);
+
+/**
+ * @name Languages
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @property {String} label required
+ * @property {String} i18n required
+ * @property {Boolean} enabled, default value: `true`
+ */
+export const Languages = new SimpleSchema({
+  label: {
+    type: String
+  },
+  i18n: {
+    type: String
+  },
+  enabled: {
+    type: Boolean,
+    defaultValue: true
+  }
+});
+
+registerSchema("Languages", Languages);
+
+/**
+ * @name Locale
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @property {Object} continents blackbox
+ * @property {Object} countries blackbox
+ */
+export const Locale = new SimpleSchema({
+  continents: {
+    type: Object,
+    blackbox: true
+  },
+  countries: {
+    type: Object,
+    blackbox: true
+  }
+});
+
+registerSchema("Locale", Locale);
+
+/**
+ * @name MerchantShop
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @property {String} _id Shop label
+ * @property {String} slug Shop slug
+ * @property {String} name Shop name
+ */
+export const MerchantShop = new SimpleSchema({
+  _id: {
+    type: String,
+    label: "Shop Label"
+  },
+  slug: {
+    type: String,
+    label: "Shop Slug"
+  },
+  name: {
+    type: String,
+    label: "Shop Name"
+  }
+});
+
+registerSchema("MerchantShop", MerchantShop);
+
+/**
  * @name ParcelSize
  * @memberof schemas
  * @type {SimpleSchema}
@@ -116,49 +205,6 @@ export const ParcelSize = new SimpleSchema({
 registerSchema("ParcelSize", ParcelSize);
 
 /**
- * @name Locale
- * @memberof Schemas
- * @type {SimpleSchema}
- * @property {Object} continents blackbox
- * @property {Object} countries blackbox
- */
-export const Locale = new SimpleSchema({
-  continents: {
-    type: Object,
-    blackbox: true
-  },
-  countries: {
-    type: Object,
-    blackbox: true
-  }
-});
-
-registerSchema("Locale", Locale);
-
-/**
- * @name Languages
- * @memberof Schemas
- * @type {SimpleSchema}
- * @property {String} label required
- * @property {String} i18n required
- * @property {Boolean} enabled, default value: `true`
- */
-export const Languages = new SimpleSchema({
-  label: {
-    type: String
-  },
-  i18n: {
-    type: String
-  },
-  enabled: {
-    type: Boolean,
-    defaultValue: true
-  }
-});
-
-registerSchema("Languages", Languages);
-
-/**
  * @name ShopTheme
  * @memberof Schemas
  * @type {SimpleSchema}
@@ -178,51 +224,6 @@ export const ShopTheme = new SimpleSchema({
 registerSchema("ShopTheme", ShopTheme);
 
 /**
- * @name BrandAsset
- * @memberof Schemas
- * @type {SimpleSchema}
- * @property {String} mediaId optional
- * @property {String} type optional
- */
-export const BrandAsset = new SimpleSchema({
-  mediaId: {
-    type: String,
-    optional: true
-  },
-  type: {
-    type: String,
-    optional: true
-  }
-});
-
-registerSchema("BrandAsset", BrandAsset);
-
-/**
- * @name MerchantShop
- * @memberof Schemas
- * @type {SimpleSchema}
- * @property {String} _id Shop label
- * @property {String} slug Shop slug
- * @property {String} name Shop name
- */
-const MerchantShop = new SimpleSchema({
-  _id: {
-    type: String,
-    label: "Shop Label"
-  },
-  slug: {
-    type: String,
-    label: "Shop Slug"
-  },
-  name: {
-    type: String,
-    label: "Shop Name"
-  }
-});
-
-registerSchema("MerchantShop", MerchantShop);
-
-/**
  * @name StorefrontUrls
  * @memberof Schemas
  * @type {SimpleSchema}
@@ -231,7 +232,7 @@ registerSchema("MerchantShop", MerchantShop);
  * @property {String[]} storefrontOrdersUrl optional
  * @property {String[]} storefrontAccountProfileUrl optional
  */
-const StorefrontUrls = new SimpleSchema({
+export const StorefrontUrls = new SimpleSchema({
   storefrontHomeUrl: {
     type: String,
     label: "Storefront Home URL",

--- a/imports/collections/schemas/shops.js
+++ b/imports/collections/schemas/shops.js
@@ -301,6 +301,7 @@ registerSchema("StorefrontUrls", StorefrontUrls);
  * @property {Date} updatedAt optional
  * @property {Object[]} paymentMethods blackbox, default value: `[]`
  * @property {String[]} availablePaymentMethods default value: `[]`
+ * @property {Object} storefrontUrls default value: `{}`
  * @property {Workflow} workflow optional
  */
 export const Shop = new SimpleSchema({

--- a/imports/plugins/core/core/server/no-meteor/mutations/index.js
+++ b/imports/plugins/core/core/server/no-meteor/mutations/index.js
@@ -1,0 +1,5 @@
+import updateShopUrls from "./updateShopUrls";
+
+export default {
+  updateShopUrls
+};

--- a/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
@@ -7,8 +7,8 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @summary Add storefront Urls to a shop
  * @param {Object} context - GraphQL execution context
  * @param {Object} input - an object of all mutation arguments that were sent
- * @param {String} args.input.shopId - The shop ID
- * @param {Object} args.input.storefrontUrls - An object containing the Urls to update
+ * @param {String} input.shopId - The shop ID
+ * @param {Object} input.storefrontUrls - An object containing the Urls to update
  * @return {Promise<Object>} with updated shop
  */
 export default async function updateShopUrls(context, input) {

--- a/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
@@ -1,0 +1,49 @@
+import ReactionError from "@reactioncommerce/reaction-error";
+
+/**
+ * @name shop/updateShopUrls
+ * @memberof Mutations/Accounts
+ * @method
+ * @summary Add a new address to an account
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - address
+ * @return {Promise<Object>} with updated shop
+ */
+export default async function updateShopUrls(context, input) {
+  const { collections, userHasPermission } = context;
+  const { Shops } = collections;
+
+  const {
+    shopId,
+    storefrontHomeUrl,
+    storefrontOrderUrl,
+    storefrontOrdersUrl,
+    storefrontAccountProfileUrl
+  } = input;
+
+  // Check permission to make sure user is allowed to do this
+  // Security check for admin access
+  if (!userHasPermission(["owner", "admin"], shopId)) {
+    throw new ReactionError("access-denied", "User does not have permission");
+  }
+
+  const { value: updatedShop } = await Shops.findOneAndUpdate(
+    { _id: shopId },
+    {
+      $set: {
+        storefrontUrls: {
+          storefrontHomeUrl,
+          storefrontOrderUrl,
+          storefrontOrdersUrl,
+          storefrontAccountProfileUrl
+        },
+        updatedAt: new Date()
+      }
+    },
+    {
+      returnOriginal: false
+    }
+  );
+
+  return updatedShop;
+}

--- a/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
@@ -15,10 +15,7 @@ export default async function updateShopUrls(context, input) {
 
   const {
     shopId,
-    storefrontHomeUrl,
-    storefrontOrderUrl,
-    storefrontOrdersUrl,
-    storefrontAccountProfileUrl
+    storefrontUrls
   } = input;
 
   // Check permission to make sure user is allowed to do this
@@ -31,12 +28,7 @@ export default async function updateShopUrls(context, input) {
     { _id: shopId },
     {
       $set: {
-        storefrontUrls: {
-          storefrontHomeUrl,
-          storefrontOrderUrl,
-          storefrontOrdersUrl,
-          storefrontAccountProfileUrl
-        },
+        storefrontUrls,
         updatedAt: new Date()
       }
     },

--- a/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
@@ -18,6 +18,13 @@ export default async function updateShopUrls(context, input) {
     storefrontUrls
   } = input;
 
+  // Only update provided fields inside `storefrontUrls`,
+  // don't update the whole object
+  const sets = {};
+  Object.keys(storefrontUrls).forEach((key) => {
+    sets[`storefrontUrls.${key}`] = storefrontUrls[key];
+  });
+
   // Check permission to make sure user is allowed to do this
   // Security check for admin access
   if (!userHasPermission(["owner", "admin"], shopId)) {
@@ -28,7 +35,7 @@ export default async function updateShopUrls(context, input) {
     { _id: shopId },
     {
       $set: {
-        storefrontUrls,
+        ...sets,
         updatedAt: new Date()
       }
     },

--- a/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/mutations/updateShopUrls.js
@@ -4,9 +4,11 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @name shop/updateShopUrls
  * @memberof Mutations/Accounts
  * @method
- * @summary Add a new address to an account
+ * @summary Add storefront Urls to a shop
  * @param {Object} context - GraphQL execution context
- * @param {Object} input - address
+ * @param {Object} input - an object of all mutation arguments that were sent
+ * @param {String} args.input.shopId - The shop ID
+ * @param {Object} args.input.storefrontUrls - An object containing the Urls to update
  * @return {Promise<Object>} with updated shop
  */
 export default async function updateShopUrls(context, input) {

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/index.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/index.js
@@ -1,0 +1,5 @@
+import updateShopUrls from "./updateShopUrls";
+
+export default {
+  updateShopUrls
+};

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/updateShopUrls.js
@@ -17,22 +17,14 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 export default async function updateShopUrls(_, { input }, context) {
   const {
     shopId: opaqueShopId,
-    storefrontHomeUrl,
-    storefrontOrderUrl,
-    storefrontOrdersUrl,
-    storefrontAccountProfileUrl,
+    storefrontUrls,
     clientMutationId = null
   } = input;
   const shopId = decodeShopOpaqueId(opaqueShopId);
 
   const updatedShop = await context.mutations.updateShopUrls(context, {
     shopId,
-    storefrontUrls: {
-      storefrontHomeUrl,
-      storefrontOrderUrl,
-      storefrontOrdersUrl,
-      storefrontAccountProfileUrl
-    }
+    storefrontUrls
   });
 
   return {

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/updateShopUrls.js
@@ -15,7 +15,14 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
  * @return {Promise<Object>} ShopsPayload
  */
 export default async function updateShopUrls(_, { input }, context) {
-  const { shopId: opaqueShopId, storefrontHomeUrl, storefrontOrderUrl, storefrontOrdersUrl, storefrontAccountProfileUrl, clientMutationId = null } = input;
+  const {
+    shopId: opaqueShopId,
+    storefrontHomeUrl,
+    storefrontOrderUrl,
+    storefrontOrdersUrl,
+    storefrontAccountProfileUrl,
+    clientMutationId = null
+  } = input;
   const shopId = decodeShopOpaqueId(opaqueShopId);
 
   const updatedShop = await context.mutations.updateShopUrls(context, {

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/updateShopUrls.js
@@ -20,10 +20,12 @@ export default async function updateShopUrls(_, { input }, context) {
 
   const updatedShop = await context.mutations.updateShopUrls(context, {
     shopId,
-    storefrontHomeUrl,
-    storefrontOrderUrl,
-    storefrontOrdersUrl,
-    storefrontAccountProfileUrl
+    storefrontUrls: {
+      storefrontHomeUrl,
+      storefrontOrderUrl,
+      storefrontOrdersUrl,
+      storefrontAccountProfileUrl
+    }
   });
 
   return {

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/updateShopUrls.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Mutation/updateShopUrls.js
@@ -1,0 +1,35 @@
+import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+
+/**
+ * @name Mutation/updateShopUrls
+ * @method
+ * @memberof Shop/GraphQL
+ * @summary resolver for the updateShopUrls GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} args.input.storefrontHomeUrl - Storefront Home URL
+ * @param {String} args.input.storefrontOrderUrl - Storefront single order URL
+ * @param {String} args.input.storefrontOrdersUrl - Storefront orders URL
+ * @param {String} args.input.storefrontAccountProfileUrl - Storefront Account Profile URL
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} ShopsPayload
+ */
+export default async function updateShopUrls(_, { input }, context) {
+  const { shopId: opaqueShopId, storefrontHomeUrl, storefrontOrderUrl, storefrontOrdersUrl, storefrontAccountProfileUrl, clientMutationId = null } = input;
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  const updatedShop = await context.mutations.updateShopUrls(context, {
+    shopId,
+    storefrontHomeUrl,
+    storefrontOrderUrl,
+    storefrontOrdersUrl,
+    storefrontAccountProfileUrl
+  });
+
+  return {
+    shop: updatedShop,
+    clientMutationId
+  };
+}
+
+

--- a/imports/plugins/core/core/server/no-meteor/resolvers/index.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/index.js
@@ -10,9 +10,6 @@ import Query from "./Query";
 import Shop from "./Shop";
 import Tag from "./Tag";
 
-console.log("mutation", Mutation);
-
-
 export default {
   Address,
   ConnectionCursor,

--- a/imports/plugins/core/core/server/no-meteor/resolvers/index.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/index.js
@@ -5,9 +5,13 @@ import ConnectionCursor from "./ConnectionCursor";
 import ConnectionLimitInt from "./ConnectionLimitInt";
 import Currency from "./Currency";
 import Money from "./Money";
+import Mutation from "./Mutation";
 import Query from "./Query";
 import Shop from "./Shop";
 import Tag from "./Tag";
+
+console.log("mutation", Mutation);
+
 
 export default {
   Address,
@@ -17,9 +21,7 @@ export default {
   Date: GraphQLDate,
   DateTime: GraphQLDateTime,
   Money,
-  Mutation: {
-    echo: (_, { str }) => `${str}`
-  },
+  Mutation,
   Query: {
     ping: () => "pong",
     ...Query

--- a/imports/plugins/core/core/server/no-meteor/resolvers/index.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/index.js
@@ -18,7 +18,10 @@ export default {
   Date: GraphQLDate,
   DateTime: GraphQLDateTime,
   Money,
-  Mutation,
+  Mutation: {
+    echo: (_, { str }) => `${str}`,
+    ...Mutation
+  },
   Query: {
     ping: () => "pong",
     ...Query

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -93,14 +93,14 @@ input StorefrontUrlsInput {
 
 "Input parameters for the updateShopUrls mutation"
 input UpdateShopUrlsInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
   "The ID of the shop to which you want to invite this person"
   shopId: ID!
 
   "URL object of all URL's for updateShopUrls mutation"
   storefrontUrls: StorefrontUrlsInput!
-
-  "An optional string identifying the mutation call, which will be returned in the response payload"
-  clientMutationId: String
 }
 
 "The response from the `inviteShopMember` mutation"

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -78,6 +78,9 @@ input InviteShopMemberInput {
 
 "Shop URLs to provide for the updateShopUrls mutation"
 input StorefrontUrlsInput {
+  "Storefront Account Profile URL (can include `:accountId` in string)"
+  storefrontAccountProfileUrl: String
+
   "Storefront Home URL"
   storefrontHomeUrl: String
 
@@ -86,9 +89,6 @@ input StorefrontUrlsInput {
 
   "Storefront orders URL (can include `:accountId` in string)"
   storefrontOrdersUrl: String
-
-  "Storefront Account Profile URL (can include `:accountId` in string)"
-  storefrontAccountProfileUrl: String
 }
 
 "Input parameters for the updateShopUrls mutation"
@@ -117,6 +117,9 @@ type ShopBrandAssets {
 
 "URLs for various routes"
 type StorefrontUrls {
+  "Storefront Account Profile URL (can include `:accountId` in string)"
+  storefrontAccountProfileUrl: String
+
   "Storefront Home URL"
   storefrontHomeUrl: String
 
@@ -125,9 +128,6 @@ type StorefrontUrls {
 
   "Storefront orders URL (can include `:accountId` in string)"
   storefrontOrdersUrl: String
-
-  "Storefront Account Profile URL (can include `:accountId` in string)"
-  storefrontAccountProfileUrl: String
 }
 
 "The response from the `updateShopUrls` mutation"

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -36,6 +36,9 @@ type Shop implements Node {
   "Returns a list of roles for this shop, as a Relay-compatible connection."
   roles(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: RoleSortByField = name): RoleConnection
 
+  "Returns URLs for various storefront routes"
+  storefrontUrls: storefrontUrls
+
   "Returns a paged list of tags for this shop"
   tags(
     "If set, the query will return only top-level tags or only non-top-level tags. By default, both types of tags are returned."
@@ -86,6 +89,21 @@ type InviteShopMemberPayload {
 type ShopBrandAssets {
   "URLs for the navigation bar brand logo image"
   navbarBrandImage: ImageSizes
+}
+
+"URLs for various routes"
+type StorefrontUrls {
+  "Storefront Home URL"
+  storefrontHomeUrl: String
+
+  "Storefront single order URL (can include `:orderReferenceId` and `:orderToken` in string)"
+  storefrontOrderUrl: String
+
+  "Storefront orders URL (can include `:accountId` in string)"
+  storefrontOrdersUrl: String
+
+  "Storefront Account Profile URL (can include `:accountId` in string)"
+  storefrontAccountProfileUrl: String
 }
 
 extend type Mutation {

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -76,7 +76,7 @@ input InviteShopMemberInput {
   shopId: ID!
 }
 
-"Input parameters for the updateShopUrls mutation"
+"Shop URLs to provide for the updateShopUrls mutation"
 input StorefrontUrlsInput {
   "Storefront Home URL"
   storefrontHomeUrl: String
@@ -96,7 +96,7 @@ input UpdateShopUrlsInput {
   "The ID of the shop to which you want to invite this person"
   shopId: ID!
 
-  "Storefront Home URL"
+  "URL object of all URL's for updateShopUrls mutation"
   storefrontUrls: StorefrontUrlsInput
 }
 

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -146,7 +146,7 @@ extend type Mutation {
   """
   inviteShopMember(input: InviteShopMemberInput!): InviteShopMemberPayload
 
-  "Given URLs for various sho pages, update the Shops collection object with URL's"
+  "Given URLs for various shop pages, update the Shops collection object with URLs"
   updateShopUrls(input: UpdateShopUrlsInput!): UpdateShopUrlsPayload
 }
 

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -37,7 +37,7 @@ type Shop implements Node {
   roles(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: RoleSortByField = name): RoleConnection
 
   "Returns URLs for various storefront routes"
-  storefrontUrls: storefrontUrls
+  storefrontUrls: StorefrontUrls
 
   "Returns a paged list of tags for this shop"
   tags(
@@ -76,6 +76,24 @@ input InviteShopMemberInput {
   shopId: ID!
 }
 
+"Input parameters for the updateShopUrls mutation"
+input UpdateShopUrlsInput {
+  "The ID of the shop to which you want to invite this person"
+  shopId: ID!
+
+  "Storefront Home URL"
+  storefrontHomeUrl: String
+
+  "Storefront single order URL (can include `:orderReferenceId` and `:orderToken` in string)"
+  storefrontOrderUrl: String
+
+  "Storefront orders URL (can include `:accountId` in string)"
+  storefrontOrdersUrl: String
+
+  "Storefront Account Profile URL (can include `:accountId` in string)"
+  storefrontAccountProfileUrl: String
+}
+
 "The response from the `inviteShopMember` mutation"
 type InviteShopMemberPayload {
   "The account that was successfully created or found and updated by inviting this shop member"
@@ -106,12 +124,24 @@ type StorefrontUrls {
   storefrontAccountProfileUrl: String
 }
 
+"The response from the `updateShopUrls` mutation"
+type UpdateShopUrlsPayload {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "The shop which was updated with URLs"
+  shop: Shop!
+}
+
 extend type Mutation {
   """
   Given a person's email address and name, invite them to create an account for a certain shop,
   and put them in the provided permission group
   """
   inviteShopMember(input: InviteShopMemberInput!): InviteShopMemberPayload
+
+  "Given URLs for various sho pages, update the Shops collection object with URL's"
+  updateShopUrls(input: UpdateShopUrlsInput!): UpdateShopUrlsPayload
 }
 
 extend type Query {

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -97,7 +97,10 @@ input UpdateShopUrlsInput {
   shopId: ID!
 
   "URL object of all URL's for updateShopUrls mutation"
-  storefrontUrls: StorefrontUrlsInput
+  storefrontUrls: StorefrontUrlsInput!
+
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
 }
 
 "The response from the `inviteShopMember` mutation"

--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -77,10 +77,7 @@ input InviteShopMemberInput {
 }
 
 "Input parameters for the updateShopUrls mutation"
-input UpdateShopUrlsInput {
-  "The ID of the shop to which you want to invite this person"
-  shopId: ID!
-
+input StorefrontUrlsInput {
   "Storefront Home URL"
   storefrontHomeUrl: String
 
@@ -92,6 +89,15 @@ input UpdateShopUrlsInput {
 
   "Storefront Account Profile URL (can include `:accountId` in string)"
   storefrontAccountProfileUrl: String
+}
+
+"Input parameters for the updateShopUrls mutation"
+input UpdateShopUrlsInput {
+  "The ID of the shop to which you want to invite this person"
+  shopId: ID!
+
+  "Storefront Home URL"
+  storefrontUrls: StorefrontUrlsInput
 }
 
 "The response from the `inviteShopMember` mutation"

--- a/imports/plugins/core/core/server/startup/startNodeApp.js
+++ b/imports/plugins/core/core/server/startup/startNodeApp.js
@@ -11,9 +11,10 @@ import { SubscriptionServer } from "subscriptions-transport-ws";
 import ReactionNodeApp from "/imports/node-app/core/ReactionNodeApp";
 import { NoMeteorMedia } from "/imports/plugins/core/files/server";
 import { setBaseContext } from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
-import coreSchemas from "../no-meteor/schemas";
-import coreResolvers from "../no-meteor/resolvers";
+import coreMutations from "../no-meteor/mutations";
 import coreQueries from "../no-meteor/queries";
+import coreResolvers from "../no-meteor/resolvers";
+import coreSchemas from "../no-meteor/schemas";
 import { functionsByType, mutations, queries, resolvers, schemas } from "../no-meteor/pluginRegistration";
 import runMeteorMethodWithContext from "../util/runMeteorMethodWithContext";
 
@@ -29,13 +30,17 @@ export default async function startNodeApp() {
   const { ROOT_URL } = process.env;
   const mongodb = MongoInternals.NpmModules.mongodb.module;
 
-  // Adding core resolvers this way because `core` is not a typical plugin and doesn't call registerPackage
-  // Note that coreResolvers comes first so that plugin resolvers can overwrite core resolvers if necessary
-  const finalResolvers = merge({}, coreResolvers, resolvers);
+  // Adding core mutations this way because `core` is not a typical plugin and doesn't call registerPackage
+  // Note that coreMutations comes first so that plugin resolvers can overwrite core mutations if necessary
+  const finalMutations = merge({}, coreMutations, mutations);
 
   // Adding core queries this way because `core` is not a typical plugin and doesn't call registerPackage
   // Note that coreQueries comes first so that plugin queries can overwrite core queries if necessary
   const finalQueries = merge({}, coreQueries, queries);
+
+  // Adding core resolvers this way because `core` is not a typical plugin and doesn't call registerPackage
+  // Note that coreResolvers comes first so that plugin resolvers can overwrite core resolvers if necessary
+  const finalResolvers = merge({}, coreResolvers, resolvers);
 
   const app = new ReactionNodeApp({
     addCallMeteorMethod(context) {
@@ -48,7 +53,7 @@ export default async function startNodeApp() {
       createUser(options) {
         return Accounts.createUser(options);
       },
-      mutations,
+      mutations: finalMutations,
       queries: finalQueries,
       rootUrl: ROOT_URL
     },


### PR DESCRIPTION
Resolves #5144 (non-UI parts)
Impact: **minor**  
Type: **refactor**

## Issue
The API does not know what the storefront URLs are, so it can't use proper URLs when generating emails or redirecting after password resets, etc.

## Solution
- Add the following fields to `Shop` schema. They have been grouped in a `storefrontUrls` object on `shop`. They are all `String` type and optional with no default value:
- - `storefrontHomeUrl`
- - `storefrontOrderUrl` (can have `:orderReferenceId` and `:orderToken` in the string)
- - `storefrontOrdersUrl` (can have `:accountId` in the string)
- - `storefrontAccountProfileUrl` (can have `:accountId` in the string)

- Add a new GraphQL mutation, `updateShopUrls` that allows admins to update these new fields.

## Breaking changes
None

## Testing
1. Go to the admin panel's shop settings.
1. Add urls for the various fields
1. See the URL's have been added to the Shop object in the DB
1. Change the values
1. See the values have been changed
1. Only pass 1 or 2 of the Urls, and see only those update

```
query {
  primaryShop {
    _id
    storefrontUrls {
      storefrontHomeUrl
      storefrontOrderUrl
      storefrontOrdersUrl
      storefrontAccountProfileUrl
    }
  }
}
```

```
mutation {
  updateShopUrls(
    input: {
    	shopId: "SHOP-ID-GOES-HERE",
        storefrontUrls: {
          storefrontHomeUrl: "storefrontHomeUrl updateTest",
          storefrontOrderUrl: " storefrontOrderUrl updateTest",
          storefrontOrdersUrl: "storefrontOrdersUrl updateTest",
          storefrontAccountProfileUrl: null
       }
     }
  ) {
    clientMutationId
    shop {
      _id
      storefrontUrls {
        storefrontHomeUrl
        storefrontOrderUrl
        storefrontOrdersUrl
        storefrontAccountProfileUrl
      }
    }
  }
}
```