### PR TITLE
chore: add overrides for eslint rules that stlll need fixing

### DIFF
--- a/package.json
+++ b/package.json
@@ -388,6 +388,20 @@
       "import/resolver": "meteor"
     },
     "rules": {
+      "jsx-a11y/label-has-for": "off",
+      "react/no-did-mount-set-state": "warn",
+      "react/no-did-update-set-state": "warn",
+      "require-jsdoc": [
+        "warn",
+        {
+          "require": {
+            "ArrowFunctionExpression": false,
+            "ClassDeclaration": false,
+            "FunctionDeclaration": true,
+            "MethodDefinition": false
+          }
+        }
+      ],
       "valid-jsdoc": [
         "warn",
         {
@@ -396,8 +410,7 @@
             "argument": "param"
           }
         }
-      ],
-      "jsx-a11y/label-has-for": "off"
+      ]
     }
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -388,6 +388,12 @@
       "import/resolver": "meteor"
     },
     "rules": {
+      "consistent-return": [
+        "warn",
+        {
+          "treatUndefinedAsUnspecified": true
+        }
+      ],
       "jsx-a11y/label-has-for": "off",
       "react/no-did-mount-set-state": "warn",
       "react/no-did-update-set-state": "warn",

--- a/package.json
+++ b/package.json
@@ -395,6 +395,7 @@
         }
       ],
       "jsx-a11y/label-has-for": "off",
+      "promise/no-callback-in-promise": "warn",
       "react/no-did-mount-set-state": "warn",
       "react/no-did-update-set-state": "warn",
       "require-jsdoc": [


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
There are six remaining `eslint` rules that output warnings in our code-base. These rules are time consuming to fix (a lot of jsdoc issues), therefore will... take some time.

Instead of going back and forth between this repo and https://github.com/reactioncommerce/reaction-eslint-config and adjusting rules one by one, we are going to:
1. create a 2.0 release of `reaction-eslint-config`, which turns all these rules into errors
1. add overrides (this PR) in the reaction repo for rules still needing audits
1. update reaction to use `reaction-eslint-config` 2.0 (a new PR once that release is made)
1. remove each override as a final step when doing the eslint tickets: https://github.com/reactioncommerce/reaction/projects/16

## Breaking changes
None

## Testing
1. make sure the app starts ... Nothing should change, as this just overrides a bit of logic from https://github.com/reactioncommerce/reaction-eslint-config, but the logic overwritten is currently the exact same as what's in the other repo