### PR TITLE
fix: race condition by awaiting each publish catalog function by type…

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/utils/createCatalogProduct.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/createCatalogProduct.js
@@ -252,10 +252,11 @@ export default async function createCatalogProduct(product, context) {
   const catalogProduct = await xformProduct({ collections, product, shop, variants });
 
   // Apply custom transformations from plugins.
-  getFunctionsOfType("publishProductToCatalog").forEach((customPublishFunc) => {
+  for (const customPublishFn of getFunctionsOfType("publishProductToCatalog")) {
     // Functions of type "publishProductToCatalog" are expected to mutate the provided catalogProduct.
-    customPublishFunc(catalogProduct, { context, product, shop, variants });
-  });
+    // eslint-disable-next-line no-await-in-loop
+    await customPublishFn(catalogProduct, { context, product, shop, variants });
+  }
 
   return catalogProduct;
 }


### PR DESCRIPTION
Resolves 
Impact: **critical**  
Type: **bugfix**

## Issue
`publishProductToCatalog` function by type would be called synchronously, this would cause partial/incomplete Catalog publish if any of the functions by type were trying to do async operations.

## Solution
Await the custom function by type calls for the `publishProductToCatalog` function.

## Breaking changes
N/A

## Testing
1. As an admin "create" and "publish" a new Product.
2. As an Admin "edit" an existing Product and "publish"
