### PR TITLE
Alphabetical currencies

### DIFF
--- a/imports/plugins/core/i18n/client/components/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/components/localizationSettings.js
@@ -72,7 +72,10 @@ class LocalizationSettings extends Component {
   }
 
   renderCurrencies() {
-    return this.props.currencies.map((currency, key) => (
+    console.log(this.props.currencies);
+    return this.props.currencies.sort(
+      (a, b) => a.name.localeCompare(b.name)
+    ).map((currency, key) => (
       <Components.ListItem
         actionType={"switch"}
         key={key}

--- a/imports/plugins/core/i18n/client/components/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/components/localizationSettings.js
@@ -72,10 +72,7 @@ class LocalizationSettings extends Component {
   }
 
   renderCurrencies() {
-    console.log(this.props.currencies);
-    return this.props.currencies.sort(
-      (a, b) => a.name.localeCompare(b.name)
-    ).map((currency, key) => (
+    return this.props.currencies.sort((a, b) => a.name.localeCompare(b.name)).map((currency, key) => (
       <Components.ListItem
         actionType={"switch"}
         key={key}

--- a/imports/plugins/core/i18n/client/components/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/components/localizationSettings.js
@@ -72,7 +72,7 @@ class LocalizationSettings extends Component {
   }
 
   renderCurrencies() {
-    return this.props.currencies.sort((a, b) => a.name.localeCompare(b.name)).map((currency, key) => (
+    return this.props.currencies.sort((currencyA, currencyB) => currencyA.name.localeCompare(currencyB.name)).map((currency, key) => (
       <Components.ListItem
         actionType={"switch"}
         key={key}


### PR DESCRIPTION
Resolves #4757
Impact: *minor**  
Type: **bugfix**

## Issue
Sorts Currencies Alphabetically in Operator UI

## Solution
`this.props.currencies.sort((a, b) => a.name.localeCompare(b.name)).map(...`

## Breaking changes
None

## Testing
1. http://localhost:3000/operator/localization
2. See that currencies are in order
