### PR TITLE
Add a setting for whether options without inventory enabled are sellable

### DIFF
--- a/imports/node-app/devserver/registerPlugins.js
+++ b/imports/node-app/devserver/registerPlugins.js
@@ -1,4 +1,5 @@
 import registerInventoryPlugin from "/imports/plugins/core/inventory/server/no-meteor/register";
+import registerSettingsPlugin from "/imports/plugins/core/settings/server/register";
 import registerSimpleInventoryPlugin from "/imports/plugins/included/simple-inventory/server/no-meteor/register";
 import registerSimplePricingPlugin from "/imports/plugins/included/simple-pricing/server/no-meteor/register";
 
@@ -10,6 +11,7 @@ import registerSimplePricingPlugin from "/imports/plugins/included/simple-pricin
  */
 export default async function registerPlugins(app) {
   await registerInventoryPlugin(app);
+  await registerSettingsPlugin(app);
   await registerSimpleInventoryPlugin(app);
   await registerSimplePricingPlugin(app);
 }

--- a/imports/plugins/core/dashboard/client/components/StorefrontUrls.js
+++ b/imports/plugins/core/dashboard/client/components/StorefrontUrls.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import styled from "styled-components"; // TODO: remove ThemeProvder when Blaze wrapper is removed
+import styled from "styled-components";
 import { Form } from "reacto-form";
 import { Mutation } from "react-apollo";
 import Button from "@material-ui/core/Button";

--- a/imports/plugins/core/dashboard/client/components/StorefrontUrls.js
+++ b/imports/plugins/core/dashboard/client/components/StorefrontUrls.js
@@ -1,8 +1,7 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import styled, { ThemeProvider } from "styled-components"; // TODO: remove ThemeProvder when Blaze wrapper is removed
-import MuiThemeProvider from "@material-ui/core/styles/MuiThemeProvider"; // TODO: remove when Blaze wrapper is removed
+import styled from "styled-components"; // TODO: remove ThemeProvder when Blaze wrapper is removed
 import { Form } from "reacto-form";
 import { Mutation } from "react-apollo";
 import Button from "@material-ui/core/Button";
@@ -16,9 +15,6 @@ import Field from "@reactioncommerce/components/Field/v1";
 import TextInput from "@reactioncommerce/components/TextInput/v1";
 import { i18next } from "/client/api";
 import withPrimaryShop from "/imports/plugins/core/graphql/lib/hocs/withPrimaryShop";
-import theme from "imports/plugins/core/router/client/theme"; // TODO: remove when Blaze wrapper is removed
-import muiTheme from "imports/plugins/core/router/client/theme/muiTheme"; // TODO: remove when Blaze wrapper is removed
-
 
 const PaddedField = styled(Field)`
   margin-bottom: 30px;
@@ -28,8 +24,8 @@ const RightAlignedGrid = styled(Grid)`
   text-align: right;
 `;
 
-const updatShopUrlsMutation = gql`
-  mutation updatShopUrlsMutation($input: UpdateShopUrlsInput!) {
+const updateShopUrlsMutation = gql`
+  mutation updateShopUrlsMutation($input: UpdateShopUrlsInput!) {
     updateShopUrls(input: $input) {
       clientMutationId
       shop {
@@ -88,92 +84,91 @@ class StorefrontUrls extends Component {
   render() {
     const { shop } = this.props;
     return (
-      <ThemeProvider theme={theme}>
-        <MuiThemeProvider theme={muiTheme}>
-          <Card>
-            <CardHeader
-              subheader={i18next.t("shopSettings.storefrontUrls.description", "Use these fields to provide your storefronts URL's to various pages to use for links inside of emails.")}
-              title={i18next.t("shopSettings.storefrontUrls.title", "Storefront Urls")}
-            />
-            <Mutation mutation={updatShopUrlsMutation}>
-              {(mutationFunc) => (
-                <Fragment>
-                  <Form
-                    ref={(formRef) => { this.form = formRef; }}
-                    onChange={this.handleFormChange}
-                    onSubmit={(data) => this.handleUpdateUrls(data, mutationFunc)}
-                    value={shop}
+      <Card>
+        <CardHeader
+          subheader={i18next.t("shopSettings.storefrontUrls.description", "Use these fields to provide your storefronts URL's to various pages to use for links inside of emails.")}
+          title={i18next.t("shopSettings.storefrontUrls.title", "Storefront Urls")}
+        />
+        <Mutation mutation={updateShopUrlsMutation}>
+          {(mutationFunc) => (
+            <Fragment>
+              <Form
+                ref={(formRef) => { this.form = formRef; }}
+                onChange={this.handleFormChange}
+                onSubmit={(data) => this.handleUpdateUrls(data, mutationFunc)}
+                value={shop}
+              >
+                <CardContent>
+                  <PaddedField
+                    name="storefrontHomeUrl"
+                    label={i18next.t("shopSettings.storefrontUrls.storefrontHomeUrlTitle", "Homepage URL")}
+                    labelFor="storefrontHomeUrlInput"
                   >
-                    <CardContent>
-                      <PaddedField
-                        name="storefrontHomeUrl"
-                        label={i18next.t("shopSettings.storefrontUrls.storefrontHomeUrlTitle", "Homepage URL")}
-                        labelFor="storefrontHomeUrlInput"
-                      >
-                        <TextInput
-                          id="storefrontHomeUrlInput"
-                          name="storefrontHomeUrl"
-                          placeholder={i18next.t("shopSettings.storefrontUrls.storefrontHomeUrlDescription", "URL of your shops homepage")}
-                          value={shop.storefrontUrls.storefrontHomeUrl}
-                        />
-                        <ErrorsBlock names={["storefrontHomeUrl"]} />
-                      </PaddedField>
-                      <PaddedField
-                        name="storefrontOrderUrl"
-                        label={i18next.t("shopSettings.storefrontUrls.storefrontOrderUrlTitle", "Single Order page URL")}
-                        labelFor="storefrontOrderUrlInput"
-                      >
-                        <TextInput
-                          id="storefrontOrderUrlInput"
-                          name="storefrontOrderUrl"
-                          placeholder={i18next.t("shopSettings.storefrontUrls.storefrontOrderUrlDescription", "URL of your shops single order page")}
-                          value={shop.storefrontUrls.storefrontOrderUrl}
-                        />
-                        <ErrorsBlock names={["storefrontOrderUrl"]} />
-                      </PaddedField>
-                      <PaddedField
-                        name="storefrontOrdersUrl"
-                        label={i18next.t("shopSettings.storefrontUrls.storefrontOrdersUrlTitle", "Orders page URL")}
-                        labelFor="storefrontOrdersUrlInput"
-                      >
-                        <TextInput
-                          id="storefrontOrdersUrlInput"
-                          name="storefrontOrdersUrl"
-                          placeholder={i18next.t("shopSettings.storefrontUrls.storefrontOrdersUrlDescription", "URL of your shops orders page")}
-                          value={shop.storefrontUrls.storefrontOrdersUrl}
-                        />
-                        <ErrorsBlock names={["storefrontOrdersUrl"]} />
-                      </PaddedField>
-                      <PaddedField
-                        name="storefrontAccountProfileUrl"
-                        label={i18next.t("shopSettings.storefrontUrls.storefrontAccountProfileUrlTitle", "Account Profile page URL")}
-                        labelFor="storefrontAccountProfileUrlInput"
-                      >
-                        <TextInput
-                          id="storefrontAccountProfileUrlInput"
-                          name="storefrontAccountProfileUrl"
-                          placeholder={i18next.t("shopSettings.storefrontUrls.storefrontAccountProfileUrlDescription", "URL of your shops account profile homepage")}
-                          value={shop.storefrontUrls.storefrontAccountProfileUrl}
-                        />
-                        <ErrorsBlock names={["storefrontAccountProfileUrl"]} />
-                      </PaddedField>
-                    </CardContent>
-                    <CardActions>
-                      <Grid container alignItems="center" justify="flex-end">
-                        <RightAlignedGrid item xs={12}>
-                          <Button color="primary" variant="contained" onClick={this.handleSubmitForm}>
-                            {i18next.t("app.save")}
-                          </Button>
-                        </RightAlignedGrid>
-                      </Grid>
-                    </CardActions>
-                  </Form>
-                </Fragment>
-              )}
-            </Mutation>
-          </Card>
-        </MuiThemeProvider>
-      </ThemeProvider>
+                    <TextInput
+                      id="storefrontHomeUrlInput"
+                      name="storefrontHomeUrl"
+                      placeholder={i18next.t("shopSettings.storefrontUrls.storefrontHomeUrlDescription", "URL of your shops homepage")}
+                      value={shop.storefrontUrls.storefrontHomeUrl}
+                    />
+                    <ErrorsBlock names={["storefrontHomeUrl"]} />
+                  </PaddedField>
+                  <PaddedField
+                    name="storefrontOrderUrl"
+                    label={i18next.t("shopSettings.storefrontUrls.storefrontOrderUrlTitle", "Single Order page URL")}
+                    labelFor="storefrontOrderUrlInput"
+                  >
+                    <TextInput
+                      id="storefrontOrderUrlInput"
+                      name="storefrontOrderUrl"
+                      placeholder={i18next.t("shopSettings.storefrontUrls.storefrontOrderUrlDescription", "URL of your shops single order page")}
+                      value={shop.storefrontUrls.storefrontOrderUrl}
+                    />
+                    <ErrorsBlock names={["storefrontOrderUrl"]} />
+                  </PaddedField>
+                  <PaddedField
+                    name="storefrontOrdersUrl"
+                    label={i18next.t("shopSettings.storefrontUrls.storefrontOrdersUrlTitle", "Orders page URL")}
+                    labelFor="storefrontOrdersUrlInput"
+                  >
+                    <TextInput
+                      id="storefrontOrdersUrlInput"
+                      name="storefrontOrdersUrl"
+                      placeholder={i18next.t("shopSettings.storefrontUrls.storefrontOrdersUrlDescription", "URL of your shops orders page")}
+                      value={shop.storefrontUrls.storefrontOrdersUrl}
+                    />
+                    <ErrorsBlock names={["storefrontOrdersUrl"]} />
+                  </PaddedField>
+                  <PaddedField
+                    name="storefrontAccountProfileUrl"
+                    label={i18next.t("shopSettings.storefrontUrls.storefrontAccountProfileUrlTitle", "Account Profile page URL")}
+                    labelFor="storefrontAccountProfileUrlInput"
+                  >
+                    <TextInput
+                      id="storefrontAccountProfileUrlInput"
+                      name="storefrontAccountProfileUrl"
+                      placeholder={i18next.t(
+                        "shopSettings.storefrontUrls.storefrontAccountProfileUrlDescription",
+                        "URL of your shops account profile homepage"
+                      )}
+                      value={shop.storefrontUrls.storefrontAccountProfileUrl}
+                    />
+                    <ErrorsBlock names={["storefrontAccountProfileUrl"]} />
+                  </PaddedField>
+                </CardContent>
+                <CardActions>
+                  <Grid container alignItems="center" justify="flex-end">
+                    <RightAlignedGrid item xs={12}>
+                      <Button color="primary" variant="contained" onClick={this.handleSubmitForm}>
+                        {i18next.t("app.save")}
+                      </Button>
+                    </RightAlignedGrid>
+                  </Grid>
+                </CardActions>
+              </Form>
+            </Fragment>
+          )}
+        </Mutation>
+      </Card>
     );
   }
 }

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
@@ -119,8 +119,12 @@
     {{/each}}
   </div>
 
-  <div>
+  <div style="margin-bottom: 20px">
     {{> React component=StorefrontUrls}}
+  </div>
+
+  <div>
+    {{> React component=Blocks region="ShopSettings" blockProps=shopSettingsBlockProps}}
   </div>
 </template>
 

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -1,6 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { AutoForm } from "meteor/aldeed:autoform";
+import { Blocks } from "@reactioncommerce/reaction-components";
 import { Reaction, i18next } from "/client/api";
 import { Packages, Shops } from "/lib/collections";
 import { Media } from "/imports/plugins/core/files/client";
@@ -171,6 +172,14 @@ Template.optionsShopSettings.helpers({
 });
 
 Template.shopSettings.helpers({
+  Blocks() {
+    return Blocks;
+  },
+
+  shopSettingsBlockProps() {
+    return { shopId: Reaction.getShopId() };
+  },
+
   versionedPackages() {
     const versionedPackages = Packages.find({ version: { $exists: true }, shopId: Reaction.getShopId() });
     return versionedPackages;

--- a/imports/plugins/core/inventory/client/InventorySettings.js
+++ b/imports/plugins/core/inventory/client/InventorySettings.js
@@ -1,0 +1,68 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Components } from "@reactioncommerce/reaction-components";
+import { i18next } from "/client/api";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Switch from "@material-ui/core/Switch";
+
+/**
+ * Inventory settings form block component
+ * @param {Object} props Component props
+ * @return {Node} React node
+ */
+function InventorySettings(props) {
+  const {
+    inventoryShopSettings,
+    isLoadingInventoryShopSettings,
+    updateInventoryShopSettings,
+    shopId
+  } = props;
+
+  if (isLoadingInventoryShopSettings) return <Components.Loading />;
+
+  const {
+    canSellVariantWithoutInventory
+  } = inventoryShopSettings || {};
+
+  return (
+    <Card>
+      <CardHeader title={i18next.t("inventorySettings.cardTitle")} />
+      <CardContent>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={canSellVariantWithoutInventory}
+              onChange={(event, checked) => {
+                updateInventoryShopSettings({
+                  variables: {
+                    input: {
+                      settingsUpdates: {
+                        canSellVariantWithoutInventory: checked
+                      },
+                      shopId
+                    }
+                  }
+                });
+              }}
+            />
+          }
+          label={i18next.t("inventorySettings.canSellVariantWithoutInventory")}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+InventorySettings.propTypes = {
+  inventoryShopSettings: PropTypes.shape({
+    canSellVariantWithoutInventory: PropTypes.bool
+  }),
+  isLoadingInventoryShopSettings: PropTypes.bool,
+  shopId: PropTypes.string.isRequired,
+  updateInventoryShopSettings: PropTypes.func
+};
+
+export default InventorySettings;

--- a/imports/plugins/core/inventory/client/index.js
+++ b/imports/plugins/core/inventory/client/index.js
@@ -1,0 +1,15 @@
+import { registerBlock } from "/imports/plugins/core/components/lib";
+import InventorySettings from "./InventorySettings";
+import withInventoryShopSettings from "./withInventoryShopSettings";
+import withUpdateInventoryShopSettings from "./withUpdateInventoryShopSettings";
+
+registerBlock({
+  region: "ShopSettings",
+  name: "InventorySettings",
+  component: InventorySettings,
+  hocs: [
+    withInventoryShopSettings,
+    withUpdateInventoryShopSettings
+  ],
+  priority: 1
+});

--- a/imports/plugins/core/inventory/client/shopSettingsQuery.js
+++ b/imports/plugins/core/inventory/client/shopSettingsQuery.js
@@ -1,0 +1,9 @@
+import gql from "graphql-tag";
+
+export default gql`
+  query shopSettingsQuery($shopId: ID!) {
+    shopSettings(shopId: $shopId) {
+      canSellVariantWithoutInventory
+    }
+  }
+`;

--- a/imports/plugins/core/inventory/client/withInventoryShopSettings.js
+++ b/imports/plugins/core/inventory/client/withInventoryShopSettings.js
@@ -1,0 +1,80 @@
+import React from "react";
+import { Query } from "react-apollo";
+import PropTypes from "prop-types";
+import getOpaqueIds from "/imports/plugins/core/core/client/util/getOpaqueIds";
+import shopSettingsQuery from "./shopSettingsQuery";
+
+export default (Component) => (
+  class InventoryShopSettingsQuery extends React.Component {
+    static propTypes = {
+      shopId: PropTypes.string.isRequired
+    }
+
+    state = {
+      shopId: null
+    }
+
+    componentDidMount() {
+      this._isMounted = true;
+    }
+
+    componentWillUnmount() {
+      this._isMounted = false;
+    }
+
+    getOpaqueIds(shopId) {
+      this.isGettingIds = true;
+      getOpaqueIds([
+        { namespace: "Shop", id: shopId }
+      ])
+        .then(([opaqueShopId]) => {
+          if (this._isMounted) {
+            this.setState({
+              opaqueShopId,
+              shopId
+            });
+          }
+          this.isGettingIds = false;
+          return null;
+        })
+        .catch((error) => {
+          throw error;
+        });
+    }
+
+    render() {
+      const { shopId } = this.props;
+
+      if (!shopId) return null;
+
+      if (shopId !== this.state.shopId && !this.isGettingIds) {
+        this.getOpaqueIds(shopId);
+        return null;
+      }
+
+      const { opaqueShopId } = this.state;
+
+      if (!opaqueShopId) return null; // still getting them
+
+      return (
+        <Query query={shopSettingsQuery} variables={{ shopId: opaqueShopId }}>
+          {({ loading, data }) => {
+            const props = {
+              ...this.props,
+              isLoadingInventoryShopSettings: loading,
+              shopId: opaqueShopId
+            };
+
+            if (!loading && data) {
+              props.inventoryShopSettings = data.shopSettings;
+            }
+
+            return (
+              <Component {...props} />
+            );
+          }}
+        </Query>
+      );
+    }
+  }
+);

--- a/imports/plugins/core/inventory/client/withUpdateInventoryShopSettings.js
+++ b/imports/plugins/core/inventory/client/withUpdateInventoryShopSettings.js
@@ -1,0 +1,53 @@
+import React from "react";
+import PropTypes from "prop-types";
+import gql from "graphql-tag";
+import { Mutation } from "react-apollo";
+import shopSettingsQuery from "./shopSettingsQuery";
+
+const updateInventoryShopSettingsMutation = gql`
+  mutation updateInventoryShopSettingsMutation($input: UpdateShopSettingsInput!) {
+    updateShopSettings(input: $input) {
+      shopSettings {
+        canSellVariantWithoutInventory
+      }
+    }
+  }
+`;
+
+export default (Component) => (
+  class WithUpdateInventoryShopSettings extends React.Component {
+    static propTypes = {
+      shopId: PropTypes.string.isRequired
+    }
+
+    render() {
+      const { shopId } = this.props;
+
+      return (
+        <Mutation
+          mutation={updateInventoryShopSettingsMutation}
+          update={(cache, { data: { updateShopSettings } }) => {
+            if (updateShopSettings && updateShopSettings.shopSettings) {
+              cache.writeQuery({
+                query: shopSettingsQuery,
+                variables: {
+                  shopId
+                },
+                data: {
+                  shopSettings: { ...updateShopSettings.shopSettings }
+                }
+              });
+            }
+          }}
+        >
+          {(updateInventoryShopSettings) => (
+            <Component
+              {...this.props}
+              updateInventoryShopSettings={updateInventoryShopSettings}
+            />
+          )}
+        </Mutation>
+      );
+    }
+  }
+);

--- a/imports/plugins/core/inventory/server/i18n/en.json
+++ b/imports/plugins/core/inventory/server/i18n/en.json
@@ -1,0 +1,12 @@
+[{
+  "i18n": "en",
+  "ns": "reaction-inventory",
+  "translation": {
+    "reaction-inventory": {
+      "inventorySettings": {
+        "canSellVariantWithoutInventory": "When a sellable product variant does not have inventory tracking enabled, allow unlimited sales. If disabled, variants without inventory info will be considered sold out with back-ordering disabled.",
+        "cardTitle": "Inventory"
+      }
+    }
+  }
+}]

--- a/imports/plugins/core/inventory/server/i18n/index.js
+++ b/imports/plugins/core/inventory/server/i18n/index.js
@@ -1,0 +1,10 @@
+import { loadTranslations } from "/imports/plugins/core/core/server/startup/i18n";
+
+import en from "./en.json";
+
+//
+// we want all the files in individual
+// imports for easier handling by
+// automated translation software
+//
+loadTranslations([en]);

--- a/imports/plugins/core/inventory/server/index.js
+++ b/imports/plugins/core/inventory/server/index.js
@@ -1,1 +1,2 @@
+import "./i18n";
 import "../lib/extendCoreSchemas";

--- a/imports/plugins/core/inventory/server/no-meteor/queries/inventoryForProductConfiguration.js
+++ b/imports/plugins/core/inventory/server/no-meteor/queries/inventoryForProductConfiguration.js
@@ -11,11 +11,12 @@
  * @return {Promise<Object>} InventoryInfo
  */
 export default async function inventoryForProductConfiguration(context, input) {
-  const { fields, productConfiguration } = input;
+  const { fields, productConfiguration, shopId } = input;
 
   const result = await context.queries.inventoryForProductConfigurations(context, {
     fields,
-    productConfigurations: [productConfiguration]
+    productConfigurations: [productConfiguration],
+    shopId
   });
 
   return result[0].inventoryInfo;

--- a/imports/plugins/core/inventory/server/no-meteor/queries/inventoryForProductConfigurations.js
+++ b/imports/plugins/core/inventory/server/no-meteor/queries/inventoryForProductConfigurations.js
@@ -25,7 +25,7 @@ const DEFAULT_SOLD_OUT_INFO = {
   inventoryAvailableToSell: 0,
   inventoryInStock: 0,
   inventoryReserved: 0,
-  isBackorder: true,
+  isBackorder: false,
   isLowQuantity: true,
   isSoldOut: true
 };

--- a/imports/plugins/core/inventory/server/no-meteor/register.js
+++ b/imports/plugins/core/inventory/server/no-meteor/register.js
@@ -25,6 +25,15 @@ export default async function register(app) {
     queries,
     graphQL: {
       schemas
+    },
+    shopSettingsConfig: {
+      canSellVariantWithoutInventory: {
+        defaultValue: true,
+        rolesThatCanEdit: ["admin"],
+        simpleSchema: {
+          type: Boolean
+        }
+      }
     }
   });
 }

--- a/imports/plugins/core/inventory/server/no-meteor/schemas/index.js
+++ b/imports/plugins/core/inventory/server/no-meteor/schemas/index.js
@@ -1,3 +1,4 @@
 import schema from "./schema.graphql";
+import settings from "./settings.graphql";
 
-export default [schema];
+export default [schema, settings];

--- a/imports/plugins/core/inventory/server/no-meteor/schemas/settings.graphql
+++ b/imports/plugins/core/inventory/server/no-meteor/schemas/settings.graphql
@@ -1,0 +1,15 @@
+extend type ShopSettings {
+  """
+  If there is no known inventory for a product configuration, this setting determines
+  whether that product configuration can be sold and should appear to be available.
+  """
+  canSellVariantWithoutInventory: Boolean!
+}
+
+extend input ShopSettingsUpdates {
+  """
+  If there is no known inventory for a product configuration, this setting determines
+  whether that product configuration can be sold and should appear to be available.
+  """
+  canSellVariantWithoutInventory: Boolean
+}

--- a/imports/plugins/core/inventory/server/no-meteor/utils/publishProductToCatalog.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/publishProductToCatalog.js
@@ -12,12 +12,13 @@ export default async function publishProductToCatalog(catalogProduct, { context,
   const topVariants = variants.filter((variant) => variant.ancestors.length === 1);
 
   const topVariantsInventoryInfo = await context.queries.inventoryForProductConfigurations(context, {
+    fields: ["isBackorder", "isLowQuantity", "isSoldOut"],
     productConfigurations: topVariants.map((option) => ({
       isSellable: !variants.some((variant) => variant.ancestors.includes(option._id)),
       productId: option.ancestors[0],
       productVariantId: option._id
     })),
-    fields: ["isBackorder", "isLowQuantity", "isSoldOut"],
+    shopId: catalogProduct.shopId,
     variants
   });
 

--- a/imports/plugins/core/inventory/server/no-meteor/utils/startup.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/startup.js
@@ -21,14 +21,16 @@ export default function startup(context) {
     }).toArray();
 
     const topVariants = variants.filter((variant) => variant.ancestors.length === 1);
+    if (topVariants.length === 0) return;
 
     const topVariantsInventoryInfo = await context.queries.inventoryForProductConfigurations(context, {
+      fields: ["isBackorder", "isLowQuantity", "isSoldOut"],
       productConfigurations: topVariants.map((option) => ({
         isSellable: !variants.some((variant) => variant.ancestors.includes(option._id)),
         productId: option.ancestors[0],
         productVariantId: option._id
       })),
-      fields: ["isBackorder", "isLowQuantity", "isSoldOut"],
+      shopId: topVariants[0].shopId,
       variants
     });
 

--- a/imports/plugins/core/inventory/server/no-meteor/utils/xformCartItems.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/xformCartItems.js
@@ -6,13 +6,16 @@
  * @return {undefined} Returns nothing. Potentially mutates `items`
  */
 export default async function xformCartItems(context, items) {
+  if (items.length === 0) return;
+
   const productConfigurations = [];
   for (const item of items) {
     productConfigurations.push({ ...item.productConfiguration, isSellable: true });
   }
 
   const variantsInventoryInfo = await context.queries.inventoryForProductConfigurations(context, {
-    productConfigurations
+    productConfigurations,
+    shopId: items[0].shopId
   });
 
   for (const item of items) {

--- a/imports/plugins/core/inventory/server/no-meteor/utils/xformCatalogProductVariants.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/xformCatalogProductVariants.js
@@ -47,8 +47,11 @@ export default async function xformCatalogProductVariants(context, catalogProduc
     }
   }
 
+  if (productConfigurations.length === 0) return;
+
   const variantsInventoryInfo = await context.queries.inventoryForProductConfigurations(context, {
-    productConfigurations
+    productConfigurations,
+    shopId: catalogProductVariants[0].shopId
   });
 
   for (const catalogProductVariant of catalogProductVariants) {

--- a/imports/plugins/core/orders/server/no-meteor/util/buildOrderItem.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/buildOrderItem.js
@@ -41,7 +41,8 @@ export default async function buildOrderItem(context, { currencyCode, inputItem 
     productConfiguration: {
       ...productConfiguration,
       isSellable: true
-    }
+    },
+    shopId: chosenProduct.shopId
   });
 
   if (!inventoryInfo.canBackorder && (quantity > inventoryInfo.inventoryAvailableToSell)) {

--- a/imports/plugins/core/settings/register.js
+++ b/imports/plugins/core/settings/register.js
@@ -1,0 +1,4 @@
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import register from "./server/register";
+
+Reaction.whenAppInstanceReady(register);

--- a/imports/plugins/core/settings/server/mutations/index.js
+++ b/imports/plugins/core/settings/server/mutations/index.js
@@ -1,0 +1,5 @@
+import updateAppSettings from "./updateAppSettings";
+
+export default {
+  updateAppSettings
+};

--- a/imports/plugins/core/settings/server/mutations/updateAppSettings.js
+++ b/imports/plugins/core/settings/server/mutations/updateAppSettings.js
@@ -1,0 +1,40 @@
+import ReactionError from "@reactioncommerce/reaction-error";
+import {
+  addGlobalSettingDefaults,
+  addShopSettingDefaults,
+  rolesThatCanEditGlobalSetting,
+  rolesThatCanEditShopSetting
+} from "../util/settingsConfig";
+
+/**
+ * @summary Updates app settings for a shop or global app settings.
+ * @param {Object} context App context
+ * @param {Object} settingsUpdates Fields to be updated
+ * @param {String} [shopId] Shop ID. Pass `null` for global settings.
+ * @return {Promise<Object>} Updated app settings for a shop or global app settings
+ */
+export default async function updateAppSettings(context, settingsUpdates, shopId = null) {
+  const { collections, userHasPermission } = context;
+  const { AppSettings } = collections;
+
+  // Look up roles that are allowed to set each setting. Throw if not allowed.
+  Object.getOwnPropertyNames(settingsUpdates).forEach((field) => {
+    const allowedRoles = shopId ? rolesThatCanEditShopSetting(field) : rolesThatCanEditGlobalSetting(field);
+    if (allowedRoles.length === 0 || !userHasPermission(allowedRoles, shopId)) {
+      throw new ReactionError("access-denied", `You are not allowed to edit the "${field}" setting`);
+    }
+  });
+
+  const { value: updatedDoc } = await AppSettings.findOneAndUpdate(
+    { shopId },
+    {
+      $set: settingsUpdates
+    },
+    {
+      returnOriginal: false,
+      upsert: true
+    }
+  );
+
+  return shopId ? addShopSettingDefaults(updatedDoc || {}) : addGlobalSettingDefaults(updatedDoc || {});
+}

--- a/imports/plugins/core/settings/server/queries/appSettings.js
+++ b/imports/plugins/core/settings/server/queries/appSettings.js
@@ -1,0 +1,16 @@
+import { addGlobalSettingDefaults, addShopSettingDefaults } from "../util/settingsConfig";
+
+/**
+ * @summary Returns app settings for a shop or global app settings.
+ * @param {Object} context App context
+ * @param {String} [shopId] Shop ID. Pass `null` for global settings.
+ * @return {Promise<Object>} App settings for a shop or global app settings
+ */
+export default async function appSettings(context, shopId = null) {
+  const { collections } = context;
+  const { AppSettings } = collections;
+
+  const settings = (await AppSettings.findOne({ shopId })) || {};
+
+  return shopId ? addShopSettingDefaults(settings) : addGlobalSettingDefaults(settings);
+}

--- a/imports/plugins/core/settings/server/queries/index.js
+++ b/imports/plugins/core/settings/server/queries/index.js
@@ -1,0 +1,5 @@
+import appSettings from "./appSettings";
+
+export default {
+  appSettings
+};

--- a/imports/plugins/core/settings/server/register.js
+++ b/imports/plugins/core/settings/server/register.js
@@ -1,0 +1,28 @@
+import mutations from "./mutations";
+import queries from "./queries";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
+import startup from "./startup";
+import { registerPluginHandler } from "./util/settingsConfig";
+
+/**
+ * @summary Import and call this function to add this plugin to your API.
+ * @param {ReactionNodeApp} app The ReactionNodeApp instance
+ * @return {undefined}
+ */
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "App Settings",
+    name: "reaction-settings",
+    functionsByType: {
+      registerPluginHandler: [registerPluginHandler],
+      startup: [startup]
+    },
+    mutations,
+    queries,
+    graphQL: {
+      resolvers,
+      schemas
+    }
+  });
+}

--- a/imports/plugins/core/settings/server/resolvers/Mutation/index.js
+++ b/imports/plugins/core/settings/server/resolvers/Mutation/index.js
@@ -1,0 +1,7 @@
+import updateGlobalSettings from "./updateGlobalSettings";
+import updateShopSettings from "./updateShopSettings";
+
+export default {
+  updateGlobalSettings,
+  updateShopSettings
+};

--- a/imports/plugins/core/settings/server/resolvers/Mutation/updateGlobalSettings.js
+++ b/imports/plugins/core/settings/server/resolvers/Mutation/updateGlobalSettings.js
@@ -1,0 +1,26 @@
+/**
+ * @name Mutation/updateGlobalSettings
+ * @method
+ * @memberof Shop/GraphQL
+ * @summary resolver for the updateGlobalSettings GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args - an object of all mutation arguments that were sent by the client
+ * @param {Object} args.input - mutation input object
+ * @param {String} args.input.shopId - Shop ID
+ * @param {Object} args.input.settingsUpdates - Updated fields
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} ShopsPayload
+ */
+export default async function updateGlobalSettings(_, { input }, context) {
+  const {
+    settingsUpdates,
+    clientMutationId = null
+  } = input;
+
+  const globalSettings = await context.mutations.updateAppSettings(context, settingsUpdates, null);
+
+  return {
+    clientMutationId,
+    globalSettings
+  };
+}

--- a/imports/plugins/core/settings/server/resolvers/Mutation/updateShopSettings.js
+++ b/imports/plugins/core/settings/server/resolvers/Mutation/updateShopSettings.js
@@ -1,0 +1,31 @@
+import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+
+/**
+ * @name Mutation/updateShopSettings
+ * @method
+ * @memberof Shop/GraphQL
+ * @summary resolver for the updateShopSettings GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args - an object of all mutation arguments that were sent by the client
+ * @param {Object} args.input - mutation input object
+ * @param {String} args.input.shopId - Shop ID
+ * @param {Object} args.input.settingsUpdates - Updated fields
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} ShopsPayload
+ */
+export default async function updateShopSettings(_, { input }, context) {
+  const {
+    shopId: opaqueShopId,
+    settingsUpdates,
+    clientMutationId = null
+  } = input;
+
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  const shopSettings = await context.mutations.updateAppSettings(context, settingsUpdates, shopId);
+
+  return {
+    clientMutationId,
+    shopSettings
+  };
+}

--- a/imports/plugins/core/settings/server/resolvers/Query/globalSettings.js
+++ b/imports/plugins/core/settings/server/resolvers/Query/globalSettings.js
@@ -1,0 +1,13 @@
+/**
+ * @name Query/globalSettings
+ * @method
+ * @memberof Core/GraphQL
+ * @summary Gets global settings
+ * @param {Object} _ - unused
+ * @param {Object} __ - unused
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} The global settings object
+ */
+export default async function globalSettings(_, __, context) {
+  return context.queries.appSettings(context);
+}

--- a/imports/plugins/core/settings/server/resolvers/Query/index.js
+++ b/imports/plugins/core/settings/server/resolvers/Query/index.js
@@ -1,0 +1,7 @@
+import globalSettings from "./globalSettings";
+import shopSettings from "./shopSettings";
+
+export default {
+  globalSettings,
+  shopSettings
+};

--- a/imports/plugins/core/settings/server/resolvers/Query/shopSettings.js
+++ b/imports/plugins/core/settings/server/resolvers/Query/shopSettings.js
@@ -1,0 +1,19 @@
+import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+
+/**
+ * @name Query/shopSettings
+ * @method
+ * @memberof Core/GraphQL
+ * @summary Gets global settings
+ * @param {Object} _ - unused
+ * @param {Object} args - Args passed by the client
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} The global settings object
+ */
+export default async function shopSettings(_, args, context) {
+  const { shopId } = args;
+
+  const internalShopId = decodeShopOpaqueId(shopId);
+
+  return context.queries.appSettings(context, internalShopId);
+}

--- a/imports/plugins/core/settings/server/resolvers/index.js
+++ b/imports/plugins/core/settings/server/resolvers/index.js
@@ -1,0 +1,7 @@
+import Mutation from "./Mutation";
+import Query from "./Query";
+
+export default {
+  Mutation,
+  Query
+};

--- a/imports/plugins/core/settings/server/schemas/index.js
+++ b/imports/plugins/core/settings/server/schemas/index.js
@@ -1,0 +1,3 @@
+import settings from "./settings.graphql";
+
+export default [settings];

--- a/imports/plugins/core/settings/server/schemas/settings.graphql
+++ b/imports/plugins/core/settings/server/schemas/settings.graphql
@@ -1,0 +1,108 @@
+"""
+App settings that are not shop specific. Plugins extend the GlobalSettings type to support
+whatever settings they need.
+"""
+type GlobalSettings {
+  "A fake setting necessary until some plugin extends this with a real setting"
+  doNotUse: String
+}
+
+"""
+App settings for a specific shop. Plugins extend the ShopSettings type to support
+whatever settings they need.
+"""
+type ShopSettings
+
+extend type Query {
+  """
+  Returns app settings that are not shop specific. Plugins extend the GlobalSettings type to support
+  whatever settings they need.
+  """
+  globalSettings: GlobalSettings!
+
+  """
+  Returns app settings for a specific shop. Plugins extend the ShopSettings type to support
+  whatever settings they need.
+  """
+  shopSettings(shopId: ID!): ShopSettings!
+}
+
+##
+# updateGlobalSettings
+##
+
+extend type Mutation {
+  """
+  Returns app settings that are not shop specific. Plugins extend the GlobalSettings type to support
+  whatever settings they need.
+  """
+  updateGlobalSettings(input: UpdateGlobalSettingsInput!): UpdateGlobalSettingsPayload!
+}
+
+"Input for the `updateGlobalSettings` mutation"
+input UpdateGlobalSettingsInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "Updated settings values. Only includes settings to be changed."
+  settingsUpdates: GlobalSettingsUpdates!
+}
+
+"""
+Updates for app settings that are not shop specific. Plugins extend
+this input type to support whatever settings they need. All fields
+must be optional.
+"""
+input GlobalSettingsUpdates {
+  "A fake setting necessary until some plugin extends this with a real setting"
+  doNotUse: String
+}
+
+"Response payload for the `updateGlobalSettings` mutation"
+type UpdateGlobalSettingsPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "Updated global settings"
+  globalSettings: GlobalSettings!
+}
+
+##
+# updateShopSettings
+##
+
+extend type Mutation {
+  """
+  Returns app settings for a specific shop. Plugins extend the ShopSettings type to support
+  whatever settings they need.
+  """
+  updateShopSettings(input: UpdateShopSettingsInput!): UpdateShopSettingsPayload!
+}
+
+"Input for the `updateShopSettings` mutation"
+input UpdateShopSettingsInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "Updated settings values. Only includes settings to be changed."
+  settingsUpdates: ShopSettingsUpdates!
+
+  "The ID of the shop to update some settings for"
+  shopId: ID!
+}
+
+"""
+Updates for app settings that are not shop specific. Plugins extend
+this input type to support whatever settings they need. All fields
+must be optional.
+"""
+input ShopSettingsUpdates
+
+"Response payload for the `updateShopSettings` mutation"
+type UpdateShopSettingsPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "Updated shop settings"
+  shopSettings: ShopSettings!
+}

--- a/imports/plugins/core/settings/server/schemas/settings.graphql
+++ b/imports/plugins/core/settings/server/schemas/settings.graphql
@@ -11,7 +11,15 @@ type GlobalSettings {
 App settings for a specific shop. Plugins extend the ShopSettings type to support
 whatever settings they need.
 """
-type ShopSettings
+type ShopSettings {
+  # Although the spec allows and Apollo supports defining an empty type
+  # that is extended later in other files, the graphql-schema-linter
+  # package currently has a problem with this, so we must add a fake field.
+  #
+  # https://github.com/cjoudrey/graphql-schema-linter/issues/151
+  "A fake setting necessary until some plugin extends this with a real setting"
+  doNotUse: String
+}
 
 extend type Query {
   """
@@ -54,7 +62,7 @@ this input type to support whatever settings they need. All fields
 must be optional.
 """
 input GlobalSettingsUpdates {
-  "A fake setting necessary until some plugin extends this with a real setting"
+  "Do not use this field"
   doNotUse: String
 }
 
@@ -96,7 +104,15 @@ Updates for app settings that are not shop specific. Plugins extend
 this input type to support whatever settings they need. All fields
 must be optional.
 """
-input ShopSettingsUpdates
+input ShopSettingsUpdates {
+  # Although the spec allows and Apollo supports defining an empty type
+  # that is extended later in other files, the graphql-schema-linter
+  # package currently has a problem with this, so we must add a fake field.
+  #
+  # https://github.com/cjoudrey/graphql-schema-linter/issues/151
+  "Do not use this field"
+  doNotUse: String
+}
 
 "Response payload for the `updateShopSettings` mutation"
 type UpdateShopSettingsPayload {

--- a/imports/plugins/core/settings/server/startup.js
+++ b/imports/plugins/core/settings/server/startup.js
@@ -1,0 +1,16 @@
+import collectionIndex from "/imports/utils/collectionIndex";
+
+/**
+ * @summary Called on startup
+ * @param {Object} context Startup context
+ * @param {Object} context.collections Map of MongoDB collections
+ * @returns {undefined}
+ */
+export default function startup(context) {
+  const { app, collections } = context;
+
+  const AppSettings = app.db.collection("AppSettings");
+  collections.AppSettings = AppSettings;
+
+  collectionIndex(AppSettings, { shopId: 1 }, { unique: true });
+}

--- a/imports/plugins/core/settings/server/util/settingsConfig.js
+++ b/imports/plugins/core/settings/server/util/settingsConfig.js
@@ -1,0 +1,129 @@
+import SimpleSchema from "simpl-schema";
+
+export const globalSettingsConfig = {};
+export const shopSettingsConfig = {};
+
+export const globalSettingsSchema = new SimpleSchema();
+export const shopSettingsSchema = new SimpleSchema();
+
+/**
+ * @param {Object} settings The settings object
+ * @return {Object} Settings object with default values added
+ */
+export function addGlobalSettingDefaults(settings) {
+  Object.getOwnPropertyNames(globalSettingsSchema).forEach((field) => {
+    const value = settings[field];
+    if (value === undefined || value === null) {
+      const config = globalSettingsSchema[field];
+      if (config.defaultValue !== undefined) {
+        settings[field] = config.defaultValue;
+      }
+    }
+  });
+  return settings;
+}
+
+/**
+ * @param {Object} settings The settings object
+ * @return {Object} Settings object with default values added
+ */
+export function addShopSettingDefaults(settings) {
+  Object.getOwnPropertyNames(shopSettingsConfig).forEach((field) => {
+    const value = settings[field];
+    if (value === undefined || value === null) {
+      const config = shopSettingsConfig[field];
+      if (config.defaultValue !== undefined) {
+        settings[field] = config.defaultValue;
+      }
+    }
+  });
+  return settings;
+}
+
+/**
+ * @param {String} field The setting field name
+ * @return {String[]} List of roles that can edit this setting.
+ */
+export function rolesThatCanEditGlobalSetting(field) {
+  const config = globalSettingsSchema[field];
+  if (!config) return [];
+
+  return config.rolesThatCanEdit || [];
+}
+
+/**
+ * @param {String} field The setting field name
+ * @return {String[]} List of roles that can edit this setting.
+ */
+export function rolesThatCanEditShopSetting(field) {
+  const config = shopSettingsConfig[field];
+  if (!config) return [];
+
+  return config.rolesThatCanEdit || [];
+}
+
+const configSchema = new SimpleSchema({
+  "defaultValue": {
+    type: SimpleSchema.oneOf(String, Number, Date, Boolean),
+    optional: true
+  },
+  "rolesThatCanEdit": {
+    type: Array,
+    optional: true
+  },
+  "rolesThatCanEdit.$": String,
+  "simpleSchema": {
+    type: Object,
+    blackbox: true
+  }
+});
+
+/**
+ * @summary Reads and merges `appSettingsConfig` from all plugin registration.
+ * @return {undefined}
+ */
+export function registerPluginHandler({
+  globalSettingsConfig: globalSettingsConfigFromPlugin,
+  name,
+  shopSettingsConfig: shopSettingsConfigFromPlugin
+}) {
+  if (globalSettingsConfigFromPlugin) {
+    Object.getOwnPropertyNames(globalSettingsConfigFromPlugin).forEach((field) => {
+      if (globalSettingsConfig[field]) {
+        throw new Error(`Plugin ${name} has field "${field}" in "globalSettingsConfig" but another plugin already defined this field`);
+      }
+
+      const config = globalSettingsConfigFromPlugin[field];
+      configSchema.validate(config);
+
+      globalSettingsConfig[field] = config;
+
+      globalSettingsSchema.extend({
+        [field]: {
+          ...config.simpleSchema,
+          optional: true
+        }
+      });
+    });
+  }
+
+  if (shopSettingsConfigFromPlugin) {
+    Object.getOwnPropertyNames(shopSettingsConfigFromPlugin).forEach((field) => {
+      if (shopSettingsConfig[field]) {
+        throw new Error(`Plugin ${name} has field "${field}" in "shopSettingsConfig" but another plugin already defined this field`);
+      }
+
+      const config = shopSettingsConfigFromPlugin[field];
+      configSchema.validate(config);
+
+      shopSettingsConfig[field] = config;
+
+      shopSettingsSchema.extend({
+        [field]: {
+          ...config.simpleSchema,
+          optional: true
+        }
+      });
+    });
+  }
+}

--- a/imports/plugins/core/ui/client/helpers/react-template-helper.js
+++ b/imports/plugins/core/ui/client/helpers/react-template-helper.js
@@ -3,10 +3,14 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { ApolloProvider } from "react-apollo";
 import { ComponentsProvider } from "@reactioncommerce/components-context";
+import { ThemeProvider } from "styled-components";
+import MuiThemeProvider from "@material-ui/core/styles/MuiThemeProvider";
 import _ from "lodash";
 import { Template } from "meteor/templating";
 import { Blaze } from "meteor/blaze";
 import appComponents from "/imports/plugins/core/router/client/appComponents";
+import theme from "/imports/plugins/core/router/client/theme";
+import muiTheme from "/imports/plugins/core/router/client/theme/muiTheme";
 import initApollo from "/imports/plugins/core/graphql/lib/helpers/initApollo";
 
 // Ideally this will be done only in browserRouter.js, but we lose context within Blaze templates,
@@ -36,7 +40,11 @@ Template.React.onRendered(function () {
       (
         <ApolloProvider client={apolloClient}>
           <ComponentsProvider value={appComponents}>
-            {elem}
+            <ThemeProvider theme={theme}>
+              <MuiThemeProvider theme={muiTheme}>
+                {elem}
+              </MuiThemeProvider>
+            </ThemeProvider>
           </ComponentsProvider>
         </ApolloProvider>
       ),

--- a/imports/plugins/included/simple-inventory/client/VariantInventoryForm.js
+++ b/imports/plugins/included/simple-inventory/client/VariantInventoryForm.js
@@ -177,6 +177,9 @@ function VariantInventoryForm(props) {
 }
 
 VariantInventoryForm.propTypes = {
+  components: PropTypes.shape({
+    Button: PropTypes.any
+  }),
   inventoryInfo: PropTypes.shape({
     canBackorder: PropTypes.bool,
     inventoryInStock: PropTypes.number,


### PR DESCRIPTION
Resolves #5185   
Impact: **minor**  
Type: **feature**

## Issue
The core `inventory` package, if no inventory plugin has inventory for an option, assumes that the option should be sellable. It is not shown as sold out, and although inventory available to sell is 0, `canBackorder` is set to `true` to allow selling always.

This is a correct default assumption because the core product should be useable out of the box without inventory tracking configured. However, in some inventory syncing situations, it is best to consider such options "out of stock" instead.

## Solution
There is a new shop-specific app setting, `canSellVariantWithoutInventory`, which is `true` by default. If this is changed to `false`, then variants/options without inventory tracking enabled will appear sold out and with back-ordering disabled.

## Other Changes
The StorefrontUrls React component had `ThemeProvider` and `MuiThemeProvider` temporarily added due to being used in `React` Blaze helper. This is removed in favor of putting the wrappers in the `React` helper itself, which is how other providers have been added in the past. This way each individual component doesn't have to solve the same issue.

A new Blocks region, "ShopSettings", is added to the bottom of the Shop Settings page. This allows React components to be added to that page with the newer and better API.

Rather than make custom GraphQL queries and mutations for this setting, I took the opportunity to implement a generic app settings pattern we have recently discussed. This is all implemented in a new `core/settings` plugin.
  - Any plugin can add any shop-specific setting by defining it in the `registerPlugin` call, using the `shopSettingsConfig` key, and extending `ShopSettings` and `ShopSettingsUpdates` in the GraphQL schema. (See core inventory plugin for example.)
  - Any plugin can add any global setting by defining it in the `registerPlugin` call, using the `globalSettingsConfig` key, and extending `GlobalSettings` and `GlobalSettingsUpdates` in the GraphQL schema. Nothing uses global settings yet.
  - GraphQL mutations `updateShopSettings` and `updateGlobalSettings` are used to set one or more registered settings
  - GraphQL queries `shopSettings` and `globalSettings` are used to get one or more registered settings

## Breaking changes
None

## Testing
1. Identify a sellable product variant that does not have inventory tracking enabled (or disable).
1. On Shop Settings page, ensure the check box on the Inventory card is enabled.
1. On the storefront, ensure that you can add any quantity of the identified variant to your cart and order it.
1. On Shop Settings page, ensure the check box on the Inventory card is disabled.
1. Refresh the storefront. The variant should now appear as sold out. Ensure that you cannot add any quantity of the identified variant to your cart, and if you already have in your cart, that you cannot order it.