### PR TITLE
fix: NaN for prices with commas

### DIFF
--- a/client/modules/i18n/currency.js
+++ b/client/modules/i18n/currency.js
@@ -69,7 +69,11 @@ export function formatPriceString(formatPrice) {
   const prices = currentPrice.indexOf(" - ") >= 0 ?
     currentPrice.split(" - ") : [currentPrice, currentPrice];
 
-  return getDisplayPrice(Number(prices[0]), Number(prices[1]), userCurrency);
+  // Remove commas
+  const price1 = prices[0].replace(/,/g, "");
+  const price2 = prices[1].replace(/,/g, "");
+
+  return getDisplayPrice(Number(price1), Number(price2), userCurrency);
 }
 
 /**


### PR DESCRIPTION
Resolves #5191   
Impact: **minor**  
Type: **bugfix**

## Issue
Prices >= 1000 show as `NaN.undefined` in the operator products table. (Technically happens anywhere where `formatPriceString` function is used in the same way.)

## Solution
Handle large prices properly

## Breaking changes
None

## Testing
Set a product price to 1000 (no need to publish) and look at the products table in the operator UI. Make sure price is displayed correctly in the table cell.