### PR TITLE
feat: add landing page for catalyst

### DIFF
--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -6,6 +6,7 @@ import withWidth, { isWidthDown } from "@material-ui/core/withWidth";
 import { CustomPropTypes } from "@reactioncommerce/components/utils";
 import { withComponents } from "@reactioncommerce/components-context";
 import { Route, Switch } from "react-router";
+import OperatorLanding from "/imports/plugins/core/dashboard/client/components/OperatorLanding";
 import PrimaryAppBar from "../components/PrimaryAppBar/PrimaryAppBar";
 import ProfileImageWithData from "../components/ProfileImageWithData";
 import Sidebar from "../components/Sidebar";
@@ -126,6 +127,21 @@ class Dashboard extends Component {
                 />
               ))
             }
+            {/*
+            Add a special route for the landing page.
+            This must go last, as it will override other
+            routes if it is placed before them.
+            This is essentially a 404 in addition to a landing page.
+            */}
+            <Route
+              key="operatorLandingPage"
+              path="/operator"
+              render={(props) => (
+                <ContentViewFullLayout isSidebarOpen={!isMobile}>
+                  <OperatorLanding uiState={this.state} {...props} />
+                </ContentViewFullLayout>
+              )}
+            />
           </Switch>
         </div>
       </UIContext.Provider>

--- a/imports/client/ui/layouts/Dashboard.js
+++ b/imports/client/ui/layouts/Dashboard.js
@@ -6,7 +6,6 @@ import withWidth, { isWidthDown } from "@material-ui/core/withWidth";
 import { CustomPropTypes } from "@reactioncommerce/components/utils";
 import { withComponents } from "@reactioncommerce/components-context";
 import { Route, Switch } from "react-router";
-import OperatorLanding from "/imports/plugins/core/dashboard/client/components/OperatorLanding";
 import PrimaryAppBar from "../components/PrimaryAppBar/PrimaryAppBar";
 import ProfileImageWithData from "../components/ProfileImageWithData";
 import Sidebar from "../components/Sidebar";
@@ -104,6 +103,7 @@ class Dashboard extends Component {
             {
               operatorRoutes.map((route) => (
                 <Route
+                  exact
                   key={route.path}
                   path={`/operator${route.path}`}
                   render={(props) => {
@@ -127,21 +127,6 @@ class Dashboard extends Component {
                 />
               ))
             }
-            {/*
-            Add a special route for the landing page.
-            This must go last, as it will override other
-            routes if it is placed before them.
-            This is essentially a 404 in addition to a landing page.
-            */}
-            <Route
-              key="operatorLandingPage"
-              path="/operator"
-              render={(props) => (
-                <ContentViewFullLayout isSidebarOpen={!isMobile}>
-                  <OperatorLanding uiState={this.state} {...props} />
-                </ContentViewFullLayout>
-              )}
-            />
           </Switch>
         </div>
       </UIContext.Provider>

--- a/imports/plugins/core/dashboard/client/components/OperatorLanding.js
+++ b/imports/plugins/core/dashboard/client/components/OperatorLanding.js
@@ -1,0 +1,38 @@
+import React from "react";
+import Grid from "@material-ui/core/Grid";
+import Link from "@material-ui/core/Link";
+import Typography from "@material-ui/core/Typography";
+import ShopLogoWithData from "/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData";
+
+/**
+ * OperatorLanding
+ * @params {Object} props Component props
+ * @returns {Node} React component
+ */
+function OperatorLanding() {
+  return (
+    <Grid
+      container
+      direction="column"
+      justify="center"
+      alignItems="center"
+      spacing={40}
+    >
+      <Grid item>
+        <ShopLogoWithData size={100} />
+      </Grid>
+      <Grid item>
+        <Typography align="center" variant="body2">
+            Use the navigation menu at the left to manage <Link href="/operator/orders">Orders</Link>, <Link href="/operator/products">Products</Link>, <Link href="/operator/tags">Tags</Link>, <Link href="/operator/accounts">Accounts</Link>, and <Link href="/operator/navigation">Navigation</Link>, or change shop settings.
+        </Typography>
+      </Grid>
+      <Grid item>
+        <Typography align="center" variant="body2">
+          See our <Link href="https://docs.reactioncommerce.com/docs/dashboard">Store Operator's Guide</Link> for more information.
+        </Typography>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default OperatorLanding;

--- a/imports/plugins/core/dashboard/client/components/OperatorLanding.js
+++ b/imports/plugins/core/dashboard/client/components/OperatorLanding.js
@@ -28,7 +28,7 @@ function OperatorLanding() {
         </Grid>
         <Grid item>
           <Typography align="center" variant="body2">
-              Use the navigation menu at the left to manage <Link to="/operator/orders">Orders</Link>, <Link to="/operator/products">Products</Link>, <Link to="/operator/tags">Tags</Link>, <Link to="/operator/accounts">Accounts</Link>, and <Link to="/operator/navigation">Navigation</Link>, or change shop settings.
+              Use the Operator UI to manage <Link to="/operator/orders">Orders</Link>, <Link to="/operator/products">Products</Link>, <Link to="/operator/tags">Tags</Link>, <Link to="/operator/accounts">Accounts</Link>, and <Link to="/operator/navigation">Navigation</Link>, or change shop settings.
           </Typography>
         </Grid>
         <Grid item>

--- a/imports/plugins/core/dashboard/client/components/OperatorLanding.js
+++ b/imports/plugins/core/dashboard/client/components/OperatorLanding.js
@@ -33,7 +33,7 @@ function OperatorLanding() {
         </Grid>
         <Grid item>
           <Typography align="center" variant="body2">
-            See our <MuiLink href="https://docs.reactioncommerce.com/docs/dashboard">Store Operator's Guide</MuiLink> for more information.
+            See our <MuiLink href="https://docs.reactioncommerce.com/docs/dashboard">Store Operator’s Guide</MuiLink> for more information.
           </Typography>
         </Grid>
       </Grid>

--- a/imports/plugins/core/dashboard/client/components/OperatorLanding.js
+++ b/imports/plugins/core/dashboard/client/components/OperatorLanding.js
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { Fragment } from "react";
+import Helmet from "react-helmet";
+import { Link } from "react-router-dom";
 import Grid from "@material-ui/core/Grid";
-import Link from "@material-ui/core/Link";
+import MuiLink from "@material-ui/core/Link";
 import Typography from "@material-ui/core/Typography";
 import ShopLogoWithData from "/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData";
 
@@ -11,27 +13,31 @@ import ShopLogoWithData from "/imports/client/ui/components/ShopLogoWithData/Sho
  */
 function OperatorLanding() {
   return (
-    <Grid
-      container
-      direction="column"
-      justify="center"
-      alignItems="center"
-      spacing={40}
-    >
-      <Grid item>
-        <ShopLogoWithData size={100} />
+    <Fragment>
+      <Helmet title="Operator UI" />
+      <Grid
+        container
+        direction="column"
+        justify="center"
+        alignItems="center"
+        spacing={40}
+      >
+        <Grid item />
+        <Grid item>
+          <ShopLogoWithData size={100} />
+        </Grid>
+        <Grid item>
+          <Typography align="center" variant="body2">
+              Use the navigation menu at the left to manage <Link to="/operator/orders">Orders</Link>, <Link to="/operator/products">Products</Link>, <Link to="/operator/tags">Tags</Link>, <Link to="/operator/accounts">Accounts</Link>, and <Link to="/operator/navigation">Navigation</Link>, or change shop settings.
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography align="center" variant="body2">
+            See our <MuiLink href="https://docs.reactioncommerce.com/docs/dashboard">Store Operator's Guide</MuiLink> for more information.
+          </Typography>
+        </Grid>
       </Grid>
-      <Grid item>
-        <Typography align="center" variant="body2">
-            Use the navigation menu at the left to manage <Link href="/operator/orders">Orders</Link>, <Link href="/operator/products">Products</Link>, <Link href="/operator/tags">Tags</Link>, <Link href="/operator/accounts">Accounts</Link>, and <Link href="/operator/navigation">Navigation</Link>, or change shop settings.
-        </Typography>
-      </Grid>
-      <Grid item>
-        <Typography align="center" variant="body2">
-          See our <Link href="https://docs.reactioncommerce.com/docs/dashboard">Store Operator's Guide</Link> for more information.
-        </Typography>
-      </Grid>
-    </Grid>
+    </Fragment>
   );
 }
 

--- a/imports/plugins/core/dashboard/client/index.js
+++ b/imports/plugins/core/dashboard/client/index.js
@@ -3,6 +3,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStore } from "@fortawesome/free-solid-svg-icons";
 
 import { registerOperatorRoute } from "/imports/client/ui";
+import OperatorLanding from "/imports/plugins/core/dashboard/client/components/OperatorLanding";
+
 import "./templates/import/import.html";
 import "./templates/import/import.js";
 
@@ -22,6 +24,14 @@ import "./templates/shop/settings/settings.js";
 
 import "./templates/dashboard.html";
 import "./templates/dashboard.js";
+
+// Default landing page
+registerOperatorRoute({
+  isNavigationLink: false,
+  isSetting: false,
+  path: "/",
+  mainComponent: OperatorLanding
+});
 
 registerOperatorRoute({
   isNavigationLink: true,

--- a/imports/plugins/core/dashboard/client/index.js
+++ b/imports/plugins/core/dashboard/client/index.js
@@ -23,8 +23,6 @@ import "./templates/shop/settings/settings.js";
 import "./templates/dashboard.html";
 import "./templates/dashboard.js";
 
-import OperatorLanding from "./components/OperatorLanding";
-
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: true,
@@ -34,12 +32,4 @@ registerOperatorRoute({
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faStore} {...props} />,
   sidebarI18nLabel: "admin.settings.shopSettingsLabel"
-});
-
-
-registerOperatorRoute({
-  isNavigationLink: false,
-  isSetting: false,
-  path: "/",
-  mainComponent: OperatorLanding
 });

--- a/imports/plugins/core/dashboard/client/index.js
+++ b/imports/plugins/core/dashboard/client/index.js
@@ -23,6 +23,8 @@ import "./templates/shop/settings/settings.js";
 import "./templates/dashboard.html";
 import "./templates/dashboard.js";
 
+import OperatorLanding from "./components/OperatorLanding";
+
 registerOperatorRoute({
   isNavigationLink: true,
   isSetting: true,
@@ -32,4 +34,12 @@ registerOperatorRoute({
   // eslint-disable-next-line react/display-name
   SidebarIconComponent: (props) => <FontAwesomeIcon icon={faStore} {...props} />,
   sidebarI18nLabel: "admin.settings.shopSettingsLabel"
+});
+
+
+registerOperatorRoute({
+  isNavigationLink: false,
+  isSetting: false,
+  path: "/",
+  mainComponent: OperatorLanding
 });


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
When a user first lands on the Operator UI, a blank screen is shown, which makes it look broken.

## Solution
Add a landing page that just lets the user know where they are, and provides links to docs, and common features.

## Breaking changes
None

## Testing
1. Go to /operator
1. See the landing page
1. Click other links and make sure they all still work, and the the landing link doesn't override them.

![Not-found](https://user-images.githubusercontent.com/4482263/59871561-b7aee200-934c-11e9-9d65-c34e64e8d6cf.png)
