### PR TITLE
chore: add language to shop query

### DIFF
--- a/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/shop.graphql
@@ -30,6 +30,9 @@ type Shop implements Node {
   "Returns a list of groups for this shop, as a Relay-compatible connection."
   groups(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = asc, sortBy: GroupSortByField = createdAt): GroupConnection
 
+  "Returns shop language"
+  language: String
+
   "Returns shop name"
   name: String
 

--- a/imports/plugins/core/graphql/lib/queries/getPrimaryShop.js
+++ b/imports/plugins/core/graphql/lib/queries/getPrimaryShop.js
@@ -4,6 +4,7 @@ export default gql`
   query getPrimaryShop($id: ID!) {
     shop(id: $id) {
       _id
+      language
       name
       storefrontUrls {
         storefrontHomeUrl


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
We use `language` in various queries to get translations. This PR adds `language` to the already existing `getPrimaryShop` graphql query, so that we can use this data from the shop.

## Testing
1. run the `primaryShop` graphql query inside GraphiQL and see that language is available on it:

```
query {
  primaryShop {
    language
  }
}
```