### PR TITLE
chore: fix prefer-const eslint error

### DIFF
--- a/imports/plugins/core/tags/server/no-meteor/mutations/updateTag.js
+++ b/imports/plugins/core/tags/server/no-meteor/mutations/updateTag.js
@@ -37,7 +37,7 @@ export default async function updateTag(context, input) {
     throw new ReactionError("access-denied", "User does not have permission");
   }
 
-  let metafields = [];
+  const metafields = [];
 
   // Filter out blank meta fields
   Array.isArray(input.metafields) && input.metafields.forEach((field) => {


### PR DESCRIPTION
Resolves #5275   
Impact: **minor**  
Type: **chore**

## Issue
- Fix all (single) `prefer-const` eslint issue.
- Update `eslint` rules to change `prefer-const` from `warning` to `error` (PR for that here: https://github.com/reactioncommerce/reaction-eslint-config/pull/9)

## Testing
1. Run `eslint` locally.
1. See that no `prefer-const` warnings / error's remain