### PR TITLE
fix: catalog sort by price for custom pricing plugins.

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/resolvers/Query/catalogItems.js
+++ b/imports/plugins/core/catalog/server/no-meteor/resolvers/Query/catalogItems.js
@@ -53,7 +53,7 @@ export default async function catalogItems(_, args, context, info) {
 
     // Allow external pricing plugins to handle this if registered. We'll use the
     // first value returned that is a string.
-    for (const func of context.getFunctionsOfType("getMinPriceSortByFieldPath")) {
+    for (const func of context.getFunctionsOfType("getMinPriceSortByFieldPath").reverse()) {
       realSortByField = await func(context, { connectionArgs }); // eslint-disable-line no-await-in-loop
       if (typeof realSortByField === "string") break;
     }


### PR DESCRIPTION
Resolves n/a
Impact: **minor**  
Type: **bugfix|refactor**

## Issue
What I've been able to uncover is the `getMinPriceSortByFieldPath` from a custom pricing-plugin doesn't change the `realSortByField` variable in the `CatalogItems` GQL [resolver code](https://github.com/reactioncommerce/reaction/blob/1295041b4b6c1f902783ffb049781882bd2ff10a/imports/plugins/core/catalog/server/no-meteor/resolvers/Query/catalogItems.js#L56). Looks like this for loop gets an array of functions, the first one is the `getMinPriceSortByFieldPath` from the simple-pricing plugin the second is the `getMinPriceSortByFieldPath` from the custom pricing-plugin, from there it executes the first function setting  `'product.pricing.usd.minPrice'` as the `realSortByField` variable this causes the `break` on the next line and the custom version of this method never gets called. This is causing the Catalog to sort by the value 0 when using Reaction with an external pricing service.

__Note:__ the sort by price feature works as expected with the included pricing plugin this is only an issue when trying to use a custom pricing plugin with Reaction.

## Solution
I don't think I'm grasping how the `getFunctionsByTypes` is suppose to work in this resolver, I've simply reversed the array of functions to call the last array item (my custom plugin's func) first. This fixes the sort by issue I'm seeing in the my custom storefront but this doesn't feel like the right solution for the situation. Thoughts @aldeed?

## Breaking changes
n/a

## Testing
TBD
