### PR TITLE
Omit email credentials from log data

### DIFF
--- a/imports/plugins/included/email-smtp/server/methods/verifySettings.js
+++ b/imports/plugins/included/email-smtp/server/methods/verifySettings.js
@@ -54,7 +54,9 @@ export default function verifySettings(settings) {
     config = Promise.await(getMailConfig(context, shopId));
   }
 
-  Logger.debug(config, "Verifying email config settings");
+  const logConfig = { ...config };
+  delete logConfig.auth;
+  Logger.debug(logConfig, "Verifying email config settings");
 
   const transporter = nodemailer.createTransport(config);
 


### PR DESCRIPTION

Impact: **minor**  
Type: **bugfix|security**

## Issue
When we test email settings, which happens when you click into the email settings in the catalyst UI, we include the email credentials in our application log data in cleartext. These are sensitive credentials and need to be kept secret.

## Solution

Remove credentials from the log data.

Before this fix:

```
reaction_1  | 15:58:30.762Z DEBUG Reaction: Verifying email config settings (host=email-smtp.us-west-2.amazonaws.com, port=465, secure=true, logger=false)
reaction_1  |   auth: {
reaction_1  |     "user": "REDACTED",
reaction_1  |     "pass": "REDACTED","
reaction_1  |   }
```

After the fix:

```
reaction_1  | 16:48:54.888Z DEBUG Reaction: Verifying email config settings (host=email-smtp.us-west-2.amazonaws.com, port=465, secure=true, logger=false)
```
## Breaking changes
N/A

## Testing
1. Launch reaction and configure your email settings
  - Ping me for a link to our internal docs that have working test credentials and setup instructions
2. Watch the reaction log file
3. Navigate to the email settings after they are set. Look for the log message matching the one posted above. Confirm your user/pass are absent.
