### PR TITLE
(chore) Remove Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: .meteor/heroku_build/bin/node .meteor/heroku_build/bin/boot_proxy.js .meteor/heroku_build/bin/node .meteor/heroku_build/app/main.js


### PR DESCRIPTION
For one brief, shining moment you could deploy Reaction on Heroku with on click. But no longer. So this file has no use and is probably confusing.