### PR TITLE
feat: add regex filter to tags GQL query

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -6,12 +6,13 @@
  * @param {Object} context - an object containing the per-request state
  * @param {String} shopId - ID of shop to query
  * @param {Object} [params] - Additional options for the query
+ * @param {Boolean} [params.filter] - If provided, look for `filter` matching this value with regex
  * @param {Boolean} [params.isTopLevel] - If set, look for `isTopLevel` matching this value
  * @param {Boolean} [params.shouldIncludeDeleted] - Admin only. Whether or not to include `isDeleted=true` tags. Default is `false`
  * @param {Boolean} [params.shouldIncludeInvisible] - Admin only. Whether or not to include `isVisible=false` tags.  Default is `false`.
  * @return {Promise<MongoCursor>} - A MongoDB cursor for the proper query
  */
-export default async function tags(context, shopId, { shouldIncludeDeleted = false, isTopLevel, shouldIncludeInvisible = false } = {}) {
+export default async function tags(context, shopId, { filter, shouldIncludeDeleted = false, isTopLevel, shouldIncludeInvisible = false } = {}) {
   const { collections } = context;
 
   const { Tags } = collections;
@@ -33,6 +34,11 @@ export default async function tags(context, shopId, { shouldIncludeDeleted = fal
   } else {
     query.isDeleted = false;
     query.isVisible = true;
+  }
+
+  // Use `filter` to filter out resutls on the server
+  if (filter) {
+    query.name = { $regex: filter, $options: "i" };
   }
 
   return Tags.find(query);

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -1,3 +1,5 @@
+import escapeRegExp from "lodash/escapeRegExp";
+
 /**
  * @name tags
  * @method
@@ -34,7 +36,7 @@ export default async function tags(context, shopId, { filter, shouldIncludeDelet
 
     // Use `filter` to filter out resutls on the server
     if (filter) {
-      query.name = { $regex: filter, $options: "i" };
+      query.name = { $regex: escapeRegExp(filter), $options: "i" };
     }
   } else {
     query.isDeleted = false;

--- a/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
+++ b/imports/plugins/core/catalog/server/no-meteor/queries/tags.js
@@ -31,14 +31,14 @@ export default async function tags(context, shopId, { filter, shouldIncludeDelet
     } else {
       query.isVisible = true;
     }
+
+    // Use `filter` to filter out resutls on the server
+    if (filter) {
+      query.name = { $regex: filter, $options: "i" };
+    }
   } else {
     query.isDeleted = false;
     query.isVisible = true;
-  }
-
-  // Use `filter` to filter out resutls on the server
-  if (filter) {
-    query.name = { $regex: filter, $options: "i" };
   }
 
   return Tags.find(query);

--- a/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
+++ b/imports/plugins/core/core/server/no-meteor/schemas/tag.graphql
@@ -119,6 +119,9 @@ extend type Query {
     "Only tags associated with this shop will be returned"
     shopId: ID!,
 
+    "If provided, this query will do a regex search using the provided filter data, and return only tags that match"
+    filter: String
+
     "If set, the query will return only top-level tags or only non-top-level tags. By default, both types of tags are returned."
     isTopLevel: Boolean,
 

--- a/imports/plugins/core/tags/client/components/TagDataTable.js
+++ b/imports/plugins/core/tags/client/components/TagDataTable.js
@@ -232,26 +232,22 @@ class TagDataTable extends Component {
    * @param {Number} numRows Number of rows in current set of data
    * @returns {node} returns JSX node or null
    */
-  renderTableFilter(numRows) {
+  renderTableFilter() {
     const { filterType } = this.props;
 
-    if (numRows !== 0) {
-      if (filterType === "both" || filterType === "table") {
-        return (
-          <FilterTextInput>
-            <TextInput
-              placeholder={i18next.t("reactionUI.components.sortableTable.filterPlaceholder", { defaultValue: "Filter Data" })}
-              onChanging={this.handleFilterInput}
-              value={this.state.filterInput}
-              name="filterInput"
-            />
-          </FilterTextInput>
+    if (filterType === "both" || filterType === "table") {
+      return (
+        <FilterTextInput>
+          <TextInput
+            placeholder={i18next.t("reactionUI.components.sortableTable.filterPlaceholder", { defaultValue: "Filter Data" })}
+            onChanging={this.handleFilterInput}
+            value={this.state.filterInput}
+            name="filterInput"
+          />
+        </FilterTextInput>
 
-        );
-      }
+      );
     }
-
-    return null;
   }
 
   /**
@@ -505,7 +501,7 @@ class TagDataTable extends Component {
           return (
             <TableContainer>
               <TableHeader>
-                {resultCount > 0 && this.renderBulkActionsSelect()}
+                {this.renderBulkActionsSelect()}
                 {this.renderTableFilter(resultCount)}
               </TableHeader>
               <CheckboxTable

--- a/imports/plugins/core/tags/client/components/TagDataTable.js
+++ b/imports/plugins/core/tags/client/components/TagDataTable.js
@@ -445,8 +445,10 @@ class TagDataTable extends Component {
 
   render() {
     const { query, variables: variablesProp, defaultPageSize, ...otherProps } = this.props;
+    const { filterInput } = this.state;
     const defaultClassName = "-striped -highlight";
     const variables = {
+      filter: filterInput || null,
       first: defaultPageSize,
       ...variablesProp
     };

--- a/imports/plugins/core/tags/lib/queries.js
+++ b/imports/plugins/core/tags/lib/queries.js
@@ -2,8 +2,8 @@ import gql from "graphql-tag";
 import { Tag } from "./fragments";
 
 export const tagListingQuery = gql`
-  query getTags($shopId: ID!, $first: ConnectionLimitInt, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor) {
-    tags(shopId: $shopId, first: $first, last: $last, before: $before, after: $after, shouldIncludeInvisible: true) {
+  query getTags($shopId: ID!, $filter: String, $first: ConnectionLimitInt, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor) {
+    tags(shopId: $shopId, filter: $filter, first: $first, last: $last, before: $before, after: $after, shouldIncludeInvisible: true) {
       pageInfo {
         endCursor
         startCursor


### PR DESCRIPTION
Resolves #5224   
Impact: **minor**  
Type: **feature**

## Issue
> Tag filtering doesn't work. The filter applies after the query, so you will still have many pages to paginate through, but sometimes the pages will have fewer results.

## Solution
Add a regex filter to the graphql input, to send to Mongo, to filter out data before it gets to the client

## Breaking changes
None

### Possible issues with this solution
Since this re-queries each time there is new input inside the tags table, this will use the GQL tags query frequently. Will this be a heavily used feature? If not, this might be OK. If so, what are some other options on how to implement this?

## Testing
1. Load a big set of Tags into the database
1. Filter the tags in the Admin UI
1. See that all the tags filtered make it to the front of the table, and you don't need to go searching through random pages of tags to find what you need.