### PR TITLE
(refactor): how to get reaction version

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -21,4 +21,4 @@ Not obligatory, but suggest a fix/reason for the bug
 
 
 ### Versions
-(run `reaction -v` from your reaction directory)
+(run `npm run version --silent` from your reaction directory)

--- a/package.json
+++ b/package.json
@@ -218,7 +218,8 @@
     "test:integration": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 REACTION_LOG_LEVEL=ERROR jest --maxWorkers=4 --no-cache /tests/integration/",
     "test:integration:watch": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 REACTION_LOG_LEVEL=ERROR jest --maxWorkers=4 --no-cache --watch /tests/integration/",
     "test:file": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 REACTION_LOG_LEVEL=ERROR jest --no-cache --watch",
-    "docs": "jsdoc . --configure .reaction/jsdoc/jsdoc.json --readme .reaction/jsdoc/templates/static/README.md"
+    "docs": "jsdoc . --configure .reaction/jsdoc/jsdoc.json --readme .reaction/jsdoc/templates/static/README.md",
+    "version": "echo $npm_package_version"
   },
   "babel": {
     "plugins": [


### PR DESCRIPTION
Resolves -
Impact: **minor**  
Type: **docs**

## Issue
Our GitHub Issue Template is asking users to check their Reaction version by running `reaction -v`. The Reaction CLI has been deprecated as of Reaction v2, therefore the template should instruct users to use an alternative.

## Solution
A script `version` was added at `package.json` that echoes the value of `$npm_package_version`.
The Issue Template was updated with instructions to run `npm run version --silent` in order to check the reaction version. The script output looks like this:
```shell
> npm run version --silent
2.0.0-rc.10
```

## Breaking changes
None

## Testing
Check the template offers the correct instructions (i.e. `npm run version --silent`).
