### PR TITLE
fix: typo breaking docs build (5286)

### DIFF
--- a/imports/plugins/included/product-admin/client/hocs/withVariant.js
+++ b/imports/plugins/included/product-admin/client/hocs/withVariant.js
@@ -106,7 +106,7 @@ function composer(props, onData) {
   } else {
     variants = ReactionProduct.getTopVariants();
   }
-  let variantMedia: [];
+  let variantMedia = [];
 
   if (variants) {
     if (Array.isArray(variants)) {


### PR DESCRIPTION
**Resolves** #5286 
Impact: **minor**  
Type: **bugfix**

## Issue
Fixes #5286 which was caused by this line
https://github.com/reactioncommerce/reaction/blob/master/imports/plugins/included/product-admin/client/hocs/withVariant.js#L109 breaking the jsdoc build.

It's unclear to me why this line didn't cause our app build to fail.