### PR TITLE
fix(5305-slow-simplschema-validate): replace simpl-schema.validate() …

### DIFF
--- a/imports/plugins/core/inventory/server/no-meteor/queries/inventoryForProductConfigurations.js
+++ b/imports/plugins/core/inventory/server/no-meteor/queries/inventoryForProductConfigurations.js
@@ -49,6 +49,13 @@ async function getInventoryResults(context, input) {
   for (const inventoryFn of context.getFunctionsOfType("inventoryForProductConfigurations")) {
     // eslint-disable-next-line no-await-in-loop
     const pluginResults = await inventoryFn(context, input);
+
+    /**
+     * Custom validation function is replacing what used to be a call to simpl-schema.
+     * However, simpl-schema validate() method on moderately large payloads adds a pretty significant
+     * performance penalty, each call on average taking 40ms.
+     * Please don't replace with simpl-schema.
+     */
     const validationErrors = validateInventoryPluginResult(pluginResults);
     if (validationErrors.length) {
       throw new Error(`Response from "inventoryForProductConfigurations" type function was invalid: ${validationErrors.join("\n")}`);
@@ -102,6 +109,12 @@ export default async function inventoryForProductConfigurations(context, input) 
   const { collections } = context;
   const { Products } = collections;
 
+  /**
+   * Custom validation function is replacing what used to be a call to simpl-schema.
+   * However, simpl-schema validate() method on moderately large payloads adds a pretty significant
+   * performance penalty, each call on average taking 40ms.
+   * Please don't replace with simpl-schema.
+   */
   const validationErrors = validateInventoryInput(input);
   if (validationErrors.length) {
     throw new Error(`Input passed into "inventoryForProductConfigurations" was invalid: ${validationErrors.join("\n")}`);

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInfo.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInfo.js
@@ -1,0 +1,10 @@
+export default function validateInventoryInfo(info, errorPrefix = "") {
+  const booleans = ["canBackorder", "isLowQuantity"];
+  const integers = ["inventoryAvailableToSell", "inventoryInStock", "inventoryReserved"];
+
+  const errors = [
+    ...booleans.map((field) => (typeof info[field] !== "boolean") && `${errorPrefix}inventoryInfoFieldIsNotBoolean[${field}]`),
+    ...integers.map((field) => (typeof info[field] !== "number" || info[field] < 0) && `${errorPrefix}inventoryInfoFieldIsNotNumber[${field}]`)
+  ];
+  return errors.filter(Boolean);
+}

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInfo.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInfo.js
@@ -1,3 +1,25 @@
+/**
+ * @summary Validates the object passed in according to this schema:
+ * {
+ *  canBackorder: Boolean,
+ *  inventoryAvailableToSell: {
+ *    type: Integer,
+ *    min: 0
+ *  },
+ *  inventoryInStock: {
+ *    type: Integer,
+ *    min: 0
+ *  },
+ *  inventoryReserved: {
+ *    type: Integer,
+ *    min: 0
+ *  },
+ *  isLowQuantity: Boolean
+ * }
+ * @param {Object} info - inventory info
+ * @param {String} errorPrefix - string to prefix every returned error message
+ * @returns {Array} array of error messages
+ */
 export default function validateInventoryInfo(info, errorPrefix = "") {
   const booleans = ["canBackorder", "isLowQuantity"];
   const integers = ["inventoryAvailableToSell", "inventoryInStock", "inventoryReserved"];

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInfo.test.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInfo.test.js
@@ -1,0 +1,36 @@
+import validateInventoryInfo from "./validateInventoryInfo";
+
+test("returns correct errors when payload is not valid", () => {
+  const errors = validateInventoryInfo({});
+  expect(errors).toEqual([
+    "inventoryInfoFieldIsNotBoolean[canBackorder]",
+    "inventoryInfoFieldIsNotBoolean[isLowQuantity]",
+    "inventoryInfoFieldIsNotNumber[inventoryAvailableToSell]",
+    "inventoryInfoFieldIsNotNumber[inventoryInStock]",
+    "inventoryInfoFieldIsNotNumber[inventoryReserved]"
+  ]);
+});
+
+test("returns empty array when payload is valid", () => {
+  const errors = validateInventoryInfo({
+    canBackorder: true,
+    isLowQuantity: false,
+    inventoryAvailableToSell: 2,
+    inventoryInStock: 2,
+    inventoryReserved: 0
+  });
+  expect(errors).toEqual([]);
+});
+
+test("returns errors for number fields with negative values", () => {
+  const errors = validateInventoryInfo({
+    canBackorder: true,
+    isLowQuantity: false,
+    inventoryAvailableToSell: -1,
+    inventoryInStock: 2,
+    inventoryReserved: 0
+  });
+  expect(errors).toEqual([
+    "inventoryInfoFieldIsNotNumber[inventoryAvailableToSell]"
+  ]);
+});

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInput.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInput.js
@@ -13,7 +13,6 @@ const ALL_FIELDS = [
 export default function validateInventoryInput(input) {
   let errors = [];
   const allFieldsLookup = ALL_FIELDS.reduce((allFields, field) => ({ ...allFields, [field]: true }), {});
-  console.log(allFieldsLookup);
   const { fields, shopId, productConfigurations } = input;
   if (!shopId) {
     errors.push("inventoryInputMissingField[shopId]");

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInput.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInput.js
@@ -10,6 +10,36 @@ const ALL_FIELDS = [
   "isSoldOut"
 ];
 
+/**
+ * @summary Validates an arbitrary object according to this schema:
+ * {
+ *   "fields": {
+ *     type: Array,
+ *     optional: true
+ *   },
+ *   "fields.$": {
+ *     type: String,
+ *     allowedValues: [
+ *       "canBackorder",
+ *       "inventoryAvailableToSell",
+ *       "inventoryInStock",
+ *       "inventoryReserved",
+ *       "isBackorder",
+ *       "isLowQuantity",
+ *       "isSoldOut"
+ *     ]
+ *   },
+ *   "productConfigurations": Array,
+ *   "productConfigurations.$": {
+ *     isSellable: Boolean,
+ *     productId: String,
+ *     productVariantId: String
+ *   },
+ *   "shopId": String
+ * }
+ * @param {Object} input - an object to validate
+ * @returns {Array} array of error messages
+ */
 export default function validateInventoryInput(input) {
   let errors = [];
   const allFieldsLookup = ALL_FIELDS.reduce((allFields, field) => ({ ...allFields, [field]: true }), {});

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInput.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInput.js
@@ -1,0 +1,31 @@
+import validateProductConfiguration from "./validateProductConfiguration";
+
+const ALL_FIELDS = [
+  "canBackorder",
+  "inventoryAvailableToSell",
+  "inventoryInStock",
+  "inventoryReserved",
+  "isBackorder",
+  "isLowQuantity",
+  "isSoldOut"
+];
+
+export default function validateInventoryInput(input) {
+  let errors = [];
+  const allFieldsLookup = ALL_FIELDS.reduce((allFields, field) => ({ ...allFields, [field]: true }), {});
+  console.log(allFieldsLookup);
+  const { fields, shopId, productConfigurations } = input;
+  if (!shopId) {
+    errors.push("inventoryInputMissingField[shopId]");
+  }
+  if (productConfigurations && productConfigurations.length) {
+    const productConfigurationErrors = productConfigurations.map((pc, index) => validateProductConfiguration(pc, true, `[${index}].`));
+    errors = [...errors, ...productConfigurationErrors.reduce((flat, toFlatten) => flat.concat(toFlatten), [])];
+  } else {
+    errors.push("inventoryInputInvalidPropertyValue[productConfigurations]");
+  }
+  if (fields && fields.length) {
+    errors = [...errors, ...fields.map((field) => !allFieldsLookup[field] && `inventoryInputInvalidFieldsPropertyValue[${field}]`)];
+  }
+  return errors.filter(Boolean);
+}

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInput.test.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryInput.test.js
@@ -1,0 +1,54 @@
+import validateInventoryInput from "./validateInventoryInput";
+
+test("returns correct errors when payload is not valid", () => {
+  const errors = validateInventoryInput({
+    fields: ["foo", "bar"]
+  });
+  expect(errors).toEqual([
+    "inventoryInputMissingField[shopId]",
+    "inventoryInputInvalidPropertyValue[productConfigurations]",
+    "inventoryInputInvalidFieldsPropertyValue[foo]",
+    "inventoryInputInvalidFieldsPropertyValue[bar]"
+  ]);
+});
+
+test("returns correct errors when productConfigurations are present but not valid", () => {
+  const errors = validateInventoryInput({
+    productConfigurations: [
+      {
+        someField: "garbage"
+      },
+      {
+        productId: "product-1",
+        productVariantId: "variant-1",
+        isSellable: true
+      }
+    ],
+    shopId: "shop-1"
+  });
+  expect(errors).toEqual([
+    "[0].productConfigurationPropertyMissing[productId]",
+    "[0].productConfigurationPropertyMissing[productVariantId]",
+    "[0].productConfigurationProperyMustBeBoolean[isSellable]"
+  ]);
+});
+
+test("returns errors when productConfigurations contain a product with no isSellable flag present", () => {
+  const errors = validateInventoryInput({
+    productConfigurations: [
+      {
+        productId: "product-2",
+        productVariantId: "variant-2",
+        isSellable: true
+      },
+      {
+        productId: "product-1",
+        productVariantId: "variant-1"
+      }
+    ],
+    shopId: "shop-1"
+  });
+  expect(errors).toEqual([
+    "[1].productConfigurationProperyMustBeBoolean[isSellable]"
+  ]);
+});

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryPluginResults.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryPluginResults.js
@@ -1,6 +1,34 @@
 import validateInventoryInfo from "./validateInventoryInfo";
 import validateProductConfiguration from "./validateProductConfiguration";
 
+/**
+ * @summary Validate an array of objects according to this schema:
+ * {
+ *  inventoryInfo: {
+ *    canBackorder: Boolean,
+ *    inventoryAvailableToSell: {
+ *      type: Integer,
+ *      min: 0
+ *    },
+ *    inventoryInStock: {
+ *      type: Integer,
+ *      min: 0
+ *    },
+ *    inventoryReserved: {
+ *      type: Integer,
+ *      min: 0
+ *    },
+ *    isLowQuantity: Boolean
+ *    optional: true
+ *  },
+ *  productConfiguration: {
+ *    productId: String,
+ *    productVariantId: String
+ *  }
+ * }
+ * @param {Object[]} results - array of objects to validate
+ * @returns {Array} array of error messages
+ */
 export default function validateInventoryPluginResults(results) {
   return results.map((result, index) => {
     if (!result.productConfiguration) {

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryPluginResults.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryPluginResults.js
@@ -1,0 +1,15 @@
+import validateInventoryInfo from "./validateInventoryInfo";
+import validateProductConfiguration from "./validateProductConfiguration";
+
+export default function validateInventoryPluginResults(results) {
+  return results.map((result, index) => {
+    if (!result.productConfiguration) {
+      return [`[${index}].inventoryPluginResultMissingField[productConfiguration]`];
+    }
+    let errors = validateProductConfiguration(result.productConfiguration, false, `[${index}].`);
+    if (result.inventoryInfo) {
+      errors = [...errors, ...validateInventoryInfo(result.inventoryInfo, `[${index}].`)];
+    }
+    return errors;
+  }).reduce((flat, toFlatten) => flat.concat(toFlatten), []);
+}

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryPluginResults.test.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateInventoryPluginResults.test.js
@@ -1,0 +1,36 @@
+import validateInventoryPluginResults from "./validateInventoryPluginResults";
+
+test("returns correct errors when payload is not valid", () => {
+  const errors = validateInventoryPluginResults([
+    {
+      inventoryInfo: {},
+      productConfiguration: {}
+    }
+  ]);
+  expect(errors).toEqual([
+    "[0].productConfigurationPropertyMissing[productId]",
+    "[0].productConfigurationPropertyMissing[productVariantId]",
+    "[0].inventoryInfoFieldIsNotBoolean[canBackorder]",
+    "[0].inventoryInfoFieldIsNotBoolean[isLowQuantity]",
+    "[0].inventoryInfoFieldIsNotNumber[inventoryAvailableToSell]",
+    "[0].inventoryInfoFieldIsNotNumber[inventoryInStock]",
+    "[0].inventoryInfoFieldIsNotNumber[inventoryReserved]"
+  ]);
+});
+
+test("returns errors only for productConfiguration when inventoryInfo is optional and not present", () => {
+  const errors = validateInventoryPluginResults([
+    {
+      productConfiguration: {}
+    }
+  ]);
+  expect(errors).toEqual([
+    "[0].productConfigurationPropertyMissing[productId]",
+    "[0].productConfigurationPropertyMissing[productVariantId]"
+  ]);
+});
+
+test("returns no errors when pluginResults is empty", () => {
+  const errors = validateInventoryPluginResults([]);
+  expect(errors).toEqual([]);
+});

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateProductConfiguration.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateProductConfiguration.js
@@ -1,0 +1,9 @@
+export default function validateProductConfiguration(config, requireIsSellable = false, errorPrefix = "") {
+  const requiredFields = ["productId", "productVariantId"];
+  const errors = requiredFields.map((field) => !config[field] && `${errorPrefix}productConfigurationPropertyMissing[${field}]`);
+
+  if (requireIsSellable && typeof config.isSellable !== "boolean") {
+    errors.push(`${errorPrefix}productConfigurationProperyMustBeBoolean[isSellable]`);
+  }
+  return errors.filter(Boolean);
+}

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateProductConfiguration.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateProductConfiguration.js
@@ -1,3 +1,15 @@
+/**
+ * @summary Validates arbitrary object according to this schema:
+ * {
+ *   isSellable: Boolean,
+ *   productId: String,
+ *   productVariantId: String
+ * }
+ * @param {*} config - object to validate
+ * @param {*} requireIsSellable - if true isSellable property is validated, otherwise optional
+ * @param {*} errorPrefix - string to prefix every returned error message
+ * @returns {Array} array of error messages
+ */
 export default function validateProductConfiguration(config, requireIsSellable = false, errorPrefix = "") {
   const requiredFields = ["productId", "productVariantId"];
   const errors = requiredFields.map((field) => !config[field] && `${errorPrefix}productConfigurationPropertyMissing[${field}]`);

--- a/imports/plugins/core/inventory/server/no-meteor/utils/validateProductConfiguration.test.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/validateProductConfiguration.test.js
@@ -1,0 +1,39 @@
+import validateProductConfiguration from "./validateProductConfiguration";
+
+test("returns correct errors when payload is not valid", () => {
+  const errors = validateProductConfiguration({});
+  expect(errors).toEqual([
+    "productConfigurationPropertyMissing[productId]",
+    "productConfigurationPropertyMissing[productVariantId]"
+  ]);
+});
+
+test("returns empty array when payload is valid", () => {
+  const errors = validateProductConfiguration({
+    productId: "product-1",
+    productVariantId: "variant-1",
+    isSellable: true
+  }, true);
+  expect(errors).toEqual([]);
+});
+
+test("returns errors when requireIsSellable is true and field is not present", () => {
+  const errors = validateProductConfiguration({
+    productId: "product-1",
+    productVariantId: "variant-1"
+  }, true);
+  expect(errors).toEqual([
+    "productConfigurationProperyMustBeBoolean[isSellable]"
+  ]);
+});
+
+test("returns errors when requireIsSellable is true and field is not Boolean", () => {
+  const errors = validateProductConfiguration({
+    productId: "product-1",
+    productVariantId: "variant-1",
+    isSellable: "random string"
+  }, true);
+  expect(errors).toEqual([
+    "productConfigurationProperyMustBeBoolean[isSellable]"
+  ]);
+});


### PR DESCRIPTION
Resolves #5305
Impact: **minor**  
Type: **performance**

## Issue
See https://github.com/reactioncommerce/reaction/issues/5305

## Solution
Implement custom validators to use in place of `simpl-schema` `validate()` calls.

## Breaking changes
None. The format of the exception message is different though.