### PR TITLE
(fix) detect and add a newline in .env file if its missing

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -23,7 +23,7 @@ function main() {
 }
 
 function file_ends_with_newline() {
-    [[ $(tail -c1 "${env_file}" | wc -l) -gt 0 ]]
+  [[ $(tail -c1 "${env_file}" | wc -l) -gt 0 ]]
 }
 
 function add_new_env_vars() {

--- a/bin/setup
+++ b/bin/setup
@@ -34,9 +34,8 @@ function add_new_env_vars() {
   }
 
   # if the file does not end with new line add a new line to it
-  if ! file_ends_with_newline
-    then
-      echo "" >> "${env_file}"
+  if ! file_ends_with_newline; then
+    echo "" >> "${env_file}"
   fi
 
   find . -name .env.example -type f -print0 |

--- a/bin/setup
+++ b/bin/setup
@@ -22,12 +22,22 @@ function main() {
   add_new_env_vars
 }
 
+function file_ends_with_newline() {
+    [[ $(tail -c1 "${env_file}" | wc -l) -gt 0 ]]
+}
+
 function add_new_env_vars() {
   # create .env and set perms if it does not exist
   [[ ! -f "${env_file}" ]] && {
     touch "${env_file}"
     chmod 0600 "${env_file}"
   }
+
+  # if the file does not end with new line add a new line to it
+  if ! file_ends_with_newline
+    then
+      echo "" >> "${env_file}"
+  fi
 
   find . -name .env.example -type f -print0 |
     (xargs -0 grep -Ehv '^\s*#' || true) |


### PR DESCRIPTION
Resolves #5111 
Impact: **minor**  
Type: **bugfix**

## Issue
Following are the steps to reproduce the issue:
1) Remove the newline from .env file. If the editor does not allow it use 
    echo -n FOO=foo >> .env
2) Add a new property in .env.example file. (Lets say we add A=a)
3) Run ./bin/setup

Expected result : 
.env should end as follows -
FOO=foo
A=a

Actual result : 
.env ends as follows - 
FOO=fooA=a

Root Cause:
This happens as the ./bin/setup script does not check if the .env file ends with a newline, and appends the variables from .env.example. 

## Solution
Add a check in ./bin/setup script to check if .env ends with a newline, if it doesn't append a new line to it first.

## Breaking changes
None


## Testing
Scenario 1:
1) .env file does not end with newline. Following is the screenshot of .env before running the script:
<img width="405" alt="Screenshot 2019-04-29 at 8 31 03 PM" src="https://user-images.githubusercontent.com/50069787/56921465-bb955500-6abd-11e9-9135-b709b1a496e6.png">

2) Add 'A=a' in .env.example
3) Run ./bin/setup
4) Verify that the new property has been added with a new line. Following is the screenshot of .env file after performing Step3 above : 
<img width="393" alt="Screenshot 2019-04-29 at 8 35 09 PM" src="https://user-images.githubusercontent.com/50069787/56921679-4d9d5d80-6abe-11e9-8548-89fefcde9c3b.png">

Scenario 2:
1) .env file ends with newline. Following is the screenshot of .env before running the script:
<img width="406" alt="Screenshot 2019-04-29 at 8 36 46 PM" src="https://user-images.githubusercontent.com/50069787/56921763-863d3700-6abe-11e9-977a-b0850c754ed1.png">

2) Add 'A=a' in .env.example
3) Run ./bin/setup
4) Verify that the new property has been added and no new line has been introduced. Following is the screenshot of .env file after performing Step3 above : 
<img width="398" alt="Screenshot 2019-04-29 at 8 38 20 PM" src="https://user-images.githubusercontent.com/50069787/56921865-c3a1c480-6abe-11e9-871a-2eb9d20b34f5.png">
