### PR TITLE
refactor: add handle to tag autosuggest results

### DIFF
--- a/imports/plugins/core/tags/server/methods.js
+++ b/imports/plugins/core/tags/server/methods.js
@@ -26,7 +26,8 @@ Meteor.methods({
     }
 
     const tags = Tags.find(selector, { limit: 4 }).map((tag) => ({
-      label: tag.name
+      label: tag.name,
+      slug: tag.slug
     }));
 
     return tags;

--- a/imports/plugins/core/ui/client/components/tags/tagItem.js
+++ b/imports/plugins/core/ui/client/components/tags/tagItem.js
@@ -262,7 +262,7 @@ class TagItem extends Component {
 
   renderSuggestion(suggestion) {
     return (
-      <span>{suggestion.label}</span>
+      <span>{suggestion.label} ({suggestion.slug})</span>
     );
   }
 


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

## Issue
When a `tag name` does not match a `tag slug`, it becomes difficult / impossible to add a tag to a product because multiple tags can have the same `Tag name`, but different slugs.

## Solution
Add the `slug` into the result UI so you can tell which tag you are currently targeting.

## Breaking changes
None


## Testing
1. Add two tags with the same `Tag Name`
1. Use the database to change one of the slugs to something random
1. See that both tags show when suggesting