### PR TITLE
feat: add resolver to get displayStatus from database

### DIFF
--- a/imports/plugins/core/orders/client/graphql/queries/orderByReferenceId.js
+++ b/imports/plugins/core/orders/client/graphql/queries/orderByReferenceId.js
@@ -31,6 +31,7 @@ export default gql`
             }
           }
         }
+        displayStatus(language: $language)
         items {
           nodes {
             _id

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/OrderFulfillmentGroup/fulfillmentGroupDisplayStatus.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/OrderFulfillmentGroup/fulfillmentGroupDisplayStatus.js
@@ -1,0 +1,30 @@
+/**
+ * @name OrderFulfillmentGroup/fulfillmentGroupDisplayStatus
+ * @method
+ * @memberof Order/GraphQL
+ * @summary Displays a human readable status of order fulfillment group state
+ * @param {Object} context An object with request-specific state
+ * @param {Object} fulfillmentGroup - Result of the parent resolver, which is a Fulfillment Group object in GraphQL schema format
+ * @param {String} language Language to filter item content by
+ * @return {String} A string of the order status
+ */
+export default async function fulfillmentGroupDisplayStatus(context, fulfillmentGroup, language) {
+  const { Shops } = context.collections;
+  const shop = await Shops.findOne({ _id: fulfillmentGroup.shopId });
+  const orderStatusLabels = shop && shop.orderStatusLabels;
+  const { workflow: { status } } = fulfillmentGroup;
+
+  // If translations are available in the `Shops` collection,
+  // and are available for this specific order status, get translations
+  if (orderStatusLabels && orderStatusLabels[status]) {
+    const orderStatusLabel = orderStatusLabels[status];
+    const translatedLabel = orderStatusLabel.find((label) => label.language === language);
+
+    // If translations are available in desired language, return them.
+    // Otherwise, return raw status
+    return (translatedLabel && translatedLabel.label) || status;
+  }
+
+  // If no translations are available in the `Shops` collection, use raw status data
+  return status;
+}

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/OrderFulfillmentGroup/index.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/OrderFulfillmentGroup/index.js
@@ -3,6 +3,7 @@ import {
   xformOrderFulfillmentGroupSelectedOption
 } from "@reactioncommerce/reaction-graphql-xforms/order";
 import { resolveShopFromShopId } from "@reactioncommerce/reaction-graphql-utils";
+import fulfillmentGroupDisplayStatus from "./fulfillmentGroupDisplayStatus";
 import items from "./items";
 import summary from "./summary";
 
@@ -14,6 +15,7 @@ export default {
     }
     return null;
   },
+  displayStatus: (node, { language }, context) => fulfillmentGroupDisplayStatus(context, node, language),
   items,
   selectedFulfillmentOption: (node) => xformOrderFulfillmentGroupSelectedOption(node.shipmentMethod, node),
   shop: resolveShopFromShopId,

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -287,6 +287,9 @@ type OrderFulfillmentGroup implements Node {
   "Information needed by the selected fulfillment method to properly fulfill the order"
   data: OrderFulfillmentGroupData
 
+  "The order status for display in UI"
+  displayStatus(language: String!): String!
+
   "The items that are part of this fulfillment group"
   items(after: ConnectionCursor, before: ConnectionCursor, first: ConnectionLimitInt, last: ConnectionLimitInt, sortOrder: SortOrder = desc, sortBy: OrderFulfillmentGroupItemsSortByField = addedAt): OrderItemConnection
 


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
Fulfillment group statuses are not translated into a human readable version, they are displayed as a workflow string, such as `coreOrderWorkflow/packed`

## Solution
Add a human readable translation, similar to how it's done with Order Statuses (See https://github.com/reactioncommerce/reaction/pull/4981)

## Breaking changes
none

## Testing
1. Start up reaction, and add the following into the `Shops` collection:
```
"orderStatusLabels": {
    "new" : [ 
        {
            "language" : "en",
            "label" : "Order received"
        }, 
        {
            "language" : "es",
            "label" : "Recibido"
        }
    ],
    "coreOrderWorkflow/processing" : [ 
        {
            "language" : "en",
            "label" : "Order received"
        }, 
        {
            "language" : "es",
            "label" : "Recibido"
        }
    ],
    "coreOrderWorkflow/completed" : [ 
        {
            "language" : "en",
            "label" : "Shipped"
        }, 
        {
            "language" : "es",
            "label" : "Enviado"
        }
    ],
    "coreOrderWorkflow/canceled" : [ 
        {
            "language" : "en",
            "label" : "Canceled"
        }, 
        {
            "language" : "es",
            "label" : "Cancelado"
        }
    ]
}
```
1. Create and order
1. use the `orderByReferenceId` query to query the order, and see that `displayStatus` is available on fulfillment groups.
```
orderByReferenceId(id: {referenceId}, shopId: {shopId}) {
      _id
      ... {any required fields}
      fulfillmentGroups {
        ... {any required fields}
        displayStatus(language: "en")
      }
}
```