### PR TITLE
refactor: enhancements to tag ui in Catalyst

### DIFF
--- a/imports/plugins/core/tags/client/components/TagProductTable.js
+++ b/imports/plugins/core/tags/client/components/TagProductTable.js
@@ -5,6 +5,7 @@ import { i18next } from "/client/api";
 import TextInput from "@reactioncommerce/components/TextInput/v1";
 import Button from "@material-ui/core/Button";
 import ExpansionPanelActions from "@material-ui/core/ExpansionPanelActions";
+import Link from "@material-ui/core/Link";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
@@ -73,7 +74,9 @@ class TagProductTable extends Component {
                     return (
                       <TableRow key={product._id}>
                         <TableCell component="th" scope="row">{product._id}</TableCell>
-                        <TableCell>{product.title}</TableCell>
+                        <TableCell>
+                          <Link href={`/operator/products/${product._id}`}>{product.title}</Link>
+                        </TableCell>
                         <TableCell align="right">
                           <TextInput
                             value={position}

--- a/imports/plugins/core/tags/server/i18n/en.json
+++ b/imports/plugins/core/tags/server/i18n/en.json
@@ -4,7 +4,8 @@
     "ns": "reaction-tags",
     "translation": {
       "reaction-tags": {
-        "tagSaved": "Tag saved",
+        "tagAddedToProduct": "Tag \"{{tagName}}\" added to product",
+        "tagRemovedFromProduct": "Tag \"{{tagName}}\" removed from product",
         "admin": {
           "tags": {
             "tags": "Tags",

--- a/imports/plugins/core/tags/server/i18n/en.json
+++ b/imports/plugins/core/tags/server/i18n/en.json
@@ -4,6 +4,7 @@
     "ns": "reaction-tags",
     "translation": {
       "reaction-tags": {
+        "tagSaved": "Tag saved",
         "admin": {
           "tags": {
             "tags": "Tags",

--- a/imports/plugins/core/ui/client/components/tags/tagItem.js
+++ b/imports/plugins/core/ui/client/components/tags/tagItem.js
@@ -2,8 +2,9 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 import Autosuggest from "react-autosuggest";
+import Link from "@material-ui/core/Link";
 import { registerComponent } from "@reactioncommerce/reaction-components";
-import { i18next } from "/client/api";
+import { i18next, Reaction } from "/client/api";
 import { Button } from "/imports/plugins/core/ui/client/components";
 import { Router } from "@reactioncommerce/reaction-router";
 import { highlightInput } from "../../helpers/animations";
@@ -44,6 +45,16 @@ class TagItem extends Component {
     if (this.props.onTagSave) {
       this.props.onTagSave(event, this.props.tag);
     }
+  }
+
+  /**
+   * Handle tag edit links to tag editing UI for this specific tag
+   * @return {void} no return value
+   */
+  handleTagEdit = () => {
+    const { tag } = this.props;
+
+    Reaction.Router.go(`/operator/tags/edit/${tag._id}`);
   }
 
   /**
@@ -214,6 +225,7 @@ class TagItem extends Component {
         >
           <form onSubmit={this.handleTagFormSubmit}>
             {this.renderAutosuggestInput()}
+            <Button icon="edit" onClick={this.handleTagEdit} status="default" />
             <Button icon="times-circle" onClick={this.handleTagRemove} status="danger" />
             {this.props.isTagNav &&
               <Button icon="chevron-down" onClick={this.handleTagSelect} status="default" />

--- a/imports/plugins/core/ui/client/components/tags/tagItem.js
+++ b/imports/plugins/core/ui/client/components/tags/tagItem.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 import Autosuggest from "react-autosuggest";
-import Link from "@material-ui/core/Link";
 import { registerComponent } from "@reactioncommerce/reaction-components";
 import { i18next, Reaction } from "/client/api";
 import { Button } from "/imports/plugins/core/ui/client/components";

--- a/imports/plugins/core/ui/client/containers/tagListContainer.js
+++ b/imports/plugins/core/ui/client/containers/tagListContainer.js
@@ -88,7 +88,7 @@ const wrapComponent = (Comp) => (
             return Alerts.toast(i18next.t("productDetail.tagExists"), "error");
           }
 
-          Alerts.toast(i18next.t("tagSaved", "Tag saved"), "success");
+          Alerts.toast(i18next.t("tagAddedToProduct", { defaultValue: `Tag "${tag.name}" added to product`, tagName: tag.name }), "success");
 
           this.setState({
             newTag: {
@@ -115,6 +115,8 @@ const wrapComponent = (Comp) => (
             return Alerts.toast(i18next.t("productDetail.tagExists"), "error");
           }
 
+          Alerts.toast(i18next.t("tagAddedToProduct", { defaultValue: `Tag "${tag.name}" added to product`, tagName: tag.name }), "success");
+
           this.setState({
             suggestions: []
           });
@@ -130,6 +132,8 @@ const wrapComponent = (Comp) => (
           if (error) {
             Alerts.toast(i18next.t("productDetail.tagInUse"), "error");
           }
+
+          Alerts.toast(i18next.t("tagRemovedFromProduct", { defaultValue: `Tag "${tag.name}" removed from product`, tagName: tag.name }), "success");
         });
       }
     }

--- a/imports/plugins/core/ui/client/containers/tagListContainer.js
+++ b/imports/plugins/core/ui/client/containers/tagListContainer.js
@@ -88,6 +88,8 @@ const wrapComponent = (Comp) => (
             return Alerts.toast(i18next.t("productDetail.tagExists"), "error");
           }
 
+          Alerts.toast(i18next.t("tagSaved", "Tag saved"), "success");
+
           this.setState({
             newTag: {
               name: ""


### PR DESCRIPTION
Resolves #5218   
Impact: **minor**  
Type: **refactor**

## Issue
From the ticket:

> There some UI issues with the tag editor that make it difficult to use for day-to-day operations.
> 
> 1. Tag filtering doesn't work. The filter applies after the query, so you will still have many pages to paginate through, but sometimes the pages will have fewer results.
> 1. Adding tags to products is sometimes unclear whether the tag was added due to some UI hiccups.
> 1. There's no way to go directly to a tag from a product, and no way to go to a product from a tag.

## Solution
1. Will be addressed in a separate PR
1. Add toast alerts to let the user know adding and removing of tags has been saved
1. Add links from product editing to tag page, and from tag editing to product page.


## Testing
1. Log into Catalyst
1. Go to product page
1. Click edit button next to a tag on the Product page, and see that it takes you to the tag
![Not-found](https://user-images.githubusercontent.com/4482263/59810134-b16f2600-92b8-11e9-9266-b28894256551.png)
1. Go to the `Product` tab of a tag edit page, and click on a product name, and see it takes you to product
![Not-found](https://user-images.githubusercontent.com/4482263/59810142-bc29bb00-92b8-11e9-91bd-df4779622a5c.png)


1. Add a new tag to a product, and see an alert that tells you the tag name, and that it was saved
![Not-found](https://user-images.githubusercontent.com/4482263/59810166-dd8aa700-92b8-11e9-885d-f8f50b3e9b8e.png)
1. Remove a tag from a product, see alert that tells you the tag name was removed
![Not-found](https://user-images.githubusercontent.com/4482263/59810177-ed09f000-92b8-11e9-86e2-61e2783022cb.png)
