### PR TITLE
Feat #63 accounts language email

### DIFF
--- a/imports/collections/schemas/accounts.js
+++ b/imports/collections/schemas/accounts.js
@@ -73,6 +73,11 @@ export const Profile = new SimpleSchema({
     optional: true,
     mockValue: null
   },
+  "language": {
+    label: "User Language",
+    type: String,
+    optional: true
+  },
   "preferences": {
     label: "User preferences",
     type: Object,

--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -458,7 +458,7 @@ export const Order = new SimpleSchema({
   "history.$": History,
   "language": {
     type: String,
-    defaultValue: "test"
+    optional: true
   },
   "notes": {
     type: Array,

--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -205,10 +205,6 @@ export const OrderItem = new SimpleSchema({
   "history.$": {
     type: History
   },
-  "language": {
-    type: String,
-    optional: true
-  },
   "optionTitle": {
     type: String,
     optional: true
@@ -460,6 +456,10 @@ export const Order = new SimpleSchema({
     optional: true
   },
   "history.$": History,
+  "language": {
+    type: String,
+    defaultValue: "test"
+  },
   "notes": {
     type: Array,
     optional: true

--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -205,6 +205,10 @@ export const OrderItem = new SimpleSchema({
   "history.$": {
     type: History
   },
+  "language": {
+    type: String,
+    optional: true
+  },
   "optionTitle": {
     type: String,
     optional: true

--- a/imports/plugins/core/accounts/server/methods/index.js
+++ b/imports/plugins/core/accounts/server/methods/index.js
@@ -13,6 +13,7 @@ import removeEmailAddress from "./removeEmailAddress";
 import removeUserPermissions from "./removeUserPermissions";
 import sendResetPasswordEmail from "./sendResetPasswordEmail";
 import setProfileCurrency from "./setProfileCurrency";
+import setProfileLanguage from "./setProfileLanguage";
 import setUserPermissions from "./setUserPermissions";
 import updateEmailAddress from "./updateEmailAddress";
 import updateServiceConfiguration from "./updateServiceConfiguration";
@@ -47,6 +48,7 @@ export default {
   "accounts/removeUserPermissions": removeUserPermissions,
   "accounts/sendResetPasswordEmail": sendResetPasswordEmail,
   "accounts/setProfileCurrency": setProfileCurrency,
+  "accounts/setProfileLanguage": setProfileLanguage,
   "accounts/setUserPermissions": setUserPermissions,
   "accounts/updateEmailAddress": updateEmailAddress,
   "accounts/updateServiceConfiguration": updateServiceConfiguration,

--- a/imports/plugins/core/accounts/server/methods/inviteShopMember.js
+++ b/imports/plugins/core/accounts/server/methods/inviteShopMember.js
@@ -116,9 +116,12 @@ export default function inviteShopMember(options) {
 
   dataForEmail.groupName = _.startCase(group.name);
 
+  const account = Accounts.findOne({ userId });
+  const language = account && account.profile && account.profile.language;
+
   // Compile Email with SSR
-  SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl));
-  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
+  SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl, language));
+  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl, language));
 
   // send invitation email from primary shop email
   Reaction.Email.send({
@@ -128,5 +131,5 @@ export default function inviteShopMember(options) {
     html: SSR.render(tpl, dataForEmail)
   });
 
-  return Accounts.findOne({ userId });
+  return account;
 }

--- a/imports/plugins/core/accounts/server/methods/inviteShopOwner.js
+++ b/imports/plugins/core/accounts/server/methods/inviteShopOwner.js
@@ -4,6 +4,7 @@ import { Meteor } from "meteor/meteor";
 import { Accounts as MeteorAccounts } from "meteor/accounts-base";
 import { check, Match } from "meteor/check";
 import { SSR } from "meteor/meteorhacks:ssr";
+import { Accounts } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
 import getCurrentUserName from "../no-meteor/util/getCurrentUserName";

--- a/imports/plugins/core/accounts/server/methods/inviteShopOwner.js
+++ b/imports/plugins/core/accounts/server/methods/inviteShopOwner.js
@@ -55,8 +55,11 @@ export default function inviteShopOwner(options, shopData) {
   const tpl = "accounts/inviteShopOwner";
   const subject = "accounts/inviteShopOwner/subject";
 
-  SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl));
-  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
+  const account = Accounts.findOne({ userId }, { _id: 0, profile: 1 });
+  const language = account && account.profile && account.profile.language;
+
+  SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl, language));
+  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl, language));
 
   const emailLogo = Reaction.Email.getShopLogo(primaryShop);
   const token = Random.id();

--- a/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
+++ b/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
@@ -1,4 +1,5 @@
 import { check, Match } from "meteor/check";
+import R from "ramda";
 import { Accounts, Shops } from "/lib/collections";
 import appEvents from "/imports/node-app/core/util/appEvents";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
@@ -28,14 +29,12 @@ export default function setProfileLanguage(languageCode, accountId) {
     throw new ReactionError("access-denied", "Access denied");
   }
 
-  // Make sure this language code is in the related shop languages list
   const primaryShopLanguages = Reaction.getPrimaryShopLanguages();
 
-  // try to find language in shop
-  const language = primaryShopLanguages.find((shopLanguage) => shopLanguage.i18n === languageCode && shopLanguage.enabled);
+  const primaryShopLanguage = R.find((shopLanguage) => shopLanguage.i18n === languageCode && shopLanguage.enabled)(primaryShopLanguages)
 
-  if (!language) {
-    throw new ReactionError("invalid-argument", `The shop for this account does not define any language with code "${languageCode}"`);
+  if (!primaryShopLanguage) {
+    throw new ReactionError("invalid-argument", `Primary shop does not define any enabled language with code "${languageCode}"`);
   }
 
   Accounts.update({ userId }, { $set: { "profile.language": languageCode } });

--- a/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
+++ b/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
@@ -1,6 +1,6 @@
 import { check, Match } from "meteor/check";
 import R from "ramda";
-import { Accounts, Shops } from "/lib/collections";
+import { Accounts } from "/lib/collections";
 import appEvents from "/imports/node-app/core/util/appEvents";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
@@ -31,7 +31,7 @@ export default function setProfileLanguage(languageCode, accountId) {
 
   const primaryShopLanguages = Reaction.getPrimaryShopLanguages();
 
-  const primaryShopLanguage = R.find((shopLanguage) => shopLanguage.i18n === languageCode && shopLanguage.enabled)(primaryShopLanguages)
+  const primaryShopLanguage = R.find((shopLanguage) => shopLanguage.i18n === languageCode && shopLanguage.enabled)(primaryShopLanguages);
 
   if (!primaryShopLanguage) {
     throw new ReactionError("invalid-argument", `Primary shop does not define any enabled language with code "${languageCode}"`);

--- a/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
+++ b/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
@@ -29,14 +29,10 @@ export default function setProfileLanguage(languageCode, accountId) {
   }
 
   // Make sure this language code is in the related shop languages list
-  const shop = Shops.findOne({ _id: account.shopId }, { fields: { languages: 1 } });
-
-  if (!shop || !shop.languages) {
-    throw new ReactionError("invalid-argument", `The shop for this account does not define any language with code "${languageCode}"`);
-  }
+  const primaryShopLanguages = Reaction.getPrimaryShopLanguages();
 
   // try to find language in shop
-  const language = shop.languages.find((shopLanguage) => shopLanguage.i18n === languageCode && shopLanguage.enabled);
+  const language = primaryShopLanguages.find((shopLanguage) => shopLanguage.i18n === languageCode && shopLanguage.enabled);
 
   if (!language) {
     throw new ReactionError("invalid-argument", `The shop for this account does not define any language with code "${languageCode}"`);

--- a/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
+++ b/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
@@ -1,0 +1,55 @@
+import { check, Match } from "meteor/check";
+import { Accounts, Shops } from "/lib/collections";
+import appEvents from "/imports/node-app/core/util/appEvents";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import ReactionError from "@reactioncommerce/reaction-error";
+
+/**
+ * @name accounts/setProfileLanguage
+ * @memberof Accounts/Methods
+ * @method
+ * @param {String} languageCode - i18n language code
+ * @param {String} [accountId] - accountId of user to set language of. Defaults to current user ID
+ * @summary Sets users profile language
+ * @returns {Object} Account document
+ */
+export default function setProfileLanguage(languageCode, accountId) {
+  check(languageCode, String);
+  check(accountId, Match.Maybe(String));
+
+  const currentUserId = this.userId;
+  const userId = accountId || currentUserId;
+  if (!userId) throw new ReactionError("access-denied", "You must be logged in to set profile language");
+
+  const account = Accounts.findOne({ userId }, { fields: { shopId: 1 } });
+  if (!account) throw new ReactionError("not-found", "Account not found");
+
+  if (userId !== currentUserId && !Reaction.hasPermission("reaction-accounts", currentUserId, account.shopId)) {
+    throw new ReactionError("access-denied", "Access denied");
+  }
+
+  // Make sure this language code is in the related shop languages list
+  const shop = Shops.findOne({ _id: account.shopId }, { fields: { languages: 1 } });
+
+  if (!shop || !shop.languages) {
+    throw new ReactionError("invalid-argument", `The shop for this account does not define any language with code "${languageCode}"`);
+  }
+
+  // try to find language in shop
+  const language = shop.languages.find((shopLanguage) => shopLanguage.i18n === languageCode);
+
+  if (!language) {
+    throw new ReactionError("invalid-argument", `The shop for this account does not define any language with code "${languageCode}"`);
+  }
+
+  Accounts.update({ userId }, { $set: { "profile.language": languageCode } });
+
+  const updatedAccount = Accounts.findOne({ userId });
+  Promise.await(appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: currentUserId,
+    updatedFields: ["profile.language"]
+  }));
+
+  return updatedAccount;
+}

--- a/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
+++ b/imports/plugins/core/accounts/server/methods/setProfileLanguage.js
@@ -36,7 +36,7 @@ export default function setProfileLanguage(languageCode, accountId) {
   }
 
   // try to find language in shop
-  const language = shop.languages.find((shopLanguage) => shopLanguage.i18n === languageCode);
+  const language = shop.languages.find((shopLanguage) => shopLanguage.i18n === languageCode && shopLanguage.enabled);
 
   if (!language) {
     throw new ReactionError("invalid-argument", `The shop for this account does not define any language with code "${languageCode}"`);

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/index.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/index.js
@@ -8,6 +8,7 @@ export default {
   _id: (account) => encodeAccountOpaqueId(account._id),
   addressBook,
   currency: (account) => getXformedCurrencyByCode(account.profile && account.profile.currency),
+  language: (account) => account.profile && account.profile.language,
   emailRecords: (account) => account.emails,
   preferences: (account) => get(account, "profile.preferences"),
   primaryEmailAddress: (account) => {

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/index.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/index.js
@@ -4,6 +4,7 @@ import inviteShopMember from "./inviteShopMember";
 import removeAccountAddressBookEntry from "./removeAccountAddressBookEntry";
 import removeAccountFromGroup from "./removeAccountFromGroup";
 import setAccountProfileCurrency from "./setAccountProfileCurrency";
+import setAccountProfileLanguage from "./setAccountProfileLanguage";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry";
 
 export default {
@@ -13,5 +14,6 @@ export default {
   removeAccountAddressBookEntry,
   removeAccountFromGroup,
   setAccountProfileCurrency,
+  setAccountProfileLanguage,
   updateAccountAddressBookEntry
 };

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/setAccountProfileLanguage.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/setAccountProfileLanguage.js
@@ -1,0 +1,25 @@
+import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
+
+/**
+ * @name "Mutation.setAccountProfileLanguage"
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver for the setAccountProfileLanguage GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} [args.input.accoundId] - The account ID, which defaults to the viewer account
+ * @param {String} args.input.languageCode - The languageCode to add to user profile
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @return {Object} setAccountProfileLanguage
+ */
+export default function setAccountProfileLanguage(_, { input }, context) {
+  const { accountId, languageCode, clientMutationId = null } = input;
+  const dbAccountId = decodeAccountOpaqueId(accountId);
+  const updatedAccount = context.callMeteorMethod("accounts/setProfileLanguage", languageCode, dbAccountId);
+
+  return {
+    account: updatedAccount,
+    clientMutationId
+  };
+}

--- a/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
+++ b/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
@@ -60,6 +60,18 @@ input SetAccountProfileCurrencyInput {
   currencyCode: String!
 }
 
+"Describes an account profile language change"
+input SetAccountProfileLanguageInput {
+  "The account ID, which defaults to the viewer account"
+  accountId: ID
+
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "The language code"
+  languageCode: String!
+}
+
 "Defines a new Email and the account to which it should be added"
 input AddAccountEmailRecordInput {
   "The account ID, which defaults to the viewer account"
@@ -123,6 +135,9 @@ type Account implements Node {
 
   "The preferred currency used by this account"
   currency: Currency
+
+  "The preferred language used by this account"
+  language: String
 
   "A list of email records associated with this account"
   emailRecords: [EmailRecord]
@@ -228,6 +243,15 @@ type SetAccountProfileCurrencyPayload {
   clientMutationId: String
 }
 
+"The response from the `setAccountProfileLanguage` mutation"
+type SetAccountProfileLanguagePayload {
+  "The updated account"
+  account: Account
+
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+}
+
 extend type Mutation {
   "Add a new address to the `addressBook` field for an account"
   addAccountAddressBookEntry(input: AddAccountAddressBookEntryInput!): AddAccountAddressBookEntryPayload
@@ -243,6 +267,9 @@ extend type Mutation {
 
   "Set the preferred currency for an account"
   setAccountProfileCurrency(input: SetAccountProfileCurrencyInput!): SetAccountProfileCurrencyPayload
+
+  "Set the preferred language for an account"
+  setAccountProfileLanguage(input: SetAccountProfileLanguageInput!): SetAccountProfileLanguagePayload
 
   "Remove an address that exists in the `addressBook` field for an account"
   updateAccountAddressBookEntry(input: UpdateAccountAddressBookEntryInput!): UpdateAccountAddressBookEntryPayload

--- a/imports/plugins/core/accounts/server/util/sendVerificationEmail.js
+++ b/imports/plugins/core/accounts/server/util/sendVerificationEmail.js
@@ -2,7 +2,8 @@ import _ from "lodash";
 import Logger from "@reactioncommerce/logger";
 import Random from "@reactioncommerce/random";
 import { Meteor } from "meteor/meteor";
-import { Accounts } from "meteor/accounts-base";
+import { Accounts as MeteorAccounts } from "meteor/accounts-base";
+import { Accounts } from "/lib/collections";
 import { SSR } from "meteor/meteorhacks:ssr";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import ReactionError from "@reactioncommerce/reaction-error";
@@ -66,7 +67,7 @@ export default async function sendVerificationEmail({
   });
 
   const shopName = Reaction.getShopName();
-  const url = Accounts.urls.verifyEmail(token);
+  const url = MeteorAccounts.urls.verifyEmail(token);
   const copyrightDate = new Date().getFullYear();
 
   const dataForEmail = {
@@ -117,8 +118,11 @@ export default async function sendVerificationEmail({
     `);
   }
 
-  SSR.compileTemplate(bodyTemplate, Reaction.Email.getTemplate(bodyTemplate));
-  SSR.compileTemplate(subjectTemplate, Reaction.Email.getSubject(bodyTemplate));
+  const account = Accounts.findOne({ userId }, { _id: 0, profile: 1 });
+  const language = account && account.profile && account.profile.language;
+
+  SSR.compileTemplate(bodyTemplate, Reaction.Email.getTemplate(bodyTemplate, language));
+  SSR.compileTemplate(subjectTemplate, Reaction.Email.getSubject(bodyTemplate, language));
 
   return Reaction.Email.send({
     to: address,

--- a/imports/plugins/core/accounts/server/util/sendWelcomeEmail.js
+++ b/imports/plugins/core/accounts/server/util/sendWelcomeEmail.js
@@ -82,8 +82,9 @@ export default function sendWelcomeEmail(shopId, userId, token) {
 
   const tpl = "accounts/sendWelcomeEmail";
   const subject = "accounts/sendWelcomeEmail/subject";
-  SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl));
-  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
+  const language = account && account.profile && account.profile.language;
+  SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl, language));
+  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl, language));
 
   Reaction.Email.send({
     to: userEmail,

--- a/imports/plugins/core/core/server/Reaction/Email/getSubject.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getSubject.js
@@ -35,7 +35,7 @@ export default function getSubject(template, language) {
 
     // use that template if found
     if (tmpl && tmpl.template) {
-      return tmpl.template;
+      return tmpl.subject;
     }
   }
 

--- a/imports/plugins/core/core/server/Reaction/Email/getSubject.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getSubject.js
@@ -29,6 +29,7 @@ export default function getSubject(template, language) {
   if (language !== undefined) {
     // check database for a matching template using language param
     const tmpl = Templates.findOne({
+      enabled: true,
       name: template,
       language
     });

--- a/imports/plugins/core/core/server/Reaction/Email/getSubject.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getSubject.js
@@ -30,7 +30,7 @@ export default function getSubject(template, language) {
     // check database for a matching template using language param
     const tmpl = Templates.findOne({
       name: template,
-      language: language
+      language
     });
 
     // use that template if found

--- a/imports/plugins/core/core/server/Reaction/Email/getSubject.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getSubject.js
@@ -10,17 +10,21 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * layout must be defined + template
  * @example SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
  * @param {String} template name of the template in either Layouts or fs
+ * @param {String} [language=Reaction.getShopLanguage()] language of a template
  * @returns {Object} returns source
  */
-export default function getSubject(template) {
+export default function getSubject(template, language = Reaction.getShopLanguage()) {
   if (typeof template !== "string") {
     const msg = "Reaction.Email.getSubject() requires a template name";
     Logger.error(msg);
     throw new ReactionError("invalid-parameter", msg);
   }
 
-  // set default
-  const language = Reaction.getShopLanguage();
+  if (typeof language !== "string") {
+    const msg = "Reaction.Email.getSubject() requires optional language code that is a string";
+    Logger.error(msg);
+    throw new ReactionError("invalid-parameter", msg);
+  }
 
   // check database for a matching template
   const tmpl = Templates.findOne({

--- a/imports/plugins/core/core/server/Reaction/Email/getSubject.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getSubject.js
@@ -10,26 +10,39 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * layout must be defined + template
  * @example SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
  * @param {String} template name of the template in either Layouts or fs
- * @param {String} [language=Reaction.getShopLanguage()] language of a template
+ * @param {String} [language] i18n language of a template
  * @returns {Object} returns source
  */
-export default function getSubject(template, language = Reaction.getShopLanguage()) {
+export default function getSubject(template, language) {
   if (typeof template !== "string") {
     const msg = "Reaction.Email.getSubject() requires a template name";
     Logger.error(msg);
     throw new ReactionError("invalid-parameter", msg);
   }
 
-  if (typeof language !== "string") {
+  if (language !== undefined && typeof language !== "string") {
     const msg = "Reaction.Email.getSubject() requires optional language code that is a string";
     Logger.error(msg);
     throw new ReactionError("invalid-parameter", msg);
   }
 
-  // check database for a matching template
+  if (language !== undefined) {
+    // check database for a matching template using language param
+    const tmpl = Templates.findOne({
+      name: template,
+      language: language
+    });
+
+    // use that template if found
+    if (tmpl && tmpl.template) {
+      return tmpl.template;
+    }
+  }
+
+  // check database for a matching template using shop language
   const tmpl = Templates.findOne({
     name: template,
-    language
+    language: Reaction.getShopLanguage()
   });
 
   // use that template if found

--- a/imports/plugins/core/core/server/Reaction/Email/getTemplate.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getTemplate.js
@@ -30,7 +30,7 @@ export default function getTemplate(template, language) {
     // check database for a matching template using language param
     const tmpl = Templates.findOne({
       name: template,
-      language: language
+      language
     });
 
     // use that template if found

--- a/imports/plugins/core/core/server/Reaction/Email/getTemplate.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getTemplate.js
@@ -29,6 +29,7 @@ export default function getTemplate(template, language) {
   if (language !== undefined) {
     // check database for a matching template using language param
     const tmpl = Templates.findOne({
+      enabled: true,
       name: template,
       language
     });

--- a/imports/plugins/core/core/server/Reaction/Email/getTemplate.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getTemplate.js
@@ -10,26 +10,39 @@ import getTemplateFile from "./getTemplateFile";
  * @summary Returns a template source for SSR consumption. layout must be defined + template
  * @example Reaction.Email.getTemplate('path/of/template');
  * @param {String} template name of the template in either Layouts or fs
- * @param {String} [language=Reaction.getShopLanguage()] language of a template
+ * @param {String} [language] i18n language of a template
  * @returns {Object} returns source
  */
-export default function getTemplate(template, language = Reaction.getShopLanguage()) {
+export default function getTemplate(template, language) {
   if (typeof template !== "string") {
     const msg = "Reaction.Email.getTemplate() requires a template name";
     Logger.error(msg);
     throw new ReactionError("invalid-parameter", msg);
   }
 
-  if (typeof language !== "string") {
+  if (language !== undefined && typeof language !== "string") {
     const msg = "Reaction.Email.getTemplate() requires optional language code that is a string";
     Logger.error(msg);
     throw new ReactionError("invalid-parameter", msg);
   }
 
-  // check database for a matching template
+  if (language !== undefined) {
+    // check database for a matching template using language param
+    const tmpl = Templates.findOne({
+      name: template,
+      language: language
+    });
+
+    // use that template if found
+    if (tmpl && tmpl.template) {
+      return tmpl.template;
+    }
+  }
+
+  // check database for a matching template using shop language
   const tmpl = Templates.findOne({
     name: template,
-    language
+    language: Reaction.getShopLanguage()
   });
 
   // use that template if found

--- a/imports/plugins/core/core/server/Reaction/Email/getTemplate.js
+++ b/imports/plugins/core/core/server/Reaction/Email/getTemplate.js
@@ -10,17 +10,21 @@ import getTemplateFile from "./getTemplateFile";
  * @summary Returns a template source for SSR consumption. layout must be defined + template
  * @example Reaction.Email.getTemplate('path/of/template');
  * @param {String} template name of the template in either Layouts or fs
+ * @param {String} [language=Reaction.getShopLanguage()] language of a template
  * @returns {Object} returns source
  */
-export default function getTemplate(template) {
+export default function getTemplate(template, language = Reaction.getShopLanguage()) {
   if (typeof template !== "string") {
     const msg = "Reaction.Email.getTemplate() requires a template name";
     Logger.error(msg);
     throw new ReactionError("invalid-parameter", msg);
   }
 
-  // set default
-  const language = Reaction.getShopLanguage();
+  if (typeof language !== "string") {
+    const msg = "Reaction.Email.getTemplate() requires optional language code that is a string";
+    Logger.error(msg);
+    throw new ReactionError("invalid-parameter", msg);
+  }
 
   // check database for a matching template
   const tmpl = Templates.findOne({

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -366,6 +366,21 @@ export default {
   },
 
   /**
+   * @name getPrimaryShopLanguages
+   * @method
+   * @memberof Core
+   * @summary Get primary shop array of languages
+   * @return {Object[]} array of languages
+   */
+  getPrimaryShopLanguages() {
+    const shop = Shops.findOne({
+      _id: this.getPrimaryShopId()
+    }, { languages: 1 });
+
+    return (shop && shop.languages) || [];
+  },
+
+  /**
    * @summary **DEPRECATED** This method has been deprecated in favor of using getShopId
    * and getPrimaryShopId. To be removed.
    * @deprecated

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -366,21 +366,6 @@ export default {
   },
 
   /**
-   * @name getPrimaryShopLanguages
-   * @method
-   * @memberof Core
-   * @summary Get primary shop array of languages
-   * @return {Object[]} array of languages
-   */
-  getPrimaryShopLanguages() {
-    const shop = Shops.findOne({
-      _id: this.getPrimaryShopId()
-    }, { languages: 1 });
-
-    return (shop && shop.languages) || [];
-  },
-
-  /**
    * @summary **DEPRECATED** This method has been deprecated in favor of using getShopId
    * and getPrimaryShopId. To be removed.
    * @deprecated

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -175,7 +175,7 @@ export default async function placeOrder(context, input) {
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
   const { Orders, Shops } = collections;
 
-  const primaryShop = await Shops.findOne({ shopType: "primary"}, { languages: 1 });
+  const primaryShop = await Shops.findOne({ shopType: "primary" }, { languages: 1 });
   const primaryShopLanguages = (primaryShop && primaryShop.languages) || [];
   const primaryShopLanguage = R.find(R.whereEq({ enabled: true, i18n: language }))(primaryShopLanguages);
 

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -65,7 +65,7 @@ async function getCurrencyExchangeObject(collections, cartCurrencyCode, shopId, 
 }
 
 /**
- * @summary Gets an object of with languages array  
+ * @summary Gets an object of with languages array
  * @param {Object} collections Map of MongoDB collections
  * @param {String} shopId The ID of the shop that owns the order
  * @returns {Object} Object with `languages` property
@@ -75,7 +75,7 @@ function getShopLanguages(collections, shopId) {
 }
 
 /**
- * @summary Gets an object of with languages array  
+ * @summary Gets an object of with languages array
  * @param {String} language i18n language code
  * @param {Object[]} shopLanguages Array of languages
  * @returns {Object} Object with `languages` property
@@ -188,16 +188,16 @@ export default async function placeOrder(context, input) {
     customFields: customFieldsFromClient,
     email,
     fulfillmentGroups,
-    language,
     shopId
   } = orderInput;
+  let { language } = orderInput;
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
   const { Orders } = collections;
 
   const shop = getShopLanguages(collections, shopId);
 
   // set to undefined value so order language will not be set
-  if(language && !isShopLanguage(language, shop.languages)) {
+  if (!shop || (language && !isShopLanguage(language, shop.languages))) {
     language = undefined;
   }
 

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -178,8 +178,7 @@ export default async function placeOrder(context, input) {
 
   const primaryShopLanguages = Reaction.getPrimaryShopLanguages();
 
-  
-  const primaryShopLanguage = R.find(R.whereEq({ enabled: true, i18n: language}))(primaryShopLanguages);
+  const primaryShopLanguage = R.find(R.whereEq({ enabled: true, i18n: language }))(primaryShopLanguages);
   // set to undefined value so order language will not be set
   if (!primaryShopLanguage) {
     language = undefined;

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -65,6 +65,26 @@ async function getCurrencyExchangeObject(collections, cartCurrencyCode, shopId, 
 }
 
 /**
+ * @summary Gets an object of with languages array  
+ * @param {Object} collections Map of MongoDB collections
+ * @param {String} shopId The ID of the shop that owns the order
+ * @returns {Object} Object with `languages` property
+ */
+function getShopLanguages(collections, shopId) {
+  return collections.Shops.findOne({ _id: shopId }, { languages: 1 });
+}
+
+/**
+ * @summary Gets an object of with languages array  
+ * @param {String} language i18n language code
+ * @param {Object[]} shopLanguages Array of languages
+ * @returns {Object} Object with `languages` property
+ */
+function isShopLanguage(language, shopLanguages) {
+  return shopLanguages.find((shopLanguage) => shopLanguage.i18n === language && shopLanguage.enabled);
+}
+
+/**
  * @summary Create all authorized payments for a potential order
  * @param {String} [accountId] The ID of the account placing the order
  * @param {Object} [billingAddress] Billing address for the order as a whole
@@ -173,6 +193,13 @@ export default async function placeOrder(context, input) {
   } = orderInput;
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
   const { Orders } = collections;
+
+  const shop = getShopLanguages(collections, shopId);
+
+  // set to undefined value so order language will not be set
+  if(language && !isShopLanguage(language, shop.languages)) {
+    language = undefined;
+  }
 
   // We are mixing concerns a bit here for now. This is for backwards compatibility with current
   // discount codes feature. We are planning to revamp discounts soon, but until then, we'll look up

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -3,7 +3,6 @@ import R from "ramda";
 import Logger from "@reactioncommerce/logger";
 import Random from "@reactioncommerce/random";
 import ReactionError from "@reactioncommerce/reaction-error";
-import Reaction from "/imports/plugins/core/core/server/Reaction";
 import hashLoginToken from "/imports/node-app/core/util/hashLoginToken";
 import appEvents from "/imports/node-app/core/util/appEvents";
 import { Order as OrderSchema, Payment as PaymentSchema } from "/imports/collections/schemas";
@@ -174,11 +173,12 @@ export default async function placeOrder(context, input) {
   } = orderInput;
   let { language } = orderInput;
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
-  const { Orders } = collections;
+  const { Orders, Shops } = collections;
 
-  const primaryShopLanguages = Reaction.getPrimaryShopLanguages();
-
+  const primaryShop = await Shops.findOne({ shopType: "primary"}, { languages: 1 });
+  const primaryShopLanguages = (primaryShop && primaryShop.languages) || [];
   const primaryShopLanguage = R.find(R.whereEq({ enabled: true, i18n: language }))(primaryShopLanguages);
+
   // set to undefined value so order language will not be set
   if (!primaryShopLanguage) {
     language = undefined;

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -175,12 +175,19 @@ export default async function placeOrder(context, input) {
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
   const { Orders, Shops } = collections;
 
-  const primaryShop = await Shops.findOne({ shopType: "primary" }, { languages: 1 });
-  const primaryShopLanguages = (primaryShop && primaryShop.languages) || [];
-  const primaryShopLanguage = R.find(R.whereEq({ enabled: true, i18n: language }))(primaryShopLanguages);
+  // first search for shop based on account id
+  let shop = await Shops.findOne({ _id: shopId }, { languages: 1 });
+
+  if (!shop || !shop.languages || shop.languages.length === 0) {
+    // if non-primary shop does not have any languages use primary shop
+    shop = await Shops.findOne({ shopType: "primary" }, { languages: 1 });
+  }
+
+  const shopLanguages = (shop && shop.languages) || [];
+  const shopLanguage = R.find(R.whereEq({ enabled: true, i18n: language }))(shopLanguages);
 
   // set to undefined value so order language will not be set
-  if (!primaryShopLanguage) {
+  if (!shopLanguage) {
     language = undefined;
   }
 

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -168,6 +168,7 @@ export default async function placeOrder(context, input) {
     customFields: customFieldsFromClient,
     email,
     fulfillmentGroups,
+    language,
     shopId
   } = orderInput;
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
@@ -248,6 +249,7 @@ export default async function placeOrder(context, input) {
     currencyCode,
     discounts,
     email,
+    language,
     payments,
     referenceId: Random.id(),
     shipping: finalFulfillmentGroups,

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -315,6 +315,8 @@ type Order implements Node {
 
   "The date and time at which this order was last updated"
   updatedAt: DateTime!
+
+  language: String
 }
 
 type OrderNote {
@@ -437,6 +439,8 @@ input OrderInput {
   order, and those shop IDs may or may not match this one.
   """
   shopId: String!
+
+  language: String
 }
 
 input PaymentInput {

--- a/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
+++ b/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
@@ -230,6 +230,10 @@ export const orderInputSchema = new SimpleSchema({
     minCount: 1
   },
   "fulfillmentGroups.$": orderFulfillmentGroupInputSchema,
+  language: {
+    type: String,
+    optional: true
+  },
   "shopId": String
 });
 

--- a/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
+++ b/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
@@ -230,7 +230,7 @@ export const orderInputSchema = new SimpleSchema({
     minCount: 1
   },
   "fulfillmentGroups.$": orderFulfillmentGroupInputSchema,
-  language: {
+  "language": {
     type: String,
     optional: true
   },

--- a/imports/plugins/core/orders/server/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/util/sendOrderEmail.js
@@ -271,10 +271,8 @@ export default function sendOrderEmail(order, action) {
 
   const account = Accounts.findOne({ _id: order.accountId }, { _id: 0, profile: 1 });
 
-  // check if account has language in profile
-  // if it doesn't use order language
-  // order language is not required and default will be used
-  const language = (account && account.profile && account.profile.language) || order.email;
+  // first try using account language, then try using order language
+  const language = (account && account.profile && account.profile.language) || order.language;
 
   SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl, language));
   SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl, language));

--- a/imports/plugins/core/orders/server/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/util/sendOrderEmail.js
@@ -65,7 +65,6 @@ function formatDateForEmail(date) {
 /**
  * @summary Sends an email about an order.
  * @param {Object} order - The order document
- * @param {String} userId - id of user to whome sendOrder is sent
  * @param {String} [action] - The action triggering the email
  * @returns {Boolean} True if sent; else false
  */

--- a/imports/plugins/core/orders/server/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/util/sendOrderEmail.js
@@ -269,7 +269,7 @@ export default function sendOrderEmail(order, action) {
     subject = `orders/${order.workflow.status}/subject`;
   }
 
-  const account = Accounts.findOne({ emails: order.emails }, { _id: 0, profile: 1 });
+  const account = Accounts.findOne({ "emails.address": order.email }, { _id: 0, profile: 1 });
   const language = account && account.profile && account.profile.language;
 
   SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl, language));

--- a/imports/plugins/core/orders/server/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/util/sendOrderEmail.js
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import Logger from "@reactioncommerce/logger";
 import { SSR } from "meteor/meteorhacks:ssr";
-import { Shops } from "/lib/collections";
+import { Accounts, Shops } from "/lib/collections";
 import Reaction from "/imports/plugins/core/core/server/Reaction";
 import formatMoney from "/imports/utils/formatMoney";
 import { Media } from "/imports/plugins/core/files/server";
@@ -65,6 +65,7 @@ function formatDateForEmail(date) {
 /**
  * @summary Sends an email about an order.
  * @param {Object} order - The order document
+ * @param {String} userId - id of user to whome sendOrder is sent
  * @param {String} [action] - The action triggering the email
  * @returns {Boolean} True if sent; else false
  */
@@ -269,8 +270,11 @@ export default function sendOrderEmail(order, action) {
     subject = `orders/${order.workflow.status}/subject`;
   }
 
-  SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl));
-  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl));
+  const account = Accounts.findOne({ emails: order.emails }, { _id: 0, profile: 1 });
+  const language = account && account.profile && account.profile.language;
+
+  SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl, language));
+  SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl, language));
 
   Reaction.Email.send({
     to: order.email,

--- a/imports/plugins/core/orders/server/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/util/sendOrderEmail.js
@@ -269,8 +269,12 @@ export default function sendOrderEmail(order, action) {
     subject = `orders/${order.workflow.status}/subject`;
   }
 
-  const account = Accounts.findOne({ "emails.address": order.email }, { _id: 0, profile: 1 });
-  const language = account && account.profile && account.profile.language;
+  const account = Accounts.findOne({ _id: order.accountId }, { _id: 0, profile: 1 });
+
+  // check if account has language in profile
+  // if it doesn't use order language
+  // order language is not required and default will be used
+  const language = (account && account.profile && account.profile.language) || order.email;
 
   SSR.compileTemplate(tpl, Reaction.Email.getTemplate(tpl, language));
   SSR.compileTemplate(subject, Reaction.Email.getSubject(tpl, language));


### PR DESCRIPTION
Resolves #63
Impact: **minor**  
Type: **feature**

## Issue
Currently all emails are sent based on language (field in mongodb) of the shop account belongs to. This means users cannot specify which language emails they want to receive. Similar for anonymous purchases.

## Solution
With this solution:
* Users can set their profile language
* All emails which are sent to accounts (not anonymous) are in language of their profile 
* Anonymous Orders can accept optional field language and then emails are sent based on this order email

## Overview
If user / order does not have specified account it still looks at shop language to find template.

* Added language field in Accounts.profile document
* Added language field in Order document
* Add graphQL query, mutation, resolvers to set and get language of account
* Modify getTemplate and getSubject to accept additional parameter language
* Modify functions where getTemplate and getSubject are used to get language for the email

## Breaking changes
There are no breaking changes.

## Testing
TBD
