### PR TITLE
fix: app will not start

### DIFF
--- a/imports/plugins/core/accounts/server/no-meteor/util/addRolesToGroups.js
+++ b/imports/plugins/core/accounts/server/no-meteor/util/addRolesToGroups.js
@@ -48,7 +48,7 @@ export default async function addRolesToGroups(context, options = { allShops: fa
 
     if (areRolesInGroup === false) {
       Logger.debug(`Adding roles (${roles}) to ${group.name} group (${group._id})`);
-      return addRolesToGroupAndUsers(group, roles);
+      return addRolesToGroupAndUsers(context, group, roles);
     }
 
     Logger.debug(`Skipping roles already assigned to ${group.name} group and its users`);


### PR DESCRIPTION
Impact: **critical**  
Type: **bugfix**

## Issue

The app will not start due to an error in the `addRolesToGroups` function in `/imports/plugins/core/accounts/server/no-meteor/util/addRolesToGroups.js:51`

## Solution

Pass context to `addRolesToGroupAndUsers()`

## Breaking changes

none

## Testing
1. start the app 
2. ensure that startup is successful and you can sign in to the operator panel
3. use the app and ensure it functions as expected
