### PR TITLE
Add offset argument for numerical pagination

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
@@ -380,6 +380,7 @@ extend type Query {
     before: ConnectionCursor,
     first: ConnectionLimitInt,
     last: ConnectionLimitInt,
+    offset: ConnectionLimitInt,
     sortOrder: SortOrder = desc,
 
     "Provide a Currency code if sortBy is minPrice"

--- a/imports/plugins/core/graphql/server/no-meteor/util/applyPaginationToMongoCursor.js
+++ b/imports/plugins/core/graphql/server/no-meteor/util/applyPaginationToMongoCursor.js
@@ -16,7 +16,7 @@ const DEFAULT_LIMIT = 20;
  *   Default is `true`. Set this to `false` if you don't need it to avoid an extra database command.
  * @return {Promise<Object>} `{ hasNextPage, hasPreviousPage }`
  */
-export default async function applyPaginationToMongoCursor(cursor, { first, last } = {}, {
+export default async function applyPaginationToMongoCursor(cursor, { first, last, offset } = {}, {
   includeHasNextPage = true,
   includeHasPreviousPage = true
 } = {}) {
@@ -26,6 +26,9 @@ export default async function applyPaginationToMongoCursor(cursor, { first, last
   const limit = first || last || DEFAULT_LIMIT;
 
   let skip = 0;
+
+  if (offset) skip = offset;
+
   let hasNextPage = null;
   let hasPreviousPage = null;
   if (last) {

--- a/tests/catalog/catalogItems.test.js
+++ b/tests/catalog/catalogItems.test.js
@@ -5,6 +5,7 @@ import { internalTagIds } from "../mocks/mockTags";
 import { internalCatalogItemIds } from "../mocks/mockCatalogProducts";
 import {
   mockCatalogItems,
+  mockOffsetCatalogItemsResponse,
   mockUnsortedCatalogItemsResponse,
   mockSortedByPriceHigh2LowCatalogItemsResponse,
   mockSortedByPriceLow2HighCatalogItemsResponse
@@ -56,6 +57,19 @@ test("expect CatalogItemProducts sorted by minPrice from highest to lowest when 
   }
 
   expect(result).toEqual(mockSortedByPriceHigh2LowCatalogItemsResponse);
+});
+
+// expect CatalogItems with offset to skip items
+test("expect CatalogitemProducts with offset to skip items", async () => {
+  let result;
+  try {
+    result = await query({ shopIds: [opaqueShopId], offset: 1 });
+  } catch (error) {
+    expect(error).toBeUndefined90;
+    return;
+  }
+
+  expect(result).toEqual(mockOffsetCatalogItemsResponse);
 });
 
 // expect CatalogItems sorted by minPrice form high to low when sortOrder is desc

--- a/tests/mocks/mockCatalogItems.js
+++ b/tests/mocks/mockCatalogItems.js
@@ -34,6 +34,8 @@ export const mockCatalogItems = [
   }
 ];
 
+export const mockOffsetCatalogItems = mockCatalogItems.shift();
+
 /**
  * Mock absolute URLs in catalog products when returned from GraphQL
  */


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
Adds `offset` as an argument to the catalogItems query to allow for numerical pagination.