### PR TITLE
chore: fix all `max-len` eslint warnings

### DIFF
--- a/imports/plugins/core/accounts/client/components/login.js
+++ b/imports/plugins/core/accounts/client/components/login.js
@@ -60,7 +60,8 @@ class Login extends Component {
     const currentRoute = Router.current().route;
     const isOauthFlow = currentRoute.options && currentRoute.options.meta && currentRoute.options.meta.oauthLoginFlow;
     const idpFormClass = isOauthFlow ? "idp-form" : "";
-    if (this.state.currentView === "loginFormSignInView" || this.state.currentView === "loginFormSignUpView" || this.state.currentView === "loginFormUpdatePasswordView") {
+    const { currentView } = this.state;
+    if (currentView === "loginFormSignInView" || currentView === "loginFormSignUpView" || currentView === "loginFormUpdatePasswordView") {
       if (isOauthFlow) {
         return (
           <Components.OAuthFormContainer
@@ -74,24 +75,26 @@ class Login extends Component {
         <Components.AuthContainer
           credentials={this.props.credentials}
           uniqueId={this.props.uniqueId}
-          currentView={this.state.currentView}
+          currentView={currentView}
           onForgotPasswordClick={this.showForgotPasswordView}
           onSignUpClick={this.showSignUpView}
           onSignInClick={this.showSignInView}
         />
       );
-    } else if (this.state.currentView === "loginFormResetPasswordView") {
+    } else if (currentView === "loginFormResetPasswordView") {
       return (
         <div className={idpFormClass}>
           <Components.ForgotPassword
             credentials={this.props.credentials}
             uniqueId={this.props.uniqueId}
-            currentView={this.state.currentView}
+            currentView={currentView}
             onSignInClick={this.showSignInView}
           />
         </div>
       );
     }
+
+    return null;
   }
 }
 

--- a/imports/plugins/core/dashboard/client/components/OperatorLanding.js
+++ b/imports/plugins/core/dashboard/client/components/OperatorLanding.js
@@ -28,7 +28,8 @@ function OperatorLanding() {
         </Grid>
         <Grid item>
           <Typography align="center" variant="body2">
-              Use the Operator UI to manage <Link to="/operator/orders">Orders</Link>, <Link to="/operator/products">Products</Link>, <Link to="/operator/tags">Tags</Link>, <Link to="/operator/accounts">Accounts</Link>, and <Link to="/operator/navigation">Navigation</Link>, or change shop settings.
+            {/* eslint-disable-next-line max-len */}
+            Use the Operator UI to manage <Link to="/operator/orders">Orders</Link>, <Link to="/operator/products">Products</Link>, <Link to="/operator/tags">Tags</Link>, <Link to="/operator/accounts">Accounts</Link>, and <Link to="/operator/navigation">Navigation</Link>, or change shop settings.
           </Typography>
         </Grid>
         <Grid item>

--- a/imports/plugins/core/dashboard/client/components/ShopLogoUrls.js
+++ b/imports/plugins/core/dashboard/client/components/ShopLogoUrls.js
@@ -108,7 +108,12 @@ class ShopLogoUrls extends Component {
                     <TextInput
                       id="primaryShopLogoUrlInput"
                       name="primaryShopLogoUrl"
-                      placeholder={i18next.t("shopSettings.shopLogoUrls.primaryShopLogoUrlDescription", "This is the primary shop logo, which is used wherever you see a logo throughout the UI")}
+                      placeholder={
+                        i18next.t(
+                          "shopSettings.shopLogoUrls.primaryShopLogoUrlDescription",
+                          "This is the primary shop logo, which is used wherever you see a logo throughout the UI"
+                        )
+                      }
                       value={primaryShopLogoUrl || ""}
                     />
                     <ErrorsBlock names={["primaryShopLogoUrl"]} />

--- a/imports/plugins/core/navigation/client/components/NavigationItemForm.js
+++ b/imports/plugins/core/navigation/client/components/NavigationItemForm.js
@@ -223,7 +223,9 @@ class NavigationItemForm extends Component {
               </ConfirmDialog>
             )}
             <Button className={classes.formActionButton} color="primary" onClick={onCloseForm} variant="outlined">{i18next.t("app.cancel")}</Button>
-            <Button className={classes.formActionButton} color="primary" onClick={this.handleClickSave} variant="contained">{i18next.t("app.saveChanges")}</Button>
+            <Button className={classes.formActionButton} color="primary" onClick={this.handleClickSave} variant="contained">
+              {i18next.t("app.saveChanges")}
+            </Button>
           </Grid>
         </Grid>
       </Fragment>

--- a/imports/plugins/core/orders/client/components/orderCardHeader.js
+++ b/imports/plugins/core/orders/client/components/orderCardHeader.js
@@ -102,7 +102,9 @@ class OrderCardHeader extends Component {
               </Button>
             </Grid>
             <Grid className={classes.openSidebarButton} item>
-              <DetailDrawerButton color="primary" size="small" variant="outlined">{i18next.t("orderCard.orderSummary.showOrderSummary", "Show order summary")}</DetailDrawerButton>
+              <DetailDrawerButton color="primary" size="small" variant="outlined">
+                {i18next.t("orderCard.orderSummary.showOrderSummary", "Show order summary")}
+              </DetailDrawerButton>
             </Grid>
           </Grid>
         </Grid>

--- a/imports/plugins/core/taxes/client/components/GeneralTaxSettings.js
+++ b/imports/plugins/core/taxes/client/components/GeneralTaxSettings.js
@@ -61,7 +61,12 @@ export default class GeneralTaxSettings extends Component {
       <div className="clearfix">
         <Form ref={(formRef) => { this.form = formRef; }} onSubmit={onSubmit} validator={validator} value={settingsDoc}>
           <Field name="primaryTaxServiceName" label={i18next.t("admin.taxSettings.primaryTaxServiceName")} labelFor={primaryTaxServiceNameInputId}>
-            <Select id={primaryTaxServiceNameInputId} name="primaryTaxServiceName" options={this.taxServicesOptions} placeholder={i18next.t("admin.taxSettings.primaryTaxServiceNamePlaceholder")} />
+            <Select
+              id={primaryTaxServiceNameInputId}
+              name="primaryTaxServiceName"
+              options={this.taxServicesOptions}
+              placeholder={i18next.t("admin.taxSettings.primaryTaxServiceNamePlaceholder")}
+            />
             <ErrorsBlock names={["primaryTaxServiceName"]} />
           </Field>
           <Field name="fallbackTaxServiceName" label={i18next.t("admin.taxSettings.fallbackTaxServiceName")} labelFor={fallbackTaxServiceNameInputId}>

--- a/imports/plugins/included/email-templates/server/templates/accounts/inviteNewShopMember.js
+++ b/imports/plugins/included/email-templates/server/templates/accounts/inviteNewShopMember.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/accounts/inviteShopMember.js
+++ b/imports/plugins/included/email-templates/server/templates/accounts/inviteShopMember.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/accounts/inviteShopOwner.js
+++ b/imports/plugins/included/email-templates/server/templates/accounts/inviteShopOwner.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/accounts/resetPassword.js
+++ b/imports/plugins/included/email-templates/server/templates/accounts/resetPassword.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/accounts/sendWelcomeEmail.js
+++ b/imports/plugins/included/email-templates/server/templates/accounts/sendWelcomeEmail.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/accounts/verifyEmail.js
+++ b/imports/plugins/included/email-templates/server/templates/accounts/verifyEmail.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/accounts/verifyUpdatedEmail.js
+++ b/imports/plugins/included/email-templates/server/templates/accounts/verifyUpdatedEmail.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/orders/itemRefund.js
+++ b/imports/plugins/included/email-templates/server/templates/orders/itemRefund.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/orders/new.js
+++ b/imports/plugins/included/email-templates/server/templates/orders/new.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/orders/refunded.js
+++ b/imports/plugins/included/email-templates/server/templates/orders/refunded.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/email-templates/server/templates/orders/shipped.js
+++ b/imports/plugins/included/email-templates/server/templates/orders/shipped.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 export default `
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/imports/plugins/included/surcharges/server/no-meteor/resolvers/AppliedSurcharge/index.js
+++ b/imports/plugins/included/surcharges/server/no-meteor/resolvers/AppliedSurcharge/index.js
@@ -5,5 +5,7 @@ import getSurchargeMessageForLanguage from "../../util/getSurchargeMessageForLan
 export default {
   _id: (node) => encodeSurchargeOpaqueId(node._id),
   amount: (node, _, context) => node.amount && xformSurchargeAmount(context, node.shopId, node.amount),
-  message: (node, { language }) => node.messagesByLanguage && node.messagesByLanguage.length && getSurchargeMessageForLanguage(language, node.messagesByLanguage)
+  message: (node, { language }) => node.messagesByLanguage &&
+    node.messagesByLanguage.length &&
+    getSurchargeMessageForLanguage(language, node.messagesByLanguage)
 };

--- a/imports/plugins/included/surcharges/server/no-meteor/resolvers/Surcharge/index.js
+++ b/imports/plugins/included/surcharges/server/no-meteor/resolvers/Surcharge/index.js
@@ -8,6 +8,8 @@ export default {
   _id: (node) => encodeSurchargeOpaqueId(node._id),
   shopId: (node) => encodeShopOpaqueId(node.shopId),
   amount: (node, _, context) => node.amount && xformSurchargeAmount(context, node.shopId, node.amount),
-  message: (node, { language }) => node.messagesByLanguage && node.messagesByLanguage.length && getSurchargeMessageForLanguage(language, node.messagesByLanguage),
+  message: (node, { language }) => node.messagesByLanguage &&
+    node.messagesByLanguage.length &&
+    getSurchargeMessageForLanguage(language, node.messagesByLanguage),
   methodIds: (node) => node.methodIds.map(encodeFulfillmentMethodOpaqueId)
 };


### PR DESCRIPTION
Resolves #5270   
Impact: **minor**  
Type: **chore**

## Issue
We currently have ~200 `max-len` eslint warnings.

## Solution
Fix (or disable) these warnings, and then update our `eslint` rules to make `max-len` an `error` so new violations are not introduced.

The errors are fixed in most places, and disabled in email template files.

Updated rules: https://github.com/reactioncommerce/reaction-eslint-config/pull/11

## Breaking changes
None.

## Testing
1. run eslint
1. see there are no longer any `max-len` warnings (and no errors)