### PR TITLE
chore: update styles for MUI Typography to match designs

### DIFF
--- a/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
+++ b/imports/client/ui/components/PrimaryAppBar/PrimaryAppBar.js
@@ -51,7 +51,7 @@ function PrimaryAppBar({ children, classes, title }) {
               <Typography
                 className={classes.title}
                 component="h1"
-                variant="h6"
+                variant="h3"
               >
                 {title}
               </Typography>

--- a/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js
+++ b/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData.js
@@ -67,7 +67,7 @@ function ShopLogoWithData({ className, classes, shopId, shouldShowShopName, link
                   <Typography
                     color="textSecondary"
                     display="display"
-                    variant="h6"
+                    variant="h3"
                     component="span"
                   >
                     {shop.name}

--- a/imports/plugins/core/router/client/theme/muiTheme.js
+++ b/imports/plugins/core/router/client/theme/muiTheme.js
@@ -8,13 +8,16 @@ const breakpoints = createBreakpoints({});
 const toolbarHeight = 80;
 const toolbarMobileHeight = 54;
 
+// Colors
+export const colorPrimaryMain = colors.coolGrey;
+export const colorSecondaryMain = colors.darkBlue500;
+
 // Spacing
 export const defaultSpacingUnit = 8;
 export const drawerWidth = 280;
 
-// Colors
-export const colorPrimaryMain = colors.coolGrey;
-export const colorSecondaryMain = colors.darkBlue500;
+// Typography
+export const defaultFontSize = 16;
 
 export const rawMuiTheme = {
   palette: {
@@ -37,21 +40,19 @@ export const rawMuiTheme = {
     }
   },
   typography: {
-    fontSize: 16,
+    fontSize: defaultFontSize,
     fontFamily: typography.bodyText.fontFamily,
     fontWeightLight: 400,
     fontWeightRegular: 400,
     fontWeightMedium: 500,
+    fontWeightSemiBold: 600,
     fontWeightBold: 700,
     useNextVariants: true,
-    h6: {
-      fontSize: 18
-    },
     subtitle1: {
-      fontSize: 16
+      fontSize: defaultFontSize
     },
     body1: {
-      fontSize: 16
+      fontSize: defaultFontSize
     },
     button: {
       fontSize: 14,
@@ -59,7 +60,26 @@ export const rawMuiTheme = {
     },
     caption: {
       color: colors.black30
+    },
+    h1: {
+      fontSize: defaultFontSize * 1.5
+    },
+    h2: {
+      fontSize: defaultFontSize * 1.25
+    },
+    h3: {
+      fontSize: defaultFontSize * 1.125
+    },
+    h4: {
+      fontSize: defaultFontSize
+    },
+    h5: {
+      fontSize: defaultFontSize * 0.875
+    },
+    h6: {
+      fontSize: defaultFontSize * 0.75
     }
+
   },
   shadows: [
     "none",

--- a/imports/plugins/core/tags/client/components/TagForm.js
+++ b/imports/plugins/core/tags/client/components/TagForm.js
@@ -405,7 +405,7 @@ class TagForm extends Component {
                   {currentTab === 0 &&
                     <Grid container spacing={24}>
                       <Grid item md={6}>
-                        <Typography variant="h6">{i18next.t("admin.tags.form.displayTitleAndSlug")}</Typography>
+                        <Typography variant="h3">{i18next.t("admin.tags.form.displayTitleAndSlug")}</Typography>
                         <PaddedField
                           helpText={i18next.t("admin.tags.form.displayTitleHelpText")}
                           name="displayTitle"
@@ -439,8 +439,8 @@ class TagForm extends Component {
                         </PaddedField>
                       </Grid>
                       <Grid item md={6}>
-                        <Typography variant="h6">{i18next.t("admin.tags.form.tagListingHero")}</Typography>
-                        <Typography>{i18next.t("admin.tags.form.tagListingHeroHelpText")}</Typography>
+                        <Typography variant="h3">{i18next.t("admin.tags.form.tagListingHero")}</Typography>
+                        <Typography variant="body2">{i18next.t("admin.tags.form.tagListingHeroHelpText")}</Typography>
                         {this.renderMediaGalleryUploader()}
 
                         <PaddedField
@@ -458,7 +458,7 @@ class TagForm extends Component {
                   {currentTab === 1 &&
                     <Grid container spacing={24}>
                       <Grid item md={6}>
-                        <Typography variant="h6">{i18next.t("admin.tags.form.keywords")}</Typography>
+                        <Typography variant="h3">{i18next.t("admin.tags.form.keywords")}</Typography>
                         <PaddedField
                           name="keywords"
                           label={i18next.t("admin.tags.form.keywords")}
@@ -479,7 +479,7 @@ class TagForm extends Component {
                         </PaddedField>
                       </Grid>
                       <Grid item md={6}>
-                        <Typography variant="h6">{i18next.t("admin.tags.form.openGraph")}</Typography>
+                        <Typography variant="h3">{i18next.t("admin.tags.form.openGraph")}</Typography>
                         <PaddedField
                           name="og:title"
                           label={i18next.t("admin.tags.form.ogTitle")}

--- a/imports/plugins/included/default-theme/client/styles/variables.less
+++ b/imports/plugins/included/default-theme/client/styles/variables.less
@@ -1,6 +1,6 @@
 //== Google Fonts
 //*requires browser-policy to be set in client
-@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,500,700,800);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,500,600,700,800);
 
 
 //


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

Add styles to our theme so we can better map MUI Typography variants to our designs.

## Breaking changes
None

## Testing
1. Start the app.
1. Go to Tags page, see that it looks the same with the updated headers
1. See that PrimaryAppBar title looks the same