### PR TITLE
[CircleCI] Fix environment variable syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           name: Restoring Meteor cache
-          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-meteor
+          key: reaction-v2-meteor
       - run:
           name: Install Meteor
           command: |
@@ -36,7 +36,7 @@ jobs:
             fi
       - save_cache:
           name: Saving Meteor to cache
-          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-meteor-{{ epoch }}
+          key: reaction-v2-meteor-{{ epoch }}
           paths:
             - ~/.meteor
       - run:
@@ -70,11 +70,11 @@ jobs:
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.
       - save_cache:
-          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: reaction-v2-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}-{{ epoch }}
+          key: reaction-v2-node-modules-{{ .Branch }}-{{ epoch }}
           paths:
             - node_modules
 
@@ -195,9 +195,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
+            - reaction-v2-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-v2-node-modules-{{ .Branch }}
+            - reaction-v2-node-modules-master
       - run:
           name: Run Lint
           command: |
@@ -209,9 +209,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
+            - reaction-v2-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-v2-node-modules-{{ .Branch }}
+            - reaction-v2-node-modules-master
       - run:
           name: Lint GraphQL schemas
           command: |
@@ -223,16 +223,16 @@ jobs:
       - checkout
       - restore_cache:
           name: Restoring Meteor cache
-          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-meteor
+          key: reaction-v2-meteor
       - run:
           name: Link Restored Meteor
           command: sudo ln -s ~/.meteor/meteor /usr/local/bin/meteor
       - restore_cache:
           # Fall back to less specific caches
           keys:
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
+            - reaction-v2-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-v2-node-modules-{{ .Branch }}
+            - reaction-v2-node-modules-master
       - run:
           name: Load App Plugins
           command: node --experimental-modules ./.reaction/scripts/build.mjs
@@ -246,9 +246,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
+            - reaction-v2-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-v2-node-modules-{{ .Branch }}
+            - reaction-v2-node-modules-master
       - run:
           name: Run Unit Tests
           command: npm run test:unit
@@ -259,9 +259,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
+            - reaction-v2-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-v2-node-modules-{{ .Branch }}
+            - reaction-v2-node-modules-master
       - run:
           name: Run Integration Tests
           command: npm run test:integration
@@ -320,9 +320,9 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
-            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
+            - reaction-v2-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-v2-node-modules-{{ .Branch }}
+            - reaction-v2-node-modules-master
       - run:
           name: Snyk Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           name: Restoring Meteor cache
-          key: ${GLOBAL_CACHE_VERSION}-meteor
+          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-meteor
       - run:
           name: Install Meteor
           command: |
@@ -36,7 +36,7 @@ jobs:
             fi
       - save_cache:
           name: Saving Meteor to cache
-          key: ${GLOBAL_CACHE_VERSION}-meteor-{{ epoch }}
+          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-meteor-{{ epoch }}
           paths:
             - ~/.meteor
       - run:
@@ -70,11 +70,11 @@ jobs:
       # Store node_modules dependency cache.
       # Saved with package.json checksum and timestamped branch name keys.
       - save_cache:
-          key: ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}-{{ epoch }}
+          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}-{{ epoch }}
           paths:
             - node_modules
 
@@ -195,9 +195,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
       - run:
           name: Run Lint
           command: |
@@ -209,9 +209,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
       - run:
           name: Lint GraphQL schemas
           command: |
@@ -223,16 +223,16 @@ jobs:
       - checkout
       - restore_cache:
           name: Restoring Meteor cache
-          key: ${GLOBAL_CACHE_VERSION}-meteor
+          key: reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-meteor
       - run:
           name: Link Restored Meteor
           command: sudo ln -s ~/.meteor/meteor /usr/local/bin/meteor
       - restore_cache:
           # Fall back to less specific caches
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
       - run:
           name: Load App Plugins
           command: node --experimental-modules ./.reaction/scripts/build.mjs
@@ -246,9 +246,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
       - run:
           name: Run Unit Tests
           command: npm run test:unit
@@ -259,9 +259,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
       - run:
           name: Run Integration Tests
           command: npm run test:integration
@@ -320,9 +320,9 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-{{ .Branch }}
-            - ${GLOBAL_CACHE_VERSION}-node-modules-master
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-{{ .Branch }}
+            - reaction-{{ .Environment.GLOBAL_CACHE_VERSION }}-node-modules-master
       - run:
           name: Snyk Test
           command: |


### PR DESCRIPTION
`save_cache` uses special syntax for variable interpolation ([docs](https://circleci.com/docs/2.0/configuration-reference/#save_cache))

Impact: **minor**  
Type: **chore**

## Issue
Currently the `GLOBAL_CACHE_VERSION` environment variable doesn't actually change the cache version.

## Solution
Change `config.yml` to use the correct syntax.

## Breaking changes
This will invalidate any build caches in CircleCI.

## Testing
1. Merge.
2. Check for the correct cache name in the logs.