### PR TITLE
feat: bulk simple inventory mutation

### DIFF
--- a/imports/plugins/core/inventory/server/no-meteor/utils/startup.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/startup.js
@@ -1,48 +1,73 @@
 /**
+ * @summary Updates `isBackorder`, `isSoldOut`, and `isLowQuantity` as necessary for
+ *   a single CatalogProduct. Call this whenever inventory changes for one or more
+ *   variants of a product.
+ * @param {Object} context App context
+ * @param {String} productId The product ID
+ * @return {undefined}
+ */
+async function updateInventoryBooleansInCatalog(context, productId) {
+  const { collections: { Catalog, Products } } = context;
+
+  const variants = await Products.find({
+    ancestors: productId,
+    isDeleted: { $ne: true },
+    isVisible: true
+  }, {
+    _id: 1,
+    ancestors: 1,
+    shopId: 1
+  }).toArray();
+
+  const topVariants = variants.filter((variant) => variant.ancestors.length === 1);
+  if (topVariants.length === 0) return;
+
+  const topVariantsInventoryInfo = await context.queries.inventoryForProductConfigurations(context, {
+    fields: ["isBackorder", "isLowQuantity", "isSoldOut"],
+    productConfigurations: topVariants.map((option) => ({
+      isSellable: !variants.some((variant) => variant.ancestors.includes(option._id)),
+      productId: option.ancestors[0],
+      productVariantId: option._id
+    })),
+    shopId: topVariants[0].shopId
+  });
+
+  await Catalog.updateOne({ "product.productId": productId }, {
+    $set: {
+      "product.isBackorder": topVariantsInventoryInfo.every(({ inventoryInfo }) => inventoryInfo.isBackorder),
+      "product.isLowQuantity": topVariantsInventoryInfo.some(({ inventoryInfo }) => inventoryInfo.isLowQuantity),
+      "product.isSoldOut": topVariantsInventoryInfo.every(({ inventoryInfo }) => inventoryInfo.isSoldOut)
+    }
+  });
+}
+
+/**
  * @summary Called on startup
  * @param {Object} context Startup context
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
 export default function startup(context) {
-  const { appEvents, collections } = context;
-  const { Catalog, Products } = collections;
+  const { appEvents } = context;
 
   // Whenever inventory is updated for any sellable variant, the plugin that did the update is
   // expected to emit `afterInventoryUpdate`. We listen for this and keep the boolean fields
   // on the CatalogProduct correct.
-  appEvents.on("afterInventoryUpdate", async ({ productConfiguration }) => {
-    const { productId } = productConfiguration;
+  appEvents.on("afterInventoryUpdate", async ({ productConfiguration }) =>
+    updateInventoryBooleansInCatalog(context, productConfiguration.productId));
 
-    const variants = await Products.find({
-      ancestors: productId,
-      isDeleted: { $ne: true },
-      isVisible: true
-    }, {
-      _id: 1,
-      ancestors: 1,
-      shopId: 1
-    }).toArray();
-
-    const topVariants = variants.filter((variant) => variant.ancestors.length === 1);
-    if (topVariants.length === 0) return;
-
-    const topVariantsInventoryInfo = await context.queries.inventoryForProductConfigurations(context, {
-      fields: ["isBackorder", "isLowQuantity", "isSoldOut"],
-      productConfigurations: topVariants.map((option) => ({
-        isSellable: !variants.some((variant) => variant.ancestors.includes(option._id)),
-        productId: option.ancestors[0],
-        productVariantId: option._id
-      })),
-      shopId: topVariants[0].shopId
-    });
-
-    await Catalog.updateOne({ "product.productId": productId }, {
-      $set: {
-        "product.isBackorder": topVariantsInventoryInfo.every(({ inventoryInfo }) => inventoryInfo.isBackorder),
-        "product.isLowQuantity": topVariantsInventoryInfo.some(({ inventoryInfo }) => inventoryInfo.isLowQuantity),
-        "product.isSoldOut": topVariantsInventoryInfo.every(({ inventoryInfo }) => inventoryInfo.isSoldOut)
+  appEvents.on("afterBulkInventoryUpdate", async ({ productConfigurations }) => {
+    // Since it is a bulk update and many of the product configurations may be for the same
+    // productId, we can avoid unnecessary work by running the update only once per productId.
+    const uniqueProductIds = productConfigurations.reduce((list, productConfiguration) => {
+      const { productId } = productConfiguration;
+      if (!list.includes(productId)) {
+        list.push(productId);
       }
+      return list;
+    }, []);
+    uniqueProductIds.forEach((productId) => {
+      updateInventoryBooleansInCatalog(context, productId);
     });
   });
 }

--- a/imports/plugins/included/simple-inventory/server/no-meteor/mutations/index.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/mutations/index.js
@@ -1,7 +1,9 @@
 import recalculateReservedSimpleInventory from "./recalculateReservedSimpleInventory";
 import updateSimpleInventory from "./updateSimpleInventory";
+import updateSimpleInventoryBulk from "./updateSimpleInventoryBulk";
 
 export default {
   recalculateReservedSimpleInventory,
+  updateSimpleInventoryBulk,
   updateSimpleInventory
 };

--- a/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventory.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventory.js
@@ -1,44 +1,6 @@
-import SimpleSchema from "simpl-schema";
-import Random from "@reactioncommerce/random";
 import ReactionError from "@reactioncommerce/reaction-error";
-import { ProductConfigurationSchema, SimpleInventoryCollectionSchema } from "../simpleSchemas";
-
-const inputSchema = new SimpleSchema({
-  productConfiguration: ProductConfigurationSchema,
-  canBackorder: {
-    type: Boolean,
-    optional: true
-  },
-  inventoryInStock: {
-    type: SimpleSchema.Integer,
-    min: 0,
-    optional: true
-  },
-  isEnabled: {
-    type: Boolean,
-    optional: true
-  },
-  lowInventoryWarningThreshold: {
-    type: SimpleSchema.Integer,
-    min: 0,
-    optional: true
-  },
-  shopId: String
-});
-
-const updateFields = [
-  "canBackorder",
-  "inventoryInStock",
-  "isEnabled",
-  "lowInventoryWarningThreshold"
-];
-
-const defaultValues = {
-  canBackorder: false,
-  inventoryInStock: 0,
-  isEnabled: false,
-  lowInventoryWarningThreshold: 0
-};
+import { inputSchema } from "../utils/defaults";
+import getModifier from "../utils/getModifier";
 
 /**
  * @summary Updates SimpleInventory data for a product configuration. Pass only
@@ -86,43 +48,7 @@ export default async function updateSimpleInventory(context, input, options = {}
     }
   }
 
-  const $set = { updatedAt: new Date() };
-  const $setOnInsert = {
-    "_id": Random.id(),
-    "createdAt": new Date(),
-    // inventoryReserved is calculated by this plugin rather than being set by
-    // users, but we need to init it to some number since this is required.
-    // Below we update this to the correct number if we inserted.
-    "inventoryReserved": 0,
-    // The upsert query below has only `productVariantId` so we need to ensure both are inserted
-    "productConfiguration.productId": productConfiguration.productId
-  };
-  updateFields.forEach((field) => {
-    const value = input[field];
-    if (value !== undefined && value !== null) {
-      $set[field] = value;
-    } else {
-      // If we are not setting the value here, then we add it to the setOnInsert.
-      // This is necessary because all fields are required by the collection schema.
-      $setOnInsert[field] = defaultValues[field];
-    }
-  });
-
-  if (Object.getOwnPropertyNames($set).length === 1) {
-    throw new ReactionError("invalid-param", "You must provide at least one field to update.");
-  }
-
-  const modifier = { $set, $setOnInsert };
-
-  SimpleInventoryCollectionSchema.validate({
-    $set,
-    $setOnInsert: {
-      ...$setOnInsert,
-      "productConfiguration.productVariantId": productConfiguration.productVariantId,
-      shopId
-    }
-  }, { modifier: true, upsert: true });
-
+  const modifier = getModifier(input);
   const { upsertedCount } = await SimpleInventory.updateOne(
     {
       "productConfiguration.productVariantId": productConfiguration.productVariantId,

--- a/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventory.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventory.js
@@ -1,6 +1,6 @@
 import ReactionError from "@reactioncommerce/reaction-error";
 import { inputSchema } from "../utils/defaults";
-import getModifier from "../utils/getModifier";
+import getModifier from "../utils/getMongoUpdateModifier";
 
 /**
  * @summary Updates SimpleInventory data for a product configuration. Pass only

--- a/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
@@ -1,0 +1,147 @@
+import SimpleSchema from "simpl-schema";
+import Random from "@reactioncommerce/random";
+import Logger from "@reactioncommerce/logger";
+import { ProductConfigurationSchema, SimpleInventoryCollectionSchema } from "../simpleSchemas";
+
+const logCtx = { name: "core-inventory" };
+
+const inputSchema = new SimpleSchema({
+  productConfiguration: ProductConfigurationSchema,
+  canBackorder: {
+    type: Boolean,
+    optional: true
+  },
+  inventoryInStock: {
+    type: SimpleSchema.Integer,
+    min: 0,
+    optional: true
+  },
+  isEnabled: {
+    type: Boolean,
+    optional: true
+  },
+  lowInventoryWarningThreshold: {
+    type: SimpleSchema.Integer,
+    min: 0,
+    optional: true
+  },
+  shopId: String
+});
+
+const updateFields = [
+  "canBackorder",
+  "inventoryInStock",
+  "isEnabled",
+  "lowInventoryWarningThreshold"
+];
+
+const defaultValues = {
+  canBackorder: false,
+  inventoryInStock: 0,
+  isEnabled: false,
+  lowInventoryWarningThreshold: 0
+};
+
+// eslint-disable-next-line require-jsdoc
+export default async function updateSimpleInventoryBulk(context, input) {
+  const { appEvents, collections } = context;
+  const { SimpleInventory } = collections;
+
+  const bulkOperations = input.updates.map((update) => {
+    const { productConfiguration, shopId } = update;
+    inputSchema.validate(update); // try/catch
+    const $set = { updatedAt: new Date() };
+    const $setOnInsert = {
+      "_id": Random.id(),
+      "createdAt": new Date(),
+      // inventoryReserved is calculated by this plugin rather than being set by
+      // users, but we need to init it to some number since this is required.
+      // Below we update this to the correct number if we inserted.
+      "inventoryReserved": 0,
+      // The upsert query below has only `productVariantId` so we need to ensure both are inserted
+      "productConfiguration.productId": productConfiguration.productId
+    };
+    updateFields.forEach((field) => {
+      const value = update[field];
+      if (value !== undefined && value !== null) {
+        $set[field] = value;
+      } else {
+        // If we are not setting the value here, then we add it to the setOnInsert.
+        // This is necessary because all fields are required by the collection schema.
+        $setOnInsert[field] = defaultValues[field];
+      }
+    });
+
+    // if (Object.getOwnPropertyNames($set).length === 1) {
+    //   throw new ReactionError("invalid-param", "You must provide at least one field to update.");
+    // }
+
+    const modifier = { $set, $setOnInsert };
+
+    SimpleInventoryCollectionSchema.validate({
+      $set,
+      $setOnInsert: {
+        ...$setOnInsert,
+        "productConfiguration.productVariantId": productConfiguration.productVariantId,
+        shopId
+      }
+    }, { modifier: true, upsert: true });
+
+    return {
+      updateOne: {
+        filter: {
+          "productConfiguration.productVariantId": productConfiguration.productVariantId,
+          shopId
+        },
+        update: modifier,
+        upsert: true
+      }
+    };
+  });
+
+  let res;
+  try {
+    res = await SimpleInventory.bulkWrite(bulkOperations, { ordered: false });
+  } catch (error) {
+    Logger.error({ ...logCtx, error });
+    error.result.result.writeErrors.forEach((writeError) => {
+      Logger.debug({
+        ...logCtx,
+        error,
+        op: writeError.err.op,
+        reason: writeError.err.errmsg
+      });
+    });
+  }
+
+  const upsertedIds = res.result.upserted.map((each) => each._id);
+
+  // If we inserted, set the "reserved" quantity to what it should be. We could have
+  // put this in the $setOnInsert but then we'd have to do the Orders lookup for
+  // calculating reserved every time, even when only an update happens. It's better
+  // to wait until here when we know whether we inserted.
+  if (res.result.nUpserted > 0) {
+    const upsertedDocsOpData = bulkOperations.filter((op) => upsertedIds.includes(op.updateOne.update.$setOnInsert._id));
+    upsertedDocsOpData.forEach((operationData) => {
+      const arg = {
+        productConfiguration: {
+          productId: operationData.updateOne.update.$setOnInsert["productConfiguration.productId"],
+          productVariantId: operationData.updateOne.filter["productConfiguration.productVariantId"]
+        },
+        shopId: operationData.updateOne.filter.shopId
+      };
+      Logger.debug({ ...logCtx, arg }, "Calling recalculateReservedSimpleInventory");
+      // for bulk version: do not await.
+      context.mutations.recalculateReservedSimpleInventory(context, arg);
+    });
+  }
+
+  if (res.result.nModified > 0) {
+    const modifiedDocsOpData = bulkOperations.filter((op) => !upsertedIds.includes(op.updateOne.update.$setOnInsert._id));
+    const productConfigurations = modifiedDocsOpData.map((operationData) => ({
+      productId: operationData.updateOne.update.$setOnInsert["productConfiguration.productId"]
+    }));
+    Logger.debug({ ...logCtx, productConfigurations }, "Product configurations for afterBulkInventoryUpdate");
+    appEvents.emit("afterBulkInventoryUpdate", { productConfigurations });
+  }
+}

--- a/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
@@ -5,7 +5,15 @@ import getModifier from "../utils/getModifier";
 
 const logCtx = { name: "simple-inventory", file: "updateSimpleInventoryBulk" };
 
-// eslint-disable-next-line require-jsdoc
+/**
+ * @summary Updates SimpleInventory data for multiple products
+ * Note/Warning: This function is only available on `context` for internal calls only - it is NOT exposed through GraphQL.
+ * As such there is no permission checks added. If this function is exposed later, it should be updated to check permissions.
+ * @param {Object} context App context
+ * @param {Object} input Input
+ * @param {Object} input.updates Array of objects, each containing fields for productConfiguration, shopId, canBackorder, inventoryInStock, isEnabled, lowInventoryWarningThreshold. See definition of these values on single updateSimpleInventory mutation.
+ * @return {Object} Empty object, or an object with a `failedOps` field containing any failed update operations
+ */
 export default async function updateSimpleInventoryBulk(context, input) {
   const { appEvents, collections, userId } = context;
   const { SimpleInventory } = collections;

--- a/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
@@ -55,9 +55,9 @@ export default async function updateSimpleInventoryBulk(context, input) {
 
   const upsertedIds = res.result.upserted.map((each) => each._id);
   const failedOps = bulkOperations.filter((op) => {
-    const match = res.result.writeErrors.find((erroredOp) => {
-      const isFilterEqual = _.isEqual(op.updateOne.filter, erroredOp.op.q);
-      const isUpdateEqual = _.isEqual(op.updateOne.update, erroredOp.op.u);
+    const match = res.result.writeErrors.find((writeError) => {
+      const isFilterEqual = _.isEqual(op.updateOne.filter, writeError.op.q);
+      const isUpdateEqual = _.isEqual(op.updateOne.update, writeError.op.u);
       return isFilterEqual && isUpdateEqual;
     });
     if (match) return true;

--- a/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
@@ -89,6 +89,7 @@ export default async function updateSimpleInventoryBulk(context, input) {
       productId: operationData.updateOne.update.$setOnInsert["productConfiguration.productId"],
       productVariantId: operationData.updateOne.filter["productConfiguration.productVariantId"]
     }));
+    Logger.debug({ ...logCtx }, "Calling afterBulkInventoryUpdate for batch");
     appEvents.emit("afterBulkInventoryUpdate", { productConfigurations, updatedBy: userId });
   }
 

--- a/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk.js
@@ -1,91 +1,28 @@
-import SimpleSchema from "simpl-schema";
-import Random from "@reactioncommerce/random";
+import _ from "lodash";
 import Logger from "@reactioncommerce/logger";
-import { ProductConfigurationSchema, SimpleInventoryCollectionSchema } from "../simpleSchemas";
+import { inputSchema } from "../utils/defaults";
+import getModifier from "../utils/getModifier";
 
-const logCtx = { name: "core-inventory" };
-
-const inputSchema = new SimpleSchema({
-  productConfiguration: ProductConfigurationSchema,
-  canBackorder: {
-    type: Boolean,
-    optional: true
-  },
-  inventoryInStock: {
-    type: SimpleSchema.Integer,
-    min: 0,
-    optional: true
-  },
-  isEnabled: {
-    type: Boolean,
-    optional: true
-  },
-  lowInventoryWarningThreshold: {
-    type: SimpleSchema.Integer,
-    min: 0,
-    optional: true
-  },
-  shopId: String
-});
-
-const updateFields = [
-  "canBackorder",
-  "inventoryInStock",
-  "isEnabled",
-  "lowInventoryWarningThreshold"
-];
-
-const defaultValues = {
-  canBackorder: false,
-  inventoryInStock: 0,
-  isEnabled: false,
-  lowInventoryWarningThreshold: 0
-};
+const logCtx = { name: "simple-inventory", file: "updateSimpleInventoryBulk" };
 
 // eslint-disable-next-line require-jsdoc
 export default async function updateSimpleInventoryBulk(context, input) {
-  const { appEvents, collections } = context;
+  const { appEvents, collections, userId } = context;
   const { SimpleInventory } = collections;
 
-  const bulkOperations = input.updates.map((update) => {
+  // generate mongo operation object for each product input. Return null on any invalid input
+  let bulkOperations = input.updates.map((update) => {
+    let modifier = {};
+    try {
+      inputSchema.validate(update);
+      modifier = getModifier(update);
+    } catch (error) {
+      Logger.error({ ...logCtx, error });
+      return null;
+    }
+
+    if (!modifier.$set || !modifier.$setOnInsert) return null;
     const { productConfiguration, shopId } = update;
-    inputSchema.validate(update); // try/catch
-    const $set = { updatedAt: new Date() };
-    const $setOnInsert = {
-      "_id": Random.id(),
-      "createdAt": new Date(),
-      // inventoryReserved is calculated by this plugin rather than being set by
-      // users, but we need to init it to some number since this is required.
-      // Below we update this to the correct number if we inserted.
-      "inventoryReserved": 0,
-      // The upsert query below has only `productVariantId` so we need to ensure both are inserted
-      "productConfiguration.productId": productConfiguration.productId
-    };
-    updateFields.forEach((field) => {
-      const value = update[field];
-      if (value !== undefined && value !== null) {
-        $set[field] = value;
-      } else {
-        // If we are not setting the value here, then we add it to the setOnInsert.
-        // This is necessary because all fields are required by the collection schema.
-        $setOnInsert[field] = defaultValues[field];
-      }
-    });
-
-    // if (Object.getOwnPropertyNames($set).length === 1) {
-    //   throw new ReactionError("invalid-param", "You must provide at least one field to update.");
-    // }
-
-    const modifier = { $set, $setOnInsert };
-
-    SimpleInventoryCollectionSchema.validate({
-      $set,
-      $setOnInsert: {
-        ...$setOnInsert,
-        "productConfiguration.productVariantId": productConfiguration.productVariantId,
-        shopId
-      }
-    }, { modifier: true, upsert: true });
 
     return {
       updateOne: {
@@ -99,22 +36,25 @@ export default async function updateSimpleInventoryBulk(context, input) {
     };
   });
 
+  bulkOperations = bulkOperations.filter((op) => op !== null);
   let res;
   try {
     res = await SimpleInventory.bulkWrite(bulkOperations, { ordered: false });
   } catch (error) {
-    Logger.error({ ...logCtx, error });
-    error.result.result.writeErrors.forEach((writeError) => {
-      Logger.debug({
-        ...logCtx,
-        error,
-        op: writeError.err.op,
-        reason: writeError.err.errmsg
-      });
-    });
+    Logger.error({ ...logCtx, error }, "One or more of the bulk update failed");
+    res = error; // error object has details about failed & successful operations
   }
 
   const upsertedIds = res.result.upserted.map((each) => each._id);
+  const failedOps = bulkOperations.filter((op) => {
+    const match = res.result.writeErrors.find((erroredOp) => {
+      const isFilterEqual = _.isEqual(op.updateOne.filter, erroredOp.op.q);
+      const isUpdateEqual = _.isEqual(op.updateOne.update, erroredOp.op.u);
+      return isFilterEqual && isUpdateEqual;
+    });
+    if (match) return true;
+    return false;
+  });
 
   // If we inserted, set the "reserved" quantity to what it should be. We could have
   // put this in the $setOnInsert but then we'd have to do the Orders lookup for
@@ -131,7 +71,6 @@ export default async function updateSimpleInventoryBulk(context, input) {
         shopId: operationData.updateOne.filter.shopId
       };
       Logger.debug({ ...logCtx, arg }, "Calling recalculateReservedSimpleInventory");
-      // for bulk version: do not await.
       context.mutations.recalculateReservedSimpleInventory(context, arg);
     });
   }
@@ -139,9 +78,11 @@ export default async function updateSimpleInventoryBulk(context, input) {
   if (res.result.nModified > 0) {
     const modifiedDocsOpData = bulkOperations.filter((op) => !upsertedIds.includes(op.updateOne.update.$setOnInsert._id));
     const productConfigurations = modifiedDocsOpData.map((operationData) => ({
-      productId: operationData.updateOne.update.$setOnInsert["productConfiguration.productId"]
+      productId: operationData.updateOne.update.$setOnInsert["productConfiguration.productId"],
+      productVariantId: operationData.updateOne.filter["productConfiguration.productVariantId"]
     }));
-    Logger.debug({ ...logCtx, productConfigurations }, "Product configurations for afterBulkInventoryUpdate");
-    appEvents.emit("afterBulkInventoryUpdate", { productConfigurations });
+    appEvents.emit("afterBulkInventoryUpdate", { productConfigurations, updatedBy: userId });
   }
+
+  return { failedOps };
 }

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/defaults.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/defaults.js
@@ -1,0 +1,39 @@
+import SimpleSchema from "simpl-schema";
+import { ProductConfigurationSchema } from "../simpleSchemas";
+
+export const inputSchema = new SimpleSchema({
+  productConfiguration: ProductConfigurationSchema,
+  canBackorder: {
+    type: Boolean,
+    optional: true
+  },
+  inventoryInStock: {
+    type: SimpleSchema.Integer,
+    min: 0,
+    optional: true
+  },
+  isEnabled: {
+    type: Boolean,
+    optional: true
+  },
+  lowInventoryWarningThreshold: {
+    type: SimpleSchema.Integer,
+    min: 0,
+    optional: true
+  },
+  shopId: String
+});
+
+export const updateFields = [
+  "canBackorder",
+  "inventoryInStock",
+  "isEnabled",
+  "lowInventoryWarningThreshold"
+];
+
+export const defaultValues = {
+  canBackorder: false,
+  inventoryInStock: 0,
+  isEnabled: false,
+  lowInventoryWarningThreshold: 0
+};

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/getModifier.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/getModifier.js
@@ -1,0 +1,46 @@
+import Random from "@reactioncommerce/random";
+import ReactionError from "@reactioncommerce/reaction-error";
+import { SimpleInventoryCollectionSchema } from "../simpleSchemas";
+import { updateFields, defaultValues } from "./defaults";
+
+// eslint-disable-next-line require-jsdoc
+export default function getModifier(input) {
+  const { productConfiguration, shopId } = input;
+
+  const $set = { updatedAt: new Date() };
+  const $setOnInsert = {
+    "_id": Random.id(),
+    "createdAt": new Date(),
+    // inventoryReserved is calculated by this plugin rather than being set by
+    // users, but we need to init it to some number since this is required.
+    // Below we update this to the correct number if we inserted.
+    "inventoryReserved": 0,
+    // The upsert query below has only `productVariantId` so we need to ensure both are inserted
+    "productConfiguration.productId": productConfiguration.productId
+  };
+  updateFields.forEach((field) => {
+    const value = input[field];
+    if (value !== undefined && value !== null) {
+      $set[field] = value;
+    } else {
+      // If we are not setting the value here, then we add it to the setOnInsert.
+      // This is necessary because all fields are required by the collection schema.
+      $setOnInsert[field] = defaultValues[field];
+    }
+  });
+
+  if (Object.getOwnPropertyNames($set).length === 1) {
+    throw new ReactionError("invalid-param", "You must provide at least one field to update.");
+  }
+
+  SimpleInventoryCollectionSchema.validate({
+    $set,
+    $setOnInsert: {
+      ...$setOnInsert,
+      "productConfiguration.productVariantId": productConfiguration.productVariantId,
+      shopId
+    }
+  }, { modifier: true, upsert: true });
+
+  return { $set, $setOnInsert };
+}

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/getModifier.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/getModifier.js
@@ -3,7 +3,13 @@ import ReactionError from "@reactioncommerce/reaction-error";
 import { SimpleInventoryCollectionSchema } from "../simpleSchemas";
 import { updateFields, defaultValues } from "./defaults";
 
-// eslint-disable-next-line require-jsdoc
+/**
+ * @summary returns object with $set & $setOnInsert to be used in mongo update call. The values are validated with the collection schema before returning
+ * @param {Object} input Input
+ * @param {Object} input.productConfiguration Product configuration object
+ * @param {String} input.shopId ID of shop that owns the product
+ * @return {Object} Object
+ */
 export default function getModifier(input) {
   const { productConfiguration, shopId } = input;
 

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/getMongoUpdateModifier.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/getMongoUpdateModifier.js
@@ -10,7 +10,7 @@ import { updateFields, defaultValues } from "./defaults";
  * @param {String} input.shopId ID of shop that owns the product
  * @return {Object} Object
  */
-export default function getModifier(input) {
+export default function getMongoUpdateModifier(input) {
   const { productConfiguration, shopId } = input;
 
   const $set = { updatedAt: new Date() };

--- a/tests/inventory/inventory.test.js
+++ b/tests/inventory/inventory.test.js
@@ -1,5 +1,6 @@
 import TestApp from "../TestApp";
 import Factory from "/imports/test-utils/helpers/factory";
+import updateSimpleInventoryBulk from "../../imports/plugins/included/simple-inventory/server/no-meteor/mutations/updateSimpleInventoryBulk";
 import catalogItemQuery from "./catalogItemQuery.graphql";
 import simpleInventoryQuery from "./simpleInventoryQuery.graphql";
 import updateSimpleInventoryMutation from "./updateSimpleInventoryMutation.graphql";
@@ -243,6 +244,72 @@ test("when all options are sold out and canBackorder, isBackorder is true in Cat
       canBackorder: true,
       inventoryInStock: 0
     }
+  });
+
+  const queryResult = await getCatalogItem({
+    slugOrId: product.handle
+  });
+  expect(queryResult).toEqual({
+    catalogItemProduct: {
+      product: {
+        isBackorder: true,
+        isLowQuantity: true,
+        isSoldOut: true,
+        variants: [{
+          canBackorder: true,
+          inventoryAvailableToSell: 0,
+          inventoryInStock: 0,
+          isBackorder: true,
+          isLowQuantity: true,
+          isSoldOut: true,
+          options: [
+            {
+              canBackorder: true,
+              inventoryAvailableToSell: 0,
+              inventoryInStock: 0,
+              isBackorder: true,
+              isLowQuantity: true,
+              isSoldOut: true
+            },
+            {
+              canBackorder: true,
+              inventoryAvailableToSell: 0,
+              inventoryInStock: 0,
+              isBackorder: true,
+              isLowQuantity: true,
+              isSoldOut: true
+            }
+          ]
+        }]
+      }
+    }
+  });
+});
+
+test("Bulk version test: when all options are sold out and canBackorder, isBackorder is true in Catalog", async () => {
+  await updateSimpleInventoryBulk(testApp.context, {
+    updates: [
+      {
+        productConfiguration: {
+          productId: internalProductId,
+          productVariantId: internalOptionId1
+        },
+        shopId: internalShopId,
+        isEnabled: true,
+        canBackorder: true,
+        inventoryInStock: 0
+      },
+      {
+        productConfiguration: {
+          productId: internalProductId,
+          productVariantId: internalOptionId2
+        },
+        shopId: internalShopId,
+        isEnabled: true,
+        canBackorder: true,
+        inventoryInStock: 0
+      }
+    ]
   });
 
   const queryResult = await getCatalogItem({


### PR DESCRIPTION
Resolves NA 
Impact: **major**  
Type: **feature|performance**

## Issue
When running large inventory import via an external sync system, the lack of a bulk mutation makes the import takes many hours. A bulk interface is needed.

## This PR solves it by:
- Adding a bulk inventory update mutation
- Only available on context. Not exposed on GQL at this point

## Breaking changes
N/A

## Testing
- Confirm that single update mutation (i.e `updateSimpleInventory`) works as before
- Test the bulk interface by running an external import process (see offline notes)