### PR TITLE
Add DataLoaders for Shops and SimpleInventory

### DIFF
--- a/imports/node-app/core/util/createDataLoaders.js
+++ b/imports/node-app/core/util/createDataLoaders.js
@@ -2,7 +2,7 @@
 import DataLoader from "dataloader";
 import convertToDataloaderResult from "./convertToDataloaderResult";
 
-export const dataLoaderFactory = (dlFunc) => new DataLoader(dlFunc);
+export const dataLoaderFactory = (dlFunc) => new DataLoader(dlFunc, { cache: false });
 
 export default async function createDataLoaders(context) {
   if (!context.getFunctionsOfType || !context.getFunctionsOfType("createDataLoaders")) return;

--- a/imports/plugins/core/shop/server/queries/index.js
+++ b/imports/plugins/core/shop/server/queries/index.js
@@ -1,7 +1,7 @@
 import url from "url";
 
 export default {
-  shopById: (context, _id) => context.collections.Shops.findOne({ _id }),
+  shopById: (context, _id) => context.dataLoaders.Shops.load(_id),
   shopBySlug: (context, slug) => context.collections.Shops.findOne({ slug }),
   primaryShop: async (context) => {
     const { collections, rootUrl } = context;

--- a/imports/plugins/core/shop/server/queries/test.js
+++ b/imports/plugins/core/shop/server/queries/test.js
@@ -5,7 +5,7 @@ const context = {
     Shops: {
       load: jest.fn(() => [
         {
-          _id: "shop-1",
+          _id: "shop-1"
         }
       ])
     }

--- a/imports/plugins/core/shop/server/queries/test.js
+++ b/imports/plugins/core/shop/server/queries/test.js
@@ -5,10 +5,7 @@ const context = {
     Shops: {
       load: jest.fn(() => [
         {
-          _id: 1,
-          productConfiguration: {
-            productVariantId: "variant-1"
-          }
+          _id: "shop-1",
         }
       ])
     }
@@ -16,6 +13,6 @@ const context = {
 };
 
 test("shopById calls Shops.load() dataloader", () => {
-  queries.shopById(context, "1");
-  expect(context.dataLoaders.Shops.load).toHaveBeenCalledWith("1");
+  queries.shopById(context, "shop-1");
+  expect(context.dataLoaders.Shops.load).toHaveBeenCalledWith("shop-1");
 });

--- a/imports/plugins/core/shop/server/queries/test.js
+++ b/imports/plugins/core/shop/server/queries/test.js
@@ -1,0 +1,21 @@
+import queries from "./";
+
+const context = {
+  dataLoaders: {
+    Shops: {
+      load: jest.fn(() => [
+        {
+          _id: 1,
+          productConfiguration: {
+            productVariantId: "variant-1"
+          }
+        }
+      ])
+    }
+  }
+};
+
+test("shopById calls Shops.load() dataloader", () => {
+  queries.shopById(context, "1");
+  expect(context.dataLoaders.Shops.load).toHaveBeenCalledWith("1");
+});

--- a/imports/plugins/core/shop/server/register.js
+++ b/imports/plugins/core/shop/server/register.js
@@ -2,6 +2,7 @@ import mutations from "./mutations";
 import queries from "./queries";
 import resolvers from "./resolvers";
 import schemas from "./schemas";
+import createDataLoaders from "./utils/createDataLoaders";
 
 /**
  * @summary Import and call this function to add this plugin to your API.
@@ -18,6 +19,9 @@ export default async function register(app) {
       schemas
     },
     queries,
-    mutations
+    mutations,
+    functionsByType: {
+      createDataLoaders: [createDataLoaders]
+    }
   });
 }

--- a/imports/plugins/core/shop/server/utils/createDataLoaders.js
+++ b/imports/plugins/core/shop/server/utils/createDataLoaders.js
@@ -1,0 +1,8 @@
+export default function createDataLoaders(context, dataloaderFactory, convertToDataloaderResult) {
+  return {
+    Shops: dataloaderFactory(async (ids) => {
+      const results = await context.collections.Shops.find({ _id: { $in: ids } }).toArray();
+      return convertToDataloaderResult(ids, results, "_id");
+    })
+  };
+}

--- a/imports/plugins/core/shop/server/utils/createDataLoaders.test.js
+++ b/imports/plugins/core/shop/server/utils/createDataLoaders.test.js
@@ -8,10 +8,10 @@ const context = {
         toArray() {
           return [
             {
-              _id: 1
+              _id: "shop-1"
             },
             {
-              _id: 2
+              _id: "shop-2"
             }
           ];
         }
@@ -34,16 +34,16 @@ test("returns a map with Shops dataloader", () => {
 
 test("dataloader function returns correct results", async () => {
   const { Shops } = createDataLoaders(context, dataloaderFactory, convertToDataloaderResult);
-  const results = await Shops(["1", "2", "3"]);
+  const results = await Shops(["shop-1", "shop-2", "shop-3"]);
   expect(results).toEqual([
-    { _id: 1 },
-    { _id: 2 },
+    { _id: "shop-1" },
+    { _id: "shop-2" },
     null
   ]);
 });
 
 test("dataloader function calls Shops.find() with correct shop ids", async () => {
   const { Shops } = createDataLoaders(context, dataloaderFactory, convertToDataloaderResult);
-  await Shops(["1"]);
-  expect(context.collections.Shops.find).toHaveBeenCalledWith({ _id: { $in: ["1"] } });
+  await Shops(["shop-1"]);
+  expect(context.collections.Shops.find).toHaveBeenCalledWith({ _id: { $in: ["shop-1"] } });
 });

--- a/imports/plugins/included/simple-inventory/server/no-meteor/register.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/register.js
@@ -4,6 +4,7 @@ import resolvers from "./resolvers";
 import schemas from "./schemas";
 import startup from "./startup";
 import inventoryForProductConfigurations from "./utils/inventoryForProductConfigurations";
+import createDataLoaders from "./utils/createDataLoaders";
 
 /**
  * @summary Import and call this function to add this plugin to your API.
@@ -28,7 +29,8 @@ export default async function register(app) {
     },
     functionsByType: {
       inventoryForProductConfigurations: [inventoryForProductConfigurations],
-      startup: [startup]
+      startup: [startup],
+      createDataLoaders: [createDataLoaders]
     },
     graphQL: {
       resolvers,

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/createDataLoaders.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/createDataLoaders.js
@@ -1,0 +1,13 @@
+import _ from "lodash";
+
+export default function createDataLoaders(context, dataloaderFactory) {
+  return {
+    SimpleInventoryByProductVariantId: dataloaderFactory(async (productVariantIds) => {
+      const results = await context.collections.SimpleInventory.find({
+        "productConfiguration.productVariantId": { $in: productVariantIds }
+      }).toArray();
+      const byVariantId = _.keyBy(results, (inventoryDoc) => inventoryDoc.productConfiguration.productVariantId);
+      return productVariantIds.map((variantId) => (byVariantId[variantId] ? byVariantId[variantId] : null));
+    })
+  };
+}

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/createDataLoaders.test.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/createDataLoaders.test.js
@@ -1,0 +1,56 @@
+import createDataLoaders from "./createDataLoaders";
+
+const context = {
+  collections: {
+    SimpleInventory: {
+      find: jest.fn(() => ({
+        toArray() {
+          return [
+            {
+              _id: 1,
+              productConfiguration: {
+                productVariantId: "variant-1"
+              }
+            },
+            {
+              _id: 2,
+              productConfiguration: {
+                productVariantId: "variant-2"
+              }
+            }
+          ];
+        }
+      }))
+    }
+  }
+};
+
+const dataloaderFactory = (fn) => fn;
+
+test("returns a map with SimpleInventoryByProductVariantId dataloader", () => {
+  let dlFn;
+  const dlFactory = (fn) => {
+    dlFn = fn;
+    return fn;
+  };
+  const dlMap = createDataLoaders(context, dlFactory);
+  expect(dlMap.SimpleInventoryByProductVariantId).toEqual(dlFn);
+});
+
+test("dataloader function returns correct results", async () => {
+  const { SimpleInventoryByProductVariantId } = createDataLoaders(context, dataloaderFactory);
+  const results = await SimpleInventoryByProductVariantId(["variant-2", "variant-3", "variant-1"]);
+  expect(results).toEqual([
+    { _id: 2, productConfiguration: { productVariantId: "variant-2" } },
+    null,
+    { _id: 1, productConfiguration: { productVariantId: "variant-1" } }
+  ]);
+});
+
+test("dataloader function calls SimpleInventory.find() with correct product variant ids", async () => {
+  const { SimpleInventoryByProductVariantId } = createDataLoaders(context, dataloaderFactory);
+  await SimpleInventoryByProductVariantId(["variant-2", "variant-3", "variant-1"]);
+  expect(context.collections.SimpleInventory.find).toHaveBeenCalledWith({
+    "productConfiguration.productVariantId": { $in: ["variant-2", "variant-3", "variant-1"] }
+  });
+});

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/createDataLoaders.test.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/createDataLoaders.test.js
@@ -7,13 +7,13 @@ const context = {
         toArray() {
           return [
             {
-              _id: 1,
+              _id: "product-1",
               productConfiguration: {
                 productVariantId: "variant-1"
               }
             },
             {
-              _id: 2,
+              _id: "product-2",
               productConfiguration: {
                 productVariantId: "variant-2"
               }
@@ -41,9 +41,9 @@ test("dataloader function returns correct results", async () => {
   const { SimpleInventoryByProductVariantId } = createDataLoaders(context, dataloaderFactory);
   const results = await SimpleInventoryByProductVariantId(["variant-2", "variant-3", "variant-1"]);
   expect(results).toEqual([
-    { _id: 2, productConfiguration: { productVariantId: "variant-2" } },
+    { _id: "product-2", productConfiguration: { productVariantId: "variant-2" } },
     null,
-    { _id: 1, productConfiguration: { productVariantId: "variant-1" } }
+    { _id: "product-1", productConfiguration: { productVariantId: "variant-1" } }
   ]);
 });
 

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.js
@@ -15,18 +15,11 @@ import isEqual from "lodash/isEqual";
  * @return {Promise<Object[]>} Array of responses, in same order as `input.productConfigurations` array.
  */
 export default async function inventoryForProductConfigurations(context, input) {
-  const { collections } = context;
-  const { SimpleInventory } = collections;
   const { productConfigurations } = input;
 
   const productVariantIds = productConfigurations.map(({ productVariantId }) => productVariantId);
 
-  const inventoryDocs = await SimpleInventory
-    .find({
-      "productConfiguration.productVariantId": { $in: productVariantIds }
-    })
-    .limit(productConfigurations.length) // optimize query speed
-    .toArray();
+  const inventoryDocs = await context.dataLoaders.SimpleInventoryByProductVariantId.loadMany(productVariantIds);
 
   return productConfigurations.map((productConfiguration) => {
     const inventoryDoc = inventoryDocs.find((doc) => isEqual(productConfiguration, doc.productConfiguration));

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.js
@@ -22,7 +22,10 @@ export default async function inventoryForProductConfigurations(context, input) 
   const inventoryDocs = await context.dataLoaders.SimpleInventoryByProductVariantId.loadMany(productVariantIds);
 
   return productConfigurations.map((productConfiguration) => {
-    const inventoryDoc = inventoryDocs.find((doc) => isEqual(productConfiguration, doc.productConfiguration));
+    const inventoryDoc = inventoryDocs.find((doc) => {
+      if (!doc) return false;
+      return isEqual(productConfiguration, doc.productConfiguration);
+    });
     if (!inventoryDoc || !inventoryDoc.isEnabled) {
       return {
         inventoryInfo: null,

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.test.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.test.js
@@ -1,0 +1,37 @@
+import inventoryForProductConfigurations from "./inventoryForProductConfigurations";
+
+const context = {
+  dataLoaders: {
+    SimpleInventoryByProductVariantId: {
+      loadMany: jest.fn(() => [
+        {
+          _id: 1,
+          productConfiguration: {
+            productVariantId: "variant-1"
+          }
+        },
+        {
+          _id: 2,
+          productConfiguration: {
+            productVariantId: "variant-2"
+          }
+        }
+      ])
+    }
+  }
+};
+
+test("calls SimpleInventoryByProductVariantId dataloader with correct product variant ids", async () => {
+  const input = {
+    productConfigurations: [
+      {
+        productVariantId: "variant-2"
+      },
+      {
+        productVariantId: "variant-1"
+      }
+    ]
+  };
+  await inventoryForProductConfigurations(context, input);
+  expect(context.dataLoaders.SimpleInventoryByProductVariantId.loadMany).toHaveBeenCalledWith(["variant-2", "variant-1"]);
+});

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.test.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.test.js
@@ -5,13 +5,13 @@ const context = {
     SimpleInventoryByProductVariantId: {
       loadMany: jest.fn(() => [
         {
-          _id: 1,
+          _id: "item-1",
           productConfiguration: {
             productVariantId: "variant-1"
           }
         },
         {
-          _id: 2,
+          _id: "item-2",
           productConfiguration: {
             productVariantId: "variant-2"
           }

--- a/tests/TestApp.js
+++ b/tests/TestApp.js
@@ -9,6 +9,7 @@ import Factory from "../imports/test-utils/helpers/factory";
 import hashLoginToken from "../imports/node-app/core/util/hashLoginToken";
 import registerPlugins from "../imports/node-app/registerPlugins";
 import "../imports/node-app/extendSchemas";
+import createDataLoaders from "../imports/node-app/core/util/createDataLoaders";
 
 class TestApp {
   constructor(options = {}) {
@@ -186,6 +187,7 @@ class TestApp {
   async start() {
     try {
       await registerPlugins(this.reactionNodeApp);
+      await createDataLoaders(this.reactionNodeApp.context);
     } catch (error) {
       Logger.error(error, "Error registering plugins in TestApp");
       throw error;


### PR DESCRIPTION
Resolves 70  
Impact: **minor**  
Type: **feature**

## Issue
The original feature request is tracked here https://github.com/reactioncommerce/reaction-feature-requests/issues/70

## Solution
With the infrastructure for DataLoaders in place, this PR adds first couple of DataLoaders for Shops and SimpleInventory. `Shops` will benefit product listing pages as product and variant resolvers all query `Shops` collection for each product. `SimpleInventory` query benefits from batching. 

## Breaking changes
None.
