### PR TITLE
chore: update js-doc throughout the app, batch 1

### DIFF
--- a/.reaction/jsdoc/templates/fixtures/documents/binder.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/binder.js
@@ -30,7 +30,7 @@ var dataBinderOptions = exports.dataBinderOptions = {
 /**
  * You can unbind previously bound objects from here.
  *
- * @param {string} path The path that was bound using {@link module:documents/binder.bind}
+ * @param {String} path The path that was bound using {@link module:documents/binder.bind}
  * @param {*} record The object that was bound
  */
 exports.unbind = function ( path, record ) {
@@ -63,9 +63,9 @@ exports.unbind = function ( path, record ) {
 
 /**
  * Bind to a property somewhere in an object. The property is found using dot notation and can be arbitrarily deep.
- * @param {string} path The path into the object to locate the property. For instance this could be `"_id"`, `"name.last"`.
+ * @param {String} path The path into the object to locate the property. For instance this could be `"_id"`, `"name.last"`.
  * or `"some.really.really.long.path.including.an.array.2.name"`
- * @param {object} record Anything you can hang a property off of
+ * @param {Object} record Anything you can hang a property off of
  * @param {options} options What you wanna do with the doohicky when yoyu bind it.
  * @param {function(*):Promise|*=} options.getter This is the method to run when getting the value. When it runs, you will receive
  * a single parameter which is the current value as the object understands it. You can return the value directly, just raise an event or

--- a/.reaction/jsdoc/templates/fixtures/documents/collector.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/collector.js
@@ -21,7 +21,7 @@ var CollectorBase = dcl( Destroyable, {
 		}
 		/**
 		 * The collection that being managed
-		 * @type {object|array}
+		 * @type {Object|Array}
 		 */
 		this.heap = obj || {};
 		// mixin the probe
@@ -434,7 +434,7 @@ exports.object = function ( obj ) {
  Remove all items in the object/array that match the query
 
  @param {Object} qu The query to execute. See {@link module:ink/probe.queryOperators} for the operators you can use.
- @return {object|array} The array or object as appropriate without the records.
+ @return {Object|Array} The array or object as appropriate without the records.
  @memberOf module:documents/collector~CollectorBase#
  @name remove
  @method

--- a/.reaction/jsdoc/templates/fixtures/documents/collector.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/collector.js
@@ -168,7 +168,7 @@ var CollectorBase = dcl( Destroyable, {
 	 * `.pluck(query, function)` and `.pluck(function)`
 	 * @param {object=} query The query to evaluate. If you pass in a query, only the items that match the query
 	 * are iterated over.
-	 * @param {string} property The property that will be 'plucked' from the contents of the collection
+	 * @param {String} property The property that will be 'plucked' from the contents of the collection
 	 * @return {*}
 	 */
 	pluck         : function ( query, property ) {
@@ -380,7 +380,7 @@ exports.object = function ( obj ) {
  Returns true if all items match the query. Aliases as `all`
  @function
 
- @param {object} qu The query to execute
+ @param {Object} qu The query to execute
  @returns {boolean}
  @name every
  @memberOf module:documents/collector~CollectorBase#
@@ -391,7 +391,7 @@ exports.object = function ( obj ) {
  Returns true if any of the items match the query. Aliases as `any`
  @function
 
- @param {object} qu The query to execute
+ @param {Object} qu The query to execute
  @returns {boolean}
  @memberOf module:documents/collector~CollectorBase#
  @name some
@@ -401,7 +401,7 @@ exports.object = function ( obj ) {
 /**
  Returns the set of unique records that match a query
 
- @param {object} qu The query to execute.
+ @param {Object} qu The query to execute.
  @return {array}
  @memberOf module:documents/collector~CollectorBase#
  @name unique
@@ -412,7 +412,7 @@ exports.object = function ( obj ) {
  Returns true if all items match the query. Aliases as `every`
  @function
 
- @param {object} qu The query to execute
+ @param {Object} qu The query to execute
  @returns {boolean}
  @name all
  @memberOf module:documents/collector~CollectorBase#
@@ -423,7 +423,7 @@ exports.object = function ( obj ) {
  Returns true if any of the items match the query. Aliases as `all`
  @function
 
- @param {object} qu The query to execute
+ @param {Object} qu The query to execute
  @returns {boolean}
  @memberOf module:documents/collector~CollectorBase#
  @name any
@@ -433,7 +433,7 @@ exports.object = function ( obj ) {
 /**
  Remove all items in the object/array that match the query
 
- @param {object} qu The query to execute. See {@link module:ink/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:ink/probe.queryOperators} for the operators you can use.
  @return {object|array} The array or object as appropriate without the records.
  @memberOf module:documents/collector~CollectorBase#
  @name remove
@@ -444,7 +444,7 @@ exports.object = function ( obj ) {
  Returns the first record that matches the query and returns its key or index depending on whether `obj` is an object or array respectively.
  Aliased as `seekKey`.
 
- @param {object} qu The query to execute.
+ @param {Object} qu The query to execute.
  @returns {object}
  @memberOf module:documents/collector~CollectorBase#
  @name findOneKey
@@ -455,7 +455,7 @@ exports.object = function ( obj ) {
 /**
  Returns the first record that matches the query. Aliased as `seek`.
 
- @param {object} qu The query to execute.
+ @param {Object} qu The query to execute.
  @returns {object}
  @memberOf module:documents/collector~CollectorBase#
  @name findOne
@@ -467,7 +467,7 @@ exports.object = function ( obj ) {
  Find all records that match a query and returns the keys for those items. This is similar to {@link module:ink/probe.find} but instead of returning
  records, returns the keys. If `obj` is an object it will return the hash key. If 'obj' is an array, it will return the index
 
- @param {object} qu The query to execute.
+ @param {Object} qu The query to execute.
  @returns {array}
  @memberOf module:documents/collector~CollectorBase#
  @name findKeys
@@ -478,7 +478,7 @@ exports.object = function ( obj ) {
 /**
  Find all records that match a query
 
- @param {object} qu The query to execute.
+ @param {Object} qu The query to execute.
  @returns {array} The results
  @memberOf module:documents/collector~CollectorBase#
  @name find
@@ -488,8 +488,8 @@ exports.object = function ( obj ) {
 /**
  Updates all records in obj that match the query. See {@link module:ink/probe.updateOperators} for the operators that are supported.
 
- @param {object} qu The query which will be used to identify the records to updated
- @param {object} setDocument The update operator. See {@link module:ink/probe.updateOperators}
+ @param {Object} qu The query which will be used to identify the records to updated
+ @param {Object} setDocument The update operator. See {@link module:ink/probe.updateOperators}
  @memberOf module:documents/collector~CollectorBase#
  @name update
  @method

--- a/.reaction/jsdoc/templates/fixtures/documents/collector.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/collector.js
@@ -43,7 +43,7 @@ var CollectorBase = dcl( Destroyable, {
 		 * See http://en.wikipedia.org/wiki/Fisher-Yates_shuffle.
 		 * @function
 		 * @memberOf module:documents/collector~CollectorBase#
-		 * @returns {array}
+		 * @returns {Array}
 		 */
 		this.shuffle = sys.bind( sys.shuffle, this, this.heap );
 
@@ -60,9 +60,9 @@ var CollectorBase = dcl( Destroyable, {
 	 * Iterate over each item in the collection, or a subset that matches a query. This supports two signatures:
 	 * `.each(query, function)` and `.each(function)`. If you pass in a query, only the items that match the query
 	 * are iterated over.
-	 * @param {object=} query A query to evaluate
+	 * @param {Object=} query A query to evaluate
 	 * @param {function(val, key)} iterator Function to execute against each item in the collection
-	 * @param {object=} thisobj The value of `this`
+	 * @param {Object=} thisobj The value of `this`
 	 */
 	each          : function ( query, iterator, thisobj ) {
 		if ( sys.isPlainObject( query ) ) {
@@ -75,14 +75,14 @@ var CollectorBase = dcl( Destroyable, {
 	},
 	/**
 	 * Returns the collection as an array. If it is already an array, it just returns that.
-	 * @return {array}
+	 * @returns {Array}
 	 */
 	toArray       : function () {
 		return sys.toArray( this.heap );
 	},
 	/**
 	 * Supports conversion to a JSON string or for passing over the wire
-	 * @return {object}
+	 * @return {Object}
 	 * @returns {Object|array}
 	 */
 	toJSON        : function () {
@@ -92,9 +92,9 @@ var CollectorBase = dcl( Destroyable, {
 	 * Maps the contents to an array by iterating over it and transforming it. You supply the iterator. Supports two signatures:
 	 * `.map(query, function)` and `.map(function)`. If you pass in a query, only the items that match the query
 	 * are iterated over.
-	 * @param {object=} query A query to evaluate
+	 * @param {Object=} query A query to evaluate
 	 * @param {function(val, key)} iterator Function to execute against each item in the collection
-	 * @param {object=} thisobj The value of `this`
+	 * @param {Object=} thisobj The value of `this`
 	 */
 	map           : function ( query, iterator, thisobj ) {
 		if ( sys.isPlainObject( query ) ) {
@@ -110,10 +110,10 @@ var CollectorBase = dcl( Destroyable, {
 	 * callback, where each successive callback execution consumes the return value of the previous execution. If accumulator
 	 * is not passed, the first element of the collection will be used as the initial accumulator value.
 	 * are iterated over.
-	 * @param {object=} query A query to evaluate
+	 * @param {Object=} query A query to evaluate
 	 * @param {function(result, val, key)} iterator The function that will be executed in each item in the collection
 	 * @param {*=} accumulator Initial value of the accumulator.
-	 * @param {object=} thisobj The value of `this`
+	 * @param {Object=} thisobj The value of `this`
 	 * @return {*}
 	 */
 	reduce        : function ( query, iterator, accumulator, thisobj ) {
@@ -129,11 +129,11 @@ var CollectorBase = dcl( Destroyable, {
 	 * Creates an object composed of keys returned from running each element
 	 * of the collection through the given callback. The corresponding value of each key
 	 * is the number of times the key was returned by the callback.
-	 * @param {object=} query A query to evaluate. If you pass in a query, only the items that match the query
+	 * @param {Object=} query A query to evaluate. If you pass in a query, only the items that match the query
 	 * are iterated over.
 	 * @param  {function(value, key, collection)} iterator
-	 * @param {object=} thisobj The value of `this`
-	 * @return {object}
+	 * @param {Object=} thisobj The value of `this`
+	 * @return {Object}
 	 */
 	countBy       : function ( query, iterator, thisobj ) {
 		if ( sys.isPlainObject( query ) ) {
@@ -148,11 +148,11 @@ var CollectorBase = dcl( Destroyable, {
 	 * Creates an object composed of keys returned from running each element of the collection through the callback.
 	 * The corresponding value of each key is an array of elements passed to callback that returned the key.
 	 * The callback is invoked with three arguments: (value, index|key, collection).
-	 * @param {object=} query A query to evaluate . If you pass in a query, only the items that match the query
+	 * @param {Object=} query A query to evaluate . If you pass in a query, only the items that match the query
 	 * are iterated over.
 	 * @param {function(value, key, collection)} iterator
-	 * @param {object=} thisobj The value of `this`
-	 * @return {object}
+	 * @param {Object=} thisobj The value of `this`
+	 * @return {Object}
 	 */
 	groupBy       : function ( query, iterator, thisobj ) {
 		if ( sys.isPlainObject( query ) ) {
@@ -166,7 +166,7 @@ var CollectorBase = dcl( Destroyable, {
 	/**
 	 * Reduce the collection to a single value. Supports two signatures:
 	 * `.pluck(query, function)` and `.pluck(function)`
-	 * @param {object=} query The query to evaluate. If you pass in a query, only the items that match the query
+	 * @param {Object=} query The query to evaluate. If you pass in a query, only the items that match the query
 	 * are iterated over.
 	 * @param {String} property The property that will be 'plucked' from the contents of the collection
 	 * @return {*}
@@ -184,11 +184,11 @@ var CollectorBase = dcl( Destroyable, {
 	},
 	/**
 	 * Returns a sorted copy of the collection.
-	 * @param {object=} query The query to evaluate. If you pass in a query, only the items that match the query
+	 * @param {Object=} query The query to evaluate. If you pass in a query, only the items that match the query
 	 * are iterated over.
 	 * @param {function(value, key)} iterator
-	 * @param {object=} thisobj The value of `this`
-	 * @return {array}
+	 * @param {Object=} thisobj The value of `this`
+	 * @returns {Array}
 	 */
 	sortBy        : function ( query, iterator, thisobj ) {
 		if ( sys.isPlainObject( query ) ) {
@@ -202,10 +202,10 @@ var CollectorBase = dcl( Destroyable, {
 	/**
 	 * Retrieves the maximum value of an array. If callback is passed,
 	 * it will be executed for each value in the array to generate the criterion by which the value is ranked.
-	 * @param {object=} query A query to evaluate . If you pass in a query, only the items that match the query
+	 * @param {Object=} query A query to evaluate . If you pass in a query, only the items that match the query
 	 * are iterated over.
 	 * @param {function(value, key, collection)} iterator
-	 * @param {object=} thisobj The value of `this`
+	 * @param {Object=} thisobj The value of `this`
 	 * @return {number}
 	 */
 	max           : function ( query, iterator, thisobj ) {
@@ -220,10 +220,10 @@ var CollectorBase = dcl( Destroyable, {
 	/**
 	 * Retrieves the minimum value of an array. If callback is passed,
 	 * it will be executed for each value in the array to generate the criterion by which the value is ranked.
-	 * @param {object=} query A query to evaluate . If you pass in a query, only the items that match the query
+	 * @param {Object=} query A query to evaluate . If you pass in a query, only the items that match the query
 	 * are iterated over.
 	 * @param {function(value, key, collection)} iterator
-	 * @param {object=} thisobj The value of `this`
+	 * @param {Object=} thisobj The value of `this`
 	 * @return {number}
 	 */
 	min           : function ( query, iterator, thisobj ) {
@@ -273,7 +273,7 @@ var ACollector = dcl( CollectorBase, {
 			this.heap = obj || [];
 			/**
 			 * Creates an array of array elements not present in the other arrays using strict equality for comparisons, i.e. ===.
-			 * @returns {array}
+			 * @returns {Array}
 			 */
 			this.difference = sys.bind( sys.difference, this, this.heap );
 			/**
@@ -329,10 +329,10 @@ var ACollector = dcl( CollectorBase, {
 		/**
 		 * Flattens a nested array (the nesting can be to any depth). If isShallow is truthy, array will only be flattened a single level.
 		 * If callback is passed, each element of array is passed through a callback before flattening.
-		 * @param {object=} query A query to evaluate . If you pass in a query, only the items that match the query
+		 * @param {Object=} query A query to evaluate . If you pass in a query, only the items that match the query
 		 * are iterated over.
 		 * @param {function(value, key, collection)} iterator,
-		 * @param {object=} thisobj The value of `this`
+		 * @param {Object=} thisobj The value of `this`
 		 * @return {number}
 		 */
 		flatten     : function ( query, iterator, thisobj ) {
@@ -381,7 +381,7 @@ exports.object = function ( obj ) {
  @function
 
  @param {Object} qu The query to execute
- @returns {boolean}
+ @returns {Boolean}
  @name every
  @memberOf module:documents/collector~CollectorBase#
  */
@@ -392,7 +392,7 @@ exports.object = function ( obj ) {
  @function
 
  @param {Object} qu The query to execute
- @returns {boolean}
+ @returns {Boolean}
  @memberOf module:documents/collector~CollectorBase#
  @name some
  */
@@ -402,7 +402,7 @@ exports.object = function ( obj ) {
  Returns the set of unique records that match a query
 
  @param {Object} qu The query to execute.
- @return {array}
+ @returns {Array}
  @memberOf module:documents/collector~CollectorBase#
  @name unique
  @method
@@ -413,7 +413,7 @@ exports.object = function ( obj ) {
  @function
 
  @param {Object} qu The query to execute
- @returns {boolean}
+ @returns {Boolean}
  @name all
  @memberOf module:documents/collector~CollectorBase#
  */
@@ -424,7 +424,7 @@ exports.object = function ( obj ) {
  @function
 
  @param {Object} qu The query to execute
- @returns {boolean}
+ @returns {Boolean}
  @memberOf module:documents/collector~CollectorBase#
  @name any
  */
@@ -445,7 +445,7 @@ exports.object = function ( obj ) {
  Aliased as `seekKey`.
 
  @param {Object} qu The query to execute.
- @returns {object}
+ @returns {Object}
  @memberOf module:documents/collector~CollectorBase#
  @name findOneKey
  @method
@@ -456,7 +456,7 @@ exports.object = function ( obj ) {
  Returns the first record that matches the query. Aliased as `seek`.
 
  @param {Object} qu The query to execute.
- @returns {object}
+ @returns {Object}
  @memberOf module:documents/collector~CollectorBase#
  @name findOne
  @method
@@ -468,7 +468,7 @@ exports.object = function ( obj ) {
  records, returns the keys. If `obj` is an object it will return the hash key. If 'obj' is an array, it will return the index
 
  @param {Object} qu The query to execute.
- @returns {array}
+ @returns {Array}
  @memberOf module:documents/collector~CollectorBase#
  @name findKeys
  @method
@@ -479,7 +479,7 @@ exports.object = function ( obj ) {
  Find all records that match a query
 
  @param {Object} qu The query to execute.
- @returns {array} The results
+ @returns {Array} The results
  @memberOf module:documents/collector~CollectorBase#
  @name find
  @method

--- a/.reaction/jsdoc/templates/fixtures/documents/probe.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/probe.js
@@ -28,7 +28,7 @@ var prefixOps = ["$and", "$or", "$nor", "$not"];
  @private
  @param {String} path The path to element to work with
  @param {Object} operand The operands to use for the query
- @return {object} A formatted operation definition
+ @return {Object} A formatted operation definition
  **/
 function processNestedOperator( path, operand ) {
 	var opKeys = Object.keys( operand );
@@ -44,7 +44,7 @@ function processNestedOperator( path, operand ) {
  @private
  @param {Object} val The expression
  @param {Object} key The prefix
- @returns {object} A formatted operation definition
+ @returns {Object} A formatted operation definition
  **/
 function processExpressionObject( val, key ) {
 	var operator;
@@ -84,7 +84,7 @@ function processExpressionObject( val, key ) {
  @private
  @param {String} operation The operation prefix
  @param {Object} operand The operands to use for the query
- @return {object} A formatted operation definition
+ @return {Object} A formatted operation definition
  **/
 function processPrefixOperator( operation, operand ) {
 	var component = {
@@ -115,7 +115,7 @@ function processPrefixOperator( operation, operand ) {
  Parses a query request and builds an object that can used to process a query target
  @private
  @param {Object} obj The expression object
- @returns {object} All components of the expression in a kind of execution tree
+ @returns {Object} All components of the expression in a kind of execution tree
  **/
 
 function parseQueryExpression( obj ) {
@@ -157,7 +157,7 @@ exports.delimiter = '.';
  Splits a path expression into its component parts
  @private
  @param {String} path The path to split
- @returns {array}
+ @returns {Array}
  **/
 
 function splitPath( path ) {
@@ -692,8 +692,8 @@ var operations = {
  @private
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute
- @param {?boolean} shortCircuit When true, the condition that matches the query stops evaluation for that record, otherwise all conditions have to be met
- @param {?boolean} stopOnFirst When true all evaluation stops after the first record is found to match the conditons
+ @param {?Boolean} shortCircuit When true, the condition that matches the query stops evaluation for that record, otherwise all conditions have to be met
+ @param {?Boolean} stopOnFirst When true all evaluation stops after the first record is found to match the conditons
  **/
 function execQuery( obj, qu, shortCircuit, stopOnFirst ) {
 	var arrayResults = [];
@@ -745,7 +745,7 @@ exports.update = function ( obj, qu, setDocument ) {
  Find all records that match a query
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
- @returns {array} The results
+ @returns {Array} The results
  **/
 exports.find = function ( obj, qu ) {
 	var expression, _i, _len;
@@ -764,7 +764,7 @@ exports.find = function ( obj, qu ) {
  records, returns the keys. If `obj` is an object it will return the hash key. If 'obj' is an array, it will return the index
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
- @returns {array}
+ @returns {Array}
  */
 exports.findKeys = function ( obj, qu ) {
 	var expression, _i, _len;
@@ -783,7 +783,7 @@ exports.findKeys = function ( obj, qu ) {
  Returns the first record that matches the query. Aliased as `seek`.
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
- @returns {object}
+ @returns {Object}
  */
 exports.findOne = function ( obj, qu ) {
 	var expression, _i, _len;
@@ -808,7 +808,7 @@ exports.seek = exports.findOne;
  Aliased as `seekKey`.
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
- @returns {object}
+ @returns {Object}
  */
 exports.findOneKey = function ( obj, qu ) {
 	var expression, _i, _len;
@@ -866,7 +866,7 @@ exports.remove = function ( obj, qu ) {
 
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
- @returns {boolean}
+ @returns {Boolean}
  **/
 exports.all = function ( obj, qu ) {
 	return exports.find( obj, qu ).length === sys.size( obj );
@@ -877,7 +877,7 @@ exports.all = function ( obj, qu ) {
 
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
- @returns {boolean}
+ @returns {Boolean}
  **/
 exports.any = function ( obj, qu ) {
 	var expression, _i, _len;
@@ -897,7 +897,7 @@ exports.any = function ( obj, qu ) {
  Returns the set of unique records that match a query
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
- @return {array}
+ @returns {Array}
  **/
 exports.unique = function ( obj, qu ) {
 	var test = exports.find( obj, qu );
@@ -936,7 +936,7 @@ exports.get = function ( record, path ) {
  @function
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute
- @returns {boolean}
+ @returns {Boolean}
  */
 exports.some = exports.any;
 
@@ -945,7 +945,7 @@ exports.some = exports.any;
  @function
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute
- @returns {boolean}
+ @returns {Boolean}
  */
 exports.every = exports.all;
 
@@ -970,7 +970,7 @@ var bindables = {
  Binds the query and update methods to a new object. When called these
  methods can skip the first parameter so that find(object, query) can just be called as find(query)
  @param {Object|Array} obj The object or array to bind to
- @return {object} An object with method bindings in place
+ @return {Object} An object with method bindings in place
  **/
 exports.proxy = function ( obj ) {
 	var retVal;
@@ -986,7 +986,7 @@ exports.proxy = function ( obj ) {
  Binds the query and update methods to a specific object and adds the methods to that object. When called these
  methods can skip the first parameter so that find(object, query) can just be called as object.find(query)
  @param {Object|Array} obj The object or array to bind to
- @param {object|array=} collection If the collection is not the same as <code>this</code> but is a property, or even
+ @param {Object|Aarray=} collection If the collection is not the same as <code>this</code> but is a property, or even
  a whole other object, you specify that here. Otherwise the <code>obj</code> is assumed to be the same as the collecion
  **/
 exports.mixin = function ( obj, collection ) {

--- a/.reaction/jsdoc/templates/fixtures/documents/probe.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/probe.js
@@ -727,7 +727,7 @@ function execQuery( obj, qu, shortCircuit, stopOnFirst ) {
 
 /**
  Updates all records in obj that match the query. See {@link module:documents/probe.updateOperators} for the operators that are supported.
- @param {object|array} obj The object to update
+ @param {Object|Array} obj The object to update
  @param {Object} qu The query which will be used to identify the records to updated
  @param {Object} setDocument The update operator. See {@link module:documents/probe.updateOperators}
  */
@@ -833,7 +833,7 @@ exports.seekKey = exports.findOneKey;
  Remove all items in the object/array that match the query
  @param {array|object} obj The object to query
  @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
- @return {object|array} The array or object as appropriate without the records.
+ @return {Object|Array} The array or object as appropriate without the records.
  **/
 exports.remove = function ( obj, qu ) {
 	var expression, _i, _len;
@@ -969,7 +969,7 @@ var bindables = {
 /**
  Binds the query and update methods to a new object. When called these
  methods can skip the first parameter so that find(object, query) can just be called as find(query)
- @param {object|array} obj The object or array to bind to
+ @param {Object|Array} obj The object or array to bind to
  @return {object} An object with method bindings in place
  **/
 exports.proxy = function ( obj ) {
@@ -985,7 +985,7 @@ exports.proxy = function ( obj ) {
 /**
  Binds the query and update methods to a specific object and adds the methods to that object. When called these
  methods can skip the first parameter so that find(object, query) can just be called as object.find(query)
- @param {object|array} obj The object or array to bind to
+ @param {Object|Array} obj The object or array to bind to
  @param {object|array=} collection If the collection is not the same as <code>this</code> but is a property, or even
  a whole other object, you specify that here. Otherwise the <code>obj</code> is assumed to be the same as the collecion
  **/

--- a/.reaction/jsdoc/templates/fixtures/documents/probe.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/probe.js
@@ -26,8 +26,8 @@ var prefixOps = ["$and", "$or", "$nor", "$not"];
 /**
  Processes a nested operator by picking the operator out of the expression object. Returns a formatted object that can be used for querying
  @private
- @param {string} path The path to element to work with
- @param {object} operand The operands to use for the query
+ @param {String} path The path to element to work with
+ @param {Object} operand The operands to use for the query
  @return {object} A formatted operation definition
  **/
 function processNestedOperator( path, operand ) {
@@ -42,8 +42,8 @@ function processNestedOperator( path, operand ) {
 /**
  Interrogates a single query expression object and calls the appropriate handler for its contents
  @private
- @param {object} val The expression
- @param {object} key The prefix
+ @param {Object} val The expression
+ @param {Object} key The prefix
  @returns {object} A formatted operation definition
  **/
 function processExpressionObject( val, key ) {
@@ -82,8 +82,8 @@ function processExpressionObject( val, key ) {
 /**
  Processes a prefixed operator and then passes control to the nested operator method to pick out the contained values
  @private
- @param {string} operation The operation prefix
- @param {object} operand The operands to use for the query
+ @param {String} operation The operation prefix
+ @param {Object} operand The operands to use for the query
  @return {object} A formatted operation definition
  **/
 function processPrefixOperator( operation, operand ) {
@@ -114,7 +114,7 @@ function processPrefixOperator( operation, operand ) {
 /**
  Parses a query request and builds an object that can used to process a query target
  @private
- @param {object} obj The expression object
+ @param {Object} obj The expression object
  @returns {object} All components of the expression in a kind of execution tree
  **/
 
@@ -156,7 +156,7 @@ exports.delimiter = '.';
 /**
  Splits a path expression into its component parts
  @private
- @param {string} path The path to split
+ @param {String} path The path to split
  @returns {array}
  **/
 
@@ -167,8 +167,8 @@ function splitPath( path ) {
 /**
  Reaches into an object and allows you to get at a value deeply nested in an object
  @private
- @param {array} path The split path of the element to work with
- @param {object} record The record to reach into
+ @param {Array} path The split path of the element to work with
+ @param {Object} record The record to reach into
  @return {*} Whatever was found in the record
  **/
 function reachin( path, record ) {
@@ -191,10 +191,10 @@ function reachin( path, record ) {
 /**
  This will write the value into a record at the path, creating intervening objects if they don't exist
  @private
- @param {array} path The split path of the element to work with
- @param {object} record The record to reach into
- @param {string} setter The set command, defaults to $set
- @param {object} newValue The value to write to the, or if the operator is $pull, the query of items to look for
+ @param {Array} path The split path of the element to work with
+ @param {Object} record The record to reach into
+ @param {String} setter The set command, defaults to $set
+ @param {Object} newValue The value to write to the, or if the operator is $pull, the query of items to look for
  */
 function pushin( path, record, setter, newValue ) {
 	var context = record;
@@ -691,7 +691,7 @@ var operations = {
  Executes a query by traversing a document and evaluating each record
  @private
  @param {array|object} obj The object to query
- @param {object} qu The query to execute
+ @param {Object} qu The query to execute
  @param {?boolean} shortCircuit When true, the condition that matches the query stops evaluation for that record, otherwise all conditions have to be met
  @param {?boolean} stopOnFirst When true all evaluation stops after the first record is found to match the conditons
  **/
@@ -728,8 +728,8 @@ function execQuery( obj, qu, shortCircuit, stopOnFirst ) {
 /**
  Updates all records in obj that match the query. See {@link module:documents/probe.updateOperators} for the operators that are supported.
  @param {object|array} obj The object to update
- @param {object} qu The query which will be used to identify the records to updated
- @param {object} setDocument The update operator. See {@link module:documents/probe.updateOperators}
+ @param {Object} qu The query which will be used to identify the records to updated
+ @param {Object} setDocument The update operator. See {@link module:documents/probe.updateOperators}
  */
 exports.update = function ( obj, qu, setDocument ) {
 	var records = exports.find( obj, qu );
@@ -744,7 +744,7 @@ exports.update = function ( obj, qu, setDocument ) {
 /**
  Find all records that match a query
  @param {array|object} obj The object to query
- @param {object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
  @returns {array} The results
  **/
 exports.find = function ( obj, qu ) {
@@ -763,7 +763,7 @@ exports.find = function ( obj, qu ) {
  Find all records that match a query and returns the keys for those items. This is similar to {@link module:documents/probe.find} but instead of returning
  records, returns the keys. If `obj` is an object it will return the hash key. If 'obj' is an array, it will return the index
  @param {array|object} obj The object to query
- @param {object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
  @returns {array}
  */
 exports.findKeys = function ( obj, qu ) {
@@ -782,7 +782,7 @@ exports.findKeys = function ( obj, qu ) {
 /**
  Returns the first record that matches the query. Aliased as `seek`.
  @param {array|object} obj The object to query
- @param {object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
  @returns {object}
  */
 exports.findOne = function ( obj, qu ) {
@@ -807,7 +807,7 @@ exports.seek = exports.findOne;
  Returns the first record that matches the query and returns its key or index depending on whether `obj` is an object or array respectively.
  Aliased as `seekKey`.
  @param {array|object} obj The object to query
- @param {object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
  @returns {object}
  */
 exports.findOneKey = function ( obj, qu ) {
@@ -832,7 +832,7 @@ exports.seekKey = exports.findOneKey;
 /**
  Remove all items in the object/array that match the query
  @param {array|object} obj The object to query
- @param {object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
  @return {object|array} The array or object as appropriate without the records.
  **/
 exports.remove = function ( obj, qu ) {
@@ -865,7 +865,7 @@ exports.remove = function ( obj, qu ) {
  Returns true if all items match the query
 
  @param {array|object} obj The object to query
- @param {object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
  @returns {boolean}
  **/
 exports.all = function ( obj, qu ) {
@@ -876,7 +876,7 @@ exports.all = function ( obj, qu ) {
  Returns true if any of the items match the query
 
  @param {array|object} obj The object to query
- @param {object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
  @returns {boolean}
  **/
 exports.any = function ( obj, qu ) {
@@ -896,7 +896,7 @@ exports.any = function ( obj, qu ) {
 /**
  Returns the set of unique records that match a query
  @param {array|object} obj The object to query
- @param {object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
+ @param {Object} qu The query to execute. See {@link module:documents/probe.queryOperators} for the operators you can use.
  @return {array}
  **/
 exports.unique = function ( obj, qu ) {
@@ -910,10 +910,10 @@ exports.unique = function ( obj, qu ) {
  This will write the value into a record at the path, creating intervening objects if they don't exist. This does not work as filtered
  update and is meant to be used on a single record. It is a nice way of setting a property at an arbitrary depth at will.
 
- @param {array} path The split path of the element to work with
- @param {object} record The record to reach into
- @param {string} setter The set operation.  See {@link module:documents/probe.updateOperators} for the operators you can use.
- @param {object} newValue The value to write to the, or if the operator is $pull, the query of items to look for
+ @param {Array} path The split path of the element to work with
+ @param {Object} record The record to reach into
+ @param {String} setter The set operation.  See {@link module:documents/probe.updateOperators} for the operators you can use.
+ @param {Object} newValue The value to write to the, or if the operator is $pull, the query of items to look for
  */
 exports.set = function ( record, path, setter, newValue ) {
 	return pushin( splitPath( path ), record, setter, newValue );
@@ -923,8 +923,8 @@ exports.set = function ( record, path, setter, newValue ) {
  Reaches into an object and allows you to get at a value deeply nested in an object. This is not a query, but a
  straight reach in, useful for event bindings
 
- @param {array} path The split path of the element to work with
- @param {object} record The record to reach into
+ @param {Array} path The split path of the element to work with
+ @param {Object} record The record to reach into
  @return {*} Whatever was found in the record
  **/
 exports.get = function ( record, path ) {
@@ -935,7 +935,7 @@ exports.get = function ( record, path ) {
  Returns true if any of the items match the query. Aliases as `any`
  @function
  @param {array|object} obj The object to query
- @param {object} qu The query to execute
+ @param {Object} qu The query to execute
  @returns {boolean}
  */
 exports.some = exports.any;
@@ -944,7 +944,7 @@ exports.some = exports.any;
  Returns true if all items match the query. Aliases as `all`
  @function
  @param {array|object} obj The object to query
- @param {object} qu The query to execute
+ @param {Object} qu The query to execute
  @returns {boolean}
  */
 exports.every = exports.all;

--- a/.reaction/jsdoc/templates/fixtures/documents/schema.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/schema.js
@@ -143,9 +143,9 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @memberOf documents/schema#
 		 * @name addType
 		 * @method
-		 * @param {string} name The name of the type
+		 * @param {String} name The name of the type
 		 * @param {function(object)} operation What to do with the type.
-		 * @param {object} operation.value The value to validation
+		 * @param {Object} operation.value The value to validation
 		 * @returns {boolean}
 		 */
 		this.addType = env.addType;
@@ -155,9 +155,9 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @memberOf documents/schema#
 		 * @name addFormat
 		 * @method
-		 * @param {string} name The name of the formatter
+		 * @param {String} name The name of the formatter
 		 * @param {function(object)} formatter How to format it
-		 * @param {object} formatter.value The value to format
+		 * @param {Object} formatter.value The value to format
 		 * @returns {boolean}
 		 */
 		this.addFormat = env.addFormat;
@@ -167,9 +167,9 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @memberOf documents/schema#
 		 * @name addCheck
 		 * @method
-		 * @param {string} name The name of the check
+		 * @param {String} name The name of the check
 		 * @param {function(...object)} formatter Perform the check
-		 * @param {object} formatter.value The value to check followed by any parameters from the schema
+		 * @param {Object} formatter.value The value to check followed by any parameters from the schema
 		 * @returns {boolean}
 		 */
 		this.addCheck = env.addCheck;
@@ -180,9 +180,9 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @memberOf documents/schema#
 		 * @name addTypeCoercion
 		 * @method
-		 * @param {string} name The name of the coercion
+		 * @param {String} name The name of the coercion
 		 * @param {function(object)} coercer Perform the coercion
-		 * @param {object} coercer.value The value to coerce
+		 * @param {Object} coercer.value The value to coerce
 		 * @returns {boolean}
 		 */
 		this.addTypeCoercion = env.addTypeCoercion;

--- a/.reaction/jsdoc/templates/fixtures/documents/schema.js
+++ b/.reaction/jsdoc/templates/fixtures/documents/schema.js
@@ -65,9 +65,9 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @method
 		 * @name validate
 		 * @memberOf documents/schema#
-		 * @param {object=} record The record to validate
+		 * @param {Object=} record The record to validate
 		 * @param {string|object=} schemaName The name of a previously registered schema
-		 * @param {object=} options Options to pass to the validator
+		 * @param {Object=} options Options to pass to the validator
 		 * @example
 		 * // This supports these signatures:
 		 *
@@ -123,7 +123,7 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * Extracts only the elements of the object that are defined in the schema
 		 * @memberOf documents/schema#
 		 * @name extract
-		 * @param {object=} record The record to extract from
+		 * @param {Object=} record The record to extract from
 		 * @param {string=} schema The name of the schema to attach
 		 * @method
 		 */
@@ -146,7 +146,7 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @param {String} name The name of the type
 		 * @param {function(object)} operation What to do with the type.
 		 * @param {Object} operation.value The value to validation
-		 * @returns {boolean}
+		 * @returns {Boolean}
 		 */
 		this.addType = env.addType;
 
@@ -158,7 +158,7 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @param {String} name The name of the formatter
 		 * @param {function(object)} formatter How to format it
 		 * @param {Object} formatter.value The value to format
-		 * @returns {boolean}
+		 * @returns {Boolean}
 		 */
 		this.addFormat = env.addFormat;
 
@@ -170,7 +170,7 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @param {String} name The name of the check
 		 * @param {function(...object)} formatter Perform the check
 		 * @param {Object} formatter.value The value to check followed by any parameters from the schema
-		 * @returns {boolean}
+		 * @returns {Boolean}
 		 */
 		this.addCheck = env.addCheck;
 
@@ -183,7 +183,7 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 		 * @param {String} name The name of the coercion
 		 * @param {function(object)} coercer Perform the coercion
 		 * @param {Object} coercer.value The value to coerce
-		 * @returns {boolean}
+		 * @returns {Boolean}
 		 */
 		this.addTypeCoercion = env.addTypeCoercion;
 
@@ -208,8 +208,8 @@ var Schema = Base.compose( [Base], /** @lends documents/schema# */{
 	 * extracted object will be represented in this class for reference objects.
 	 *
 	 * @param {string=} schema The schema name to use
-	 * @param {object=} src The object to extract fields from
-	 * @return {object} Data-only version of the class instance.
+	 * @param {Object=} src The object to extract fields from
+	 * @return {Object} Data-only version of the class instance.
 	 */
 	extract     : function ( schemaName, src ) {
 		if ( sys.isObject( schemaName ) ) {

--- a/.reaction/jsdoc/templates/fixtures/mixins/bussable.js
+++ b/.reaction/jsdoc/templates/fixtures/mixins/bussable.js
@@ -35,7 +35,7 @@ var Bussable = Base.compose( [Base], /** @lends mixins/bussable# */{
 	 * @param {String} channel The channel to subscribe to
 	 * @param {String} topic The topic to subscribe to
 	 * @param {callback} callback What to do when you get the event
-	 * @returns {object} The subscription definition
+	 * @returns {Object} The subscription definition
 	 */
 	subscribe : function ( channel, topic, callback ) {
 		this.log.trace( "Bussable subscribe" );
@@ -49,7 +49,7 @@ var Bussable = Base.compose( [Base], /** @lends mixins/bussable# */{
 	 * @param {String} channel The channel to subscribe to
 	 * @param {String} topic The topic to subscribe to
 	 * @param {callback} callback What to do when you get the event
-	 * @returns {object} The subscription definition
+	 * @returns {Object} The subscription definition
 	 */
 	once : function ( channel, topic, callback ) {
 		this.log.trace( "Bussable once" );
@@ -63,7 +63,7 @@ var Bussable = Base.compose( [Base], /** @lends mixins/bussable# */{
 	 * Publish an event on the system bus
 	 * @param {String} channel The channel to publish to
 	 * @param {String} topic The topic to publish to
-	 * @param {object=} options What to pass to the event
+	 * @param {Object=} options What to pass to the event
 	 */
 	publish : function ( channel, topic, options ) {
 		this.log.trace( "Bussable publish" );
@@ -75,7 +75,7 @@ var Bussable = Base.compose( [Base], /** @lends mixins/bussable# */{
 	 *
 	 * @param {String} channel
 	 * @param {String} topic
-	 * @returns {object=} The subscription definition
+	 * @returns {Object=} The subscription definition
 	 */
 	getSubscription : function ( channel, topic ) {
 		this.log.trace( "Bussable getSubscription" );

--- a/.reaction/jsdoc/templates/fixtures/mixins/bussable.js
+++ b/.reaction/jsdoc/templates/fixtures/mixins/bussable.js
@@ -32,8 +32,8 @@ var Bussable = Base.compose( [Base], /** @lends mixins/bussable# */{
 
 	/**
 	 * Subscribe to an event
-	 * @param {string} channel The channel to subscribe to
-	 * @param {string} topic The topic to subscribe to
+	 * @param {String} channel The channel to subscribe to
+	 * @param {String} topic The topic to subscribe to
 	 * @param {callback} callback What to do when you get the event
 	 * @returns {object} The subscription definition
 	 */
@@ -46,8 +46,8 @@ var Bussable = Base.compose( [Base], /** @lends mixins/bussable# */{
 
 	/**
 	 * Subscribe to an event once
-	 * @param {string} channel The channel to subscribe to
-	 * @param {string} topic The topic to subscribe to
+	 * @param {String} channel The channel to subscribe to
+	 * @param {String} topic The topic to subscribe to
 	 * @param {callback} callback What to do when you get the event
 	 * @returns {object} The subscription definition
 	 */
@@ -61,8 +61,8 @@ var Bussable = Base.compose( [Base], /** @lends mixins/bussable# */{
 
 	/**
 	 * Publish an event on the system bus
-	 * @param {string} channel The channel to publish to
-	 * @param {string} topic The topic to publish to
+	 * @param {String} channel The channel to publish to
+	 * @param {String} topic The topic to publish to
 	 * @param {object=} options What to pass to the event
 	 */
 	publish : function ( channel, topic, options ) {
@@ -73,8 +73,8 @@ var Bussable = Base.compose( [Base], /** @lends mixins/bussable# */{
 	/**
 	 * Get a subscription definition
 	 *
-	 * @param {string} channel
-	 * @param {string} topic
+	 * @param {String} channel
+	 * @param {String} topic
 	 * @returns {object=} The subscription definition
 	 */
 	getSubscription : function ( channel, topic ) {

--- a/.reaction/jsdoc/templates/fixtures/mixins/signalable.js
+++ b/.reaction/jsdoc/templates/fixtures/mixins/signalable.js
@@ -125,7 +125,7 @@ var Signal = Base.compose( [Base, signals.Signal], /** @lends module:mixins/sign
 	 * Check if listener was attached to Signal.
 	 * @param {function} listener The function to check
 	 * @param {?object} listenerContext The context that was bound
-	 * @returns {boolean}
+	 * @returns {Boolean}
 	 */
 	has      : function ( listener, listenerContext ) {
 		listenerContext = listenerContext || this.defaultContext || this.host;

--- a/.reaction/jsdoc/templates/fixtures/mixins/signalable.js
+++ b/.reaction/jsdoc/templates/fixtures/mixins/signalable.js
@@ -190,7 +190,7 @@ var Signalable = Base.compose( [Base], /** @lends mixins/signalable# */{
 	},
 	/**
 	 * Creates a single signal
-	 * @param {string} name The name of the signal
+	 * @param {String} name The name of the signal
 	 * @param {module:mixins/signalable~SignalOptions} options The options the signal expects
 	 * @private
 	 */

--- a/.reaction/jsdoc/templates/fixtures/strings/format.js
+++ b/.reaction/jsdoc/templates/fixtures/strings/format.js
@@ -9,7 +9,7 @@
  * Format a string quickly and easily using .net style format strings
  * @param {string} format A string format like "Hello {0}, now take off your {1}!"
  * @param {...?} args One argument per `{}` in the string, positionally replaced
- * @returns {string}
+ * @returns {String}
  *
  * @example
  * var strings = require("papyrus/strings");

--- a/.reaction/jsdoc/templates/fixtures/strings/format.js
+++ b/.reaction/jsdoc/templates/fixtures/strings/format.js
@@ -7,7 +7,7 @@
 
 /**
  * Format a string quickly and easily using .net style format strings
- * @param {string} format A string format like "Hello {0}, now take off your {1}!"
+ * @param {String} format A string format like "Hello {0}, now take off your {1}!"
  * @param {...?} args One argument per `{}` in the string, positionally replaced
  * @returns {String}
  *

--- a/.reaction/jsdoc/templates/fixtures/utils/logger.js
+++ b/.reaction/jsdoc/templates/fixtures/utils/logger.js
@@ -37,7 +37,7 @@ var Logger = dcl( null, /** @lends  utils/logger.Logger# */{
 	},
 	/**
 	 * Sets the logging level to one of `trace`, `debug`, `info`, `warn`, `error`.
-	 * @param {string} lvl The level to set it to. Can be  one of `trace`, `debug`, `info`, `warn`, `error`.
+	 * @param {String} lvl The level to set it to. Can be  one of `trace`, `debug`, `info`, `warn`, `error`.
 	 *
 	 */
 	level  : function ( lvl ) {
@@ -50,31 +50,31 @@ var Logger = dcl( null, /** @lends  utils/logger.Logger# */{
 	/**
 	 * Log a `trace` call
 	 * @method
-	 * @param {string} The value to log
+	 * @param {String} The value to log
 	 */
 	trace  : log.trace,
 	/**
 	 * Log a `debug` call
 	 * @method
-	 * @param {string} The value to log
+	 * @param {String} The value to log
 	 */
 	debug  : log.debug,
 	/**
 	 * Log a `info` call
 	 * @method
-	 * @param {string} The value to log
+	 * @param {String} The value to log
 	 */
 	info   : log.info,
 	/**
 	 * Log a `warn` call
 	 * @method
-	 * @param {string} The value to log
+	 * @param {String} The value to log
 	 */
 	warn   : log.warn,
 	/**
 	 * Log a `error` call
 	 * @method
-	 * @param {string} The value to log
+	 * @param {String} The value to log
 	 */
 	error  : log.error
 } );

--- a/.reaction/jsdoc/templates/publish.js
+++ b/.reaction/jsdoc/templates/publish.js
@@ -352,7 +352,7 @@ function linktoExternal(longName, name) {
 
 /**
  * Create the navigation sidebar.
- * @param {object} members The members that will be used to create the sidebar.
+ * @param {Object} members The members that will be used to create the sidebar.
  * @param {array<object>} members.classes
  * @param {array<object>} members.externals
  * @param {array<object>} members.globals
@@ -404,7 +404,7 @@ function buildNav(members) {
 
 /**
     @param {TAFFY} taffyData See <http://taffydb.com/>.
-    @param {object} opts
+    @param {Object} opts
     @param {Tutorial} tutorials
  */
 exports.publish = function(taffyData, opts, tutorials) {

--- a/.reaction/waitForMongo.js
+++ b/.reaction/waitForMongo.js
@@ -3,7 +3,7 @@ const { MongoClient } = require("mongodb");
 
 /**
  * Print a message to the console (no trailing newline)
- * @param {string} message User progress message to print
+ * @param {String} message User progress message to print
  * @returns {undefined}
  */
 function defaultOut(message) {
@@ -20,7 +20,7 @@ function defaultOut(message) {
  *   the main check operation. Throw an exception to cause a retry. Resolve the
  *   promise to indicate success.
  * @param {number} options.waitMs milliseconds to wait between checks
- * @param {string} options.timeoutMessage for final timeout
+ * @param {String} options.timeoutMessage for final timeout
  * @returns {Promise} a promise indicating success/failure of the check
  */
 async function checkWaitRetry({
@@ -34,7 +34,7 @@ async function checkWaitRetry({
   /**
    * Show a progress/info message, but not over and over again
    *
-   * @param {string} message to be printed
+   * @param {String} message to be printed
    * @param {number} count retry number for progress dots
    * @returns {undefined}
    */
@@ -74,7 +74,7 @@ async function checkWaitRetry({
 /**
  * Connect to mongodb
  *
- * @param {object} parsedUrl URL to mongodb server and database name, parsed
+ * @param {Object} parsedUrl URL to mongodb server and database name, parsed
  * @returns {Promise} a promise resolving to the mongodb db instance
  */
 async function connect(parsedUrl) {
@@ -92,8 +92,8 @@ async function connect(parsedUrl) {
  * Runs the mongo command replSetInitiate,
  * which we need for the oplog for meteor real-time
  *
- * @param {object} db connected mongo db instance
- * @param {string} parsedUrl URL to mongodb, parsed to an object
+ * @param {Object} db connected mongo db instance
+ * @param {String} parsedUrl URL to mongodb, parsed to an object
  * @returns {Promise} indication of success/failure
  */
 async function initReplicaSet(db, parsedUrl) {

--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -346,6 +346,7 @@ export default {
    * @name hasOwnerAccess
    * @method
    * @memberof Core/Client
+   * @returns {Boolean} Boolean - true if user has owner permissions
    */
   hasOwnerAccess() {
     const ownerPermissions = ["owner"];
@@ -373,6 +374,7 @@ export default {
    * @name hasDashboardAccess
    * @method
    * @memberof Core/Client
+   * @returns {Boolean} true if user has access to dashboard access
    */
   hasDashboardAccess() {
     const dashboardPermissions = ["owner", "admin", "dashboard"];
@@ -383,6 +385,7 @@ export default {
    * @name hasShopSwitcherAccess
    * @method
    * @memberof Core/Client
+   * @returns {Boolean} true if user has access to dashboard for multiple shops
    */
   hasShopSwitcherAccess() {
     return this.hasDashboardAccessForMultipleShops();
@@ -392,6 +395,7 @@ export default {
    * @name getSellerShopId
    * @method
    * @memberof Core/Client
+   * @returns {Boolean|String} the shop ID of a seller
    */
   getSellerShopId(userId = getUserId(), noFallback = false) {
     if (userId) {
@@ -422,6 +426,7 @@ export default {
    * @name getPrimaryShopId
    * @method
    * @memberof Core/Client
+   * @returns {String} primary shop ID
    */
   getPrimaryShopId() {
     return this._primaryShopId.get();
@@ -450,6 +455,7 @@ export default {
    * @name getPrimaryShopSettings
    * @method
    * @memberof Core/Client
+   * @returns {Object} shop settings of the primary shop
    */
   getPrimaryShopSettings() {
     const settings = Packages.findOne({
@@ -463,6 +469,7 @@ export default {
    * @name getPrimaryShopCurrency
    * @method
    * @memberof Core/Client
+   * @returns {String} primary shop currency abbreviation
    */
   getPrimaryShopCurrency() {
     const shop = Shops.findOne({
@@ -904,6 +911,7 @@ export default {
    * @name hideActionView
    * @method
    * @memberof Core/Client
+   * @returns {undefined}
    */
   hideActionView() {
     Session.set("admin/showActionView", false);
@@ -914,6 +922,7 @@ export default {
    * @name hideActionViewDetail
    * @method
    * @memberof Core/Client
+   * @returns {undefined}
    */
   hideActionViewDetail() {
     Session.set("admin/showActionViewDetail", false);
@@ -963,6 +972,8 @@ export default {
    * @name getRegistryForCurrentRoute
    * @method
    * @memberof Core/Client
+   * @param {String} provides type of template from registry
+   * @returns {Object} settings data from this package
    */
   getRegistryForCurrentRoute(provides = "dashboard") {
     this.Router.watchPathChange();

--- a/imports/plugins/core/accounts/client/helpers/accountsHelper.js
+++ b/imports/plugins/core/accounts/client/helpers/accountsHelper.js
@@ -138,7 +138,7 @@ export function groupPermissions(packages) {
  * @memberOf Accounts
  * @summary Returns a user that matches the
  * @param email
- * @returns {object}
+ * @returns {Object}
  */
 export function getUserByEmail(email) {
   return Collections.Accounts.findOne({ "emails.address": email });

--- a/imports/plugins/core/accounts/client/helpers/util.js
+++ b/imports/plugins/core/accounts/client/helpers/util.js
@@ -112,7 +112,7 @@ export class ServiceConfigHelper {
    * @example ServiceConfigHelper.addProvider("Untappd", [{ property: "clientId", label: "Client ID" }]), { property:
    *  "secret", label: "Client Secret" }]);
    * @see https://github.com/reactioncommerce/reaction/pull/3231
-   * @param {string} provider Display Name of the provider
+   * @param {String} provider Display Name of the provider
    * @param {object[]} fields Array of plain old JavaScript objects with the keys `property`
    * ("apiKey", for example. `apiKey` should correspond to your OAuth provider's
    * implementation) and `label` ("API Key", for example)

--- a/imports/plugins/core/accounts/client/helpers/util.js
+++ b/imports/plugins/core/accounts/client/helpers/util.js
@@ -113,7 +113,7 @@ export class ServiceConfigHelper {
    *  "secret", label: "Client Secret" }]);
    * @see https://github.com/reactioncommerce/reaction/pull/3231
    * @param {String} provider Display Name of the provider
-   * @param {object[]} fields Array of plain old JavaScript objects with the keys `property`
+   * @param {Object[]} fields Array of plain old JavaScript objects with the keys `property`
    * ("apiKey", for example. `apiKey` should correspond to your OAuth provider's
    * implementation) and `label` ("API Key", for example)
    */

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/addressBook.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/addressBook.js
@@ -2,11 +2,12 @@ import { get } from "lodash";
 import { xformArrayToConnection } from "@reactioncommerce/reaction-graphql-xforms/connection";
 
 /**
- * @name "Account.addressBook"
+ * @name Account/addressBook
  * @method
  * @memberof Accounts/GraphQL
  * @summary converts the `addressBook` prop on the provided account to a connection
  * @param {Object} account - result of the parent resolver, which is an Account object in GraphQL schema format
+ * @param {ConnectionArgs} connectionArgs - an object of all arguments that were sent by the client
  * @return {Promise<Object>} A connection object
  */
 export default async function addressBook(account, connectionArgs) {

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Group/createdBy.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Group/createdBy.js
@@ -1,5 +1,5 @@
 /**
- * @name "Group.createdBy"
+ * @name Group/createdBy
  * @method
  * @memberof Accounts/GraphQL
  * @summary query the Accounts collection and return user account data

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/addAccountAddressBookEntry.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/addAccountAddressBookEntry.js
@@ -1,7 +1,7 @@
 import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
 
 /**
- * @name "Mutation.addAccountAddressBookEntry"
+ * @name Mutation/addAccountAddressBookEntry
  * @method
  * @memberof Accounts/GraphQL
  * @summary resolver for the addAccountAddressBookEntry GraphQL mutation

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/inviteShopMember.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/inviteShopMember.js
@@ -2,7 +2,7 @@ import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/g
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name "Mutation.inviteShopMember"
+ * @name Mutation/inviteShopMember
  * @method
  * @memberof Accounts/GraphQL
  * @summary resolver for the inviteShopMember GraphQL mutation

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/removeAccountAddressBookEntry.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/removeAccountAddressBookEntry.js
@@ -2,7 +2,7 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { decodeAddressOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/address";
 
 /**
- * @name "Mutation.removeAccountAddressBookEntry"
+ * @name Mutation/removeAccountAddressBookEntry
  * @method
  * @memberof Accounts/GraphQL
  * @summary resolver for the removeAccountAddressBookEntry GraphQL mutation

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/removeAccountFromGroup.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/removeAccountFromGroup.js
@@ -2,7 +2,7 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
 
 /**
- * @name "Mutation.removeAccountFromGroup"
+ * @name Mutation/removeAccountFromGroup
  * @method
  * @memberof Accounts/GraphQL
  * @summary resolver for the removeAccountFromGroup GraphQL mutation

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/setAccountProfileCurrency.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/setAccountProfileCurrency.js
@@ -1,7 +1,7 @@
 import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
 
 /**
- * @name "Mutation.setAccountProfileCurrency"
+ * @name Mutation/setAccountProfileCurrency
  * @method
  * @memberof Accounts/GraphQL
  * @summary resolver for the setAccountProfileCurrency GraphQL mutation

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/updateAccountAddressBookEntry.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/updateAccountAddressBookEntry.js
@@ -2,7 +2,7 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { xformAddressInput } from "@reactioncommerce/reaction-graphql-xforms/address";
 
 /**
- * @name "Mutation.updateAccountAddressBookEntry"
+ * @name Mutation/updateAccountAddressBookEntry
  * @method
  * @memberof Accounts/GraphQL
  * @summary resolver for the updateAccountAddressBookEntry GraphQL mutation

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/account.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/account.js
@@ -1,7 +1,7 @@
 import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
 
 /**
- * @name "Query.account"
+ * @name Query/account
  * @method
  * @memberof Accounts/GraphQL
  * @summary query the Accounts collection and return user account data

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/group.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/group.js
@@ -1,7 +1,7 @@
 import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
 
 /**
- * @name "Query.group"
+ * @name Query/group
  * @method
  * @memberof Accounts/GraphQL
  * @summary query the Groups collection and return a group by id

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/viewer.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Query/viewer.js
@@ -1,13 +1,14 @@
 import { optimizeIdOnly } from "@reactioncommerce/reaction-graphql-utils";
 
 /**
- * @name "Query.viewer"
+ * @name Query/viewer
  * @method
  * @memberof Accounts/GraphQL
  * @summary query the Accounts collection and return user account data for the current user
  * @param {Object} _ - unused
- * @param {Object} args - an object of all arguments that were sent by the client
+ * @param {Object} __ - unused
  * @param {Object} context - an object containing the per-request state
+ * @param {Object} info - an object of all arguments that were sent by the client
  * @return {Object} user account object
  */
 export default async function viewer(_, __, context, info) {

--- a/imports/plugins/core/address/server/no-meteor/resolvers/Query/addressValidation.js
+++ b/imports/plugins/core/address/server/no-meteor/resolvers/Query/addressValidation.js
@@ -1,7 +1,7 @@
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name "Query.addressValidation"
+ * @name Query/addressValidation
  * @method
  * @memberof Address/GraphQL
  * @summary Returns address validation results for an address

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Cart/checkout.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Cart/checkout.js
@@ -1,11 +1,13 @@
 import { xformCartCheckout } from "@reactioncommerce/reaction-graphql-xforms/cart";
 
 /**
- * @name "Cart.checkout"
+ * @name Cart/checkout
  * @method
  * @memberof Accounts/GraphQL
  * @summary converts the props on the provided cart to an object matching the Checkout GraphQL schema
  * @param {Object} cart - result of the parent resolver, which is a Cart object in GraphQL schema format
+ * @param {ConnectionArgs} connectionArgs - an object of all arguments that were sent by the client
+ * @param {Object} context - an object containing the per-request state
  * @return {Promise<Object>} A connection object
  */
 export default async function checkout(cart, connectionArgs, context) {

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Cart/items.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Cart/items.js
@@ -27,7 +27,7 @@ function sortCartItems(cartItems, connectionArgs) {
 }
 
 /**
- * @name "Cart.items"
+ * @name Cart/items
  * @method
  * @memberof Cart/GraphQL
  * @summary converts the `items` prop on the provided cart to a connection

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Cart/totalItemQuantity.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Cart/totalItemQuantity.js
@@ -1,7 +1,7 @@
 import { xformTotalItemQuantity } from "@reactioncommerce/reaction-graphql-xforms/cart";
 
 /**
- * @name "Cart.totalItemQuantity"
+ * @name Cart/totalItemQuantity
  * @method
  * @memberof Cart/GraphQL
  * @summary Calculates the total quantity of items in the cart and returns a number

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/addCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/addCartItems.js
@@ -1,7 +1,7 @@
 import { decodeCartItemsOpaqueIds, decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
 
 /**
- * @name "Mutation.addCartItems"
+ * @name Mutation/addCartItems
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the addCartItems GraphQL mutation

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/createCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/createCart.js
@@ -2,7 +2,7 @@ import { decodeCartItemsOpaqueIds } from "@reactioncommerce/reaction-graphql-xfo
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name "Mutation.createCart"
+ * @name Mutation/createCart
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the createCart GraphQL mutation

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/reconcileCarts.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/reconcileCarts.js
@@ -1,7 +1,7 @@
 import { decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
 
 /**
- * @name "Mutation.reconcileCarts"
+ * @name Mutation/reconcileCarts
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the reconcileCarts GraphQL mutation

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/removeCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/removeCartItems.js
@@ -1,7 +1,7 @@
 import { decodeCartItemOpaqueId, decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
 
 /**
- * @name "Mutation.removeCartItems"
+ * @name Mutation/removeCartItems
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the removeCartItems GraphQL mutation

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/setEmailOnAnonymousCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/setEmailOnAnonymousCart.js
@@ -1,7 +1,7 @@
 import { decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
 
 /**
- * @name "Mutation.setEmailOnAnonymousCart"
+ * @name Mutation/setEmailOnAnonymousCart
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the setEmailOnAnonymousCart GraphQL mutation

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/setShippingAddressOnCart.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/setShippingAddressOnCart.js
@@ -2,7 +2,7 @@ import { decodeAddressOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
 
 /**
- * @name "Mutation.setShippingAddressOnCart"
+ * @name Mutation/setShippingAddressOnCart
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the setShippingAddressOnCart GraphQL mutation

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/updateCartItemsQuantity.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Mutation/updateCartItemsQuantity.js
@@ -1,7 +1,7 @@
 import { decodeCartItemOpaqueId, decodeCartOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/cart";
 
 /**
- * @name "Mutation.updateCartItemsQuantity"
+ * @name Mutation/updateCartItemsQuantity
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the updateCartItemsQuantity GraphQL mutation

--- a/imports/plugins/core/cart/server/no-meteor/resolvers/Query/accountCartByAccountId.js
+++ b/imports/plugins/core/cart/server/no-meteor/resolvers/Query/accountCartByAccountId.js
@@ -2,7 +2,7 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name "Query.accountCartByAccountId"
+ * @name Query/accountCartByAccountId
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the accountCartByAccountId GraphQL mutation

--- a/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProduct/tagIds.js
+++ b/imports/plugins/core/catalog/server/no-meteor/resolvers/CatalogProduct/tagIds.js
@@ -1,7 +1,7 @@
 import { encodeTagOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/tag";
 
 /**
- * @name "CatalogProduct.tagIds"
+ * @name CatalogProduct/tagIds
  * @method
  * @memberof Catalog/GraphQL
  * @summary Returns the product tagIds prop to opaque IDs

--- a/imports/plugins/core/catalog/server/no-meteor/utils/getVariants.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/getVariants.js
@@ -2,9 +2,9 @@
  *
  * @method getVariants
  * @summary Get all of a Product's Variants or only a Product's top level Variants.
- * @param {string} productOrVariantId - A Product or top level Product Variant ID.
+ * @param {String} productOrVariantId - A Product or top level Product Variant ID.
  * @param {Object} collections - Raw mongo collections.
- * @param {boolean} topOnly - True to return only a products top level variants.
+ * @param {Boolean} topOnly - True to return only a products top level variants.
  * @return {Promise<Object[]>} Array of Product Variant objects.
  */
 export default async function getVariants(productOrVariantId, collections, topOnly) {

--- a/imports/plugins/core/catalog/server/no-meteor/utils/hasChildVariant.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/hasChildVariant.js
@@ -2,7 +2,7 @@
  *
  * @method hasChildVariant
  * @summary Return true if a Product or Variant has at least 1 child Product that is visible and not deleted.
- * @param {string} productOrVariantId - A Product or Product Variant ID.
+ * @param {String} productOrVariantId - A Product or Product Variant ID.
  * @param {Object} collections - Raw mongo collections.
  * @return {Promise<boolean>} True if Product has a child.
  */

--- a/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalogById.js
+++ b/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalogById.js
@@ -4,7 +4,7 @@ import publishProductToCatalog from "./publishProductToCatalog";
  * @method publishProductToCatalogById
  * @summary Publish a product to the Catalog by ID
  * @memberof Catalog
- * @param {string} productId - A product ID. Must be a top-level product.
+ * @param {String} productId - A product ID. Must be a top-level product.
  * @param {Object} context - The app context
  * @return {boolean} true on successful publish, false if publish was unsuccessful
  */

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -213,7 +213,7 @@ export default {
    * @param  {array} roles an array of roles to check. Will return a shopId if the user has _any_ of the roles
    * @param  {string} userId Optional userId, defaults to logged in userId
    *                                           Must pass this.userId from publications to avoid error!
-   * @return {array} Array of shopIds that the user has at least one of the given set of roles for
+   * @returns {Array} Array of shopIds that the user has at least one of the given set of roles for
    */
   getShopsWithRoles(roles, userId = getUserId()) {
     // Owner permission for a shop supersedes grantable permissions, so we always check for owner permissions as well

--- a/imports/plugins/core/core/server/fixtures/cart.js
+++ b/imports/plugins/core/core/server/fixtures/cart.js
@@ -13,9 +13,9 @@ import { addProduct } from "./products";
  * @method getCartItem
  * @memberof Fixtures
  * @param {Object} [options] - Options object (optional)
- * @param {string} [options._id] - id of CartItem
- * @param {string} [options.productId] - _id of product that item came from
- * @param {string} [options.shopId] - _id of shop that item came from
+ * @param {String} [options._id] - id of CartItem
+ * @param {String} [options.productId] - _id of product that item came from
+ * @param {String} [options.shopId] - _id of shop that item came from
  * @param {number} [options.quantity] - quantity of item in CartItem
  * @param {Object} [options.variants] - _single_ variant object. ¯\_(ツ)_/¯ why called variants
  *
@@ -75,9 +75,9 @@ export function getCartItem(options = {}) {
  * @method getSingleCartItem
  * @memberof Fixtures
  * @param {Object} [options] - Options object (optional)
- * @param {string} [options._id] - id of CartItem
- * @param {string} [options.productId] - _id of product that item came from
- * @param {string} [options.shopId] - _id of shop that item came from
+ * @param {String} [options._id] - id of CartItem
+ * @param {String} [options.productId] - _id of product that item came from
+ * @param {String} [options.shopId] - _id of shop that item came from
  * @returns {Object} - randomly generated cartItem/orderItem data object with only one cart item
  */
 function getSingleCartItem(options = {}) {

--- a/imports/plugins/core/core/server/no-meteor/resolvers/Tag/heroMediaUrl.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/Tag/heroMediaUrl.js
@@ -1,10 +1,10 @@
 /**
- * @name "Tag.heroMediaUrl"
+ * @name Tag/heroMediaUrl
  * @method
  * @memberof Tag/GraphQL
  * @summary Makes the URL absolute if it is relative
  * @param {Object} tag - Tag response from parent resolver
- * @param {SubTagConnectionArgs} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}
+ * @param {SubTagConnectionArgs} connectionArgs - arguments sent by the client {@link ConnectionArgs|See default connection arguments}
  * @param {Object} context - an object containing the per-request state
  * @return {String|null} The absolute URL
  */

--- a/imports/plugins/core/core/server/startup/i18n.js
+++ b/imports/plugins/core/core/server/startup/i18n.js
@@ -147,7 +147,7 @@ export function reloadAllTranslations() {
  * @method reloadTranslationsForShop
  * @memberof i18n
  * @summary Reload translations for specified shop
- * @param {string} shopId - Shop Id to reset translations for
+ * @param {String} shopId - Shop Id to reset translations for
  * @return {undefined}
 */
 export function reloadTranslationsForShop(shopId) {

--- a/imports/plugins/core/dashboard/client/components/shopSelect.js
+++ b/imports/plugins/core/dashboard/client/components/shopSelect.js
@@ -11,7 +11,7 @@ class ShopSelect extends Component {
   /**
    * renderDropDownMenu
    * @summary Handles dropdown menu display
-   * @param {object} menuItems
+   * @param {Object} menuItems
    * @return {JSX} React node containing dropdown menu
    */
   renderDropDownMenu(menuItems) {

--- a/imports/plugins/core/orders/client/helpers/index.js
+++ b/imports/plugins/core/orders/client/helpers/index.js
@@ -5,8 +5,8 @@ import { Reaction } from "/client/api";
  * @method isPaymentRiskElevated
  * @private
  * @summary Gets the riskLevel on each payment object of an order, and checks if any payment has an elevated risk.
- * @param {object} order - order object
- * @param {array} paymentIds - paymentIds to check
+ * @param {Object} order - order object
+ * @param {Array} paymentIds - paymentIds to check
  * @return {boolean} is there an elevated risk level value for any payment on this order?
  * */
 export function isPaymentRiskElevated(order, paymentIds) {
@@ -42,7 +42,7 @@ export async function approvePayment(orderId, paymentId) {
  * @method getOrderRiskBadge
  * @private
  * @summary Selects appropriate color badge (e.g  danger, warning) value based on risk level
- * @param {string} riskLevel - risk level value on the payment
+ * @param {String} riskLevel - risk level value on the payment
  * @return {string} label - style color class based on risk level
  */
 export function getOrderRiskBadge(riskLevel) {
@@ -65,7 +65,7 @@ export function getOrderRiskBadge(riskLevel) {
  * @private
  * @summary Gets the risk label on the payment object for a shop on an order.
  * An empty string is returned if the value is "normal" because we don't flag a normal charge
- * @param {object} order - order object
+ * @param {Object} order - order object
  * @return {string} label - risk level value (if risk level is not normal)
  */
 export function getOrderRiskStatus(order) {
@@ -84,7 +84,7 @@ export function getOrderRiskStatus(order) {
  * @method getTaxRiskStatus
  * @private
  * @summary Gets the tax status of the order.
- * @param {object} order - order object
+ * @param {Object} order - order object
  * @return {boolean} label - true if the tax was not submitted by user.
  */
 export function getTaxRiskStatus(order) {

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/Mutation/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/Mutation/placeOrder.js
@@ -3,7 +3,7 @@ import { decodeFulfillmentMethodOpaqueId } from "@reactioncommerce/reaction-grap
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name "Mutation.placeOrder"
+ * @name Mutation/placeOrder
  * @method
  * @memberof Payments/GraphQL
  * @summary resolver for the placeOrder GraphQL mutation

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/Order/totalItemQuantity.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/Order/totalItemQuantity.js
@@ -1,5 +1,5 @@
 /**
- * @name "Order.totalItemQuantity"
+ * @name Order/totalItemQuantity
  * @method
  * @memberof Order/GraphQL
  * @summary Calculates the total quantity of items in the order and returns a number

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/OrderFulfillmentGroup/items.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/OrderFulfillmentGroup/items.js
@@ -27,7 +27,7 @@ function sortOrderItems(orderItems, connectionArgs) {
 }
 
 /**
- * @name "OrderFulfillmentGroup.items"
+ * @name OrderFulfillmentGroup/items
  * @method
  * @memberof Order/GraphQL
  * @summary converts the `items` prop on the provided order fulfillment group to a connection

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/OrderFulfillmentGroup/summary.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/OrderFulfillmentGroup/summary.js
@@ -1,7 +1,7 @@
 import { xformRateToRateObject } from "@reactioncommerce/reaction-graphql-xforms/core";
 
 /**
- * @name "OrderFulfillmentGroup.summary"
+ * @name OrderFulfillmentGroup/summary
  * @method
  * @memberof Order/GraphQL
  * @summary converts the `invoice` prop on the provided order fulfillment group to a summary object

--- a/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
+++ b/imports/plugins/core/payments/server/no-meteor/resolvers/Mutation/enablePaymentMethodForShop.js
@@ -1,7 +1,7 @@
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name "Mutation.enablePaymentMethodForShop"
+ * @name Mutation/enablePaymentMethodForShop
  * @method
  * @memberof Payment/GraphQL
  * @summary resolver for the enablePaymentMethodForShop GraphQL mutation

--- a/imports/plugins/core/shipping/client/components/parcelSizeSettings.js
+++ b/imports/plugins/core/shipping/client/components/parcelSizeSettings.js
@@ -37,6 +37,7 @@ class ParcelSizeSettings extends Component {
   * @param {Object} card - card component
   * @param {String} cardName - card name
   * @param {Boolean} isExpanded - boolean value from card component
+  * @returns {undefined}
   */
   handleCardExpand = (event, card, cardName, isExpanded) => {
     if (this.props.onCardExpand) {
@@ -48,10 +49,10 @@ class ParcelSizeSettings extends Component {
   }
 
   /**
-  * renderComponent
+  * @name renderComponent
   * @method render()
   * @summary React component for displaying default parcel size form
-  * @return {Node} React node containing form view
+  * @returns {Node} React node containing form view
   */
   render() {
     const { hiddenFields, shownFields, fieldsProp } = this.props;

--- a/imports/plugins/core/shipping/server/no-meteor/resolvers/Mutation/selectFulfillmentOptionForGroup.js
+++ b/imports/plugins/core/shipping/server/no-meteor/resolvers/Mutation/selectFulfillmentOptionForGroup.js
@@ -3,7 +3,7 @@ import { decodeFulfillmentMethodOpaqueId } from "@reactioncommerce/reaction-grap
 import selectFulfillmentOptionForGroupMutation from "../../mutations/selectFulfillmentOptionForGroup";
 
 /**
- * @name "Mutation.selectFulfillmentOptionForGroup"
+ * @name Mutation/selectFulfillmentOptionForGroup
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the selectFulfillmentOptionForGroup GraphQL mutation

--- a/imports/plugins/core/shipping/server/no-meteor/resolvers/Mutation/updateFulfillmentOptionsForGroup.js
+++ b/imports/plugins/core/shipping/server/no-meteor/resolvers/Mutation/updateFulfillmentOptionsForGroup.js
@@ -2,7 +2,7 @@ import { decodeCartOpaqueId, decodeFulfillmentGroupOpaqueId } from "@reactioncom
 import updateFulfillmentOptionsForGroupMutation from "../../mutations/updateFulfillmentOptionsForGroup";
 
 /**
- * @name "Mutation.updateFulfillmentOptionsForGroup"
+ * @name Mutation/updateFulfillmentOptionsForGroup
  * @method
  * @memberof Cart/GraphQL
  * @summary resolver for the updateFulfillmentOptionsForGroup GraphQL mutation

--- a/imports/plugins/core/shop/server/resolvers/Query/primaryShop.js
+++ b/imports/plugins/core/shop/server/resolvers/Query/primaryShop.js
@@ -1,10 +1,10 @@
 /**
- * @name "Query.primaryShop"
+ * @name Query/primaryShop
  * @method
  * @memberof Shop/GraphQL
  * @summary Gets the primary shop
- * @param {Object} parentObject - unused
- * @param {Object} args - unused
+ * @param {Object} _ - unused
+ * @param {Object} __ - unused
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<Object>} The shop, based on the domain in ROOT_URL
  */

--- a/imports/plugins/core/shop/server/resolvers/Query/primaryShopId.js
+++ b/imports/plugins/core/shop/server/resolvers/Query/primaryShopId.js
@@ -1,12 +1,12 @@
 import { encodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name "Query.primaryShopId"
+ * @name Query/primaryShopId
  * @method
  * @memberof Shop/GraphQL
  * @summary Gets the primary shop ID
- * @param {Object} parentObject - unused
- * @param {Object} args - unused
+ * @param {Object} _ - unused
+ * @param {Object} __ - unused
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<String>} The shop ID based on the domain in ROOT_URL
  */

--- a/imports/plugins/core/shop/server/resolvers/Shop/brandAssets.js
+++ b/imports/plugins/core/shop/server/resolvers/Shop/brandAssets.js
@@ -1,10 +1,10 @@
 /**
- * @name "Shop.brandAssets"
+ * @name Shop/brandAssets
  * @method
  * @memberof Shop/GraphQL
  * @summary Builds the `brandAssets` object for a shop
  * @param {Object} shop - an object containing the result returned from the parent resolver
- * @param {Object} _ - unused
+ * @param {ConnectionArgs} args - an object of all arguments that were sent by the client
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<Object>} Promise that resolves with the `brandAssets` object
  */

--- a/imports/plugins/core/shop/server/resolvers/Shop/tags.js
+++ b/imports/plugins/core/shop/server/resolvers/Shop/tags.js
@@ -2,12 +2,12 @@ import { getPaginatedResponse, wasFieldRequested } from "@reactioncommerce/react
 import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/shop";
 
 /**
- * @name "Shop.tags"
+ * @name Shop/tags
  * @method
  * @memberof Shop/GraphQL
  * @summary Returns the tags for the parent resolver shop
  * @param {Object} _ - unused
- * @param {TagConnectionArgs} args - arguments sent by the client {@link ConnectionArgs|See default connection arguments}
+ * @param {TagConnectionArgs} connectionArgs - arguments sent by the client {@link ConnectionArgs|See default connection arguments}
  * @param {Object} context - an object containing the per-request state
  * @param {Object} info Info about the GraphQL request
  * @return {Promise<Object[]>} Promise that resolves with array of Tag objects

--- a/imports/plugins/core/tags/client/components/TagDataTable.js
+++ b/imports/plugins/core/tags/client/components/TagDataTable.js
@@ -122,7 +122,7 @@ class TagDataTable extends Component {
   /**
    * @name handleFilterInput
    * @summary Update state when filter is changed
-   * @param {string} value text field input
+   * @param {String} value text field input
    * @return {function} state for field value
    */
   handleFilterInput = (value) => {
@@ -154,7 +154,7 @@ class TagDataTable extends Component {
   /**
    * @name handleClick
    * @summary Handle click on table row
-   * @param {object} rowInfo row data passed in from ReactTable
+   * @param {Object} rowInfo row data passed in from ReactTable
    * @return {function} return onRowClick function prop, or undefined if not supplied
    */
   handleClick(rowInfo) {
@@ -175,8 +175,8 @@ class TagDataTable extends Component {
   /**
    * @name handleCellClick
    * @summary Handle click on table cell
-   * @param {object} rowInfo row data passed in from ReactTable
-   * @param {object} column Column data
+   * @param {Object} rowInfo row data passed in from ReactTable
+   * @param {Object} column Column data
    * @return {function} return onRowClick function prop, or undefined if not supplied
    */
   handleCellClick(rowInfo, column) {
@@ -334,7 +334,7 @@ class TagDataTable extends Component {
    * @name selectedRowsClassName
    * @method
    * @summary If any rows are selected, give them a className of "selected-row"
-   * @param {object} rowInfo row data passed in from ReactTable
+   * @param {Object} rowInfo row data passed in from ReactTable
    * @returns {String} className to apply to row that is selected, or empty string if no row is selected
    */
   selectedRowsClassName(rowInfo) {

--- a/imports/plugins/core/ui/client/components/table/sortableTable.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTable.js
@@ -96,8 +96,8 @@ class SortableTable extends Component {
    * @name handleFilterInput()
    * @summary Update state when filter is changed
    * @param {script} event onChange event when typing in filter field
-   * @param {string} value text field input
-   * @param {string} field input field name to watch
+   * @param {String} value text field input
+   * @param {String} field input field name to watch
    * @return {function} state for field value
    */
   handleFilterInput = (event, value, field) => {
@@ -110,7 +110,7 @@ class SortableTable extends Component {
   /**
    * @name handleClick()
    * @summary Handle click on table row
-   * @param {object} rowInfo row data passed in from ReactTable
+   * @param {Object} rowInfo row data passed in from ReactTable
    * @return {function} return onRowClick function prop, or undefined if not supplied
    */
   handleClick(rowInfo) {
@@ -234,7 +234,7 @@ class SortableTable extends Component {
    * @name selectedRowsClassName()
    * @method
    * @summary If any rows are selected, give them a className of "selected-row"
-   * @param {object} rowInfo row data passed in from ReactTable
+   * @param {Object} rowInfo row data passed in from ReactTable
    * @returns {String} className to apply to row that is selected, or empty string if no row is selected
    */
   selectedRowsClassName(rowInfo) {

--- a/imports/plugins/core/versions/server/util/convert51.js
+++ b/imports/plugins/core/versions/server/util/convert51.js
@@ -39,9 +39,9 @@ function getVariantInventoryNotAvailableToSellQuantity(variant, collections) {
  *
  * @method getVariants
  * @summary Get all of a Product's Variants or only a Product's top level Variants.
- * @param {string} productOrVariantId - A Product or top level Product Variant ID.
+ * @param {String} productOrVariantId - A Product or top level Product Variant ID.
  * @param {Object} collections - Raw mongo collections.
- * @param {boolean} topOnly - True to return only a products top level variants.
+ * @param {Boolean} topOnly - True to return only a products top level variants.
  * @return {Promise<Object[]>} Array of Product Variant objects.
  */
 function getVariants(productOrVariantId, collections, topOnly) {
@@ -292,7 +292,7 @@ export function addInventoryAvailableToSellFieldToProduct(item, collections) {
  *
  * @method hasChildVariant
  * @summary Return true if a Product or Variant has at least 1 child Product that is visible and not deleted.
- * @param {string} productOrVariantId - A Product or Product Variant ID.
+ * @param {String} productOrVariantId - A Product or Product Variant ID.
  * @param {Object} collections - Raw mongo collections.
  * @return {Promise<boolean>} True if Product has a child.
  */

--- a/imports/plugins/included/marketplace/server/no-meteor/util/stripeCaptureCharge.js
+++ b/imports/plugins/included/marketplace/server/no-meteor/util/stripeCaptureCharge.js
@@ -7,7 +7,7 @@ import getStripeApi from "./getStripeApi";
  * @summary Capture the results of a previous charge
  * @param {Object} context - an object containing the per-request state
  * @param {Object} payment - object containing info about the previous transaction
- * @returns {object} Object indicating the result, saved = true means success
+ * @returns {Object} Object indicating the result, saved = true means success
  * @private
  */
 export default async function stripeCaptureCharge(context, payment) {

--- a/imports/plugins/included/marketplace/server/no-meteor/util/stripeCaptureCharge.js
+++ b/imports/plugins/included/marketplace/server/no-meteor/util/stripeCaptureCharge.js
@@ -5,8 +5,8 @@ import getStripeApi from "./getStripeApi";
 
 /**
  * @summary Capture the results of a previous charge
- * @param {object} context - an object containing the per-request state
- * @param {object} payment - object containing info about the previous transaction
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} payment - object containing info about the previous transaction
  * @returns {object} Object indicating the result, saved = true means success
  * @private
  */

--- a/imports/plugins/included/payments-stripe/server/no-meteor/util/stripeCaptureCharge.js
+++ b/imports/plugins/included/payments-stripe/server/no-meteor/util/stripeCaptureCharge.js
@@ -7,7 +7,7 @@ import getStripeInstance from "./getStripeInstance";
  * @summary Capture the results of a previous charge
  * @param {Object} context - an object containing the per-request state
  * @param {Object} payment - object containing info about the previous transaction
- * @returns {object} Object indicating the result, saved = true means success
+ * @returns {Object} Object indicating the result, saved = true means success
  * @private
  */
 export default async function stripeCaptureCharge(context, payment) {

--- a/imports/plugins/included/payments-stripe/server/no-meteor/util/stripeCaptureCharge.js
+++ b/imports/plugins/included/payments-stripe/server/no-meteor/util/stripeCaptureCharge.js
@@ -5,8 +5,8 @@ import getStripeInstance from "./getStripeInstance";
 
 /**
  * @summary Capture the results of a previous charge
- * @param {object} context - an object containing the per-request state
- * @param {object} payment - object containing info about the previous transaction
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} payment - object containing info about the previous transaction
  * @returns {object} Object indicating the result, saved = true means success
  * @private
  */

--- a/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/createFlatRateFulfillmentMethod.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/createFlatRateFulfillmentMethod.js
@@ -2,7 +2,7 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 import createFlatRateFulfillmentMethodMutation from "../../mutations/createFlatRateFulfillmentMethod";
 
 /**
- * @name "Mutation.createFlatRateFulfillmentMethod"
+ * @name Mutation/createFlatRateFulfillmentMethod
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the createFlatRateFulfillmentMethod GraphQL mutation

--- a/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/createFlatRateFulfillmentRestriction.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/createFlatRateFulfillmentRestriction.js
@@ -3,7 +3,7 @@ import { decodeFulfillmentMethodOpaqueId } from "@reactioncommerce/reaction-grap
 import createFlatRateFulfillmentRestrictionMutation from "../../mutations/createFlatRateFulfillmentRestriction";
 
 /**
- * @name "Mutation/createFlatRateFulfillmentMethod"
+ * @name Mutation/createFlatRateFulfillmentMethod
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the createFlatRateFulfillmentMethod GraphQL mutation

--- a/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/deleteFlatRateFulfillmentMethod.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/deleteFlatRateFulfillmentMethod.js
@@ -3,7 +3,7 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 import deleteFlatRateFulfillmentMethodMutation from "../../mutations/deleteFlatRateFulfillmentMethod";
 
 /**
- * @name "Mutation.deleteFlatRateFulfillmentMethod"
+ * @name Mutation/deleteFlatRateFulfillmentMethod
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the deleteFlatRateFulfillmentMethod GraphQL mutation

--- a/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/deleteFlatRateFulfillmentRestriction.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/deleteFlatRateFulfillmentRestriction.js
@@ -3,7 +3,7 @@ import { decodeFulfillmentRestrictionOpaqueId } from "../../xforms/flatRateFulfi
 import deleteFlatRateFulfillmentRestrictionMutation from "../../mutations/deleteFlatRateFulfillmentRestriction";
 
 /**
- * @name "Mutation.deleteFlatRateFulfillmentRestriction"
+ * @name Mutation/deleteFlatRateFulfillmentRestriction
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the deleteFlatRateFulfillmentRestriction GraphQL mutation

--- a/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/updateFlatRateFulfillmentMethod.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/updateFlatRateFulfillmentMethod.js
@@ -3,7 +3,7 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 import updateFlatRateFulfillmentMethodMutation from "../../mutations/updateFlatRateFulfillmentMethod";
 
 /**
- * @name "Mutation.updateFlatRateFulfillmentMethod"
+ * @name Mutation/updateFlatRateFulfillmentMethod
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the updateFlatRateFulfillmentMethod GraphQL mutation

--- a/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/updateFlatRateFulfillmentRestriction.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Mutation/updateFlatRateFulfillmentRestriction.js
@@ -4,7 +4,7 @@ import { decodeFulfillmentRestrictionOpaqueId } from "../../xforms/flatRateFulfi
 import updateFlatRateFulfillmentRestrictionMutation from "../../mutations/updateFlatRateFulfillmentRestriction";
 
 /**
- * @name "Mutation.updateFlatRateFulfillmentRestriction"
+ * @name Mutation/updateFlatRateFulfillmentRestriction
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the updateFlatRateFulfillmentRestriction GraphQL mutation

--- a/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Query/getFlatRateFulfillmentRestriction.js
+++ b/imports/plugins/included/shipping-rates/server/no-meteor/resolvers/Query/getFlatRateFulfillmentRestriction.js
@@ -2,14 +2,13 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 import { decodeFulfillmentRestrictionOpaqueId } from "../../xforms/flatRateFulfillmentRestriction";
 
 /**
- * @name "Query.getFlatRateFulfillmentRestriction"
+ * @name Query/getFlatRateFulfillmentRestriction
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the getFlatRateFulfillmentRestriction GraphQL mutation
  * @param {Object} parentResult - unused
- * @param {Object} args - an object of all arguments that were sent by the client
- * @param {String} args.shopId - The shop that owns this restriction
  * @param {ConnectionArgs} args - an object of all arguments that were sent by the client
+ * @param {String} args.shopId - The shop that owns this restriction
  * @param {Object} context - an object containing the per-request state
  * @return {Promise<Object>|undefined} A Restriction object
  */

--- a/imports/plugins/included/surcharges/server/no-meteor/resolvers/Mutation/createSurcharge.js
+++ b/imports/plugins/included/surcharges/server/no-meteor/resolvers/Mutation/createSurcharge.js
@@ -3,7 +3,7 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 import createSurchargeMutation from "../../mutations/createSurcharge";
 
 /**
- * @name "Mutation.createSurcharge"
+ * @name Mutation/createSurcharge
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the createSurcharge GraphQL mutation

--- a/imports/plugins/included/surcharges/server/no-meteor/resolvers/Mutation/deleteSurcharge.js
+++ b/imports/plugins/included/surcharges/server/no-meteor/resolvers/Mutation/deleteSurcharge.js
@@ -3,7 +3,7 @@ import { decodeSurchargeOpaqueId } from "../../xforms/surcharge";
 import deleteSurchargeMutation from "../../mutations/deleteSurcharge";
 
 /**
- * @name "Mutation.deleteSurcharge"
+ * @name Mutation/deleteSurcharge
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the deleteSurcharge GraphQL mutation

--- a/imports/plugins/included/surcharges/server/no-meteor/resolvers/Mutation/updateSurcharge.js
+++ b/imports/plugins/included/surcharges/server/no-meteor/resolvers/Mutation/updateSurcharge.js
@@ -4,7 +4,7 @@ import { decodeSurchargeOpaqueId } from "../../xforms/surcharge";
 import updateSurchargeMutation from "../../mutations/updateSurcharge";
 
 /**
- * @name "Mutation.updateSurcharge"
+ * @name Mutation/updateSurcharge
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the updateSurcharge GraphQL mutation

--- a/imports/plugins/included/surcharges/server/no-meteor/resolvers/Query/surchargeById.js
+++ b/imports/plugins/included/surcharges/server/no-meteor/resolvers/Query/surchargeById.js
@@ -2,7 +2,7 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
 import { decodeSurchargeOpaqueId } from "../../xforms/surcharge";
 
 /**
- * @name "Query.surchargeById"
+ * @name Query/surchargeById
  * @method
  * @memberof Fulfillment/GraphQL
  * @summary resolver for the surchargeById GraphQL mutation

--- a/imports/test-utils/helpers/getFakeMongoCursor.js
+++ b/imports/test-utils/helpers/getFakeMongoCursor.js
@@ -9,6 +9,7 @@
  * @memberof TestHelpers
  * @param {String} collectionName - name of the collection
  * @param {Any} results - results to be returned as part of the cursor
+ * @param {Object} options - options to pass to the query
  * @return {Object} fake cursor
  */
 export default function getFakeMongoCursor(collectionName, results, options) {

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -241,7 +241,7 @@ export function convertLength(from, to, length) {
  * @summary Gets the FileRecord for the primary media item associated with the variant or product
  *   for the given item
  * @param {Object} item Must have `productId` and/or `variantId` set to get back a result.
- * @return {FileRecord|null}
+ * @return {FileRecord|null} primary media for item
  */
 export function getPrimaryMediaForItem({ productId, variantId } = {}) {
   let result;
@@ -268,7 +268,7 @@ export function getPrimaryMediaForItem({ productId, variantId } = {}) {
  * @summary Gets the FileRecord for the primary media item associated with the variant or product
  *   for the given item
  * @param {Object} item Must have `productId` and `variantId` set to get back a result.
- * @return {FileRecord|null}
+ * @return {FileRecord|null} primary media for order item
  */
 export function getPrimaryMediaForOrderItem({ productId, variantId } = {}) {
   return getPrimaryMediaForItem({ productId, variantId });

--- a/lib/api/helpers.js
+++ b/lib/api/helpers.js
@@ -67,7 +67,7 @@ export function translateRegistry(registry, app) {
  * @memberof Helpers
  * @summary Simple is object check.
  * @param {Object} item item to check if is an object
- * @returns {boolean} return true if object
+ * @returns {Boolean} return true if object
  */
 export function isObject(item) {
   return (item && typeof item === "object" && !Array.isArray(item) && item !== null);

--- a/lib/collections/transform/cartOrder.js
+++ b/lib/collections/transform/cartOrder.js
@@ -110,7 +110,7 @@ export const cartOrderTransform = {
   /**
    * @summary Aggregates the subtotals by shopId
    * @method getSubtotalByShop
-   * @return {object} Object with a key for each shopId in the cart/order where the value is the subtotal for that shop
+   * @return {Object} Object with a key for each shopId in the cart/order where the value is the subtotal for that shop
    */
   getSubtotalByShop() {
     return this.items.reduce((uniqueShopSubTotals, item) => {
@@ -144,7 +144,7 @@ export const cartOrderTransform = {
   /**
    * @summary Return an array of payment methods for display removing duplicates
    * @method getUniquePaymentMethods
-   * @returns {object} - An object containing the payment methods used on this order excluding duplicates
+   * @returns {Object} - An object containing the payment methods used on this order excluding duplicates
    */
   getUniquePaymentMethods() {
     const uniqueMethods = {};


### PR DESCRIPTION
Resolves parts of #5269 & #5267   
Impact: **major**  
Type: **docs|chore**

## Issue
We are missing entire `jsdoc` blocks in some instances, and param / return / description lines of `jsdoc` in other instances, along with other `jsdoc` errors, all throughout Reaction. This is the biggest contributor to our `eslint` warnings.

## Solution
Add / fix `jsdoc` where necessary.
Since there are so many of these warnings, I'm going to split it up into multiple PR's to keep the file count low for easier viewing / less conflicts with open branches.

## Breaking changes
None

## Testing
1. Start the app
1. Make sure it runs
1. All changes are documentation changes, there should be no effect on the app in general

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
