### PR TITLE
fix(5313-dataloaders-not-found): use SimpleInventory collection to fe…

### DIFF
--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.js
@@ -20,7 +20,7 @@ export default async function inventoryForProductConfigurations(context, input) 
 
   const productVariantIds = productConfigurations.map(({ productVariantId }) => productVariantId);
 
-  const inventoryDocs = dataLoaders 
+  const inventoryDocs = dataLoaders
     ? await dataLoaders.SimpleInventoryByProductVariantId.loadMany(productVariantIds)
     : await collections.SimpleInventory
       .find({

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.test.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.test.js
@@ -18,6 +18,18 @@ const context = {
         }
       ])
     }
+  },
+  collections: {
+    SimpleInventory: {
+      find: jest.fn(() => ({
+        toArray() {
+          return [];
+        },
+        limit() {
+          return this;
+        }
+      }))
+    }
   }
 };
 
@@ -34,4 +46,19 @@ test("calls SimpleInventoryByProductVariantId dataloader with correct product va
   };
   await inventoryForProductConfigurations(context, input);
   expect(context.dataLoaders.SimpleInventoryByProductVariantId.loadMany).toHaveBeenCalledWith(["variant-2", "variant-1"]);
+});
+
+test("calls SimpleInventory.find() on Mongo Collection when isInternalCall set to true", async () => {
+  const input = {
+    productConfigurations: [
+      {
+        productVariantId: "variant-2"
+      },
+      {
+        productVariantId: "variant-1"
+      }
+    ]
+  };
+  await inventoryForProductConfigurations({ ...context, isInternalCall: true }, input);
+  expect(context.collections.SimpleInventory.find).toHaveBeenCalledWith({ "productConfiguration.productVariantId": { $in: ["variant-2", "variant-1"] } });
 });

--- a/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.test.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/utils/inventoryForProductConfigurations.test.js
@@ -48,7 +48,7 @@ test("calls SimpleInventoryByProductVariantId dataloader with correct product va
   expect(context.dataLoaders.SimpleInventoryByProductVariantId.loadMany).toHaveBeenCalledWith(["variant-2", "variant-1"]);
 });
 
-test("calls SimpleInventory.find() on Mongo Collection when isInternalCall set to true", async () => {
+test("calls SimpleInventory.find() on Mongo Collection when DataLoader is not registered", async () => {
   const input = {
     productConfigurations: [
       {
@@ -59,6 +59,10 @@ test("calls SimpleInventory.find() on Mongo Collection when isInternalCall set t
       }
     ]
   };
-  await inventoryForProductConfigurations({ ...context, isInternalCall: true }, input);
+
+  const newContext = { ...context };
+  delete newContext.dataLoaders;
+
+  await inventoryForProductConfigurations(newContext, input);
   expect(context.collections.SimpleInventory.find).toHaveBeenCalledWith({ "productConfiguration.productVariantId": { $in: ["variant-2", "variant-1"] } });
 });


### PR DESCRIPTION
Resolves #5313 
Impact: **major**  
Type: **bugfix**

## Issue
DataLoaders do not exist when Reaction is running in a topic `consumer` mode or any other "non-web-request-serving" mode. DataLoaders are only supposed to be used in the context of a web request.

## Solution
Check if `context.dataLoaders` is not empty, otherwise fallback to Mongo collection.

## Breaking changes
None
