### PR TITLE
chore: fix all `id-length` eslint warnings

### DIFF
--- a/client/modules/core/domains.test.js
+++ b/client/modules/core/domains.test.js
@@ -41,7 +41,7 @@ describe("DomainsMixin", () => {
       });
 
       test("wraps composeUrl with options only", () => {
-        const options = { a: 1, b: 2 };
+        const options = { optionA: 1, optionB: 2 };
 
         DomainsMixin.absoluteUrl(options);
 
@@ -49,7 +49,7 @@ describe("DomainsMixin", () => {
       });
 
       test("wraps composeUrl both a path and options", () => {
-        const options = { a: 1, b: 2 };
+        const options = { optionA: 1, optionB: 2 };
 
         DomainsMixin.absoluteUrl(path, options);
 

--- a/client/modules/core/helpers/apps.js
+++ b/client/modules/core/helpers/apps.js
@@ -145,7 +145,7 @@ export function Apps(optionHash) {
   });
 
   // Sort apps by priority (registry.priority)
-  return reactionApps.sort((a, b) => a.priority - b.priority).slice();
+  return reactionApps.sort((appA, appB) => appA.priority - appB.priority).slice();
 }
 
 /**

--- a/client/modules/i18n/main.js
+++ b/client/modules/i18n/main.js
@@ -46,9 +46,9 @@ export function getLabelsFor(schema, name) {
   Object.keys(schema.mergedSchema()).forEach((fieldName) => {
     const i18nKey = `${titleCaseName}.${fieldName.split(".$").join("")}`;
     // translate autoform label
-    const t = i18next.t(i18nKey);
-    if (t && new RegExp("string").test(t) !== true && t !== i18nKey) {
-      labels[fieldName] = t;
+    const translation = i18next.t(i18nKey);
+    if (translation && new RegExp("string").test(translation) !== true && translation !== i18nKey) {
+      labels[fieldName] = translation;
     }
   });
   return labels;
@@ -84,7 +84,7 @@ export const localeDep = new Tracker.Dependency();
 export const currencyDep = new Tracker.Dependency();
 
 Meteor.startup(() => {
-  Tracker.autorun((c) => {
+  Tracker.autorun((trackerInstance) => {
     let merchantShopsReadyOrSkipped = false;
 
     // Choose shopSubscription based on marketplace settings
@@ -111,7 +111,7 @@ Meteor.startup(() => {
         localeDep.changed();
 
         // Stop the tracker
-        c.stop();
+        trackerInstance.stop();
       });
     }
   });

--- a/imports/plugins/core/accounts/client/components/editGroup.js
+++ b/imports/plugins/core/accounts/client/components/editGroup.js
@@ -115,9 +115,9 @@ class EditGroup extends Component {
     });
   };
 
-  showForm = ((grp) = {}) => (e) => {
-    e.preventDefault();
-    e.stopPropagation();
+  showForm = ((grp) = {}) => (event) => {
+    event.preventDefault();
+    event.stopPropagation();
     this.setState({ isEditing: true, selectedGroup: grp });
   };
 

--- a/imports/plugins/core/accounts/client/components/signIn.js
+++ b/imports/plugins/core/accounts/client/components/signIn.js
@@ -71,15 +71,17 @@ class SignIn extends Component {
         </span>
       );
     }
+
+    return null;
   }
 
   renderPasswordErrors() {
     return (
       <span className="help-block">
         {this.props.onError(this.props.messages.errors && this.props.messages.errors.password) &&
-          this.props.messages.errors.password.map((error, i) => (
+          this.props.messages.errors.password.map((error, index) => (
             <Components.Translation
-              key={i}
+              key={index}
               defaultValue={error.reason}
               i18nKey={error.i18nKeyReason}
             />
@@ -97,6 +99,8 @@ class SignIn extends Component {
         </div>
       );
     }
+
+    return null;
   }
 
   renderSpinnerOnWait() {

--- a/imports/plugins/core/accounts/client/components/signUp.js
+++ b/imports/plugins/core/accounts/client/components/signUp.js
@@ -56,15 +56,17 @@ class SignUp extends Component {
         </span>
       );
     }
+
+    return null;
   }
 
   renderPasswordErrors() {
     return (
       <span className="help-block">
         {this.props.onError(this.props.messages.errors && this.props.messages.errors.password) &&
-          this.props.messages.errors.password.map((error, i) => (
+          this.props.messages.errors.password.map((error, index) => (
             <Components.Translation
-              key={i}
+              key={index}
               defaultValue={error.reason}
               i18nKey={error.i18nKeyReason}
             />
@@ -82,6 +84,8 @@ class SignUp extends Component {
         </div>
       );
     }
+
+    return null;
   }
 
   renderSpinnerOnWait() {
@@ -160,6 +164,8 @@ class SignUp extends Component {
         </form>
       );
     }
+
+    return null;
   }
 
   render() {

--- a/imports/plugins/core/accounts/client/components/updatePassword.js
+++ b/imports/plugins/core/accounts/client/components/updatePassword.js
@@ -63,15 +63,17 @@ class UpdatePassword extends Component {
         </div>
       );
     }
+
+    return null;
   }
 
   renderPasswordErrors() {
     return (
       <span className="help-block">
         {this.props.onError(this.props.messages.errors && this.props.messages.errors.password) &&
-        this.props.messages.errors.password.map((error, i) => (
+        this.props.messages.errors.password.map((error, index) => (
           <Components.Translation
-            key={i}
+            key={index}
             defaultValue={error.reason}
             i18nKey={error.i18nKeyReason}
           />

--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -116,7 +116,7 @@ export function groupPermissions(packages) {
         }
       }
       // TODO review this, hardcoded WIP "reaction"
-      const label = pkg.name.replace("reaction", "").replace(/(-.)/g, (x) => ` ${x[1].toUpperCase()}`);
+      const label = pkg.name.replace("reaction", "").replace(/(-.)/g, (string) => ` ${string[1].toUpperCase()}`);
 
       const newObj = {
         shopId: pkg.shopId,

--- a/imports/plugins/core/accounts/client/templates/members/member.js
+++ b/imports/plugins/core/accounts/client/templates/members/member.js
@@ -107,7 +107,7 @@ Template.memberSettings.helpers({
           }
         }
         // TODO review this, hardcoded WIP
-        const label = pkg.name.replace("reaction", "").replace(/(-.)/g, (x) => ` ${x[1].toUpperCase()}`);
+        const label = pkg.name.replace("reaction", "").replace(/(-.)/g, (string) => ` ${string[1].toUpperCase()}`);
 
         return permissionGroups.push({
           shopId: pkg.shopId,

--- a/imports/plugins/core/catalog/server/methods/catalog.app-test.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.app-test.js
@@ -96,7 +96,7 @@ Reaction.onAppStartupComplete(() => {
 
         Meteor.call("products/cloneVariant", product._id, variant[0]._id);
         const variants = Products.find({ ancestors: [product._id] }).fetch();
-        const clonedVariant = variants.filter((v) => v._id !== variant[0]._id);
+        const clonedVariant = variants.filter((filteredVariant) => filteredVariant._id !== variant[0]._id);
         expect(variant[0]._id).to.not.equal(clonedVariant[0]._id);
         expect(_.isEqual(variant[0].ancestors, clonedVariant[0].ancestors)).to.be.true;
         // expect(variant[0].ancestors).to.equal(clonedVariant[0].ancestors);
@@ -226,8 +226,8 @@ Reaction.onAppStartupComplete(() => {
           ancestors: { $in: [clone._id] }
         }).fetch();
         expect(cloneVariants.length).to.equal(3);
-        for (let i = 0; i < variants.length; i += 1) {
-          expect(cloneVariants.some((clonedVariant) => clonedVariant.title === variants[i].title)).to.be.ok;
+        for (let inc = 0; inc < variants.length; inc += 1) {
+          expect(cloneVariants.some((clonedVariant) => clonedVariant.title === variants[inc].title)).to.be.ok;
         }
       });
 

--- a/imports/plugins/core/catalog/server/no-meteor/utils/getCatalogProductMedia.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/getCatalogProductMedia.js
@@ -39,7 +39,7 @@ export default async function getCatalogProductMedia(productId, collections) {
         }
       };
     })
-    .sort((a, b) => a.priority - b.priority);
+    .sort((mediaA, mediaB) => mediaA.priority - mediaB.priority);
 
   return catalogProductMedia;
 }

--- a/imports/plugins/core/core/server/Reaction/importer.js
+++ b/imports/plugins/core/core/server/Reaction/importer.js
@@ -144,8 +144,8 @@ Importer.commit = function (collection) {
       const message = `Error while importing to ${name}`;
       const writeErrors = result.getWriteErrors();
 
-      for (let i = 0; i < writeErrors.length; i += 1) {
-        Logger.warn(`${message}: ${writeErrors[i].errmsg}`);
+      for (let inc = 0; inc < writeErrors.length; inc += 1) {
+        Logger.warn(`${message}: ${writeErrors[inc].errmsg}`);
       }
       const writeConcernError = result.getWriteConcernError();
       if (writeConcernError) {
@@ -460,12 +460,12 @@ Importer.process = function (json, keys, callback, cbArgs) {
 
   const array = EJSON.parse(json);
 
-  for (let i = 0; i < array.length; i += 1) {
+  for (let inc = 0; inc < array.length; inc += 1) {
     const key = {};
-    for (let j = 0; j < keys.length; j += 1) {
-      key[keys[j]] = array[i][keys[j]];
+    for (let subInc = 0; subInc < keys.length; subInc += 1) {
+      key[keys[subInc]] = array[inc][keys[subInc]];
     }
-    callback.call(this, key, array[i], ...cbArgs);
+    callback.call(this, key, array[inc], ...cbArgs);
   }
 };
 

--- a/imports/plugins/core/core/server/fixtures/products.js
+++ b/imports/plugins/core/core/server/fixtures/products.js
@@ -128,8 +128,8 @@ export function getProduct() {
 export function getProducts(limit = 2) {
   const products = [];
   const existingProducts = Products.find({}, { limit }).fetch();
-  for (let i = 0; i < limit; i += 1) {
-    const product = existingProducts[i] || Factory.create("product");
+  for (let inc = 0; inc < limit; inc += 1) {
+    const product = existingProducts[inc] || Factory.create("product");
     products.push(product);
   }
   return products;

--- a/imports/plugins/core/core/server/fixtures/users.js
+++ b/imports/plugins/core/core/server/fixtures/users.js
@@ -24,8 +24,8 @@ export function getUser() {
 export function getUsers(limit = 2) {
   const users = [];
   const existingUsers = Meteor.users.find({}, { limit }).fetch();
-  for (let i = 0; i < limit; i += 1) {
-    const user = existingUsers[i] || Factory.create("user");
+  for (let inc = 0; inc < limit; inc += 1) {
+    const user = existingUsers[inc] || Factory.create("user");
     users.push(user);
   }
   return users;

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/tag.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/tag.js
@@ -26,7 +26,7 @@ export default async function tag(_, connectionArgs, context) {
 
   try {
     dbTagId = decodeTagOpaqueId(slugOrId);
-  } catch (e) {
+  } catch (error) {
     dbTagId = slugOrId;
   }
 

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Query/tags.test.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Query/tags.test.js
@@ -3,7 +3,7 @@ import getFakeMongoCursor from "/imports/test-utils/helpers/getFakeMongoCursor";
 import Factory from "/imports/test-utils/helpers/factory";
 
 const base64ID = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
-const mockTags = Factory.Tag.makeMany(3, { _id: (i) => (i + 100).toString() });
+const mockTags = Factory.Tag.makeMany(3, { _id: (newId) => (newId + 100).toString() });
 const mockTagsQuery = getFakeMongoCursor("Tags", mockTags);
 
 test("calls queries.tags and returns a partial connection", async () => {

--- a/imports/plugins/core/core/server/startup/i18n.js
+++ b/imports/plugins/core/core/server/startup/i18n.js
@@ -191,12 +191,12 @@ export function importAllTranslations() {
     // Then loop through those I18N assets and import them
     if (shopId) {
       // If there isn't a shop yet, and for future shops, this will be done in the "afterShopCreate" listener
-      Assets.find({ type: "i18n" }).forEach((t) => {
-        Logger.debug(`Importing ${t.name} translation for "${t.ns}"`);
-        if (t.content) {
-          Reaction.Importer.process(t.content, ["i18n"], Reaction.Importer.translation, [shopId]);
+      Assets.find({ type: "i18n" }).forEach((translation) => {
+        Logger.debug(`Importing ${translation.name} translation for "${translation.ns}"`);
+        if (translation.content) {
+          Reaction.Importer.process(translation.content, ["i18n"], Reaction.Importer.translation, [shopId]);
         } else {
-          Logger.debug(`No translation content found for ${t.name} - ${t.ns} asset`);
+          Logger.debug(`No translation content found for ${translation.name} - ${translation.ns} asset`);
         }
       });
     }

--- a/imports/plugins/core/core/server/util/geocoder.js
+++ b/imports/plugins/core/core/server/util/geocoder.js
@@ -45,11 +45,11 @@ function GeoCoder(options) {
 }
 
 function gc(address, options, callback) {
-  const g = require("node-geocoder")(
+  const geocoder = require("node-geocoder")(
     options.geocoderProvider, options.httpAdapter,
     options.extra
   );
-  g.geocode(address, callback);
+  geocoder.geocode(address, callback);
 }
 
 GeoCoder.prototype.geocode = function geoCoderGeocode(address, callback) {
@@ -67,11 +67,11 @@ GeoCoder.prototype.geocode = function geoCoderGeocode(address, callback) {
 };
 
 function rv(lat, lng, options, callback) {
-  const g = require("node-geocoder")(
+  const geocoder = require("node-geocoder")(
     options.geocoderProvider, options.httpAdapter,
     options.extra
   );
-  g.reverse({
+  geocoder.reverse({
     lat,
     lon: lng
   }, callback);

--- a/imports/plugins/core/dashboard/client/components/packageList.js
+++ b/imports/plugins/core/dashboard/client/components/packageList.js
@@ -69,7 +69,7 @@ class PackageList extends Component {
 
             try {
               actionComponent = getComponent(`${packageData.template}_ActionDashboard`);
-            } catch (e) {
+            } catch (error) {
               actionComponent = null;
             } finally {
               // If one exists, add it to the list of elements

--- a/imports/plugins/core/dashboard/client/containers/packageListContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/packageListContainer.js
@@ -46,7 +46,7 @@ function composer(props, onData) {
   const settings = Reaction.Apps({ provides: "settings", enabled: true, audience }) || [];
 
   const dashboard = Reaction.Apps({ provides: "dashboard", enabled: true, audience })
-    .filter((d) => typeof Template[d.template] !== "undefined") || [];
+    .filter((dash) => typeof Template[dash.template] !== "undefined") || [];
 
   onData(null, {
     currentView: Reaction.getActionView(),

--- a/imports/plugins/core/dashboard/client/templates/import/import.js
+++ b/imports/plugins/core/dashboard/client/templates/import/import.js
@@ -9,8 +9,8 @@ function uploadHandler(event) {
   const userId = Reaction.getUserId();
   const { files } = event.target.files;
 
-  for (let i = 0; i < files.length; i += 1) {
-    const parts = files[i].name.split(".");
+  for (let inc = 0; inc < files.length; inc += 1) {
+    const parts = files[inc].name.split(".");
     let product;
     if (parts[0]) {
       product = Products.findOne({
@@ -24,7 +24,7 @@ function uploadHandler(event) {
       });
     }
     if (product) {
-      const fileRecord = FileRecord.fromFile(files[i]);
+      const fileRecord = FileRecord.fromFile(files[inc]);
       fileRecord.metadata = {
         ownerId: userId,
         productId: product._id,

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/ramda-ext.test.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/ramda-ext.test.js
@@ -1,11 +1,11 @@
 import { renameKeys } from "./ramda-ext";
 
 test("renameKeys renames keys in a map", () => {
-  const input = { a: 1, b: 2 };
-  expect(renameKeys({ a: "d" }, input)).toEqual({ d: 1, b: 2 });
+  const input = { varA: 1, varB: 2 };
+  expect(renameKeys({ varA: "d" }, input)).toEqual({ varD: 1, varB: 2 });
 });
 
 test("renameKeys passes over missing keys", () => {
-  const input = { a: 1, b: 2 };
-  expect(renameKeys({ f: "d" }, input)).toEqual({ a: 1, b: 2 });
+  const input = { varA: 1, varB: 2 };
+  expect(renameKeys({ varF: "d" }, input)).toEqual({ varA: 1, varB: 2 });
 });

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/ramda-ext.test.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/ramda-ext.test.js
@@ -2,10 +2,10 @@ import { renameKeys } from "./ramda-ext";
 
 test("renameKeys renames keys in a map", () => {
   const input = { varA: 1, varB: 2 };
-  expect(renameKeys({ varA: "d" }, input)).toEqual({ varD: 1, varB: 2 });
+  expect(renameKeys({ varA: "varD" }, input)).toEqual({ varD: 1, varB: 2 });
 });
 
 test("renameKeys passes over missing keys", () => {
   const input = { varA: 1, varB: 2 };
-  expect(renameKeys({ varF: "d" }, input)).toEqual({ varA: 1, varB: 2 });
+  expect(renameKeys({ varF: "varD" }, input)).toEqual({ varA: 1, varB: 2 });
 });

--- a/imports/plugins/core/i18n/client/containers/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/containers/localizationSettings.js
@@ -13,7 +13,7 @@ const wrapComponent = (Comp) => (
     static propTypes = LocalizationSettings.propTypes
 
     handleUpdateLanguageConfiguration = (event, isChecked, name) => {
-      const language = this.props.languages.find((l) => l.value === name);
+      const language = this.props.languages.find((lang) => lang.value === name);
 
       if (language) {
         Meteor.call("shop/updateLanguageConfiguration", language.value, isChecked);

--- a/imports/plugins/core/layout/client/templates/layout/alerts/inlineAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/inlineAlerts.js
@@ -74,7 +74,7 @@ const Alerts = {
   See Alerts.defaultOptions for all values.
    */
   add(alertMessage, mode, alertOptions) {
-    let a;
+    let alert;
     let message = alertMessage;
     let options = alertOptions;
     // check options to see if we have translation
@@ -85,11 +85,11 @@ const Alerts = {
     options = _.defaults(alertOptions || {}, Alerts.defaultOptions);
 
     if (options.type) {
-      a = Alerts.collection_.findOne({
+      alert = Alerts.collection_.findOne({
         "options.type": options.type
       });
-      if (a) {
-        Alerts.collection_.update(a._id, {
+      if (alert) {
+        Alerts.collection_.update(alert._id, {
           $set: {
             message,
             mode,

--- a/imports/plugins/core/layout/lib/components.js
+++ b/imports/plugins/core/layout/lib/components.js
@@ -19,7 +19,7 @@ export function getComponent(name) {
 
   try {
     component = newGetComponent(name);
-  } catch (e) {
+  } catch (error) {
     console.log("Component not found");
   }
 

--- a/imports/plugins/core/layout/lib/reactionLayout.js
+++ b/imports/plugins/core/layout/lib/reactionLayout.js
@@ -53,7 +53,7 @@ class ReactionLayout extends Component {
                 ...(child.props || {}),
                 ...this.props.layoutProps
               });
-            } catch (e) {
+            } catch (error) {
               return null;
             }
           }

--- a/imports/plugins/core/router/lib/router.js
+++ b/imports/plugins/core/router/lib/router.js
@@ -434,7 +434,7 @@ function ReactionLayout(options = {}) {
   // Find a registered layout using the layoutName and workflowName
   if (shop) {
     const sortedLayout = shop.layout.sort((prev, next) => prev.priority - next.priority);
-    const foundLayout = sortedLayout.find((x) => selectLayout(x, layoutName, workflowName));
+    const foundLayout = sortedLayout.find((layout) => selectLayout(layout, layoutName, workflowName));
 
     if (foundLayout) {
       if (foundLayout.structure) {
@@ -469,7 +469,7 @@ function ReactionLayout(options = {}) {
 
   try {
     getComponent(layoutStructure.template);
-  } catch (e) {
+  } catch (error) {
     hasReactComponent = false;
   }
 
@@ -504,7 +504,7 @@ function ReactionLayout(options = {}) {
           ...props,
           structure
         });
-      } catch (e) {
+      } catch (error) {
         // eslint-disable-next-line
         console.warn(e, "Failed to create a React layout element");
       }

--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -146,7 +146,7 @@ class Form extends Component {
   }
 
   handleMultiSelectChange = (value, name) => {
-    this.handleChange(new Event("onMultiSelect"), value.map((v) => v.value), name);
+    this.handleChange(new Event("onMultiSelect"), value.map((val) => val.value), name);
   }
 
   handleSubmit = async (event) => {
@@ -228,7 +228,7 @@ class Form extends Component {
 
     if (this.state.isValid === false) {
       this.state.schema.validationErrors()
-        .filter((v) => v.name === field.name)
+        .filter((val) => val.name === field.name)
         .forEach((validationError) => {
           const message = this.state.schema.keyErrorMessage(validationError.name);
           fieldHasError = true;

--- a/imports/plugins/core/ui/client/components/table/sortableTable.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTable.js
@@ -313,7 +313,7 @@ class SortableTable extends Component {
             }
 
             return {
-              onClick: (e) => { // eslint-disable-line no-unused-vars
+              onClick: (event) => { // eslint-disable-line no-unused-vars
                 this.handleClick(rowInfo);
               },
               className: this.selectedRowsClassName(rowInfo)

--- a/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
@@ -43,8 +43,8 @@ class SortableTablePagination extends Component {
     onPageSizeChange && onPageSizeChange(Number(event.target.value));
   }
 
-  applyPage(e) {
-    e && e.preventDefault();
+  applyPage(event) {
+    event && event.preventDefault();
     const { page } = this.state;
     this.changePage(page === "" ? this.props.page : page);
   }
@@ -78,8 +78,8 @@ class SortableTablePagination extends Component {
               ? <div className="-pageJump">
                 <input
                   type={this.state.page === "" ? "text" : "number"}
-                  onChange={(e) => {
-                    const val = e.target.value;
+                  onChange={(event) => {
+                    const val = event.target.value;
                     const currentPage = val - 1;
                     if (val === "") {
                       return this.setState({ page: val });
@@ -88,8 +88,8 @@ class SortableTablePagination extends Component {
                   }}
                   value={this.state.page === "" ? "" : this.state.page + 1}
                   onBlur={this.applyPage}
-                  onKeyPress={(e) => {
-                    if (e.which === 13 || e.keyCode === 13) {
+                  onKeyPress={(event) => {
+                    if (event.which === 13 || event.keyCode === 13) {
                       this.applyPage();
                     }
                   }}
@@ -106,8 +106,8 @@ class SortableTablePagination extends Component {
                 onChange={this.handlePageSizeChange}
                 value={pageSize}
               >
-                {pageSizeOptions.map((option, i) => (
-                  <option key={i} value={option}>
+                {pageSizeOptions.map((option, index) => (
+                  <option key={index} value={option}>
                     {option} {this.props.rowsText}
                   </option>
                 ))}
@@ -116,7 +116,7 @@ class SortableTablePagination extends Component {
         </div>
         <div className="-previous">
           <PreviousComponent
-            onClick={(e) => { // eslint-disable-line no-unused-vars
+            onClick={(event) => { // eslint-disable-line no-unused-vars
               if (canPrevious) {
                 return this.changePage(page - 1);
               }
@@ -129,7 +129,7 @@ class SortableTablePagination extends Component {
         <span className="-divider">|</span>
         <div className="-next">
           <NextComponent
-            onClick={(e) => { // eslint-disable-line no-unused-vars
+            onClick={(event) => { // eslint-disable-line no-unused-vars
               if (canNext) {
                 return this.changePage(page + 1);
               }

--- a/imports/plugins/core/ui/client/containers/mediaGallery.js
+++ b/imports/plugins/core/ui/client/containers/mediaGallery.js
@@ -214,8 +214,8 @@ const wrapComponent = (Comp) => (
 
 // resort the media in
 function sortMedia(media) {
-  const sortedMedia = _.sortBy(media, (m) => {
-    const { priority } = (m && m.metadata) || {};
+  const sortedMedia = _.sortBy(media, (med) => {
+    const { priority } = (med && med.metadata) || {};
     if (!priority && priority !== 0) {
       return 1000;
     }

--- a/imports/plugins/core/ui/client/helpers/react-template-helper.js
+++ b/imports/plugins/core/ui/client/helpers/react-template-helper.js
@@ -69,12 +69,12 @@ function parentTemplateName() {
   // find the first parent view which is a template or body
   view = view.parentView;
   while (view) {
-    const m = view.name.match(/^Template\.(.*)/);
+    const match = view.name.match(/^Template\.(.*)/);
     // check `view.name.match(/^Template\./)` because iron-router (and
     // maybe other packages) create a view named "yield" that has the
     // `template` property set
-    if (view.template && view.name && m) {
-      return m[1];
+    if (view.template && view.name && match) {
+      return match[1];
     } else if (view.name === "body") {
       return "<body>";
     }

--- a/imports/plugins/core/versions/server/migrations/5_update_defaultRoles_to_groups.js
+++ b/imports/plugins/core/versions/server/migrations/5_update_defaultRoles_to_groups.js
@@ -123,16 +123,16 @@ Migrations.add({
  * and returns this: [["product", "tag"], ["product", "shop", "tag"], ["shop", "tag"]]
  */
 function sortUniqueArray(multiArray) {
-  const sorted = multiArray.map((x) => {
-    if (!x) { return []; }
-    return x.sort();
+  const sorted = multiArray.map((array) => {
+    if (!array) { return []; }
+    return array.sort();
   }).sort();
   const uniqueArray = [];
   uniqueArray.push(sorted[0]);
 
-  for (let i = 1; i < sorted.length; i += 1) {
-    if (JSON.stringify(sorted[i]) !== JSON.stringify(sorted[i - 1])) {
-      uniqueArray.push(sorted[i]);
+  for (let inc = 1; inc < sorted.length; inc += 1) {
+    if (JSON.stringify(sorted[inc]) !== JSON.stringify(sorted[inc - 1])) {
+      uniqueArray.push(sorted[inc]);
     }
   }
   return uniqueArray;

--- a/imports/plugins/included/email-smtp/client/components/SMTPEmailSettings.js
+++ b/imports/plugins/included/email-smtp/client/components/SMTPEmailSettings.js
@@ -17,14 +17,14 @@ class SMTPEmailSettings extends Component {
     this.handleSelect = this.handleSelect.bind(this);
   }
 
-  handleStateChange(e) {
+  handleStateChange(event) {
     const { settings } = this.state;
-    settings[e.target.name] = e.target.value;
+    settings[event.target.name] = event.target.value;
     this.setState({ settings });
   }
 
-  handleSubmit(e) {
-    e.preventDefault();
+  handleSubmit(event) {
+    event.preventDefault();
     const { saveSettings, providers } = this.props;
     const { settings } = this.state;
     let newSettings = settings;

--- a/imports/plugins/included/payments-example/client/settings/components/exampleSettingsForm.js
+++ b/imports/plugins/included/payments-example/client/settings/components/exampleSettingsForm.js
@@ -12,14 +12,14 @@ class ExampleSettingsForm extends Component {
     };
   }
 
-  handleStateChange = (e) => {
+  handleStateChange = (event) => {
     const { settings } = this.state;
-    settings[e.target.name] = e.target.value;
+    settings[event.target.name] = event.target.value;
     this.setState({ settings });
   }
 
-  handleSubmit = (e) => {
-    e.preventDefault();
+  handleSubmit = (event) => {
+    event.preventDefault();
     return this.props.onSubmit(this.state.settings);
   }
 

--- a/imports/plugins/included/payments-example/client/settings/containers/exampleSettingsFormContainer.js
+++ b/imports/plugins/included/payments-example/client/settings/containers/exampleSettingsFormContainer.js
@@ -19,9 +19,9 @@ class ExampleSettingsFormContainer extends Component {
     this.saveUpdate = this.saveUpdate.bind(this);
   }
 
-  handleChange(e) {
-    e.preventDefault();
-    this.setState({ apiKey: e.target.value });
+  handleChange(event) {
+    event.preventDefault();
+    this.setState({ apiKey: event.target.value });
   }
 
   handleSubmit(settings) {

--- a/imports/plugins/included/product-admin/client/hocs/withProduct.js
+++ b/imports/plugins/included/product-admin/client/hocs/withProduct.js
@@ -190,7 +190,7 @@ function getTopVariants() {
       }
     }
     // sort variants in correct order
-    variants.sort((a, b) => a.index - b.index);
+    variants.sort((variantA, variantB) => variantA.index - variantB.index);
 
     return variants;
   }

--- a/imports/plugins/included/product-admin/client/hocs/withProductMedia.js
+++ b/imports/plugins/included/product-admin/client/hocs/withProductMedia.js
@@ -219,8 +219,8 @@ const wrapComponent = (Comp) => (
  * @returns {Array<Object>} sorted media
  */
 function sortMedia(media) {
-  const sortedMedia = _.sortBy(media, (m) => {
-    const { priority } = (m && m.metadata) || {};
+  const sortedMedia = _.sortBy(media, (med) => {
+    const { priority } = (med && med.metadata) || {};
     if (!priority && priority !== 0) {
       return 1000;
     }

--- a/imports/plugins/included/product-detail-simple/client/containers/variantList.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/variantList.js
@@ -77,7 +77,7 @@ function getTopVariants() {
       }
     }
     // sort variants in correct order
-    variants.sort((a, b) => a.index - b.index);
+    variants.sort((variantA, variantB) => variantA.index - variantB.index);
 
     return variants;
   }

--- a/imports/plugins/included/product-variant/containers/gridPublishContainer.js
+++ b/imports/plugins/included/product-variant/containers/gridPublishContainer.js
@@ -47,7 +47,7 @@ function composer(props, onData) {
   if (Array.isArray(selectedProducts) && selectedProducts.length) {
     productIds = selectedProducts;
   } else if (Array.isArray(products) && products.length) {
-    productIds = products.map((p) => p._id);
+    productIds = products.map((product) => product._id);
   }
 
   if (productIds) {

--- a/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridItemsContainer.js
@@ -49,8 +49,8 @@ const wrapComponent = (Comp) => (
           Array.prototype.indexOf.call(items, activeItems[0]),
           Array.prototype.indexOf.call(items, activeItems[selected - 1])
         ];
-        for (let i = _.min(indexes); i <= _.max(indexes); i += 1) {
-          checkbox = items[i].querySelector("input[type=checkbox]");
+        for (let inc = _.min(indexes); inc <= _.max(indexes); inc += 1) {
+          checkbox = items[inc].querySelector("input[type=checkbox]");
           if (checkbox.checked === false) {
             checkbox.checked = true;
             this.props.itemSelectHandler(checkbox.checked, product._id);

--- a/imports/plugins/included/social/client/components/facebook.js
+++ b/imports/plugins/included/social/client/components/facebook.js
@@ -37,6 +37,7 @@ export function getOpenGraphMeta(props) {
 class FacebookSocialButton extends Component {
   componentDidMount() {
     /* eslint-disable wrap-iife */
+    /* eslint-disable id-length */
     if (window && document) {
       $('<div id="fb-root"></div>').appendTo("body");
 
@@ -56,6 +57,7 @@ class FacebookSocialButton extends Component {
         fjs.parentNode.insertBefore(js, fjs);
       })(document, "script", "facebook-jssdk");
     }
+    /* eslint-enable id-length */
     /* eslint-enable wrap-iife */
   }
 

--- a/imports/plugins/included/social/client/templates/social.js
+++ b/imports/plugins/included/social/client/templates/social.js
@@ -34,8 +34,8 @@ Template.reactionSocial.helpers({
       if (socialSettings.appsOrder) {
         const { appsOrder } = socialSettings;
 
-        for (let i = 0; i < appsOrder.length; i += 1) {
-          const app = appsOrder[i];
+        for (let inc = 0; inc < appsOrder.length; inc += 1) {
+          const app = appsOrder[inc];
 
           if (typeof socialSettings.apps[app] === "object" &&
             socialSettings.apps[app].enabled) {

--- a/imports/plugins/included/social/lib/helpers.js
+++ b/imports/plugins/included/social/lib/helpers.js
@@ -17,8 +17,8 @@ export function createSocialSettings(options) {
 
     if (socialSettings.appsOrder) {
       const { appsOrder } = socialSettings;
-      for (let i = 0; i < appsOrder.length; i += 1) {
-        const app = appsOrder[i];
+      for (let inc = 0; inc < appsOrder.length; inc += 1) {
+        const app = appsOrder[inc];
 
         if (typeof socialSettings.apps[app] === "object" && socialSettings.apps[app].enabled) {
           socialButtons.push(app);

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -22,11 +22,11 @@ if (Meteor.isClient) {
  * @return {String} camelCased string
  */
 export function toCamelCase(needscamels) {
-  let s;
-  s = needscamels.replace(/([^a-zA-Z0-9_\- ])|^[_0-9]+/g, "").trim().toLowerCase();
-  s = s.replace(/([ -]+)([a-zA-Z0-9])/g, (a, b, c) => c.toUpperCase());
-  s = s.replace(/([0-9]+)([a-zA-Z])/g, (a, b, c) => b + c.toUpperCase());
-  return s;
+  let string;
+  string = needscamels.replace(/([^a-zA-Z0-9_\- ])|^[_0-9]+/g, "").trim().toLowerCase();
+  string = string.replace(/([ -]+)([a-zA-Z0-9])/g, (splitA, splitB, splitC) => splitC.toUpperCase());
+  string = string.replace(/([0-9]+)([a-zA-Z])/g, (splitA, splitB, splitC) => splitB + splitC.toUpperCase());
+  return string;
 }
 
 /**
@@ -284,19 +284,19 @@ export function getPrimaryMediaForOrderItem({ productId, variantId } = {}) {
  * @private
  */
 function luhnValid(cardNumber) {
-  return [...cardNumber].reverse().reduce((sum, c, i) => {
-    let d = parseInt(c, 10);
-    if (i % 2 !== 0) { d *= 2; }
-    if (d > 9) { d -= 9; }
-    return sum + d;
+  return [...cardNumber].reverse().reduce((sum, card, index) => {
+    let basedCard = parseInt(card, 10);
+    if (index % 2 !== 0) { basedCard *= 2; }
+    if (basedCard > 9) { basedCard -= 9; }
+    return sum + basedCard;
   }, 0) % 10 === 0;
 }
 
 // Regex to do card validations
-export const ValidCardNumber = Match.Where((x) => /^[0-9]{12,19}$/.test(x) && luhnValid(x));
+export const ValidCardNumber = Match.Where((cardValue) => /^[0-9]{12,19}$/.test(cardValue) && luhnValid(cardValue));
 
-export const ValidExpireMonth = Match.Where((x) => /^[0-9]{1,2}$/.test(x));
+export const ValidExpireMonth = Match.Where((cardValue) => /^[0-9]{1,2}$/.test(cardValue));
 
-export const ValidExpireYear = Match.Where((x) => /^[0-9]{4}$/.test(x));
+export const ValidExpireYear = Match.Where((cardValue) => /^[0-9]{4}$/.test(cardValue));
 
-export const ValidCVV = Match.Where((x) => /^[0-9]{3,4}$/.test(x));
+export const ValidCVV = Match.Where((cardValue) => /^[0-9]{3,4}$/.test(cardValue));

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -42,7 +42,7 @@ function getSummary(items, prop, prop2, shopId) {
           item[prop[0]][prop[1]]);
       }, 0);
     }
-  } catch (e) {
+  } catch (error) {
     // If data not prepared we should send a number to avoid exception with
     // `toFixed`. This could happens if user stuck on `completed` checkout stage
     // by some reason.

--- a/tests/meteor/tags.app-test.js
+++ b/tests/meteor/tags.app-test.js
@@ -57,8 +57,8 @@ Reaction.onAppStartupComplete(() => {
       collector.collect("Tags", (collections) => {
         const collectionTags = collections.Tags;
 
-        expect(collectionTags.map((t) => t.name))
-          .to.eql(expectedTags.map((t) => t.name));
+        expect(collectionTags.map((collectionTag) => collectionTag.name))
+          .to.eql(expectedTags.map((collectionTag) => collectionTag.name));
       }).then(() => done()).catch(done);
     });
 
@@ -72,7 +72,7 @@ Reaction.onAppStartupComplete(() => {
       collector.collect("Tags", (collections) => {
         const collectionTags = collections.Tags;
 
-        expect(collectionTags.map((t) => t.name))
+        expect(collectionTags.map((collectionTag) => collectionTag.name))
           .to.eql([tag.name]);
       }).then(() => done()).catch(done);
     });


### PR DESCRIPTION
Resolves #5268    
Impact: **minor**  
Type: **chore**

## Issue
We currently have ~100 `id-length` eslint warnings.

## Solution
Fix (or disable) these warnings, and then update our `eslint` rules to make `id-length` an `error` so new violations are not introduced.

Updated rules: https://github.com/reactioncommerce/reaction-eslint-config/pull/14

## Breaking changes
None.

## Testing
1. run eslint
1. see there are no longer any `id-length` warnings (and no errors)