### PR TITLE
fix: Remove product-admin dead import

### DIFF
--- a/imports/plugins/included/product-admin/client/components/index.js
+++ b/imports/plugins/included/product-admin/client/components/index.js
@@ -1,1 +1,0 @@
-export { default as ProductAdmin } from "./productAdmin.js";


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #5179  
Impact: **minor**  
Type: **bugfix**

## Issue
`/imports/plugins/included/product-admin/client/components/index.js` contains an import/export for `./productAdmin.js`, which doesn't exist anymore.

For some reason, it would **sometimes** make the Products link in the operator sidebar disappear, along with showing an error about this file not existing in the client-side console. I still can't understand why this behavior isn't consistent.

## Solution
Remove the dead import. As `/imports/plugins/included/product-admin/client/components/index.js` contains just this import, we can even remove the whole file.

## Breaking changes
None.


## Testing
1. Open the Operator.
2. Notice that the Products link shows up and works every time.