### PR TITLE
Taxation based on origin

### DIFF
--- a/imports/plugins/included/taxes-rates/client/settings/custom.html
+++ b/imports/plugins/included/taxes-rates/client/settings/custom.html
@@ -32,6 +32,7 @@
             <span class="help-block">{{afFieldMessage name="region"}}</span>
           {{/if}}
           {{> afQuickField name='postal' class='form-control' placeholder="Postal Code"}}
+          {{> afQuickField name='taxLocale' options=localeOptions class='form-control'}}
           {{> afQuickField name='taxCode' class='form-control' placeholder="Tax only products with this tax code (optional)"}}
           {{> afQuickField name='rate' class='form-control' placeholder="Rate as a percentage"}}
         </div>
@@ -63,6 +64,7 @@
           {{/if}}
 
           {{> afQuickField name='postal' class='form-control' placeholder="Postal Code"}}
+          {{> afQuickField name='taxLocale' options=localeOptions class='form-control'}}
           {{> afQuickField name='rate' class='form-control' placeholder="Rate as a percentage"}}
         </div>
         {{> taxSettingsSubmitButton instance=instance}}

--- a/imports/plugins/included/taxes-rates/client/settings/custom.js
+++ b/imports/plugins/included/taxes-rates/client/settings/custom.js
@@ -124,6 +124,8 @@ Template.customTaxRates.helpers({
   countryOptions() {
     return Countries.find().fetch();
   },
+  // list of options for taxation location
+  localeOptions: TaxSchema.getAllowedValuesForKey("taxLocale").map((location) => ({ label: location, value: location })),
   statesForCountry() {
     const shop = Shops.findOne();
     const selectedCountry = AutoForm.getFieldValue("country");

--- a/imports/plugins/included/taxes-rates/server/no-meteor/util/calculateOrderTaxes.js
+++ b/imports/plugins/included/taxes-rates/server/no-meteor/util/calculateOrderTaxes.js
@@ -3,29 +3,46 @@ import Random from "@reactioncommerce/random";
 const TAX_SERVICE_NAME = "custom-rates";
 
 /**
- * @summary Gets all applicable tax definitions based on shop ID and shipping address of a fulfillment group
+ * @summary Gets all applicable tax definitions based on shop ID and shipping address or origin addres
+ * of a fulfillment group
  * @param {Object} collections Map of MongoDB collections
  * @param {Object} order The order
  * @returns {Object[]} Array of tax definition docs
  */
 async function getTaxesForShop(collections, order) {
   const { Taxes } = collections;
-  const { shippingAddress, shopId } = order;
+  const { originAddress, shippingAddress, shopId } = order;
 
   // Find all defined taxes where the shipping address is a match
   const taxDocs = await Taxes.find({
     shopId,
-    taxLocale: "destination",
     $or: [{
-      postal: shippingAddress.postal
-    }, {
-      postal: null,
-      region: shippingAddress.region,
-      country: shippingAddress.country
-    }, {
-      postal: null,
-      region: null,
-      country: shippingAddress.country
+      taxLocale: "destination",
+      $or: [{
+        postal: shippingAddress.postal
+      }, {
+        postal: null,
+        region: shippingAddress.region,
+        country: shippingAddress.country
+      }, {
+        postal: null,
+        region: null,
+        country: shippingAddress.country
+      }]
+    },
+    {
+      taxLocale: "origin",
+      $or: [{
+        postal: originAddress.postal
+      }, {
+        postal: null,
+        region: originAddress.region,
+        country: originAddress.country
+      }, {
+        postal: null,
+        region: null,
+        country: originAddress.country
+      }]
     }]
   }).toArray();
 
@@ -45,9 +62,9 @@ async function getTaxesForShop(collections, order) {
  * @returns {Object|null} Calculated tax information, in `TaxServiceResult` schema, or `null` if can't calculate
  */
 export default async function calculateOrderTaxes({ context, order }) {
-  const { items, shippingAddress } = order;
+  const { items, originAddress, shippingAddress } = order;
 
-  if (!shippingAddress) return null;
+  if (!shippingAddress && !originAddress) return null;
 
   const allTaxes = await getTaxesForShop(context.collections, order);
 


### PR DESCRIPTION
Resolves #5166   
Impact: **minor**  
Type: **feature**

## Issue
The Taxes schemas in taxes-rates and taxes provide fields to specify whether a tax should be applied based on the destination or origin of an order. This setting can neither be edited in the backend nor are taxes based on the origin applied.

## Solution
It is possible to chose between available values for `taxLocale` in tax settings (currently "destination" and "origin"). Both types of taxes, those applied based on the origin and those applied based on the destination are used when calculating taxes.

## Testing
1. Go to the Taxes section in operator ui
2. Add or edit a custom rate
3. Set the value of "Taxation Location" to "origin"
4. Make sure that the shop's address lies in a jurisdiction where the tax is applied
5. Buy an item for which the tax is applied
6. Note that the tax is calculated for the item during checkout