### PR TITLE
feat: Update sidebar, fix mobile responsiveness

### DIFF
--- a/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
+++ b/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
@@ -15,7 +15,7 @@ const styles = (theme) => ({
     marginLeft: theme.spacing.unit
   },
   primarySidebarOpen: {
-    paddingLeft: 280 + (theme.spacing.unit * 2)
+    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
   },
   title: {
     flex: 1

--- a/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
+++ b/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
@@ -31,15 +31,19 @@ const styles = (theme) => ({
 function PrimaryAppBar({ children, classes, title }) {
   return (
     <UIContext.Consumer>
-      {({ isPrimarySidebarOpen, onTogglePrimarySidebar }) => {
+      {({ isMobile, isPrimarySidebarOpen, onTogglePrimarySidebar }) => {
         const toolbarClassName = classNames({
-          [classes.primarySidebarOpen]: isPrimarySidebarOpen
+          // Add padding to the right when the primary sidebar is open,
+          // only if we're on desktop. On Mobile the sidebar floats over
+          // the content like a modal that's docked to either the left
+          // or right side of the screen.
+          [classes.primarySidebarOpen]: isPrimarySidebarOpen && !isMobile
         });
 
         return (
           <AppBar>
             <Toolbar className={toolbarClassName}>
-              <Hidden smUp>
+              <Hidden mdUp>
                 <IconButton onClick={onTogglePrimarySidebar}>
                   <MenuIcon />
                 </IconButton>

--- a/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
+++ b/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
@@ -34,7 +34,7 @@ function PrimaryAppBar({ children, classes, title }) {
       {({ isMobile, isPrimarySidebarOpen, onTogglePrimarySidebar }) => {
         const toolbarClassName = classNames({
           // Add padding to the right when the primary sidebar is open,
-          // only if we're on desktop. On Mobile the sidebar floats over
+          // only if we're on desktop. On mobile the sidebar floats over
           // the content like a modal that's docked to either the left
           // or right side of the screen.
           [classes.primarySidebarOpen]: isPrimarySidebarOpen && !isMobile

--- a/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
+++ b/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
@@ -1,0 +1,74 @@
+import React, { Children } from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import AppBar from "@material-ui/core/AppBar";
+import Hidden from "@material-ui/core/Hidden";
+import IconButton from "@material-ui/core/IconButton";
+import Toolbar from "@material-ui/core/Toolbar";
+import Typography from "@material-ui/core/Typography";
+import withStyles from "@material-ui/core/styles/withStyles";
+import MenuIcon from "mdi-material-ui/Menu";
+import { UIContext } from "../../context/UIContext";
+
+const styles = (theme) => ({
+  action: {
+    marginLeft: theme.spacing.unit
+  },
+  primarySidebarOpen: {
+    paddingLeft: 280 + (theme.spacing.unit * 2)
+  },
+  title: {
+    flex: 1
+  }
+});
+
+/**
+ * An AppBar for the main content area that provides a place for a title,
+ * actions to the right, and a menu button for opening and closing the sidebar drawer menu
+ * @param {Object} props Component props
+ * @returns {React.Component} A react component
+ */
+function PrimaryAppBar({ children, classes, title }) {
+  return (
+    <UIContext.Consumer>
+      {({ isPrimarySidebarOpen, onTogglePrimarySidebar }) => {
+        const toolbarClassName = classNames({
+          [classes.primarySidebarOpen]: isPrimarySidebarOpen
+        });
+
+        return (
+          <AppBar>
+            <Toolbar className={toolbarClassName}>
+              <Hidden smUp>
+                <IconButton onClick={onTogglePrimarySidebar}>
+                  <MenuIcon />
+                </IconButton>
+              </Hidden>
+              <Typography
+                className={classes.title}
+                component="h1"
+                variant="h6"
+              >
+                {title}
+              </Typography>
+              {Children.map(children, (child) => (
+                <div className={classes.action}>
+                  {child}
+                </div>
+              ))}
+            </Toolbar>
+          </AppBar>
+        );
+      }}
+    </UIContext.Consumer>
+  );
+}
+
+PrimaryAppBar.propTypes = {
+  children: PropTypes.node,
+  classes: PropTypes.object,
+  onToggleDrawerOpen: PropTypes.func,
+  title: PropTypes.string
+};
+
+export default withStyles(styles, { name: "RuiPrimaryAppBar" })(PrimaryAppBar);

--- a/imports/client/ui/components/PrimaryAppBar/index.js
+++ b/imports/client/ui/components/PrimaryAppBar/index.js
@@ -1,0 +1,1 @@
+export { default } from "./PrimaryAppBar";

--- a/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js
+++ b/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js
@@ -1,8 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { compose } from "recompose";
+import classNames from "classnames";
 import gql from "graphql-tag";
 import { Query } from "react-apollo";
 import { Link } from "react-router-dom";
+import Typography from "@material-ui/core/Typography";
+import withStyles from "@material-ui/core/styles/withStyles";
 import { withComponents } from "@reactioncommerce/components-context";
 import withPrimaryShopId from "/imports/plugins/core/graphql/lib/hocs/withPrimaryShopId";
 import GenericErrorBoundary from "../GenericErrorBoundary";
@@ -20,12 +24,22 @@ const getShop = gql`
   }
 `;
 
+const styles = (theme) => ({
+  root: {
+    display: "flex",
+    alignItems: "center"
+  },
+  logo: {
+    marginRight: theme.spacing.unit * 2
+  }
+});
+
 /**
  * ShopLogoWithData
  * @params {Object} props Component props
  * @returns {Node} React component
  */
-function ShopLogoWithData({ shopId, linkTo, size }) {
+function ShopLogoWithData({ className, classes, shopId, shouldShowShopName, linkTo, size }) {
   if (!shopId) return null;
 
   return (
@@ -39,15 +53,30 @@ function ShopLogoWithData({ shopId, linkTo, size }) {
             const defaultLogo = "/resources/reaction-logo-circular.svg";
 
             return (
-              <Link to={linkTo}>
+              <Link
+                className={classNames(classes.root, className)}
+                to={linkTo}
+              >
                 <img
                   alt={shop.name}
+                  className={classes.logo}
                   src={customLogo || defaultLogo}
                   width={size}
                 />
+                {shouldShowShopName &&
+                  <Typography
+                    color="textSecondary"
+                    display="display"
+                    variant="h6"
+                    component="span"
+                  >
+                    {shop.name}
+                  </Typography>
+                }
               </Link>
             );
           }
+
           // Return null if the shop data couldn't be found.
           return null;
         }}
@@ -57,16 +86,22 @@ function ShopLogoWithData({ shopId, linkTo, size }) {
 }
 
 ShopLogoWithData.propTypes = {
+  className: PropTypes.string,
+  classes: PropTypes.object,
   linkTo: PropTypes.string,
   shopId: PropTypes.string,
+  shouldShowShopName: PropTypes.bool,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
-
 ShopLogoWithData.defaultProps = {
   linkTo: "/operator",
+  shouldShowShopName: false,
   size: 60
 };
 
-
-export default withPrimaryShopId(withComponents(ShopLogoWithData));
+export default compose(
+  withPrimaryShopId,
+  withComponents,
+  withStyles(styles, { name: "RuiShopLogoWithData" })
+)(ShopLogoWithData);

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -95,7 +95,7 @@ function Sidebar(props) {
       <AppBar
         color="secondary"
         elevation={0}
-        position="static"
+        position="sticky"
       >
         <Toolbar className={classes.toolbar}>
           <ShopLogoWithData className={classes.shopLogo} shouldShowShopName size={32} />

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -156,7 +156,7 @@ function Sidebar(props) {
           className={classes.listItem}
           onClick={() => {
             // Push the first setting route when opened, but not on mobile
-            if (!isSettingsOpen) {
+            if (!isSettingsOpen && !isMobile) {
               const [firstRoute] = settingRoutes;
 
               if (firstRoute) {

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -192,5 +192,5 @@ Sidebar.defaultProps = {
 
 export default compose(
   withStyles(styles, { name: "RuiSidebar" }),
-  withState("isSettingsOpen", "setIsSettingsOpen", true)
+  withState("isSettingsOpen", "setIsSettingsOpen", false)
 )(Sidebar);

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -4,9 +4,9 @@ import { NavLink } from "react-router-dom";
 import PropTypes from "prop-types";
 import AppBar from "@material-ui/core/AppBar";
 import Collapse from "@material-ui/core/Collapse";
+import Fab from "@material-ui/core/Fab";
 import Hidden from "@material-ui/core/Hidden";
 import Toolbar from "@material-ui/core/Toolbar";
-import IconButton from "@material-ui/core/IconButton";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemIcon from "@material-ui/core/ListItemIcon";
@@ -101,9 +101,9 @@ function Sidebar(props) {
           <ShopLogoWithData className={classes.shopLogo} shouldShowShopName size={32} />
 
           <Hidden mdUp>
-            <IconButton onClick={onDrawerClose}>
+            <Fab color="secondary" onClick={onDrawerClose} size="small">
               <CloseIcon />
-            </IconButton>
+            </Fab>
           </Hidden>
 
         </Toolbar>

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -125,7 +125,7 @@ function Sidebar(props) {
       <List disablePadding>
         {primaryRoutes.map((route) => (
           <NavLink
-            activeClassName={activeClassName}
+            activeClassName={!isSettingsOpen ? activeClassName : null}
             className={classes.link}
             to={`/operator${route.path}`}
             key={route.path}

--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -21,6 +21,9 @@ import { Translation } from "/imports/plugins/core/ui/client/components";
 
 const activeClassName = "nav-item-active";
 
+// Route sorting by priority. Items without a priority get pushed the bottom.
+const routeSort = (routeA, routeB) => (routeA.priority || Number.MAX_SAFE_INTEGER) - (routeB.priority || Number.MAX_SAFE_INTEGER);
+
 const styles = (theme) => ({
   icon: {
     width: 32,
@@ -78,8 +81,8 @@ function Sidebar(props) {
     routes
   } = props;
 
-  const primaryRoutes = routes.filter(({ isNavigationLink, isSetting }) => isNavigationLink && !isSetting);
-  const settingRoutes = routes.filter(({ isNavigationLink, isSetting }) => isNavigationLink && isSetting);
+  const primaryRoutes = routes.filter(({ isNavigationLink, isSetting }) => isNavigationLink && !isSetting).sort(routeSort);
+  const settingRoutes = routes.filter(({ isNavigationLink, isSetting }) => isNavigationLink && isSetting).sort(routeSort);
 
   let drawerProps = {
     classes: {

--- a/imports/client/ui/context/UIContext.js
+++ b/imports/client/ui/context/UIContext.js
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+export const UIContext = createContext({
+  isPrimarySidebarOpen: true,
+  onClosePrimarySidebar: () => { },
+  onTogglePrimarySidebar: () => { }
+});

--- a/imports/client/ui/context/UIContext.js
+++ b/imports/client/ui/context/UIContext.js
@@ -1,6 +1,7 @@
 import { createContext } from "react";
 
 export const UIContext = createContext({
+  isMobile: false,
   isPrimarySidebarOpen: true,
   onClosePrimarySidebar: () => { },
   onTogglePrimarySidebar: () => { }

--- a/imports/client/ui/layouts/ContentViewExtraWideLayout.js
+++ b/imports/client/ui/layouts/ContentViewExtraWideLayout.js
@@ -19,7 +19,7 @@ const styles = (theme) => ({
     transition: "padding 225ms cubic-bezier(0, 0, 0.2, 1) 0ms"
   },
   leftSidebarOpen: {
-    paddingLeft: 280 + (theme.spacing.unit * 3)
+    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
   }
 });
 

--- a/imports/client/ui/layouts/ContentViewExtraWideLayout.js
+++ b/imports/client/ui/layouts/ContentViewExtraWideLayout.js
@@ -23,11 +23,11 @@ const styles = (theme) => ({
   }
 });
 
-const ContentViewExtraWideLayout = ({ children, classes, isMobile, isSidebarOpen }) => (
+const ContentViewExtraWideLayout = ({ children, classes, isSidebarOpen }) => (
   <div
     className={
       classNames(classes.root, {
-        [classes.leftSidebarOpen]: isSidebarOpen && isMobile === false
+        [classes.leftSidebarOpen]: isSidebarOpen
       })
     }
   >

--- a/imports/client/ui/layouts/ContentViewFullLayout.js
+++ b/imports/client/ui/layouts/ContentViewFullLayout.js
@@ -22,11 +22,11 @@ const styles = (theme) => ({
   }
 });
 
-const ContentViewFullLayout = ({ children, classes, isMobile, isSidebarOpen }) => (
+const ContentViewFullLayout = ({ children, classes, isSidebarOpen }) => (
   <div
     className={
       classNames(classes.root, {
-        [classes.leftSidebarOpen]: isSidebarOpen && isMobile === false
+        [classes.leftSidebarOpen]: isSidebarOpen
       })
     }
   >

--- a/imports/client/ui/layouts/ContentViewFullLayout.js
+++ b/imports/client/ui/layouts/ContentViewFullLayout.js
@@ -18,7 +18,7 @@ const styles = (theme) => ({
     overflow: "hidden"
   },
   leftSidebarOpen: {
-    paddingLeft: 280
+    paddingLeft: theme.spacing.drawerWidth
   }
 });
 

--- a/imports/client/ui/layouts/ContentViewStandardLayout.js
+++ b/imports/client/ui/layouts/ContentViewStandardLayout.js
@@ -18,7 +18,7 @@ const styles = (theme) => ({
     margin: "0 auto"
   },
   leftSidebarOpen: {
-    paddingLeft: 280
+    paddingLeft: theme.spacing.drawerWidth
   }
 });
 

--- a/imports/client/ui/layouts/ContentViewStandardLayout.js
+++ b/imports/client/ui/layouts/ContentViewStandardLayout.js
@@ -22,11 +22,11 @@ const styles = (theme) => ({
   }
 });
 
-const ContentViewStandardLayout = ({ children, classes, isMobile, isSidebarOpen }) => (
+const ContentViewStandardLayout = ({ children, classes, isSidebarOpen }) => (
   <div
     className={
       classNames(classes.root, {
-        [classes.leftSidebarOpen]: isSidebarOpen && isMobile === false
+        [classes.leftSidebarOpen]: isSidebarOpen
       })
     }
   >

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { compose } from "recompose";
-import { injectGlobal } from "styled-components";
 import withStyles from "@material-ui/core/styles/withStyles";
 import withWidth, { isWidthDown } from "@material-ui/core/withWidth";
 import { CustomPropTypes } from "@reactioncommerce/components/utils";
@@ -13,20 +12,19 @@ import Sidebar from "../components/Sidebar";
 import { operatorRoutes } from "../index";
 import { UIContext } from "../context/UIContext";
 import ContentViewFullLayout from "./ContentViewFullLayout";
-import ContentViewStandardayout from "./ContentViewStandardLayout";
-
-// Remove the 10px fontSize from the html element as it affects fonts that rely on rem
-injectGlobal`
-  html {
-    font-size: inherit;
-  }
-`;
+import ContentViewStandardLayout from "./ContentViewStandardLayout";
 
 const styles = (theme) => ({
-  container: {
+  "@global": {
+    html: {
+      // Remove the 10px fontSize from the html element as it affects fonts that rely on rem
+      fontSize: "inherit"
+    }
+  },
+  "container": {
     display: "flex"
   },
-  leftSidebarOpen: {
+  "leftSidebarOpen": {
     paddingLeft: 280 + (theme.spacing.unit * 2)
   }
 });
@@ -46,10 +44,30 @@ class Dashboard extends Component {
     // State also contains the updater function so it will
     // be passed down into the context provider
     this.state = {
+      isMobile: false,
       isPrimarySidebarOpen: true,
       onClosePrimarySidebar: this.onClosePrimarySidebar,
       onTogglePrimarySidebar: this.onTogglePrimarySidebar
     };
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { width } = this.props;
+    const isMobile = isWidthDown("sm", width);
+
+    if (prevState.isMobile !== isMobile) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({
+        isMobile
+      });
+    }
+
+    if (!isMobile && prevState.isPrimarySidebarOpen === false) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({
+        isPrimarySidebarOpen: true
+      });
+    }
   }
 
   onTogglePrimarySidebar = () => {
@@ -64,10 +82,7 @@ class Dashboard extends Component {
 
   render() {
     const { classes, width } = this.props;
-    const { isPrimarySidebarOpen } = this.state;
-
     const isMobile = isWidthDown("sm", width);
-    const isSidebarOpen = isPrimarySidebarOpen && !isMobile;
 
     return (
       <UIContext.Provider value={this.state}>
@@ -94,16 +109,16 @@ class Dashboard extends Component {
                     // If the layout component is explicitly null
                     if (route.layoutComponent === null) {
                       return (
-                        <ContentViewFullLayout isMobile={isMobile} isSidebarOpen={isSidebarOpen}>
+                        <ContentViewFullLayout isSidebarOpen={!isMobile}>
                           <route.mainComponent uiState={this.state} {...props} />
                         </ContentViewFullLayout>
                       );
                     }
 
-                    const LayoutComponent = route.layoutComponent || ContentViewStandardayout;
+                    const LayoutComponent = route.layoutComponent || ContentViewStandardLayout;
 
                     return (
-                      <LayoutComponent isMobile={isMobile} isSidebarOpen={isSidebarOpen}>
+                      <LayoutComponent isSidebarOpen={!isMobile}>
                         <route.mainComponent uiState={this.state} {...props} />
                       </LayoutComponent>
                     );

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -1,27 +1,19 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { compose } from "recompose";
-import classNames from "classnames";
-import styled, { injectGlobal } from "styled-components";
-import { ContainerQuery } from "react-container-query";
+import { injectGlobal } from "styled-components";
 import withStyles from "@material-ui/core/styles/withStyles";
-import AppBar from "@material-ui/core/AppBar";
-import Toolbar from "@material-ui/core/Toolbar";
+import withWidth, { isWidthDown } from "@material-ui/core/withWidth";
 import { CustomPropTypes } from "@reactioncommerce/components/utils";
 import { withComponents } from "@reactioncommerce/components-context";
 import { Route, Switch } from "react-router";
+import PrimaryAppBar from "../components/PrimaryAppBar/PrimaryAppBar";
 import ProfileImageWithData from "../components/ProfileImageWithData";
 import Sidebar from "../components/Sidebar";
 import { operatorRoutes } from "../index";
+import { UIContext } from "../context/UIContext";
 import ContentViewFullLayout from "./ContentViewFullLayout";
 import ContentViewStandardayout from "./ContentViewStandardLayout";
-
-const query = {
-  isMobile: {
-    minWidth: 0,
-    maxWidth: 600
-  }
-};
 
 // Remove the 10px fontSize from the html element as it affects fonts that rely on rem
 injectGlobal`
@@ -30,15 +22,10 @@ injectGlobal`
   }
 `;
 
-const Container = styled.div`
-  display: flex;
-`;
-
-const Grow = styled.div`
-  flex-grow: 1;
-`;
-
 const styles = (theme) => ({
+  container: {
+    display: "flex"
+  },
   leftSidebarOpen: {
     paddingLeft: 280 + (theme.spacing.unit * 2)
   }
@@ -49,97 +36,89 @@ class Dashboard extends Component {
     classes: PropTypes.object,
     components: PropTypes.shape({
       IconHamburger: CustomPropTypes.component.isRequired
-    })
+    }),
+    width: PropTypes.number
   };
 
-  state = {
-    isSidebarOpen: true
+  constructor(props) {
+    super(props);
+
+    // State also contains the updater function so it will
+    // be passed down into the context provider
+    this.state = {
+      isPrimarySidebarOpen: true,
+      onClosePrimarySidebar: this.onClosePrimarySidebar,
+      onTogglePrimarySidebar: this.onTogglePrimarySidebar
+    };
+  }
+
+  onTogglePrimarySidebar = () => {
+    this.setState((state) => ({
+      isPrimarySidebarOpen: !state.isPrimarySidebarOpen
+    }));
   };
 
-  handleDrawerClose = () => {
-    this.setState({ isSidebarOpen: false });
-  };
-
-  handleDrawerToggle = () => {
-    this.setState({ isSidebarOpen: !this.state.isSidebarOpen });
+  onClosePrimarySidebar = () => {
+    this.setState({ isPrimarySidebarOpen: false });
   };
 
   render() {
-    const { classes } = this.props;
-    const { isSidebarOpen } = this.state;
-    const uiState = {
-      isLeftDrawerOpen: isSidebarOpen
-    };
+    const { classes, width } = this.props;
+    const { isPrimarySidebarOpen } = this.state;
 
-    const toolbarClassName = classNames({
-      [classes.leftSidebarOpen]: uiState.isLeftDrawerOpen
-    });
+    const isMobile = isWidthDown("sm", width);
 
     return (
-      <ContainerQuery query={query}>
-        {({ isMobile }) => {
-          // Sidebar should be initially open on desktop but not on mobile.
-          // isMobile is initially undefined, so need the explicit `=== false` check
-          if (isSidebarOpen === null && isMobile === false) {
-            // React logs warnings when using `setState` in render, but in this
-            // case it works fine and I don't see any other way given how `ContainerQuery`
-            // works. Wrapping in `setTimeout` fools React into not printing the warning.
-            setTimeout(() => {
-              this.setState({ isSidebarOpen: true });
-            }, 0);
-          }
+      <UIContext.Provider value={this.state}>
+        <div className={classes.container}>
+          <PrimaryAppBar>
+            <ProfileImageWithData size={40} />
+          </PrimaryAppBar>
+          <Sidebar
+            isMobile={isMobile}
+            isSidebarOpen={this.state.isPrimarySidebarOpen}
+            setIsSidebarOpen={(value) => {
+              this.setState({ isPrimarySidebarOpen: value });
+            }}
+            onDrawerClose={this.state.onClosePrimarySidebar}
+            routes={operatorRoutes}
+          />
+          <Switch>
+            {
+              operatorRoutes.map((route) => (
+                <Route
+                  key={route.path}
+                  path={`/operator${route.path}`}
+                  render={(props) => {
+                    // If the layout component is explicitly null
+                    if (route.layoutComponent === null) {
+                      return (
+                        <ContentViewFullLayout isMobile={isMobile} isSidebarOpen={isPrimarySidebarOpen}>
+                          <route.mainComponent uiState={this.state} {...props} />
+                        </ContentViewFullLayout>
+                      );
+                    }
 
-          return (
-            <Container>
-              <AppBar position="fixed">
-                <Toolbar className={toolbarClassName}>
-                  <Grow />
-                  <ProfileImageWithData size={40} />
-                </Toolbar>
-              </AppBar>
-              <Sidebar
-                isMobile={isMobile}
-                isSidebarOpen={true}
-                onDrawerClose={this.handleDrawerClose}
-                routes={operatorRoutes}
-              />
-              <Switch>
-                {
-                  operatorRoutes.map((route) => (
-                    <Route
-                      key={route.path}
-                      path={`/operator${route.path}`}
-                      render={(props) => {
-                        // If the layout component is explicitly null
-                        if (route.layoutComponent === null) {
-                          return (
-                            <ContentViewFullLayout isMobile={isMobile} isSidebarOpen={isSidebarOpen}>
-                              <route.mainComponent uiState={uiState} {...props} />
-                            </ContentViewFullLayout>
-                          );
-                        }
+                    const LayoutComponent = route.layoutComponent || ContentViewStandardayout;
 
-                        const LayoutComponent = route.layoutComponent || ContentViewStandardayout;
-
-                        return (
-                          <LayoutComponent isMobile={isMobile} isSidebarOpen={isSidebarOpen}>
-                            <route.mainComponent uiState={uiState} {...props} />
-                          </LayoutComponent>
-                        );
-                      }}
-                    />
-                  ))
-                }
-              </Switch>
-            </Container>
-          );
-        }}
-      </ContainerQuery>
+                    return (
+                      <LayoutComponent isMobile={isMobile} isSidebarOpen={isPrimarySidebarOpen}>
+                        <route.mainComponent uiState={this.state} {...props} />
+                      </LayoutComponent>
+                    );
+                  }}
+                />
+              ))
+            }
+          </Switch>
+        </div>
+      </UIContext.Provider>
     );
   }
 }
 
 export default compose(
   withComponents,
+  withWidth({ initialWidth: "md" }),
   withStyles(styles, { name: "RuiDashboard" })
 )(Dashboard);

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -35,7 +35,7 @@ class Dashboard extends Component {
     components: PropTypes.shape({
       IconHamburger: CustomPropTypes.component.isRequired
     }),
-    width: PropTypes.number
+    width: PropTypes.string
   };
 
   constructor(props) {

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -67,6 +67,7 @@ class Dashboard extends Component {
     const { isPrimarySidebarOpen } = this.state;
 
     const isMobile = isWidthDown("sm", width);
+    const isSidebarOpen = isPrimarySidebarOpen && !isMobile;
 
     return (
       <UIContext.Provider value={this.state}>
@@ -93,7 +94,7 @@ class Dashboard extends Component {
                     // If the layout component is explicitly null
                     if (route.layoutComponent === null) {
                       return (
-                        <ContentViewFullLayout isMobile={isMobile} isSidebarOpen={isPrimarySidebarOpen}>
+                        <ContentViewFullLayout isMobile={isMobile} isSidebarOpen={isSidebarOpen}>
                           <route.mainComponent uiState={this.state} {...props} />
                         </ContentViewFullLayout>
                       );
@@ -102,7 +103,7 @@ class Dashboard extends Component {
                     const LayoutComponent = route.layoutComponent || ContentViewStandardayout;
 
                     return (
-                      <LayoutComponent isMobile={isMobile} isSidebarOpen={isPrimarySidebarOpen}>
+                      <LayoutComponent isMobile={isMobile} isSidebarOpen={isSidebarOpen}>
                         <route.mainComponent uiState={this.state} {...props} />
                       </LayoutComponent>
                     );

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -25,7 +25,7 @@ const styles = (theme) => ({
     display: "flex"
   },
   "leftSidebarOpen": {
-    paddingLeft: 280 + (theme.spacing.unit * 2)
+    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
   }
 });
 

--- a/imports/plugins/core/accounts/client/index.js
+++ b/imports/plugins/core/accounts/client/index.js
@@ -1,6 +1,5 @@
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faUsers, faSignInAlt } from "@fortawesome/free-solid-svg-icons";
+import AccountIcon from "mdi-material-ui/AccountMultiple";
 
 import { registerOperatorRoute } from "/imports/client/ui";
 import Accounts from "./containers/accountsDashboardContainer";
@@ -55,19 +54,21 @@ registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
   path: "/accounts",
+  priority: 10,
   mainComponent: Accounts,
   // eslint-disable-next-line react/display-name, react/no-multi-comp
-  SidebarIconComponent: (props) => <FontAwesomeIcon icon={faUsers} {...props} />,
+  SidebarIconComponent: (props) => <AccountIcon {...props} />,
   sidebarI18nLabel: "admin.dashboard.accountsLabel"
 });
 
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: true,
+  priority: 10,
   path: "/login-services",
   mainComponent: "accountsSettings",
   // eslint-disable-next-line react/display-name, react/no-multi-comp
-  SidebarIconComponent: (props) => <FontAwesomeIcon icon={faSignInAlt} {...props} />,
+  // SidebarIconComponent: (props) => <FontAwesomeIcon icon={faSignInAlt} {...props} />,
   sidebarI18nLabel: "admin.settings.accountSettingsLabel"
 });
 

--- a/imports/plugins/core/accounts/client/index.js
+++ b/imports/plugins/core/accounts/client/index.js
@@ -54,7 +54,7 @@ registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
   path: "/accounts",
-  priority: 10,
+  priority: 40,
   mainComponent: Accounts,
   // eslint-disable-next-line react/display-name, react/no-multi-comp
   SidebarIconComponent: (props) => <AccountIcon {...props} />,
@@ -64,7 +64,6 @@ registerOperatorRoute({
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: true,
-  priority: 10,
   path: "/login-services",
   mainComponent: "accountsSettings",
   // eslint-disable-next-line react/display-name, react/no-multi-comp

--- a/imports/plugins/core/catalog/client/components/publishControls.js
+++ b/imports/plugins/core/catalog/client/components/publishControls.js
@@ -1,12 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Components } from "@reactioncommerce/reaction-components";
-import AppBar from "@material-ui/core/AppBar";
 import Button from "@material-ui/core/Button";
-import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 import { i18next } from "/client/api";
+import PrimaryAppBar from "../../../../../client/ui/components/PrimaryAppBar/PrimaryAppBar";
 
 const styles = (theme) => ({
   label: {
@@ -42,22 +40,18 @@ class PublishControls extends Component {
     const { documentIds, onPublishClick } = this.props;
 
     return (
-      <AppBar color="default">
-        <Toolbar>
-          <Components.ToolbarGroup lastChild={true}>
-            {this.renderChangesNotification()}
-            <Button
-              color="primary"
-              variant="contained"
-              disabled={Array.isArray(documentIds) && documentIds.length === 0}
-              label="Publish"
-              onClick={onPublishClick}
-            >
-              {i18next.t("productDetailEdit.publish")}
-            </Button>
-          </Components.ToolbarGroup>
-        </Toolbar>
-      </AppBar>
+      <PrimaryAppBar>
+        {this.renderChangesNotification()}
+        <Button
+          color="primary"
+          variant="contained"
+          disabled={Array.isArray(documentIds) && documentIds.length === 0}
+          label="Publish"
+          onClick={onPublishClick}
+        >
+          {i18next.t("productDetailEdit.publish")}
+        </Button>
+      </PrimaryAppBar>
     );
   }
 }

--- a/imports/plugins/core/catalog/client/components/publishControls.js
+++ b/imports/plugins/core/catalog/client/components/publishControls.js
@@ -4,7 +4,7 @@ import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 import { i18next } from "/client/api";
-import PrimaryAppBar from "../../../../../client/ui/components/PrimaryAppBar/PrimaryAppBar";
+import PrimaryAppBar from "/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar";
 
 const styles = (theme) => ({
   label: {

--- a/imports/plugins/core/dashboard/client/index.js
+++ b/imports/plugins/core/dashboard/client/index.js
@@ -26,6 +26,7 @@ import "./templates/dashboard.js";
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: true,
+  priority: 10,
   path: "/shop-settings",
   mainComponent: "shopSettings",
   // eslint-disable-next-line react/display-name

--- a/imports/plugins/core/navigation/client/components/NavigationDashboard.js
+++ b/imports/plugins/core/navigation/client/components/NavigationDashboard.js
@@ -19,7 +19,7 @@ const styles = (theme) => ({
     overflow: "hidden"
   },
   leftSidebarOpen: {
-    paddingLeft: 280 + (theme.spacing.unit * 2)
+    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
   },
   title: {
     flex: 1

--- a/imports/plugins/core/navigation/client/components/NavigationDashboard.js
+++ b/imports/plugins/core/navigation/client/components/NavigationDashboard.js
@@ -1,27 +1,22 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import classnames from "classnames";
-import AppBar from "@material-ui/core/AppBar";
 import Dialog from "@material-ui/core/Dialog";
 import DialogContent from "@material-ui/core/DialogContent";
 import Button from "@material-ui/core/Button";
-import Toolbar from "@material-ui/core/Toolbar";
-import Typography from "@material-ui/core/Typography";
 import { withStyles } from "@material-ui/core/styles";
 import HTML5Backend from "react-dnd-html5-backend";
 import { DragDropContext } from "react-dnd";
 import NavigationItemForm from "./NavigationItemForm";
 import NavigationTreeContainer from "./NavigationTreeContainer";
 import NavigationItemList from "./NavigationItemList";
+import PrimaryAppBar from "/imports/client/ui/components/PrimaryAppBar";
+
 
 const styles = (theme) => ({
   root: {
     display: "flex",
     height: `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`,
     overflow: "hidden"
-  },
-  toolbarButton: {
-    marginLeft: theme.spacing.unit
   },
   leftSidebarOpen: {
     paddingLeft: 280 + (theme.spacing.unit * 2)
@@ -103,7 +98,6 @@ class NavigationDashboard extends Component {
       navigationItems,
       onSetSortableNavigationTree,
       sortableNavigationTree,
-      uiState,
       onDiscardNavigationTreeChanges,
       updateNavigationItem,
       updateNavigationTree
@@ -116,19 +110,12 @@ class NavigationDashboard extends Component {
       sortableTreeNode
     } = this.state;
 
-    const toolbarClassName = classnames({
-      [classes.leftSidebarOpen]: uiState.isLeftDrawerOpen
-    });
-
     return (
       <div className={classes.root}>
-        <AppBar color="default">
-          <Toolbar className={toolbarClassName}>
-            <Typography className={classes.title} variant="h6">Main Navigation</Typography>
-            <Button className={classes.toolbarButton} color="primary" onClick={onDiscardNavigationTreeChanges}>Discard</Button>
-            <Button className={classes.toolbarButton} color="primary" variant="contained" onClick={updateNavigationTree}>Save Changes</Button>
-          </Toolbar>
-        </AppBar>
+        <PrimaryAppBar title="Main Navigation">
+          <Button color="primary" onClick={onDiscardNavigationTreeChanges}>Discard</Button>
+          <Button color="primary" variant="contained" onClick={updateNavigationTree}>Save Changes</Button>
+        </PrimaryAppBar>
         <NavigationItemList
           onClickAddNavigationItem={this.addNavigationItem}
           navigationItems={navigationItems}

--- a/imports/plugins/core/navigation/client/index.js
+++ b/imports/plugins/core/navigation/client/index.js
@@ -10,7 +10,7 @@ import "./templates";
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
-  priority: 40,
+  priority: 50,
   layoutComponent: null,
   mainComponent: NavigationDashboard,
   path: "/navigation",

--- a/imports/plugins/core/navigation/client/index.js
+++ b/imports/plugins/core/navigation/client/index.js
@@ -1,7 +1,6 @@
 
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faLink } from "@fortawesome/free-solid-svg-icons";
+import LinkIcon from "mdi-material-ui/LinkVariant";
 import { registerOperatorRoute } from "/imports/client/ui";
 import NavigationDashboard from "./containers/navigationDashboardContainer";
 
@@ -10,11 +9,12 @@ import "./templates";
 
 registerOperatorRoute({
   isNavigationLink: true,
-  isSetting: true,
+  isSetting: false,
+  priority: 40,
   layoutComponent: null,
   mainComponent: NavigationDashboard,
   path: "/navigation",
   // eslint-disable-next-line react/display-name
-  SidebarIconComponent: (props) => <FontAwesomeIcon icon={faLink} {...props} />,
+  SidebarIconComponent: (props) => <LinkIcon {...props} />,
   sidebarI18nLabel: "admin.navigation.navigation"
 });

--- a/imports/plugins/core/orders/client/components/orderCardAppBar.js
+++ b/imports/plugins/core/orders/client/components/orderCardAppBar.js
@@ -8,7 +8,7 @@ import Toolbar from "@material-ui/core/Toolbar";
 
 const styles = (theme) => ({
   leftSidebarOpen: {
-    paddingLeft: 280 + (theme.spacing.unit * 2)
+    ...theme.mixins.leadingPaddingWhenPrimaryDrawerIsOpen
   }
 });
 

--- a/imports/plugins/core/orders/client/index.js
+++ b/imports/plugins/core/orders/client/index.js
@@ -1,6 +1,5 @@
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faInbox } from "@fortawesome/free-solid-svg-icons";
+import InboxIcon from "mdi-material-ui/Inbox";
 import { registerBlock } from "@reactioncommerce/reaction-components";
 import { registerOperatorRoute } from "/imports/client/ui";
 import ContentViewExtraWideLayout from "/imports/client/ui/layouts/ContentViewExtraWideLayout";
@@ -44,11 +43,12 @@ registerOperatorRoute({
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
+  priority: 20,
   layoutComponent: ContentViewExtraWideLayout,
   mainComponent: Orders,
   path: "/orders",
   // eslint-disable-next-line react/display-name
-  SidebarIconComponent: (props) => <FontAwesomeIcon icon={faInbox} {...props} />,
+  SidebarIconComponent: (props) => <InboxIcon {...props} />,
   sidebarI18nLabel: "admin.dashboard.ordersLabel"
 });
 

--- a/imports/plugins/core/orders/client/index.js
+++ b/imports/plugins/core/orders/client/index.js
@@ -43,7 +43,7 @@ registerOperatorRoute({
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
-  priority: 20,
+  priority: 10,
   layoutComponent: ContentViewExtraWideLayout,
   mainComponent: Orders,
   path: "/orders",

--- a/imports/plugins/core/payments/client/index.js
+++ b/imports/plugins/core/payments/client/index.js
@@ -10,6 +10,7 @@ registerOperatorRoute({
   isNavigationLink: true,
   isSetting: true,
   mainComponent: "paymentSettings",
+  priority: 20,
   path: "/payment",
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faCreditCard} {...props} />,

--- a/imports/plugins/core/router/client/theme/muiTheme.js
+++ b/imports/plugins/core/router/client/theme/muiTheme.js
@@ -8,7 +8,9 @@ const breakpoints = createBreakpoints({});
 const toolbarHeight = 80;
 const toolbarMobileHeight = 54;
 
+// Spacing
 export const defaultSpacingUnit = 8;
+export const drawerWidth = 280;
 
 // Colors
 export const colorPrimaryMain = colors.coolGrey;
@@ -90,9 +92,13 @@ export const rawMuiTheme = {
     borderRadius: 2
   },
   spacing: {
+    drawerWidth,
     unit: defaultSpacingUnit
   },
   mixins: {
+    leadingPaddingWhenPrimaryDrawerIsOpen: {
+      paddingLeft: drawerWidth + (defaultSpacingUnit * 2)
+    },
     toolbar: {
       minHeight: toolbarHeight,
       [`${breakpoints.up("xs")} and (orientation: landscape)`]: {
@@ -189,7 +195,7 @@ export const rawMuiTheme = {
     },
     MuiDrawer: {
       paper: {
-        width: 280
+        width: drawerWidth
       },
       paperAnchorLeft: {
         borderRight: "none",

--- a/imports/plugins/core/router/client/theme/muiTheme.js
+++ b/imports/plugins/core/router/client/theme/muiTheme.js
@@ -1,18 +1,18 @@
 import { defaultComponentTheme } from "@reactioncommerce/components";
 import createMuiTheme from "@material-ui/core/styles/createMuiTheme";
 import createBreakpoints from "@material-ui/core/styles/createBreakpoints";
-import { fade } from "@material-ui/core/styles/colorManipulator";
 import colors from "./colors";
 
 const { rui_typography: typography } = defaultComponentTheme;
 const breakpoints = createBreakpoints({});
 const toolbarHeight = 80;
+const toolbarMobileHeight = 54;
 
 export const defaultSpacingUnit = 8;
 
 // Colors
 export const colorPrimaryMain = colors.coolGrey;
-export const colorSecondaryMain = colors.coolGrey;
+export const colorSecondaryMain = colors.darkBlue500;
 
 export const rawMuiTheme = {
   palette: {
@@ -30,7 +30,8 @@ export const rawMuiTheme = {
     divider: colors.black10,
     text: {
       secondary: colors.black15,
-      active: colors.reactionBlue
+      secondaryActive: colors.white,
+      active: "#8acef2"
     }
   },
   typography: {
@@ -95,7 +96,14 @@ export const rawMuiTheme = {
     toolbar: {
       minHeight: toolbarHeight,
       [`${breakpoints.up("xs")} and (orientation: landscape)`]: {
-        minHeight: toolbarHeight
+        minHeight: toolbarMobileHeight,
+        paddingLeft: defaultSpacingUnit,
+        paddingRight: defaultSpacingUnit
+      },
+      [`${breakpoints.up("xs")} and (orientation: portrait)`]: {
+        minHeight: toolbarMobileHeight,
+        paddingLeft: defaultSpacingUnit,
+        paddingRight: defaultSpacingUnit
       },
       [breakpoints.up("sm")]: {
         minHeight: toolbarHeight
@@ -105,7 +113,7 @@ export const rawMuiTheme = {
   // Override default props
   props: {
     MuiAppBar: {
-      elevation: 3
+      elevation: 0
     },
     MuiCardHeader: {
       titleTypographyProps: {
@@ -117,16 +125,27 @@ export const rawMuiTheme = {
   overrides: {
     MuiAppBar: {
       root: {
-        height: toolbarHeight
+        height: toolbarHeight,
+        [`${breakpoints.up("xs")} and (orientation: landscape)`]: {
+          height: toolbarMobileHeight
+        },
+        [`${breakpoints.up("xs")} and (orientation: portrait)`]: {
+          height: toolbarMobileHeight
+        },
+        [breakpoints.up("sm")]: {
+          height: toolbarHeight
+        }
       },
       colorPrimary: {
-        backgroundColor: colors.white
+        backgroundColor: colors.white,
+        borderBottom: `1px solid ${colors.black05}`
       },
       colorSecondary: {
-        backgroundColor: fade(colors.coolGrey, 0.2)
+        backgroundColor: "#3C4950" // colors.coolGrey with 20% opacity, opaque
       },
       colorDefault: {
-        backgroundColor: colors.white
+        backgroundColor: colors.white,
+        borderBottom: `1px solid ${colors.black05}`
       }
     },
     MuiButton: {
@@ -179,6 +198,12 @@ export const rawMuiTheme = {
       },
       paperAnchorDockedLeft: {
         borderRight: "none"
+      }
+    },
+    MuiFab: {
+      sizeSmall: {
+        width: 36,
+        height: 36
       }
     },
     MuiOutlinedInput: {

--- a/imports/plugins/core/router/client/theme/muiTheme.js
+++ b/imports/plugins/core/router/client/theme/muiTheme.js
@@ -1,13 +1,14 @@
 import { defaultComponentTheme } from "@reactioncommerce/components";
 import createMuiTheme from "@material-ui/core/styles/createMuiTheme";
 import createBreakpoints from "@material-ui/core/styles/createBreakpoints";
+import { fade } from "@material-ui/core/styles/colorManipulator";
 import colors from "./colors";
 
 const { rui_typography: typography } = defaultComponentTheme;
 const breakpoints = createBreakpoints({});
 const toolbarHeight = 80;
 
-export const defaultSpacingUnit = 10;
+export const defaultSpacingUnit = 8;
 
 // Colors
 export const colorPrimaryMain = colors.coolGrey;
@@ -26,7 +27,11 @@ export const rawMuiTheme = {
       main: colorSecondaryMain,
       dark: colors.coolGrey400
     },
-    divider: colors.black10
+    divider: colors.black10,
+    text: {
+      secondary: colors.black15,
+      active: colors.reactionBlue
+    }
   },
   typography: {
     fontSize: 16,
@@ -40,6 +45,9 @@ export const rawMuiTheme = {
       fontSize: 18
     },
     subtitle1: {
+      fontSize: 16
+    },
+    body1: {
       fontSize: 16
     },
     button: {
@@ -114,6 +122,9 @@ export const rawMuiTheme = {
       colorPrimary: {
         backgroundColor: colors.white
       },
+      colorSecondary: {
+        backgroundColor: fade(colors.coolGrey, 0.2)
+      },
       colorDefault: {
         backgroundColor: colors.white
       }
@@ -158,8 +169,13 @@ export const rawMuiTheme = {
       }
     },
     MuiDrawer: {
+      paper: {
+        width: 280
+      },
       paperAnchorLeft: {
-        borderRight: "none"
+        borderRight: "none",
+        backgroundColor: colors.darkBlue500,
+        color: colors.black15
       },
       paperAnchorDockedLeft: {
         borderRight: "none"

--- a/imports/plugins/core/shipping/client/index.js
+++ b/imports/plugins/core/shipping/client/index.js
@@ -12,6 +12,7 @@ registerOperatorRoute({
   isNavigationLink: true,
   isSetting: true,
   mainComponent: Shipping,
+  priority: 40,
   path: "/shipping",
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faShippingFast} {...props} />,

--- a/imports/plugins/core/tags/client/components/TagForm.js
+++ b/imports/plugins/core/tags/client/components/TagForm.js
@@ -25,10 +25,6 @@ import { addTagMutation, updateTagMutation, removeTagMutation, setTagHeroMediaMu
 import TagToolbar from "./TagToolbar";
 import TagProductTable from "./TagProductTable";
 
-const Title = styled.h3`
-  margin-bottom: 16px;
-`;
-
 const CardActions = styled(MUICardActions)`
   justify-content: flex-end;
   padding-right: 0 !important;
@@ -369,13 +365,13 @@ class TagForm extends Component {
             <Mutation mutation={removeTagMutation}>
               {(removeMutationFunc) => (
                 <TagToolbar
+                  title={title}
                   onDelete={() => { this.handleRemove(tag._id, removeMutationFunc); }}
                   onCancel={this.handleCancel}
                   onSave={this.handleSave}
                 />
               )}
             </Mutation>
-            <Title>{title}</Title>
             <Form
               ref={(formRef) => { this.form = formRef; }}
               onChange={this.handleFormChange}

--- a/imports/plugins/core/tags/client/components/TagForm.js
+++ b/imports/plugins/core/tags/client/components/TagForm.js
@@ -319,7 +319,7 @@ class TagForm extends Component {
     const { tag } = this.props;
 
     if (tag) {
-      let metafields = {};
+      const metafields = {};
 
       if (Array.isArray(tag.metafields)) {
         tag.metafields.forEach((field) => {

--- a/imports/plugins/core/tags/client/components/TagToolbar.js
+++ b/imports/plugins/core/tags/client/components/TagToolbar.js
@@ -1,46 +1,50 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Button from "@reactioncommerce/components/Button/v1";
 import { i18next } from "/client/api";
 import PrimaryAppBar from "/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar";
 
-class TagToolbar extends Component {
-  static propTypes = {
-    canBeDeleted: PropTypes.bool,
-    isNew: PropTypes.bool,
-    onCancel: PropTypes.func,
-    onDelete: PropTypes.func,
-    onSave: PropTypes.func
-  }
+/**
+ * Tag toolbar component
+ * @param {Object} props Component props
+ * @returns {React.Component} Tag toolbar component
+ */
+function TagToolbar(props) {
+  const { canBeDeleted, onDelete, onCancel, onSave, title } = props;
 
-  static defaultProps = {
-    allowsDeletion: true,
-    isNew: true
-  }
-
-  render() {
-    const { onDelete, onCancel, onSave, canBeDeleted } = this.props;
-
-    return (
-      <PrimaryAppBar title="Main Navigation">
-        {(canBeDeleted) &&
-          <Button
-            actionType="secondary"
-            isTextOnly={true}
-            onClick={onDelete}
-          >
-            {i18next.t("admin.tags.form.delete")}
-          </Button>
-        }
-        <Button actionType="secondary" onClick={onCancel}>
-          {i18next.t("admin.tags.form.cancel")}
+  return (
+    <PrimaryAppBar title={title}>
+      {(canBeDeleted) &&
+        <Button
+          actionType="secondary"
+          isTextOnly={true}
+          onClick={onDelete}
+        >
+          {i18next.t("admin.tags.form.delete")}
         </Button>
-        <Button onClick={onSave}>
-          {i18next.t("admin.tags.form.saveChanges")}
-        </Button>
-      </PrimaryAppBar>
-    );
-  }
+      }
+      <Button actionType="secondary" onClick={onCancel}>
+        {i18next.t("admin.tags.form.cancel")}
+      </Button>
+      <Button onClick={onSave}>
+        {i18next.t("admin.tags.form.saveChanges")}
+      </Button>
+    </PrimaryAppBar>
+  );
 }
+
+TagToolbar.propTypes = {
+  canBeDeleted: PropTypes.bool,
+  isNew: PropTypes.bool,
+  onCancel: PropTypes.func,
+  onDelete: PropTypes.func,
+  onSave: PropTypes.func.props,
+  title: PropTypes.string
+};
+
+TagToolbar.defaultProps = {
+  allowsDeletion: true,
+  isNew: true
+};
 
 export default TagToolbar;

--- a/imports/plugins/core/tags/client/components/TagToolbar.js
+++ b/imports/plugins/core/tags/client/components/TagToolbar.js
@@ -1,18 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Button from "@reactioncommerce/components/Button/v1";
-import AppBar from "@material-ui/core/AppBar";
-import Toolbar from "@material-ui/core/Toolbar";
 import { i18next } from "/client/api";
-import styled from "styled-components";
-
-const Title = styled.div`
-  flex: 1;
-`;
-
-const ToolbarItem = styled.div`
-  margin-left: 8px;
-`;
+import PrimaryAppBar from "/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar";
 
 class TagToolbar extends Component {
   static propTypes = {
@@ -32,32 +22,23 @@ class TagToolbar extends Component {
     const { onDelete, onCancel, onSave, canBeDeleted } = this.props;
 
     return (
-      <AppBar position="fixed" color="default">
-        <Toolbar>
-          <Title />
-          {(canBeDeleted) &&
-            <ToolbarItem>
-              <Button
-                actionType="secondary"
-                isTextOnly={true}
-                onClick={onDelete}
-              >
-                {i18next.t("admin.tags.form.delete")}
-              </Button>
-            </ToolbarItem>
-          }
-          <ToolbarItem>
-            <Button actionType="secondary" onClick={onCancel}>
-              {i18next.t("admin.tags.form.cancel")}
-            </Button>
-          </ToolbarItem>
-          <ToolbarItem>
-            <Button onClick={onSave}>
-              {i18next.t("admin.tags.form.saveChanges")}
-            </Button>
-          </ToolbarItem>
-        </Toolbar>
-      </AppBar>
+      <PrimaryAppBar title="Main Navigation">
+        {(canBeDeleted) &&
+          <Button
+            actionType="secondary"
+            isTextOnly={true}
+            onClick={onDelete}
+          >
+            {i18next.t("admin.tags.form.delete")}
+          </Button>
+        }
+        <Button actionType="secondary" onClick={onCancel}>
+          {i18next.t("admin.tags.form.cancel")}
+        </Button>
+        <Button onClick={onSave}>
+          {i18next.t("admin.tags.form.saveChanges")}
+        </Button>
+      </PrimaryAppBar>
     );
   }
 }

--- a/imports/plugins/core/tags/client/index.js
+++ b/imports/plugins/core/tags/client/index.js
@@ -26,7 +26,7 @@ registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
   path: "/tags",
-  priority: 50,
+  priority: 30,
   mainComponent: TagSettingsPage,
   // eslint-disable-next-line react/display-name, react/no-multi-comp
   SidebarIconComponent: (props) => <TagIcon {...props} />,

--- a/imports/plugins/core/tags/client/index.js
+++ b/imports/plugins/core/tags/client/index.js
@@ -1,7 +1,6 @@
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { registerOperatorRoute } from "/imports/client/ui";
-import { faTag } from "@fortawesome/free-solid-svg-icons";
+import TagIcon from "mdi-material-ui/Tag";
 
 export { default as DataTable } from "./components/TagDataTable";
 export { default as TagDataTableColumn } from "./components/TagDataTableColumn";
@@ -11,24 +10,25 @@ import TagSettingsPage from "./pages/TagSettingsPageWithData";
 
 registerOperatorRoute({
   isNavigationLink: false,
-  isSetting: true,
+  isSetting: false,
   path: "/tags/create",
   mainComponent: TagFormPage
 });
 
 registerOperatorRoute({
   isNavigationLink: false,
-  isSetting: true,
+  isSetting: false,
   path: "/tags/edit/:tagId",
   mainComponent: TagFormPage
 });
 
 registerOperatorRoute({
   isNavigationLink: true,
-  isSetting: true,
+  isSetting: false,
   path: "/tags",
+  priority: 50,
   mainComponent: TagSettingsPage,
   // eslint-disable-next-line react/display-name, react/no-multi-comp
-  SidebarIconComponent: (props) => <FontAwesomeIcon icon={faTag} {...props} />,
+  SidebarIconComponent: (props) => <TagIcon {...props} />,
   sidebarI18nLabel: "admin.tags.tags"
 });

--- a/imports/plugins/core/taxes/client/index.js
+++ b/imports/plugins/core/taxes/client/index.js
@@ -11,6 +11,7 @@ registerOperatorRoute({
   isNavigationLink: true,
   isSetting: true,
   mainComponent: "taxSettings",
+  priority: 30,
   path: "/tax-settings",
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faUniversity} {...props} />,

--- a/imports/plugins/included/product-admin/client/index.js
+++ b/imports/plugins/included/product-admin/client/index.js
@@ -3,8 +3,7 @@ import "./templates/productAdmin.js";
 import "./blocks";
 
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBox } from "@fortawesome/free-solid-svg-icons";
+import CubeIcon from "mdi-material-ui/Cube";
 import { registerOperatorRoute } from "/imports/client/ui";
 
 import ProductTable from "./components/ProductTable";
@@ -51,11 +50,12 @@ registerOperatorRoute({
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
+  priority: 30,
   layoutComponent: ContentViewExtraWideLayout,
   path: "/products",
   mainComponent: ProductTable,
   hocs: [withCreateProduct],
   // eslint-disable-next-line react/display-name, react/no-multi-comp
-  SidebarIconComponent: (props) => <FontAwesomeIcon icon={faBox} {...props} />,
+  SidebarIconComponent: (props) => <CubeIcon {...props} />,
   sidebarI18nLabel: "admin.products"
 });

--- a/imports/plugins/included/product-admin/client/index.js
+++ b/imports/plugins/included/product-admin/client/index.js
@@ -50,7 +50,7 @@ registerOperatorRoute({
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: false,
-  priority: 30,
+  priority: 20,
   layoutComponent: ContentViewExtraWideLayout,
   path: "/products",
   mainComponent: ProductTable,


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue

- Sidebar design is out-of-date with current designs
- Sidebar isn't closable on mobile

## Solution

- Update sidebar to current design spec
- Fix mobile responsiveness
- Make it easier to create toolbars without having to re-implement the same logic over and over

## Breaking changes

`uiState.isLeftSidebarOpen` renamed to `uiState.isPrimarySidebarOpen`.

## Testing
1. Run the app, and login into the admin
2. See the new sidebar
3. Click around
4. Resize to mobile
5. Open / close sidebar
6. With the sidebar open, click on a menu item
7. The sidebar should close and navigate you to that page
8. Resize back to desktop
9. Continue to use the sidebar

