### PR TITLE
fix: #5182 add subtotal display amount to dataForOrderEmail

### DIFF
--- a/imports/plugins/core/orders/server/no-meteor/util/getDataForOrderEmail.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/getDataForOrderEmail.js
@@ -106,6 +106,11 @@ export default async function getDataForOrderEmail(context, { order }) {
         // Add displayAmount to match user currency settings
         displayAmount: formatMoney(item.price.amount * userCurrencyExchangeRate, userCurrency)
       },
+      subtotal: {
+        ...item.subtotal,
+        // Add displayAmount to match user currency settings
+        displayAmount: formatMoney(item.subtotal.amount * userCurrencyExchangeRate, userCurrency)
+      },
       // These next two are for backward compatibility with existing email templates.
       // New templates should use `imageURLs` instead.
       productImage: item.imageURLs && item.imageURLs.large,

--- a/imports/plugins/core/orders/server/no-meteor/util/getDataForOrderEmail.test.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/getDataForOrderEmail.test.js
@@ -108,7 +108,8 @@ test("returns expected data structure", async () => {
         variantImage: "large.jpg",
         subtotal: {
           amount: jasmine.any(Number),
-          currencyCode: "mockCurrencyCode"
+          currencyCode: "mockCurrencyCode",
+          displayAmount: jasmine.any(String)
         }
       }
     ],

--- a/imports/plugins/core/orders/server/no-meteor/util/getDataForOrderEmail.test.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/getDataForOrderEmail.test.js
@@ -146,7 +146,8 @@ test("returns expected data structure", async () => {
               variantImage: "large.jpg",
               subtotal: {
                 amount: jasmine.any(Number),
-                currencyCode: "mockCurrencyCode"
+                currencyCode: "mockCurrencyCode",
+                displayAmount: jasmine.any(String)
               }
             }
           ]


### PR DESCRIPTION
Resolves #5182  
Impact: **minor**  
Type: **feature|bugfix**

## Issue
The Order Email's `getDataForOrderEmail` method's return object should also return `subtotal`'s displayAmount.

## Solution
Adds displayAmount to subtotal
Updates tests

## Testing
1. Run the test
1. Use `subtotal.displayAmount` in an email