### PR TITLE
feat: DangerButton and ConfirmButton components

### DIFF
--- a/imports/client/ui/components/ConfirmButton/ConfirmButton.js
+++ b/imports/client/ui/components/ConfirmButton/ConfirmButton.js
@@ -1,0 +1,101 @@
+import React, { Component, Fragment } from "react";
+import PropTypes from "prop-types";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import DangerButton from "../DangerButton";
+
+
+class ConfirmButton extends Component {
+  static propTypes = {
+    buttonColor: PropTypes.string,
+    buttonText: PropTypes.string,
+    buttonVariant: PropTypes.string,
+    cancelActionText: PropTypes.string,
+    children: PropTypes.object,
+    confirmActionText: PropTypes.string,
+    message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    onConfirm: PropTypes.func,
+    onSecondaryConfirm: PropTypes.func,
+    secondaryConfirmActionText: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+  }
+
+  static defaultProps = {
+    cancelActionText: "Cancel",
+    confirmActionText: "OK",
+    onConfirm() {}
+  }
+
+  state = {
+    isOpen: false
+  }
+
+  handleClose = () => {
+    this.setState({
+      isOpen: false
+    });
+  }
+
+  handleConfirm = () => {
+    this.props.onConfirm();
+    this.handleClose();
+  }
+
+  handleOpen = () => {
+    this.setState({
+      isOpen: true
+    });
+  }
+
+  renderButton = () => {
+    const { buttonColor, buttonText, buttonVariant } = this.props;
+
+    if (buttonColor === "danger") {
+      return <DangerButton color="primary" variant={buttonVariant} onClick={this.handleOpen}>{buttonText}</DangerButton>;
+    }
+
+    return (
+      <Button color={buttonColor} variant={buttonVariant} onClick={this.handleOpen}>{buttonText}</Button>
+    );
+  }
+
+  render() {
+    const { cancelActionText, children, confirmActionText, message, title } = this.props;
+    const { isOpen } = this.state;
+
+    return (
+      <Fragment>
+        {this.renderButton()}
+        <Dialog
+          aria-labelledby="confirm-action-dialog-title"
+          maxWidth="sm"
+          onClose={this.handleClose}
+          open={isOpen}
+        >
+          <DialogTitle id="confirm-action-dialog-title">{title}</DialogTitle>
+          {message && (
+            <DialogContent>
+              <DialogContentText>{message}</DialogContentText>
+              {children}
+            </DialogContent>
+          )}
+
+          <DialogActions>
+            <Button onClick={this.handleClose} color="primary" variant="outlined">
+              {cancelActionText}
+            </Button>
+            <Button onClick={this.handleConfirm} color="primary" variant="contained">
+              {confirmActionText}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Fragment>
+    );
+  }
+}
+
+export default ConfirmButton;

--- a/imports/client/ui/components/ConfirmButton/ConfirmButton.js
+++ b/imports/client/ui/components/ConfirmButton/ConfirmButton.js
@@ -19,8 +19,6 @@ class ConfirmButton extends Component {
     confirmActionText: PropTypes.string,
     message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     onConfirm: PropTypes.func,
-    onSecondaryConfirm: PropTypes.func,
-    secondaryConfirmActionText: PropTypes.string,
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
   }
 

--- a/imports/client/ui/components/ConfirmButton/index.js
+++ b/imports/client/ui/components/ConfirmButton/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ConfirmButton";

--- a/imports/client/ui/components/DangerButton/DangerButton.js
+++ b/imports/client/ui/components/DangerButton/DangerButton.js
@@ -36,10 +36,6 @@ const styles = (theme) => ({
  * @returns {React.Component} returns a React component
  */
 function DangerButton({ children, classes, color, onClick, variant }) {
-  const handleClick = () => {
-    onClick();
-  };
-
   return (
     <Button
       classes={{
@@ -47,7 +43,7 @@ function DangerButton({ children, classes, color, onClick, variant }) {
         outlinedPrimary: classes.outlinedPrimary
       }}
       color={color}
-      onClick={handleClick}
+      onClick={onClick}
       variant={variant}
     >
       {children}

--- a/imports/client/ui/components/DangerButton/DangerButton.js
+++ b/imports/client/ui/components/DangerButton/DangerButton.js
@@ -1,0 +1,75 @@
+import React from "react";
+import PropTypes from "prop-types";
+import withStyles from "@material-ui/core/styles/withStyles";
+import Button from "@material-ui/core/Button";
+
+
+const styles = (theme) => ({
+  containedPrimary: {
+    "color": theme.palette.primary.contrastText,
+    "backgroundColor": theme.palette.colors.red,
+    "&:hover": {
+      "backgroundColor": theme.palette.colors.redHover,
+      // Reset on touch devices, it doesn't add specificity
+      "@media (hover: none)": {
+        backgroundColor: theme.palette.colors.redHover
+      }
+    }
+  },
+  outlinedPrimary: {
+    "color": theme.palette.colors.red,
+    "border": `1px solid ${theme.palette.colors.red}`,
+    "&:hover": {
+      "border": `1px solid ${theme.palette.colors.redBorder}`,
+      "backgroundColor": theme.palette.colors.redBackground,
+      // Reset on touch devices, it doesn't add specificity
+      "@media (hover: none)": {
+        backgroundColor: "transparent"
+      }
+    }
+  }
+});
+
+/**
+ * @name DangerButton
+ * @params {Object} props Component props
+ * @returns {React.Component} returns a React component
+ */
+function DangerButton({ children, classes, color, onClick, variant }) {
+  const handleClick = () => {
+    onClick();
+  };
+
+  return (
+    <Button
+      classes={{
+        containedPrimary: classes.containedPrimary,
+        outlinedPrimary: classes.outlinedPrimary
+      }}
+      color={color}
+      onClick={handleClick}
+      variant={variant}
+    >
+      {children}
+    </Button>
+  );
+}
+
+DangerButton.propTypes = {
+  buttonVariant: PropTypes.string,
+  children: PropTypes.any,
+  classes: PropTypes.object,
+  color: PropTypes.string,
+  onClick: PropTypes.func,
+  variant: PropTypes.string
+};
+
+
+DangerButton.defaultProps = {
+  color: "primary",
+  variant: "outlined"
+};
+
+
+export default withStyles(styles, { name: "RuiDangerButton" })(DangerButton);
+

--- a/imports/client/ui/components/DangerButton/index.js
+++ b/imports/client/ui/components/DangerButton/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DangerButton";

--- a/imports/client/ui/components/DangerChip/DangerChip.js
+++ b/imports/client/ui/components/DangerChip/DangerChip.js
@@ -1,0 +1,57 @@
+import React from "react";
+import PropTypes from "prop-types";
+import withStyles from "@material-ui/core/styles/withStyles";
+import Chip from "@material-ui/core/Chip";
+
+
+const styles = (theme) => ({
+  containedPrimary: {
+    color: theme.palette.primary.contrastText,
+    backgroundColor: theme.palette.colors.red
+  },
+  outlinedPrimary: {
+    color: theme.palette.colors.red,
+    border: `1px solid ${theme.palette.colors.red}`
+  }
+});
+
+/**
+ * @name DangerChip
+ * @params {Object} props Component props
+ * @returns {React.Component} returns a React component
+ */
+function DangerChip({ classes, color, label, onClick, size, variant }) {
+  return (
+    <Chip
+      classes={{
+        containedPrimary: classes.containedPrimary,
+        outlinedPrimary: classes.outlinedPrimary
+      }}
+      color={color}
+      onClick={onClick}
+      label={label}
+      size={size}
+      variant={variant}
+    />
+  );
+}
+
+DangerChip.propTypes = {
+  buttonVariant: PropTypes.string,
+  children: PropTypes.any,
+  classes: PropTypes.object,
+  color: PropTypes.string,
+  label: PropTypes.string,
+  onClick: PropTypes.func,
+  size: PropTypes.string,
+  variant: PropTypes.string
+};
+
+
+DangerChip.defaultProps = {
+  color: "primary",
+  size: "small",
+  variant: "outlined"
+};
+
+export default withStyles(styles, { name: "RuiDangerChip" })(DangerChip);

--- a/imports/client/ui/components/DangerChip/index.js
+++ b/imports/client/ui/components/DangerChip/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DangerChip";

--- a/imports/plugins/core/router/client/theme/muiTheme.js
+++ b/imports/plugins/core/router/client/theme/muiTheme.js
@@ -34,6 +34,7 @@ export const rawMuiTheme = {
     fontWeightLight: 400,
     fontWeightRegular: 400,
     fontWeightMedium: 500,
+    fontWeightBold: 700,
     useNextVariants: true,
     h6: {
       fontSize: 18


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
Added three new Button / Chip components that wrap the MUI button, but give us more control of styling. Also added a `fontWeightBold` option in our MUI theme.

1) `DangerButton`, which just provides a red / danger style on top of the existing MUI button, as the provided MUI button does not come with a red / danger style.

2) `DangerChip`, which just provides a red / danger style on top of the existing MUI Chip, as the provided MUI Chip does not come with a red / danger style.

3) `ConfirmButton`, which provides a button that when clicked, opens a confirmation modal.

## Testing
1. Add the buttons in places. See that they work.