### PR TITLE
fix #5300 Wrong template reference

### DIFF
--- a/imports/plugins/core/orders/server/no-meteor/register.js
+++ b/imports/plugins/core/orders/server/no-meteor/register.js
@@ -135,12 +135,12 @@ export default async function register(app) {
       workflow: "coreOrderWorkflow",
       audience: ["dashboard/orders"]
     }, { // Standard Order Fulfillment with shipping
-      template: "coreOrderShippingSummary",
+      template: "OrderSummary",
       label: "Summary",
       workflow: "coreOrderShipmentWorkflow",
       audience: ["dashboard/orders"]
     }, {
-      template: "coreOrderShippingInvoice",
+      template: "OrderInvoice",
       label: "Invoice",
       workflow: "coreOrderShipmentWorkflow",
       audience: ["dashboard/orders"]


### PR DESCRIPTION
Signed-off-by: Janus Reith <janus.reith@googlemail.com>

Resolves #5300  
Impact: **major**  
Type: **bugfix**

## Issue
See https://github.com/reactioncommerce/reaction/issues/5300.
The wrong templates `coreOrderShippingSummary` and `coreOrderShippingInvoice` were registered. 

## Solution
Register the correct templates OrderSummary and OrderInvoice.

## Breaking changes
None.


## Testing
1. Create an order
2. Go to your orders operator panel
3. Oberseve that the correct templates are loaded.
