### PR TITLE
chore: use npm command rather than meteor npm

### DIFF
--- a/.reaction/scripts/loadPlugins.mjs
+++ b/.reaction/scripts/loadPlugins.mjs
@@ -94,7 +94,7 @@ function getImportPaths(baseDirPath) {
       Log.info(`Installing dependencies for ${plugin}...\n`);
 
       try {
-        childProcess.execSync(`cd ${baseDirPath}${plugin} && meteor npm i`, { stdio: 'inherit' });
+        childProcess.execSync(`cd ${baseDirPath}${plugin} && npm i`, { stdio: 'inherit' });
       } catch (err) {
         Log.error(`Failed to install npm dependencies for plugin: ${plugin}`);
         process.exit(1);


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
Running the `.reaction/scripts/build.mjs` Node script finds and loads all plugins. There was one Meteor dependency in this script, preventing it from working if you haven't installed Meteor in the environment.

## Solution
The `meteor npm i` command this script runs in each plugin folder is changed to `npm i`. This means there will no longer be a Meteor layer ensuring that the correct version of NPM is used. However, we keep the version in the image consistent with the version that Meteor ships with, so this shouldn't be a problem.

## Breaking changes
None.

## Testing
Verify you can run `node --experimental-modules ./.reaction/scripts/build.mjs` without errors in an environment that doesn't have the `meteor` CLI available.