### PR TITLE
add approveOrderPayments graphql mutation

### DIFF
--- a/imports/plugins/core/payments/server/no-meteor/mutations/__snapshots__/approveOrderPayments.test.js.snap
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/__snapshots__/approveOrderPayments.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throws if orderId isn't supplied 1`] = `"Order ID is required"`;
+
+exports[`throws if paymentIds isn't supplied 1`] = `"Payment ids is required"`;
+
+exports[`throws if permission check fails 1`] = `"Access denied"`;
+
+exports[`throws if shopId isn't supplied 1`] = `"Shop ID is required"`;
+
+exports[`throws if the order doesn't exist 1`] = `"Access denied"`;
+
+exports[`throws if the order payment doesn't exist 1`] = `"Cannot read property 'status' of undefined"`;

--- a/imports/plugins/core/payments/server/no-meteor/mutations/__snapshots__/approveOrderPayments.test.js.snap
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/__snapshots__/approveOrderPayments.test.js.snap
@@ -8,6 +8,4 @@ exports[`throws if permission check fails 1`] = `"Access denied"`;
 
 exports[`throws if shopId isn't supplied 1`] = `"Shop ID is required"`;
 
-exports[`throws if the order doesn't exist 1`] = `"Access denied"`;
-
-exports[`throws if the order payment doesn't exist 1`] = `"Cannot read property 'status' of undefined"`;
+exports[`throws if the order doesn't exist 1`] = `"Order not found"`;

--- a/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.js
@@ -39,7 +39,7 @@ export default async function approveOrderPayments(context, input = {}) {
   // Set payment.status to approved for all paymentIds provided
   paymentIds.forEach((paymentId) => {
     const payment = updatedPayments.find((pmt) => pmt._id === paymentId);
-    if (paymentStatusesAllowedToBeApproved.includes(payment.status)) {
+    if (payment && paymentStatusesAllowedToBeApproved.includes(payment.status)) {
       payment.status = "approved";
     }
   });

--- a/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.js
@@ -1,0 +1,67 @@
+import ReactionError from "@reactioncommerce/reaction-error";
+import SimpleSchema from "simpl-schema";
+
+const inputSchema = new SimpleSchema({
+  orderId: String,
+  paymentIds: [String],
+  shopId: String
+});
+
+/**
+ * @method approveOrderPayments
+ * @summary Attempt to approve one or more authorized payments for an order
+ * @param {Object} context -  an object containing the per-request state
+ * @param {Object} input - ApproveOrderPaymentsInput
+ * @param {String} input.orderId - The order ID
+ * @param {String[]} input.paymentIds - An array of one or more payment IDs to approve
+ * @param {String} input.shopId - The ID of the shop that owns this order
+ * @return {Promise<Object>} ApproveOrderPaymentsResult
+ */
+export default async function approveOrderPayments(context, input = {}) {
+  inputSchema.validate(input);
+
+  const { appEvents, collections, userId } = context;
+  const { Orders } = collections;
+  const { orderId, paymentIds, shopId } = input;
+
+  if (!context.userHasPermission(["orders"], shopId)) {
+    throw new ReactionError("access-denied", "Access denied");
+  }
+
+  const order = await Orders.findOne({ _id: orderId, shopId });
+  if (!order) throw new ReactionError("not-found", "Order not found");
+
+  if (paymentIds.length === 0) return { order };
+
+  const updatedPayments = order.payments;
+  const paymentStatusesAllowedToBeApproved = ["adjustments", "created"];
+
+  // Set payment.status to approved for all paymentIds provided
+  paymentIds.forEach((paymentId) => {
+    const payment = updatedPayments.find((pmt) => pmt._id === paymentId);
+    if (paymentStatusesAllowedToBeApproved.includes(payment.status)) {
+      payment.status = "approved";
+    }
+  });
+
+  // Update Order with new payment status
+  const { value: updatedOrder } = await Orders.findOneAndUpdate({
+    _id: orderId
+  }, {
+    $set: {
+      payments: updatedPayments
+    }
+  }, { returnOriginal: false });
+
+  await appEvents.emit("afterOrderUpdate", {
+    order: updatedOrder,
+    updatedBy: userId
+  });
+
+  appEvents.emit("afterOrderApprovePayment", {
+    approvedBy: userId,
+    order: updatedOrder
+  });
+
+  return { order: updatedOrder };
+}

--- a/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.test.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.test.js
@@ -92,16 +92,16 @@ test("updates an order status", async () => {
     shopId: "SHOP_ID"
   }));
 
+  mockContext.collections.Orders.findOneAndUpdate.mockReturnValueOnce(Promise.resolve({
+    modifiedCount: 1,
+    value: {}
+  }));
+
   await approveOrderPayments(mockContext, {
     orderId: "abc",
     paymentIds: ["1"],
     shopId: "SHOP_ID"
   });
-
-  mockContext.collections.Orders.findOneAndUpdate.mockReturnValueOnce(Promise.resolve({
-    modifiedCount: 1,
-    value: {}
-  }));
 
   await expect(mockContext.collections.Orders.findOneAndUpdate).toHaveBeenCalledWith(
     { _id: "abc" },

--- a/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.test.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.test.js
@@ -27,6 +27,8 @@ test("throws if shopId isn't supplied", async () => {
 });
 
 test("throws if the order doesn't exist", async () => {
+  mockContext.userHasPermission.mockReturnValueOnce(true);
+
   mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve(null));
 
   await expect(approveOrderPayments(mockContext, {
@@ -57,25 +59,6 @@ test("throws if permission check fails", async () => {
   })).rejects.toThrowErrorMatchingSnapshot();
 
   expect(mockContext.userHasPermission).toHaveBeenCalledWith(["orders"], "SHOP_ID");
-});
-
-test("throws if the order payment doesn't exist", async () => {
-  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve({
-    payments: [
-      {
-        _id: "2"
-      }
-    ],
-    shopId: "SHOP_ID"
-  }));
-
-  mockContext.userHasPermission.mockReturnValueOnce(true);
-
-  await expect(approveOrderPayments(mockContext, {
-    orderId: "abc",
-    paymentIds: ["1"],
-    shopId: "SHOP_ID"
-  })).rejects.toThrowErrorMatchingSnapshot();
 });
 
 test("updates an order status", async () => {

--- a/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.test.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.test.js
@@ -118,16 +118,3 @@ test("updates an order status", async () => {
     { returnOriginal: false }
   );
 });
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.test.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/approveOrderPayments.test.js
@@ -1,0 +1,133 @@
+import mockContext from "/imports/test-utils/helpers/mockContext";
+import approveOrderPayments from "./approveOrderPayments";
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test("throws if orderId isn't supplied", async () => {
+  await expect(approveOrderPayments(mockContext, {
+    paymentIds: ["1"],
+    shopId: "SHOP_ID"
+  })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("throws if paymentIds isn't supplied", async () => {
+  await expect(approveOrderPayments(mockContext, {
+    orderId: "abc",
+    shopId: "SHOP_ID"
+  })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("throws if shopId isn't supplied", async () => {
+  await expect(approveOrderPayments(mockContext, {
+    orderId: "abc",
+    paymentIds: ["1"]
+  })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("throws if the order doesn't exist", async () => {
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve(null));
+
+  await expect(approveOrderPayments(mockContext, {
+    orderId: "abc",
+    paymentIds: ["1"],
+    shopId: "SHOP_ID"
+  })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("throws if permission check fails", async () => {
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve({
+    _id: "abc",
+    payments: [
+      {
+        _id: "1",
+        status: "created"
+      }
+    ],
+    shopId: "SHOP_ID"
+  }));
+
+  mockContext.userHasPermission.mockReturnValueOnce(false);
+
+  await expect(approveOrderPayments(mockContext, {
+    orderId: "abc",
+    paymentIds: ["1"],
+    shopId: "SHOP_ID"
+  })).rejects.toThrowErrorMatchingSnapshot();
+
+  expect(mockContext.userHasPermission).toHaveBeenCalledWith(["orders"], "SHOP_ID");
+});
+
+test("throws if the order payment doesn't exist", async () => {
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve({
+    payments: [
+      {
+        _id: "2"
+      }
+    ],
+    shopId: "SHOP_ID"
+  }));
+
+  mockContext.userHasPermission.mockReturnValueOnce(true);
+
+  await expect(approveOrderPayments(mockContext, {
+    orderId: "abc",
+    paymentIds: ["1"],
+    shopId: "SHOP_ID"
+  })).rejects.toThrowErrorMatchingSnapshot();
+});
+
+test("updates an order status", async () => {
+  mockContext.userHasPermission.mockReturnValueOnce(true);
+
+  mockContext.collections.Orders.findOne.mockReturnValueOnce(Promise.resolve({
+    _id: "abc",
+    payments: [
+      {
+        _id: "1",
+        status: "created"
+      }
+    ],
+    shopId: "SHOP_ID"
+  }));
+
+  await approveOrderPayments(mockContext, {
+    orderId: "abc",
+    paymentIds: ["1"],
+    shopId: "SHOP_ID"
+  });
+
+  mockContext.collections.Orders.findOneAndUpdate.mockReturnValueOnce(Promise.resolve({
+    modifiedCount: 1,
+    value: {}
+  }));
+
+  await expect(mockContext.collections.Orders.findOneAndUpdate).toHaveBeenCalledWith(
+    { _id: "abc" },
+    {
+      $set: {
+        payments: [
+          {
+            _id: "1",
+            status: "approved"
+          }
+        ]
+      }
+    },
+    { returnOriginal: false }
+  );
+});
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/imports/plugins/core/payments/server/no-meteor/mutations/index.js
+++ b/imports/plugins/core/payments/server/no-meteor/mutations/index.js
@@ -1,7 +1,9 @@
+import approveOrderPayments from "./approveOrderPayments";
 import captureOrderPayments from "./captureOrderPayments";
 import enablePaymentMethodForShop from "./enablePaymentMethodForShop";
 
 export default {
+  approveOrderPayments,
   captureOrderPayments,
   enablePaymentMethodForShop
 };

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/approveOrderPayments.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/approveOrderPayments.js
@@ -1,0 +1,35 @@
+import { decodeOrderOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/order";
+import { decodePaymentOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/payment";
+import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
+
+/**
+ * @name Mutation/approveOrderPayments
+ * @method
+ * @memberof Payment/GraphQL
+ * @summary resolver for the approveOrderPayments GraphQL mutation
+ * @param {Object} parentResult - unused
+ * @param {String} args.input.orderId - The order ID
+ * @param {String[]} args.input.paymentIds - An array of one or more payment IDs to approve
+ * @param {String} args.input.shopId - The ID of the shop that owns this order
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} ApproveOrderPaymentsPayload
+ */
+export default async function approveOrderPayments(parentResult, { input }, context) {
+  const { clientMutationId, orderId: opaqueOrderId, paymentIds: opaquePaymentIds, shopId: opaqueShopId } = input;
+
+  const orderId = decodeOrderOpaqueId(opaqueOrderId);
+  const paymentIds = opaquePaymentIds.map(decodePaymentOpaqueId);
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  const { order } = await context.mutations.approveOrderPayments(context, {
+    orderId,
+    paymentIds,
+    shopId
+  });
+
+  return {
+    clientMutationId,
+    order
+  };
+}

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/index.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/index.js
@@ -1,7 +1,9 @@
+import approveOrderPayments from "./approveOrderPayments";
 import captureOrderPayments from "./captureOrderPayments";
 import enablePaymentMethodForShop from "./enablePaymentMethodForShop";
 
 export default {
+  approveOrderPayments,
   captureOrderPayments,
   enablePaymentMethodForShop
 };

--- a/imports/plugins/core/payments/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/payments/server/no-meteor/schemas/schema.graphql
@@ -72,7 +72,7 @@ type Payment implements Node {
   method: PaymentMethod!
 
   "Risk level of payment"
-  riskLevel: String
+  riskLevel: RiskLevels
 
   "The current status of this payment"
   status: PaymentStatus!
@@ -103,6 +103,18 @@ enum PaymentStatus {
 
   "A shop operator has refunded all of this payment"
   refunded
+}
+
+"Valid payment risk levels"
+enum RiskLevels {
+  "A normal risk level for a payment"
+  normal
+
+  "An elevated risk level for a payment"
+  elevated
+
+  "The highest rist level for a payment"
+  highest
 }
 
 # Use `extend union` to define a payment plugin's PaymentData type

--- a/imports/plugins/core/payments/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/payments/server/no-meteor/schemas/schema.graphql
@@ -11,6 +11,9 @@ extend type Query {
 }
 
 extend type Mutation {
+  "Approve one or more payments for an order"
+  approveOrderPayments(input: ApproveOrderPaymentsInput!): ApproveOrderPaymentsPayload!
+
   "Capture one or more payments for an order"
   captureOrderPayments(input: CaptureOrderPaymentsInput!): CaptureOrderPaymentsPayload!
 
@@ -67,6 +70,9 @@ type Payment implements Node {
 
   "The payment method"
   method: PaymentMethod!
+
+  "Risk level of payment"
+  riskLevel: String
 
   "The current status of this payment"
   status: PaymentStatus!
@@ -158,6 +164,30 @@ type EnablePaymentMethodForShopPayload {
 
   "The full list of payment methods for the shop"
   paymentMethods: [PaymentMethod]!
+}
+
+"Input for the `approveOrderPayments` mutation"
+input ApproveOrderPaymentsInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "The order ID"
+  orderId: ID!
+
+  "The IDs of one or more payments to approve for this order"
+  paymentIds: [ID]!
+
+  "The ID of the shop that owns this order"
+  shopId: ID!
+}
+
+"Response from the `approveOrderPayments` mutation"
+type ApproveOrderPaymentsPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "The updated order"
+  order: Order!
 }
 
 "Input for the `captureOrderPayments` mutation"

--- a/imports/plugins/core/payments/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/payments/server/no-meteor/schemas/schema.graphql
@@ -72,7 +72,7 @@ type Payment implements Node {
   method: PaymentMethod!
 
   "Risk level of payment"
-  riskLevel: RiskLevels
+  riskLevel: RiskLevel
 
   "The current status of this payment"
   status: PaymentStatus!
@@ -106,15 +106,15 @@ enum PaymentStatus {
 }
 
 "Valid payment risk levels"
-enum RiskLevels {
-  "A normal risk level for a payment"
-  normal
-
+enum RiskLevel {
   "An elevated risk level for a payment"
   elevated
 
-  "The highest rist level for a payment"
+  "The highest risk level for a payment"
   highest
+
+  "A normal risk level for a payment"
+  normal
 }
 
 # Use `extend union` to define a payment plugin's PaymentData type


### PR DESCRIPTION
Part of #5157 
Impact: **minor**  
Type: **feature**

## Changes
A new `approveOrderPayments` mutation allows you to approve order payments, one by one, or multiple payments at one time. This is currently a required step in our workflow, and triggers a few changes with other packages, like inventory. Although we might remove this step in the future, this mutation can be used by existing users who use this step in the process.

## Breaking changes
None

## Testing
1. Place an order with one or more payments.
1. Verify that the mutation works as described, by updating payment status to `approved` for the corresponding payments.