### PR TITLE
chore: fix consistent-return eslint warnings

### DIFF
--- a/client/modules/core/main.js
+++ b/client/modules/core/main.js
@@ -966,6 +966,8 @@ export default {
     if (this.Router.getRouteName() === "tag") {
       return this.Router.current().params.slug;
     }
+
+    return null;
   },
 
   /**

--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -124,6 +124,7 @@ Meteor.startup(() => {
     //
     // subscribe to user + shop Translations
     //
+    // eslint-disable-next-line consistent-return
     return Meteor.subscribe("Translations", language, () => {
       //
       // reduce and merge translations
@@ -180,8 +181,8 @@ Meteor.startup(() => {
           return $("html").removeClass("rtl");
         });
 
-        return null;
-    }); // return
+      return null;
+    });
   });
 
   // Detect user currency changes.

--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -18,6 +18,7 @@ import { mergeDeep } from "/lib/api";
  * Every schema that feature an expireMonth and an expireYear
  * field will be validated against the dateBeforeNow rule.
  */
+// eslint-disable-next-line consistent-return
 SimpleSchema.addValidator(function () {
   let expireMonth;
   let expireYear;

--- a/client/modules/i18n/startup.js
+++ b/client/modules/i18n/startup.js
@@ -50,6 +50,8 @@ SimpleSchema.addValidator(function () {
       }
     }
   }
+
+  return null;
 });
 
 /**
@@ -177,6 +179,8 @@ Meteor.startup(() => {
           }
           return $("html").removeClass("rtl");
         });
+
+        return null;
     }); // return
   });
 

--- a/imports/collections/schemas/helpers.js
+++ b/imports/collections/schemas/helpers.js
@@ -14,9 +14,13 @@ export function createdAtAutoValue() {
   // document, for example, in a product being added to cart items
   if (this.closestSubschemaFieldName) return;
 
+  /* eslint-disable consistent-return */
+  // This function returns different `types`, therefore
+  // consistent-return needs to be disabled
   if (this.isInsert) return new Date();
   if (this.isUpsert) return { $setOnInsert: new Date() };
-  this.unset();
+  return this.unset();
+  /* eslint-enable consistent-return */
 }
 
 /**
@@ -30,7 +34,7 @@ export function createdAtAutoValue() {
 export function updatedAtAutoValue() {
   // We don't want to overwrite an updatedAt in a nested
   // document, for example, in a product being added to cart items
-  if (this.closestSubschemaFieldName) return;
+  if (this.closestSubschemaFieldName) return null;
 
   return new Date();
 }

--- a/imports/plugins/core/accounts/client/components/editGroup.js
+++ b/imports/plugins/core/accounts/client/components/editGroup.js
@@ -111,7 +111,7 @@ class EditGroup extends Component {
         Object.assign({}, this.state.alertOptions, { i18nKey: "admin.settings.updateGroupSuccess" })
       );
 
-      this.setState({ isEditing: false });
+      return this.setState({ isEditing: false });
     });
   };
 

--- a/imports/plugins/core/accounts/client/components/editGroup.js
+++ b/imports/plugins/core/accounts/client/components/editGroup.js
@@ -87,7 +87,7 @@ class EditGroup extends Component {
         Object.assign({}, this.state.alertOptions, { i18nKey: "admin.settings.createGroupSuccess" })
       );
 
-      this.setState({ isEditing: false });
+      return this.setState({ isEditing: false });
     });
   };
 

--- a/imports/plugins/core/accounts/client/components/forgotPassword.js
+++ b/imports/plugins/core/accounts/client/components/forgotPassword.js
@@ -48,6 +48,8 @@ class Forgot extends Component {
         </div>
       );
     }
+
+    return null;
   }
 
   renderEmailErrors() {
@@ -61,6 +63,8 @@ class Forgot extends Component {
         </span>
       );
     }
+
+    return null;
   }
 
   renderSpinnerOnWait() {

--- a/imports/plugins/core/accounts/client/components/groupForm.js
+++ b/imports/plugins/core/accounts/client/components/groupForm.js
@@ -39,6 +39,8 @@ class GroupForm extends Component {
     if (this.props.updateGroup) {
       return this.props.updateGroup(this.props.group._id, this.state);
     }
+
+    return null;
   };
 
   render() {

--- a/imports/plugins/core/accounts/client/components/loginButtons.js
+++ b/imports/plugins/core/accounts/client/components/loginButtons.js
@@ -60,6 +60,8 @@ class LoginButtons extends Component {
         </div>
       );
     }
+
+    return null;
   }
 
   render() {

--- a/imports/plugins/core/accounts/client/components/permissionsList.js
+++ b/imports/plugins/core/accounts/client/components/permissionsList.js
@@ -3,8 +3,12 @@ import PropTypes from "prop-types";
 import _ from "lodash";
 import { Components, registerComponent } from "@reactioncommerce/reaction-components";
 
-// resolvePermissions - helper to resolve toggled permission(s).
-// It returns a list of all parent and child permissions when a parent permission is toggled.
+/**
+ * @function
+ * @description helper to resolve toggled permissions
+ * @param {Object} permission permission to check
+ * @return {Array} list of all parent and child permissions when a parent permission is toggled
+ */
 function resolvePermissions(permission) {
   const result = [];
 
@@ -19,7 +23,14 @@ function resolvePermissions(permission) {
 
   return result;
 }
-// helper to remove all array items in "old" from "current"
+
+/**
+ * @function
+ * @description helper to remove all array items in "old" from "current"
+ * @param {Array} current current array items
+ * @param {Array} old older array items
+ * @return {Array} updated permissions array
+ */
 function removePermissions(current, old) {
   const currentArray = [...current];
 

--- a/imports/plugins/core/accounts/client/components/permissionsList.js
+++ b/imports/plugins/core/accounts/client/components/permissionsList.js
@@ -76,6 +76,8 @@ class PermissionsList extends Component {
     if (this.props.updateGroup) {
       return this.props.updateGroup(this.state.group._id, groupData);
     }
+
+    return null;
   };
 
   checked = (permission) => {

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -207,6 +207,12 @@ class AuthContainer extends Component {
   }
 }
 
+/**
+ * @summary Composer
+ * @param {Object} props Provided props
+ * @param {Function} onData Call this with props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   onData(null, { currentRoute: Router.current() });
 }

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -189,6 +189,8 @@ class AuthContainer extends Component {
         />
       );
     }
+
+    return null;
   }
 
   render() {

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -210,9 +210,9 @@ class AuthContainer extends Component {
 }
 
 /**
- * @summary Composer
- * @param {Object} props Provided props
- * @param {Function} onData Call this with props
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
  * @returns {undefined}
  */
 function composer(props, onData) {

--- a/imports/plugins/core/accounts/client/containers/updateEmail.js
+++ b/imports/plugins/core/accounts/client/containers/updateEmail.js
@@ -24,7 +24,11 @@ const handlers = {
           Alerts.toast(i18next.t("accountsUI.info.emailUpdated"), "success");
           return callback();
         });
+
+        return null;
       });
+
+      return null;
     });
   }
 };

--- a/imports/plugins/core/accounts/client/helpers/helpers.js
+++ b/imports/plugins/core/accounts/client/helpers/helpers.js
@@ -26,6 +26,8 @@ export const LoginFormSharedHelpers = {
     if (error !== true && typeof error !== "undefined") {
       return "has-error has-feedback";
     }
+
+    return null;
   },
 
   /**

--- a/imports/plugins/core/accounts/client/helpers/templates.js
+++ b/imports/plugins/core/accounts/client/helpers/templates.js
@@ -29,4 +29,6 @@ Template.registerHelper("displayName", (displayUser) => {
       return i18next.t("accountsUI.guest", { defaultValue: "Guest" });
     }
   }
+
+  return null;
 });

--- a/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
+++ b/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
@@ -106,6 +106,7 @@ Template.accountsSettings.helpers({
     const serviceHelper = new ServiceConfigHelper();
     const configurations = ServiceConfiguration.configurations.find().fetch();
 
+    // eslint-disable-next-line consistent-return
     const services = serviceHelper.services((item) => {
       const matchingConfigurations = _.filter(configurations, {
         service: item.name

--- a/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
+++ b/imports/plugins/core/accounts/client/templates/dashboard/dashboard.js
@@ -82,6 +82,8 @@ Template.accountsDashboard.helpers({
         });
       }
     }
+
+    return null;
   },
 
   accountsDashboard() {

--- a/imports/plugins/core/accounts/client/templates/dropdown/helpers/helpers.js
+++ b/imports/plugins/core/accounts/client/templates/dropdown/helpers/helpers.js
@@ -11,6 +11,8 @@ export const LoginFormSharedHelpers = {
     if (error !== true && typeof error !== "undefined") {
       return "has-error has-feedback";
     }
+
+    return null;
   },
   capitalize(str) {
     const finalString = str === null ? "" : String(str);

--- a/imports/plugins/core/accounts/client/templates/dropdown/helpers/templates.js
+++ b/imports/plugins/core/accounts/client/templates/dropdown/helpers/templates.js
@@ -26,4 +26,6 @@ Template.registerHelper("displayName", (displayUser) => {
       return i18next.t("accountsUI.guest", { defaultValue: "Guest" });
     }
   }
+
+  return null;
 });

--- a/imports/plugins/core/accounts/client/templates/members/member.js
+++ b/imports/plugins/core/accounts/client/templates/members/member.js
@@ -123,6 +123,8 @@ Template.memberSettings.helpers({
           permissions: _.uniq(permissions)
         });
       }
+
+      return null;
     });
 
     return permissionGroups;

--- a/imports/plugins/core/accounts/client/templates/members/member.js
+++ b/imports/plugins/core/accounts/client/templates/members/member.js
@@ -43,6 +43,8 @@ Template.memberSettings.helpers({
         return true;
       }
     }
+
+    return false;
   },
   userId() {
     return Reaction.getUserId();
@@ -54,6 +56,8 @@ Template.memberSettings.helpers({
     ))) {
       return "checked";
     }
+
+    return null;
   },
   groupsForUser(groupUserId) {
     const userId = groupUserId || this.userId || Template.parentData(1).userId;
@@ -67,6 +71,8 @@ Template.memberSettings.helpers({
     if (shop && shop.name) {
       return shop.name || "Default Shop";
     }
+
+    return null;
   },
   permissionGroups(thisShopId) {
     const permissionGroups = [];
@@ -188,5 +194,7 @@ Template.memberSettings.events({
       }
       return results;
     }
+
+    return null;
   }
 });

--- a/imports/plugins/core/accounts/client/templates/profile/profile.js
+++ b/imports/plugins/core/accounts/client/templates/profile/profile.js
@@ -129,6 +129,8 @@ Template.accountProfile.helpers({
     if (Reaction.hasPermission("account/profile")) {
       return i18next.t("accountsUI.guest", { defaultValue: "Guest" });
     }
+
+    return null;
   },
 
   /**
@@ -147,6 +149,8 @@ Template.accountProfile.helpers({
         return (defaultEmail && defaultEmail.address) || account.emails[0].address;
       }
     }
+
+    return null;
   },
 
   /**

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/addAccountToGroup.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/addAccountToGroup.js
@@ -2,7 +2,7 @@ import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms
 import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
 
 /**
- * @name "Mutation.addAccountToGroup"
+ * @name Mutation/addAccountToGroup
  * @method
  * @memberof Accounts/GraphQL
  * @summary resolver for the addAccountToGroup GraphQL mutation

--- a/imports/plugins/core/catalog/server/methods/catalog.js
+++ b/imports/plugins/core/catalog/server/methods/catalog.js
@@ -658,6 +658,7 @@ Meteor.methods({
    * @param {String} productId - productId to delete
    * @returns {Number} returns number of removed products
    */
+  // eslint-disable-next-line consistent-return
   "products/archiveProduct"(productId) {
     check(productId, Match.OneOf(Array, String));
 

--- a/imports/plugins/core/core/server/no-meteor/resolvers/ConnectionLimitInt.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/ConnectionLimitInt.js
@@ -1,10 +1,11 @@
+/* eslint-disable consistent-return */
 import { GraphQLScalarType } from "graphql";
 import { Kind } from "graphql/language";
 
 const MAX_LIMIT = 200;
 
 /**
- * Adjusts value to be between 1 and MAX_LIMIT, inclusive
+ * @description Adjusts value to be between 1 and MAX_LIMIT, inclusive
  * @private
  * @param {Number|undefined} value value to check
  * @return {Number|undefined} parsed value

--- a/imports/plugins/core/core/server/no-meteor/resolvers/ConnectionLimitInt.js
+++ b/imports/plugins/core/core/server/no-meteor/resolvers/ConnectionLimitInt.js
@@ -6,11 +6,15 @@ const MAX_LIMIT = 200;
 /**
  * Adjusts value to be between 1 and MAX_LIMIT, inclusive
  * @private
+ * @param {Number|undefined} value value to check
+ * @return {Number|undefined} parsed value
  */
 function parseValue(value) {
+  /* eslint-disable consistent-return */
   if (value === undefined || isNaN(value)) return undefined;
   if (typeof value !== "number") return MAX_LIMIT;
   return Math.min(Math.max(1, value), MAX_LIMIT);
+  /* eslint-enable consistent-return */
 }
 
 const description = `

--- a/imports/plugins/core/core/server/publications/collections/packages.js
+++ b/imports/plugins/core/core/server/publications/collections/packages.js
@@ -87,6 +87,7 @@ function transform(doc, userId) {
   return doc;
 }
 
+// eslint-disable-next-line consistent-return
 Meteor.publish("Packages", function (shopId) {
   check(shopId, Match.Maybe(String));
 

--- a/imports/plugins/core/core/server/publications/collections/reactiveAggregate.js
+++ b/imports/plugins/core/core/server/publications/collections/reactiveAggregate.js
@@ -36,10 +36,17 @@ Mongo.Collection.prototype._getCollection = function () {
   return db.collection(this._name);
 };
 
+/**
+ * Provides a way to get at the underlying instance of the DB connection
+ * @param {Object} mongoConn mongo connection
+ * @returns {Object} The underlying Mongo connection database
+ */
 function wrapWithDb(mongoConn) {
   if (mongoConn.db) {
     return mongoConn.db;
   }
+
+  return null;
 }
 
 
@@ -92,7 +99,9 @@ export function ReactiveAggregate(pub, collection, pipeline, options) {
   pub._ids = {};
   pub._iteration = 1;
 
-  // run this function every time a record changes
+  /**
+   * @return {undefined}
+   */
   function update() {
     if (initializing) {
       return;

--- a/imports/plugins/core/core/server/startup/i18n.js
+++ b/imports/plugins/core/core/server/startup/i18n.js
@@ -16,6 +16,11 @@ const translationSources = [];
 const rawAssetsCollection = Assets.rawCollection();
 let bulkAssetOp;
 
+/**
+ * @function directoryExists
+ * @param {String} dirPath directory path
+ * @return {Boolean} isDirectory
+ */
 async function directoryExists(dirPath) {
   let info;
 
@@ -85,6 +90,8 @@ export async function flushTranslationLoad() {
   } catch (error) {
     Logger.error("Error flushing the translation asset upserts");
   }
+
+  return Promise.resolve();
 }
 
 /**
@@ -94,6 +101,7 @@ export async function flushTranslationLoad() {
  * Assets collection is processed with Reaction.Import
  * after all assets have been loaded.
  * @async
+ * @return {undefined} no return
  */
 export async function loadCoreTranslations() {
   const meteorPath = await fs.realpath(`${process.cwd()}/../`);

--- a/imports/plugins/core/core/server/util/geocoder.js
+++ b/imports/plugins/core/core/server/util/geocoder.js
@@ -85,25 +85,24 @@ GeoCoder.prototype.reverse = function geoCoderReverse(lat, lng, callback) {
     geoCallback = Meteor.bindEnvironment(geoCallback, (error) => {
       if (error) throw error;
     });
-    rv(lat, lng, this.options, geoCallback);
-  } else {
-    try {
-      const address = Meteor.wrapAsync(rv)(lat, lng, this.options);
-      return address[0];
-    } catch (_error) {
-      return {
-        latitude: null,
-        longitude: null,
-        country: "United States",
-        city: null,
-        state: null,
-        stateCode: null,
-        zipcode: null,
-        streetName: null,
-        streetNumber: null,
-        countryCode: "US"
-      };
-    }
+    return rv(lat, lng, this.options, geoCallback);
+  }
+  try {
+    const address = Meteor.wrapAsync(rv)(lat, lng, this.options);
+    return address[0];
+  } catch (_error) {
+    return {
+      latitude: null,
+      longitude: null,
+      country: "United States",
+      city: null,
+      state: null,
+      stateCode: null,
+      zipcode: null,
+      streetName: null,
+      streetNumber: null,
+      countryCode: "US"
+    };
   }
 };
 
@@ -126,15 +125,14 @@ GeoCoder.prototype.geoip = function geoCoderGeocode(address, callback) {
     geoCallback = Meteor.bindEnvironment(geoCallback, (error) => {
       if (error) throw error;
     });
-    gi(geoAddress, this.options, geoCallback);
-  } else {
-    try {
-      geoAddress = Meteor.wrapAsync(gi)(geoAddress);
-      return geoAddress.data;
-    } catch (error) {
-      Logger.warn("shop/getLocale geoip lookup failure", error);
-      return {};
-    }
+    return gi(geoAddress, this.options, geoCallback);
+  }
+  try {
+    geoAddress = Meteor.wrapAsync(gi)(geoAddress);
+    return geoAddress.data;
+  } catch (error) {
+    Logger.warn("shop/getLocale geoip lookup failure", error);
+    return {};
   }
 };
 

--- a/imports/plugins/core/core/server/util/geocoder.js
+++ b/imports/plugins/core/core/server/util/geocoder.js
@@ -64,6 +64,8 @@ GeoCoder.prototype.geocode = function geoCoderGeocode(address, callback) {
     geoAddress = Meteor.wrapAsync(gc)(geoAddress, this.options);
     return geoAddress[0];
   }
+
+  return null;
 };
 
 function rv(lat, lng, options, callback) {

--- a/imports/plugins/core/dashboard/client/templates/dashboard.js
+++ b/imports/plugins/core/dashboard/client/templates/dashboard.js
@@ -13,6 +13,8 @@ Template.dashboardHeader.helpers({
     if (registry && route) {
       return translateRegistry(registry);
     }
+
+    return null;
   }
 });
 

--- a/imports/plugins/core/dashboard/client/templates/packages/grid/grid.js
+++ b/imports/plugins/core/dashboard/client/templates/packages/grid/grid.js
@@ -46,6 +46,7 @@ function enableReactionPackage(reactionPackage) {
         "warning"
       );
     }
+    return null;
   });
 }
 
@@ -64,6 +65,7 @@ function disableReactionPackage(reactionPackage) {
       showCancelButton: true
     },
     () => {
+      // eslint-disable-next-line consistent-return
       Meteor.call("shop/togglePackage", self.packageId, true, (error, result) => {
         if (result === 1) {
           return Alerts.toast(

--- a/imports/plugins/core/dashboard/client/templates/packages/grid/package.js
+++ b/imports/plugins/core/dashboard/client/templates/packages/grid/package.js
@@ -71,5 +71,6 @@ Template.gridPackage.helpers({
     if (pkg.name && pkg.route && pkg.template) {
       return "showPackageManagement";
     }
+    return null;
   }
 });

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/shopBrandImageOption.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/shopBrandImageOption.js
@@ -25,7 +25,7 @@ class ShopBrandImageOption extends Component {
         return Alerts.toast(i18next.t("shopSettings.shopBrandAssetsFailed"), "error");
       }
 
-      Alerts.toast(i18next.t("shopSettings.shopBrandAssetsSaved"), "success");
+      return Alerts.toast(i18next.t("shopSettings.shopBrandAssetsSaved"), "success");
     });
   };
 

--- a/imports/plugins/core/discounts/client/components/form.js
+++ b/imports/plugins/core/discounts/client/components/form.js
@@ -79,7 +79,7 @@ export default class DiscountForm extends Component {
     });
     // TODO: this.debounce doesn't always need to exec we should add some logic to determine based on attempts or some other
     // cleverness if now is a good time to apply the code.
-    this.debounceDiscounts();
+    return this.debounceDiscounts();
   }
 
   // handle display or not

--- a/imports/plugins/core/files/server/no-meteor/setUpFileCollections.js
+++ b/imports/plugins/core/files/server/no-meteor/setUpFileCollections.js
@@ -71,7 +71,7 @@ export default function setUpFileCollections({
       mongodb,
       name,
       async transformWrite(fileRecord) {
-        if (!transform) return;
+        if (!transform) return null;
 
         const { size, mod, format, type } = transform;
 
@@ -81,7 +81,7 @@ export default function setUpFileCollections({
         fileRecord.extension(format, { store: name });
 
         // resizing image, adding mod, setting output format
-        sharp().resize(size, size)[mod]().toFormat(format);
+        return sharp().resize(size, size)[mod]().toFormat(format);
       }
     })
   );

--- a/imports/plugins/core/files/server/no-meteor/setUpFileCollections.js
+++ b/imports/plugins/core/files/server/no-meteor/setUpFileCollections.js
@@ -81,7 +81,7 @@ export default function setUpFileCollections({
         fileRecord.extension(format, { store: name });
 
         // resizing image, adding mod, setting output format
-        return sharp().resize(size, size)[mod]().toFormat(format);
+        sharp().resize(size, size)[mod]().toFormat(format);
       }
     })
   );

--- a/imports/plugins/core/layout/client/components/quickMenu.js
+++ b/imports/plugins/core/layout/client/components/quickMenu.js
@@ -29,6 +29,8 @@ class QuickMenu extends Component {
         );
       });
     }
+
+    return null;
   }
 
   render() {

--- a/imports/plugins/core/orders/client/containers/orderSubscriptionContainer.js
+++ b/imports/plugins/core/orders/client/containers/orderSubscriptionContainer.js
@@ -30,6 +30,8 @@ function composer(props, onData) {
       currentPage
     });
   }
+
+  return null;
 }
 
 export default composeWithTracker(composer, Components.Loading)(OrderSubscription);

--- a/imports/plugins/core/router/lib/hooks.js
+++ b/imports/plugins/core/router/lib/hooks.js
@@ -27,6 +27,7 @@ const Hooks = {
     }
   },
 
+  // eslint-disable-next-line consistent-return
   leave(callback) {
     if (Array.isArray(callback)) {
       callback.forEach((cb) => {

--- a/imports/plugins/core/tags/client/components/TagDataTable.js
+++ b/imports/plugins/core/tags/client/components/TagDataTable.js
@@ -117,6 +117,8 @@ class TagDataTable extends Component {
         ? String(row[id].toLowerCase()).includes(filter.value.toLowerCase())
         : true);
     }
+
+    return null;
   }
 
   /**
@@ -248,6 +250,8 @@ class TagDataTable extends Component {
 
       );
     }
+
+    return null;
   }
 
   /**

--- a/imports/plugins/core/tags/client/pages/TagSettingsPageWithData.js
+++ b/imports/plugins/core/tags/client/pages/TagSettingsPageWithData.js
@@ -107,6 +107,8 @@ class TagSettings extends Component {
     if (action === "delete") {
       this.tableRef.current.refetch();
     }
+
+    return null;
   }
 
   reset() {

--- a/imports/plugins/core/templates/client/templates/settings.js
+++ b/imports/plugins/core/templates/client/templates/settings.js
@@ -163,4 +163,6 @@ Blaze.TemplateInstance.prototype.parentTemplate = function (levels = 1) {
     numLevel -= 1;
     view = view.parentView;
   }
+
+  return null;
 };

--- a/imports/plugins/core/ui-navbar/client/components/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/components/navbar.js
@@ -92,6 +92,8 @@ class NavBar extends Component {
         </div>
       );
     }
+
+    return null;
   }
 
   renderNotificationIcon() {
@@ -102,6 +104,8 @@ class NavBar extends Component {
         </div>
       );
     }
+
+    return null;
   }
 
   renderMainDropdown() {

--- a/imports/plugins/core/ui-tagnav/client/components/tagGroup.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagGroup.js
@@ -118,6 +118,8 @@ class TagGroup extends Component {
         </div>
       ));
     }
+
+    return null;
   }
 
   render() {

--- a/imports/plugins/core/ui-tagnav/client/components/tagGroupBody.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagGroupBody.js
@@ -82,7 +82,7 @@ class TagGroupBody extends Component {
 
     // Set local state so the component does't have to wait for a round-trip
     // to the server to get the updated list of variants
-    this.setState(newState, () => {
+    return this.setState(newState, () => {
       _.debounce(() => this.props.onTagSort(this.state.tagIds, this.state.parentTag), 500)();
     });
   }
@@ -129,6 +129,8 @@ class TagGroupBody extends Component {
         />
       ));
     }
+
+    return null;
   }
 
   render() {

--- a/imports/plugins/core/ui/client/components/button/button.js
+++ b/imports/plugins/core/ui/client/components/button/button.js
@@ -62,6 +62,7 @@ Template.button.helpers({
           if (!href) {
             return type || "button";
           }
+          return href;
         }
       }
     };
@@ -92,6 +93,8 @@ Template.button.helpers({
 
       return toggleOn;
     }
+
+    return null;
   }
 });
 

--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -348,6 +348,8 @@ class Form extends Component {
         </Components.FormActions>
       );
     }
+
+    return null;
   }
 
   render() {

--- a/imports/plugins/core/ui/client/components/forms/form.js
+++ b/imports/plugins/core/ui/client/components/forms/form.js
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { at, get, isEqual, set, update } from "lodash";

--- a/imports/plugins/core/ui/client/components/media/mediaGallery.js
+++ b/imports/plugins/core/ui/client/components/media/mediaGallery.js
@@ -59,7 +59,7 @@ class MediaGallery extends Component {
   };
 
   handleDrop = (files) => {
-    if (files.length === 0) return;
+    if (files.length === 0) return null;
     return this.props.onDrop(files);
   };
 

--- a/imports/plugins/core/ui/client/components/menu/menu.js
+++ b/imports/plugins/core/ui/client/components/menu/menu.js
@@ -25,6 +25,8 @@ class Menu extends Component {
         );
       });
     }
+
+    return null;
   }
 
   render() {

--- a/imports/plugins/core/ui/client/components/table/sortableTable.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTable.js
@@ -90,6 +90,8 @@ class SortableTable extends Component {
         ? String(row[id].toLowerCase()).includes(filter.value.toLowerCase())
         : true);
     }
+
+    return null;
   }
 
 
@@ -130,6 +132,8 @@ class SortableTable extends Component {
         })
       );
     }
+
+    return null;
   }
 
 

--- a/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
+++ b/imports/plugins/core/ui/client/components/table/sortableTableComponents/pagination.js
@@ -85,7 +85,7 @@ class SortableTablePagination extends Component {
                     if (val === "") {
                       return this.setState({ page: val });
                     }
-                    this.setState({ page: this.getSafePage(currentPage) });
+                    return this.setState({ page: this.getSafePage(currentPage) });
                   }}
                   value={this.state.page === "" ? "" : this.state.page + 1}
                   onBlur={this.applyPage}
@@ -121,6 +121,7 @@ class SortableTablePagination extends Component {
               if (canPrevious) {
                 return this.changePage(page - 1);
               }
+              return null;
             }}
             disabled={!canPrevious}
           >
@@ -134,6 +135,7 @@ class SortableTablePagination extends Component {
               if (canNext) {
                 return this.changePage(page + 1);
               }
+              return null;
             }}
             disabled={!canNext}
           >

--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -29,11 +29,9 @@ class TextField extends Component {
 
     if (typeof isValid === "boolean") {
       return isValid;
-    } else if (this.validationMessage) {
-      return false;
     }
 
-    return undefined;
+    return false;
   }
 
   get isHelpMode() {
@@ -53,6 +51,7 @@ class TextField extends Component {
       return validation.messages[name];
     }
 
+    // eslint-disable-next-line consistent-return
     return undefined;
   }
 

--- a/imports/plugins/core/ui/client/containers/mediaGallery.js
+++ b/imports/plugins/core/ui/client/containers/mediaGallery.js
@@ -129,6 +129,7 @@ const wrapComponent = (Comp) => (
       });
     };
 
+    // eslint-disable-next-line consistent-return
     handleUpload = (files) => {
       const productId = ReactionProduct.selectedProductId();
       const variant = ReactionProduct.selectedVariant();
@@ -213,7 +214,11 @@ const wrapComponent = (Comp) => (
   }
 );
 
-// resort the media in
+/**
+ * @description re-sort the media
+ * @param {Array} media media to sort
+ * @return {Array} sorted media
+ */
 function sortMedia(media) {
   const sortedMedia = _.sortBy(media, (med) => {
     const { priority } = (med && med.metadata) || {};

--- a/imports/plugins/core/versions/server/migrations/5_update_defaultRoles_to_groups.js
+++ b/imports/plugins/core/versions/server/migrations/5_update_defaultRoles_to_groups.js
@@ -25,6 +25,7 @@ Migrations.add({
           .map((user) => user.roles && user.roles[shop._id]);
         // sorts the array of permission sets to contain only unique sets to avoid creating groups with same permissions
         const permissionsArray = sortUniqueArray(customPermissions);
+        // eslint-disable-next-line consistent-return
         permissionsArray.forEach((permissions, index) => {
           if (!permissions) { return null; }
           Logger.debug(`creating custom group for shop ${shop.name}`);

--- a/imports/plugins/included/email-smtp/client/containers/SMTPEmailConfigContainer.js
+++ b/imports/plugins/included/email-smtp/client/containers/SMTPEmailConfigContainer.js
@@ -95,6 +95,8 @@ const composer = (props, onData) => {
     }
     return onData(null, { settings });
   }
+
+  return null;
 };
 
 const handlers = { saveSettings: actions.settings.saveSettings };

--- a/imports/plugins/included/marketplace/client/templates/settings/authorize.js
+++ b/imports/plugins/included/marketplace/client/templates/settings/authorize.js
@@ -22,6 +22,8 @@ Template.stripeConnectAuthorize.onCreated(() => {
       Router.go("/");
     });
   }
+
+  return null;
 });
 
 Template.stripeConnectAuthorize.helpers({

--- a/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
+++ b/imports/plugins/included/marketplace/client/templates/shops/shopSelect.js
@@ -8,6 +8,8 @@ Template.shopSelect.helpers({
     if (Reaction.Subscriptions.PrimaryShop.ready() && Reaction.Subscriptions.MerchantShops.ready()) {
       return Shops.find();
     }
+
+    return null;
   },
 
   isActiveShop(shopId) {

--- a/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
+++ b/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
@@ -61,6 +61,6 @@ Template.stripeConnectSignupButton.events({
 
     const stripeConnectAuthorizeUrl = `https://connect.stripe.com/oauth/authorize?response_type=code&state=${shopId}&client_id=${clientId}&scope=read_write`;
     const autofillParams = `&stripe_user[email]=${defaultEmailAddress}&stripe_user[country]=${country}&stripe_user[phone_number]=${phoneNumber}&stripe_user[business_name]=${businessName}&stripe_user[street_address]=${streetAddress}&stripe_user[city]=${city}&stripe_user[state]=${state}&stripe_user[zip]=${zip}&stripe_user[first_name]=${firstName}&stripe_user[last_name]=${lastName}`; // eslint-disable-line max-len
-    window.open(stripeConnectAuthorizeUrl + autofillParams, "_blank");
+    return window.open(stripeConnectAuthorizeUrl + autofillParams, "_blank");
   }
 });

--- a/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
+++ b/imports/plugins/included/marketplace/client/templates/stripeConnectSignupButton/stripeConnectSignupButton.js
@@ -25,21 +25,25 @@ Template.stripeConnectSignupButton.events({
       // If the primaryshop has stripe enabled and set the client_id
       clientId = primaryStripePackage.settings.public.client_id;
     } else {
-      return Alerts.toast(`${i18next.t("admin.connect.stripeConnectNotEnabled")}`, "error");
+      Alerts.toast(`${i18next.t("admin.connect.stripeConnectNotEnabled")}`, "error");
+      return;
     }
 
     const shop = Shops.findOne({ _id: shopId });
 
     if (!shop || !shop.workflow || shop.workflow.status !== "active") {
-      return Alerts.toast(`${i18next.t("admin.connect.shopNotActive")}`, "error");
+      Alerts.toast(`${i18next.t("admin.connect.shopNotActive")}`, "error");
+      return;
     }
 
     if (!shop.emails || !Array.isArray(shop.emails) || shop.emails.length === 0) {
-      return Alerts.toast(`${i18next.t("admin.connect.shopEmailNotConfigured")}`, "error");
+      Alerts.toast(`${i18next.t("admin.connect.shopEmailNotConfigured")}`, "error");
+      return;
     }
 
     if (!shop.addressBook || !Array.isArray(shop.addressBook) || shop.addressBook.length === 0) {
-      return Alerts.toast(`${i18next.t("admin.connect.shopAddressNotConfigured")}`, "error");
+      Alerts.toast(`${i18next.t("admin.connect.shopAddressNotConfigured")}`, "error");
+      return;
     }
 
     const { country } = shop.addressBook[0];
@@ -61,6 +65,6 @@ Template.stripeConnectSignupButton.events({
 
     const stripeConnectAuthorizeUrl = `https://connect.stripe.com/oauth/authorize?response_type=code&state=${shopId}&client_id=${clientId}&scope=read_write`;
     const autofillParams = `&stripe_user[email]=${defaultEmailAddress}&stripe_user[country]=${country}&stripe_user[phone_number]=${phoneNumber}&stripe_user[business_name]=${businessName}&stripe_user[street_address]=${streetAddress}&stripe_user[city]=${city}&stripe_user[state]=${state}&stripe_user[zip]=${zip}&stripe_user[first_name]=${firstName}&stripe_user[last_name]=${lastName}`; // eslint-disable-line max-len
-    return window.open(stripeConnectAuthorizeUrl + autofillParams, "_blank");
+    window.open(stripeConnectAuthorizeUrl + autofillParams, "_blank");
   }
 });

--- a/imports/plugins/included/product-admin/client/hocs/withVariantForm.js
+++ b/imports/plugins/included/product-admin/client/hocs/withVariantForm.js
@@ -83,6 +83,8 @@ const wrapComponent = (Comp) => (
       if (this.hasChildVariants(variant)) {
         return { backgroundColor: "lightgrey", cursor: "not-allowed" };
       }
+
+      return null;
     }
 
     restoreVariant = (variant) => {
@@ -261,6 +263,8 @@ const wrapComponent = (Comp) => (
           }
         });
       }
+
+      return null;
     }
 
     updateLowInventoryThresholdIfChildVariants = (variant) => {

--- a/imports/plugins/included/product-variant/containers/variantFormContainer.js
+++ b/imports/plugins/included/product-variant/containers/variantFormContainer.js
@@ -65,6 +65,8 @@ const wrapComponent = (Comp) => (
       if (this.hasChildVariants(variant)) {
         return { backgroundColor: "lightgrey", cursor: "not-allowed" };
       }
+
+      return null;
     }
 
     restoreVariant = (variant) => {
@@ -109,6 +111,8 @@ const wrapComponent = (Comp) => (
             if (result && ReactionProduct.selectedVariantId() === id) {
               return ReactionProduct.setCurrentVariant(null);
             }
+
+            return null;
           });
         }
       });
@@ -203,6 +207,8 @@ const wrapComponent = (Comp) => (
           }
         });
       }
+
+      return null;
     }
 
     updateLowInventoryThresholdIfChildVariants = (variant) => {

--- a/lib/api/products.js
+++ b/lib/api/products.js
@@ -199,7 +199,7 @@ ReactionProduct.selectedProduct = function () {
   if (typeof id === "string") {
     return Products.findOne(id);
   }
-  return undefined;
+  return null;
 };
 
 /**

--- a/lib/core/url-common.app-test.js
+++ b/lib/core/url-common.app-test.js
@@ -155,6 +155,10 @@ describe("urlCommon", () => {
     });
   });
 
+  /**
+   * @method randomString
+   * @return {String} random string
+   */
   function randomString() {
     return Math.random().toString(36);
   }

--- a/package.json
+++ b/package.json
@@ -391,12 +391,6 @@
       "import/resolver": "meteor"
     },
     "rules": {
-      "consistent-return": [
-        "warn",
-        {
-          "treatUndefinedAsUnspecified": true
-        }
-      ],
       "jsx-a11y/label-has-for": "off",
       "no-undef": "warn",
       "no-process-exit": "warn",


### PR DESCRIPTION
Resolves #5272   
Impact: **breaking|minor**  
Type: **chore**

## Issue
We currently have many `consistent-return` eslint warnings.

## Solution
Fix (or disable) these warnings, and then remove the `warn` override in our package.json eslint rules to make `consistent-return` an error so new violations are not introduced.

Most of the changes add `null` as a return. Some return a boolean where deemed appropriate.

## Breaking changes
`return null` has been added in a lot of places. While this shouldn't affect anything that is updated, please not that there is no longer no return / undefined return in many functions.

## Testing
1. run `eslint`
1. see there are no longer any `consistent-return` warnings
1. see that the override for this rule was removed, so in the future all issues will be errors

## Notes
- There are a few `jsdoc`s added in the PR as well, as I tried to add them if I saw missing jsdoc in a file I was updating.