### PR TITLE
feat: better cart and order item attributes, with labels

### DIFF
--- a/imports/collections/schemas/cart.js
+++ b/imports/collections/schemas/cart.js
@@ -10,14 +10,11 @@ import { Metafield } from "./metafield";
  * @name CartItemAttribute
  * @memberof Schemas
  * @type {SimpleSchema}
- * @property {String} label optional
+ * @property {String} label required
  * @property {String} value optional
  */
 const CartItemAttribute = new SimpleSchema({
-  label: {
-    type: String,
-    optional: true
-  },
+  label: String,
   value: {
     type: String,
     optional: true

--- a/imports/collections/schemas/catalog.js
+++ b/imports/collections/schemas/catalog.js
@@ -98,6 +98,7 @@ export const SocialMetadata = new SimpleSchema({
  * @memberof Schemas
  * @type {SimpleSchema}
  * @property {String} _id required
+ * @property {String} attributeLabel required
  * @property {String} barcode optional
  * @property {Date} createdAt required
  * @property {Number} height optional, default value: `0`
@@ -122,6 +123,7 @@ export const VariantBaseSchema = new SimpleSchema({
     type: String,
     label: "Catalog product variant Id"
   },
+  "attributeLabel": String,
   "barcode": {
     type: String,
     label: "Barcode",
@@ -226,7 +228,7 @@ export const VariantBaseSchema = new SimpleSchema({
 });
 
 /**
- * @name VariantBaseSchema
+ * @name CatalogVariantSchema
  * @memberof Schemas
  * @type {SimpleSchema}
  * @extends VariantBaseSchema

--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -156,12 +156,28 @@ export const OrderDiscount = new SimpleSchema({
 });
 
 /**
+ * @name OrderItemAttribute
+ * @memberof Schemas
+ * @type {SimpleSchema}
+ * @property {String} label required
+ * @property {String} value optional
+ */
+export const OrderItemAttribute = new SimpleSchema({
+  label: String,
+  value: {
+    type: String,
+    optional: true
+  }
+});
+
+/**
  * @name OrderItem
  * @memberof Schemas
  * @summary Defines one item in an order
  * @type {SimpleSchema}
  * @property {String} _id Unique ID for the item
  * @property {String} addedAt Date/time when this was first added to the cart/order
+ * @property {OrderItemAttribute[]} attributes Attributes of this item
  * @property {String} cancelReason Free text reason for cancel, if this item is canceled
  * @property {String} createdAt Date/time when this order item was created
  * @property {Document[]} documents optional
@@ -186,6 +202,11 @@ export const OrderDiscount = new SimpleSchema({
 export const OrderItem = new SimpleSchema({
   "_id": String,
   "addedAt": Date,
+  "attributes": {
+    type: Array,
+    optional: true
+  },
+  "attributes.$": OrderItemAttribute,
   "cancelReason": {
     type: String,
     optional: true

--- a/imports/collections/schemas/products.js
+++ b/imports/collections/schemas/products.js
@@ -85,17 +85,14 @@ export const ProductVariant = new SimpleSchema({
   "ancestors.$": {
     type: String
   },
+  "attributeLabel": {
+    type: String,
+    optional: true
+  },
   "barcode": {
     label: "Barcode",
     type: String,
-    optional: true,
-    custom() {
-      if (Meteor.isClient) {
-        if (this.siblingField("type").value === "inventory" && !this.value) {
-          return SimpleSchema.ErrorTypes.REQUIRED;
-        }
-      }
-    }
+    optional: true
   },
   "createdAt": {
     label: "Created at",
@@ -155,8 +152,7 @@ export const ProductVariant = new SimpleSchema({
   "optionTitle": {
     label: "Option",
     type: String,
-    optional: true,
-    defaultValue: "Untitled Option"
+    optional: true
   },
   "originCountry": {
     type: String,
@@ -174,7 +170,7 @@ export const ProductVariant = new SimpleSchema({
   "title": {
     label: "Label",
     type: String,
-    defaultValue: ""
+    optional: true
   },
   "type": {
     label: "Type",

--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -93,16 +93,15 @@ export default async function addCartItems(context, currentItems, inputItems, op
     // not ordered unless back-ordering is enabled.
 
     // Until we do a more complete attributes revamp, we'll do our best to fudge attributes here.
-    // The main issue is we do not have labels.
     const attributes = [];
     if (parentVariant) {
       attributes.push({
-        label: null, // Set label to null for now. We expect to use it in the future.
+        label: parentVariant.attributeLabel,
         value: parentVariant.optionTitle
       });
     }
     attributes.push({
-      label: null, // Set label to null for now. We expect to use it in the future.
+      label: chosenVariant.attributeLabel,
       value: chosenVariant.optionTitle
     });
 

--- a/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/util/addCartItems.js
@@ -98,12 +98,12 @@ export default async function addCartItems(context, currentItems, inputItems, op
     if (parentVariant) {
       attributes.push({
         label: null, // Set label to null for now. We expect to use it in the future.
-        value: parentVariant.title
+        value: parentVariant.optionTitle
       });
     }
     attributes.push({
       label: null, // Set label to null for now. We expect to use it in the future.
-      value: chosenVariant.title
+      value: chosenVariant.optionTitle
     });
 
     const cartItem = {

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -409,12 +409,6 @@ Meteor.methods({
     };
 
     const isOption = ancestors.length > 1;
-    if (isOption) {
-      Object.assign(newVariant, {
-        optionTitle: "Untitled",
-        title: `${parent.title} - Untitled`
-      });
-    }
 
     createProduct(newVariant, { product, parentVariant, isOption });
 
@@ -650,7 +644,6 @@ Meteor.methods({
     // Create a product variant
     createProduct({
       ancestors: [newSimpleProduct._id],
-      title: "",
       type: "variant" // needed for multi-schema
     }, { product: newSimpleProduct, parentVariant: null, isOption: false });
 

--- a/imports/plugins/core/catalog/server/no-meteor/mutations/hashProduct.js
+++ b/imports/plugins/core/catalog/server/no-meteor/mutations/hashProduct.js
@@ -31,6 +31,7 @@ const productFieldsThatNeedPublishing = [
 
 const variantFieldsThatNeedPublishing = [
   "_id",
+  "attributeLabel",
   "barcode",
   "compareAtPrice",
   "height",

--- a/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/catalog/server/no-meteor/schemas/schema.graphql
@@ -189,6 +189,12 @@ type CatalogProductVariant implements CatalogProductOrVariant & Node {
   "The CatalogProductVariant ID. Do not assume that this is the same as the related variant ID. See `variantId` for that."
   _id: ID!
 
+  """
+  The attribute label describes the category of variant, for example, "Color" or "Size".
+  In most cases this will be the same for all variants at the same level.
+  """
+  attributeLabel: String!
+
   "The product variant barcode value, if it has one"
   barcode: String
 
@@ -213,7 +219,7 @@ type CatalogProductVariant implements CatalogProductOrVariant & Node {
   "The minimum quantity that must be added to a cart"
   minOrderQuantity: Int
 
-  "An option title. If this is set and this variant has a CatalogProductVariant parent, treat this variant as an option"
+  "A short title to use for product detail select lists"
   optionTitle: String
 
   "Child variants, if any"
@@ -231,7 +237,12 @@ type CatalogProductVariant implements CatalogProductOrVariant & Node {
   "A stock keeping unit (SKU) identifier for this product"
   sku: String
 
-  "Product title"
+  """
+  The full variant title for use on cart, checkout, and order summaries and on invoices.
+  This fully describes the configured variant. For example, if this is an option with
+  `optionTitle` "Large", its parent variant has `optionTitle` "Red", and the product
+  `title` is "Fancy T-Shirt", then this `title` will be something like "Fancy T-Shirt - Red - Large".
+  """
   title: String
 
   "The date and time at which this CatalogProduct was last updated, which is when the related product was most recently published"

--- a/imports/plugins/core/catalog/server/no-meteor/utils/createCatalogProduct.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/createCatalogProduct.js
@@ -13,6 +13,7 @@ export function xformVariant(variant, variantMedia) {
 
   return {
     _id: variant._id,
+    attributeLabel: variant.attributeLabel,
     barcode: variant.barcode,
     createdAt: variant.createdAt || new Date(),
     height: variant.height,

--- a/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalog.test.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalog.test.js
@@ -21,6 +21,7 @@ const updatedAt = new Date("2018-04-17T15:34:28.043Z");
 const mockVariants = [
   {
     _id: internalVariantIds[0],
+    attributeLabel: "attributeLabel",
     barcode: "barcode",
     createdAt,
     height: 0,
@@ -49,6 +50,7 @@ const mockVariants = [
   },
   {
     _id: internalVariantIds[0],
+    attributeLabel: "attributeLabel",
     barcode: "barcode",
     createdAt,
     height: 0,

--- a/imports/plugins/core/core/server/no-meteor/util/sampleData.js
+++ b/imports/plugins/core/core/server/no-meteor/util/sampleData.js
@@ -40,6 +40,7 @@ export default {
     ancestors: [
       "BCTMZ6HTxFSppJESk"
     ],
+    attributeLabel: "Size",
     title: "Example Product - Small",
     optionTitle: "Small",
     price: 19.99,
@@ -61,6 +62,7 @@ export default {
       "BCTMZ6HTxFSppJESk",
       "6qiqPwBkeJdtdQc4G"
     ],
+    attributeLabel: "Color",
     title: "Example Product - Small - Red",
     optionTitle: "Red",
     price: 19.99,
@@ -85,6 +87,7 @@ export default {
       "BCTMZ6HTxFSppJESk",
       "6qiqPwBkeJdtdQc4G"
     ],
+    attributeLabel: "Color",
     title: "Example Product - Small - Green",
     optionTitle: "Green",
     price: 12.99,

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.test.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.test.js
@@ -107,6 +107,12 @@ test("places an anonymous $0 order with no cartId and no payments", async () => 
           {
             _id: jasmine.any(String),
             addedAt: jasmine.any(Date),
+            attributes: [
+              {
+                label: "mockAttributeLabel",
+                value: "mockOptionTitle"
+              }
+            ],
             createdAt: jasmine.any(Date),
             optionTitle: catalogProductVariant.optionTitle,
             parcel: undefined,

--- a/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
+++ b/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
@@ -13,14 +13,11 @@ const Money = new SimpleSchema({
  * @name CommonOrderItemAttribute
  * @memberof Schemas
  * @type {SimpleSchema}
- * @property {String} label optional
+ * @property {String} label required
  * @property {String} value optional
  */
 export const CommonOrderItemAttribute = new SimpleSchema({
-  label: {
-    type: String,
-    optional: true
-  },
+  label: String,
   value: {
     type: String,
     optional: true

--- a/imports/plugins/core/orders/server/no-meteor/util/buildOrderItem.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/buildOrderItem.js
@@ -21,6 +21,7 @@ export default async function buildOrderItem(context, { currencyCode, inputItem 
 
   const {
     catalogProduct: chosenProduct,
+    parentVariant,
     variant: chosenVariant
   } = await queries.findProductAndVariant(context, productId, productVariantId);
 
@@ -49,10 +50,24 @@ export default async function buildOrderItem(context, { currencyCode, inputItem 
     throw new ReactionError("invalid-order-quantity", `Quantity ordered is more than available inventory for  "${chosenVariant.title}"`);
   }
 
+  // Until we do a more complete attributes revamp, we'll do our best to fudge attributes here.
+  const attributes = [];
+  if (parentVariant) {
+    attributes.push({
+      label: parentVariant.attributeLabel,
+      value: parentVariant.optionTitle
+    });
+  }
+  attributes.push({
+    label: chosenVariant.attributeLabel,
+    value: chosenVariant.optionTitle
+  });
+
   const now = new Date();
   const newItem = {
     _id: Random.id(),
     addedAt: addedAt || now,
+    attributes,
     createdAt: now,
     optionTitle: chosenVariant && chosenVariant.optionTitle,
     parcel: chosenVariant.parcel,

--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -196,7 +196,7 @@ class TextField extends Component {
    * @return {ReactNode|null} react node or null
    */
   renderLabel() {
-    if (this.props.label) {
+    if (this.props.label || this.props.i18nKeyLabel) {
       return (
         <label htmlFor={this.props.id}>
           <Components.Translation defaultValue={this.props.label} i18nKey={this.props.i18nKeyLabel} />
@@ -232,7 +232,7 @@ class TextField extends Component {
     }
 
     // If this is a non-validation message, only show if helpMode is true
-    if (helpText && helpMode) {
+    if (helpMode && (helpText || i18nKey)) {
       return (
         <span className="help-block">
           <Components.Translation defaultValue={helpText} i18nKey={i18nKey} />

--- a/imports/plugins/core/versions/server/migrations/66_attribute_labels.js
+++ b/imports/plugins/core/versions/server/migrations/66_attribute_labels.js
@@ -1,0 +1,81 @@
+import { Migrations } from "meteor/percolate:migrations";
+import rawCollections from "/imports/collections/rawCollections";
+import findAndConvertInBatches from "../no-meteor/util/findAndConvertInBatches";
+
+const defaultVariantLabel = "Variant";
+const defaultOptionLabel = "Option";
+
+Migrations.add({
+  version: 66,
+  async up() {
+    const {
+      Catalog,
+      Cart,
+      Products
+    } = rawCollections;
+
+    // Add `attributeLabel` to all existing product variants. It's not required,
+    // but it is required when publishing them to the catalog, and we want to
+    // avoid unexpected errors when publishing.
+    await Products.updateMany({
+      "ancestors.1": { $exists: false },
+      "attributeLabel": null,
+      "type": "variant"
+    }, {
+      $set: {
+        attributeLabel: defaultVariantLabel
+      }
+    });
+
+    // Same for option variants
+    await Products.updateMany({
+      "ancestors.1": { $exists: true },
+      "attributeLabel": null,
+      "type": "variant"
+    }, {
+      $set: {
+        attributeLabel: defaultOptionLabel
+      }
+    });
+
+    // Similarly, update all `Catalog` docs
+    await Catalog.updateMany({}, {
+      $set: {
+        "product.variants.$[variantWithNoAttrLabel].attributeLabel": defaultVariantLabel,
+        "product.variants.$[variantWithOptions].options.$[optionWithNoAttrLabel].attributeLabel": defaultOptionLabel
+      }
+    }, {
+      arrayFilters: [
+        { "variantWithOptions.options": { $exists: true } },
+        { "variantWithNoAttrLabel.attributeLabel": null },
+        { "optionWithNoAttrLabel.attributeLabel": null }
+      ]
+    });
+
+    // In all carts, set all attribute labels that are null because the label is
+    // now required.
+    await findAndConvertInBatches({
+      collection: Cart,
+      async converter(cart) {
+        if (Array.isArray(cart.items)) {
+          for (const item of cart.items) {
+            if (Array.isArray(item.attributes)) {
+              const attr1 = item.attributes[0];
+              if (attr1 && !attr1.label) {
+                attr1.label = defaultVariantLabel;
+              }
+
+              const attr2 = item.attributes[1];
+              if (attr2 && !attr2.label) {
+                attr2.label = defaultOptionLabel;
+              }
+            }
+          }
+        }
+
+        return cart;
+      },
+      query: { "items.attributes.label": null }
+    });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -64,3 +64,4 @@ import "./62_drop_indexes";
 import "./63_inventory_to_collection";
 import "./64_rename_navigation_package";
 import "./65_update_navigation_tree";
+import "./66_attribute_labels";

--- a/imports/plugins/included/product-admin/client/blocks/VariantDetailForm.js
+++ b/imports/plugins/included/product-admin/client/blocks/VariantDetailForm.js
@@ -30,30 +30,37 @@ function VariantDetailForm(props) {
       <CardHeader title={i18next.t("productDetailEdit.variantDetails")} />
       <CardContent>
         <Components.TextField
-          i18nKeyLabel="productVariant.title"
-          i18nKeyPlaceholder="productVariant.title"
-          placeholder="Label"
-          label="Label"
-          name="title"
-          value={variant.title}
+          i18nKeyHelpText="admin.helpText.attributeLabel"
+          i18nKeyLabel="admin.productVariant.attributeLabelLabel"
+          i18nKeyPlaceholder="admin.productVariant.attributeLabelPlaceholder"
+          name="attributeLabel"
           onBlur={onVariantFieldBlur}
           onChange={onVariantFieldChange}
           onReturnKeyDown={onVariantFieldBlur}
           validation={validation}
+          value={variant.attributeLabel}
         />
         <Components.TextField
+          i18nKeyHelpText="admin.helpText.optionTitle"
           i18nKeyLabel="productVariant.optionTitle"
-          i18nKeyPlaceholder="productVariant.optionTitle"
-          placeholder="optionTitle"
-          label="Short Label"
+          i18nKeyPlaceholder="admin.productVariant.optionTitlePlaceholder"
           name="optionTitle"
-          value={variant.optionTitle}
           onBlur={onVariantFieldBlur}
           onChange={onVariantFieldChange}
           onReturnKeyDown={onVariantFieldBlur}
           validation={validation}
-          helpText={"Displayed on Product Detail Page"}
-          i18nKeyHelpText={"admin.helpText.optionTitle"}
+          value={variant.optionTitle}
+        />
+        <Components.TextField
+          i18nKeyHelpText="admin.helpText.title"
+          i18nKeyLabel="productVariant.title"
+          i18nKeyPlaceholder="admin.productVariant.titlePlaceholder"
+          name="title"
+          onBlur={onVariantFieldBlur}
+          onChange={onVariantFieldChange}
+          onReturnKeyDown={onVariantFieldBlur}
+          validation={validation}
+          value={variant.title}
         />
         <Components.Select
           clearable={false}

--- a/imports/plugins/included/product-admin/client/components/ProductHeader.js
+++ b/imports/plugins/included/product-admin/client/components/ProductHeader.js
@@ -123,7 +123,7 @@ function ProductHeader(props) {
               className={classes.breadcrumbLink}
               to={`/operator/products/${product._id}/${parentVariant._id}`}
             >
-              {parentVariant.title || "Untitled Variant"}
+              {parentVariant.optionTitle || "Untitled Variant"}
             </Link>
           </Fragment>
         )}
@@ -135,7 +135,7 @@ function ProductHeader(props) {
               className={classes.breadcrumbLink}
               to={`/operator/products/${variant.ancestors.join("/")}/${variant._id}`}
             >
-              {variant.title || "Untitled Variant"}
+              {variant.optionTitle || "Untitled Variant"}
             </Link>
           </Fragment>
         )}

--- a/imports/plugins/included/product-admin/client/components/ProductList.js
+++ b/imports/plugins/included/product-admin/client/components/ProductList.js
@@ -72,7 +72,7 @@ function ProductList({ items, title, onCreate, selectedVariantId }) {
                 />
               ) || ""}
               <ListItemText
-                primary={item.title || "Untitled"}
+                primary={item.optionTitle || item.title || "Untitled"}
                 secondary={getItemSecondaryLabel(item)}
               />
             </ListItem>

--- a/imports/plugins/included/product-admin/client/components/VariantTable.js
+++ b/imports/plugins/included/product-admin/client/components/VariantTable.js
@@ -116,7 +116,7 @@ function VariantTable(props) {
               </TableCell>
               <TableCell>
                 <Link to={getURL(item)}>
-                  {item.title || item.optionTitle || item.name}
+                  {item.optionTitle || item.title || item.name}
                 </Link>
               </TableCell>
               <TableCell>{item.displayPrice}</TableCell>

--- a/imports/plugins/included/product-variant/server/i18n/en.json
+++ b/imports/plugins/included/product-variant/server/i18n/en.json
@@ -5,19 +5,24 @@
     "reaction-product-variant": {
       "admin": {
         "helpText": {
+          "attributeLabel": "The attribute label describes the category of variant, for example, \"Color\" or \"Size\". In most cases you should enter the same value here for all variants at the same level.",
           "compareAtPrice": "Original price or MSRP",
           "optionInventoryAvailableToSell": "Inventory available to sell",
           "optionInventoryInStock": "Inventory in stock",
-          "optionTitle": "Displayed on Product Detail Page",
+          "optionTitle": "The short title is the value for the attribute label. For example, a variant with attribute label \"Color\" might have short title \"Red\". This is usually shown in a select list or button set on a product detail page in your storefront.",
           "price": "Purchase price",
-          "title": "Displayed in cart, checkout, and orders",
+          "title": "The full title is usually shown on cart, checkout, and order summaries and on invoices. It should fully describe the configured variant. For example, if this is an option with short title \"Large\", its parent variant has short title \"Red\", and the product title is \"Fancy T-Shirt\", then a good title might be \"Fancy T-Shirt - Red - Large\".",
           "variantBackorderToggle": "Backorder allowance is now controlled by options",
           "variantInventoryAvailableToSell": "Variant inventory available to sell quantity is calculated by options inventory",
           "variantInventoryInStock": "Variants inventory in stock quantity is calculated by options inventory"
         },
         "productVariant": {
+          "attributeLabelLabel": "Attribute label",
+          "attributeLabelPlaceholder": "Examples: Color, Size",
           "inventoryAvailableToSell": "Available to sell",
-          "inventoryInStock": "In stock"
+          "inventoryInStock": "In stock",
+          "optionTitlePlaceholder": "Examples: Red, Large",
+          "titlePlaceholder": "Example: Fancy T-Shirt - Red - Large"
         },
         "tooltip": {
           "validationError": "Validation error"

--- a/private/data/i18n/en.json
+++ b/private/data/i18n/en.json
@@ -272,7 +272,7 @@
         "addVariantOptions": "Add options to enable 'Add to Cart' button",
         "title": "Title",
         "price": "Price",
-        "optionTitle": "Option title",
+        "optionTitle": "Short title",
         "barcode": "Barcode",
         "compareAtPrice": "Compare at price",
         "fulfillmentService": "Fulfillment service",

--- a/tests/catalog/publishProductsToCatalog.test.js
+++ b/tests/catalog/publishProductsToCatalog.test.js
@@ -30,6 +30,7 @@ const mockProduct = {
 const mockVariant = {
   _id: internalVariantIds[0],
   ancestors: [internalProductId],
+  attributeLabel: "Variant",
   title: "Fake Product Variant",
   shopId: internalShopId,
   isDeleted: false,
@@ -39,6 +40,7 @@ const mockVariant = {
 const mockOptionOne = {
   _id: internalVariantIds[1],
   ancestors: [internalProductId, internalVariantIds[0]],
+  attributeLabel: "Option",
   title: "Fake Product Option One",
   shopId: internalShopId,
   isDeleted: false,
@@ -48,6 +50,7 @@ const mockOptionOne = {
 const mockOptionTwo = {
   _id: internalVariantIds[2],
   ancestors: [internalProductId, internalVariantIds[0]],
+  attributeLabel: "Option",
   title: "Fake Product Option Two",
   shopId: internalShopId,
   isDeleted: false,

--- a/tests/inventory/inventory.test.js
+++ b/tests/inventory/inventory.test.js
@@ -30,6 +30,7 @@ const product = Factory.Product.makeOne({
 const variant = Factory.Product.makeOne({
   _id: internalVariantId,
   ancestors: [internalProductId],
+  attributeLabel: "Variant",
   isDeleted: false,
   isVisible: true,
   shopId: internalShopId,
@@ -39,6 +40,7 @@ const variant = Factory.Product.makeOne({
 const option1 = Factory.Product.makeOne({
   _id: internalOptionId1,
   ancestors: [internalProductId, internalVariantId],
+  attributeLabel: "Option",
   isDeleted: false,
   isVisible: true,
   shopId: internalShopId,
@@ -48,6 +50,7 @@ const option1 = Factory.Product.makeOne({
 const option2 = Factory.Product.makeOne({
   _id: internalOptionId2,
   ancestors: [internalProductId, internalVariantId],
+  attributeLabel: "Option",
   isDeleted: false,
   isVisible: true,
   shopId: internalShopId,


### PR DESCRIPTION
Resolves #5208  
Impact: **minor**  
Type: **feature**

## Issue
`CartItem` and `OrderItem` have `attributes` array, but `label` was `null` and `value` was pulled from the wrong product field. `OrderItem` always had empty array.

One underlying problem is that we had no label for variants, which is why we have null attribute labels.

A related problem is general confusion around `title` vs. `optionTitle` fields for variants.

## Solution
- Added optional `attributeLabel` string field to `Products` of type "variant"
- Added required `attributeLabel` string field to all `CatalogProductVariant`
- Added an operator UI field to the variant edit form, "Attribute label". Also generally improved the labels, placeholder text, and help text for the `attributeLabel`, `optionTitle`, and `title` fields on that form, to help avoid more confusion.
- Properly set `attributes` array on `OrderItem`s when they are created
- Properly set `attributes` array on `CartItem`s when they are created
- Migration to set `attributeLabel` to a default value in `Products` and `Catalog` collections. For top-level variants, set to "Variant". For option variants, set to "Option".
- Migration to set `label` for all `attributes` on all `CartItem` to a default value in `Cart` collection. For first attribute, set to "Variant". For second attribute, if present, set to "Option".

NOTE: I opted not to do #5206 in this PR to avoid it becoming too large.

## Breaking changes
As long as migrations run, nothing should break. If client code is using cart item `attributes` and depending on what the `value` of them currently is (the full title), it may need to be updated.

## Testing
1. Test the new and updated fields at the top of the variant edit form. Test for top-level variant and for option variant. Verify you cannot publish without an attribute label set.
2. Verify you can query GraphQL for `attributeLabel` field for any variant or option in a `CatalogItemProduct`.
3. Test the migration and verify that all data is migrated as described.