### PR TITLE
refactor: add title as backup in product admin breadcrumb

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductHeader.js
+++ b/imports/plugins/included/product-admin/client/components/ProductHeader.js
@@ -123,7 +123,7 @@ function ProductHeader(props) {
               className={classes.breadcrumbLink}
               to={`/operator/products/${product._id}/${parentVariant._id}`}
             >
-              {parentVariant.optionTitle || "Untitled Variant"}
+              {parentVariant.optionTitle || parentVariant.title || "Untitled Variant"}
             </Link>
           </Fragment>
         )}
@@ -135,7 +135,7 @@ function ProductHeader(props) {
               className={classes.breadcrumbLink}
               to={`/operator/products/${variant.ancestors.join("/")}/${variant._id}`}
             >
-              {variant.optionTitle || "Untitled Variant"}
+              {variant.optionTitle || variant.title || "Untitled Variant"}
             </Link>
           </Fragment>
         )}


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

## Issue
When an option doesn't have the `optionTitle` field set, we default to a hardcodeded `Untitled variant` to display in our breadcrumbs. We should first also check to see it `title` is set and use that prior to the `Untitled variant`.

## Solution
Add a check to see if `title` is available.

## Breaking changes
None

## Testing
1. Create a product
1. Leave `Option Title` blank (if this is even possible, it might be required in our UI. If so, use Robo3T to change the option field after it's been created).
1. Fill in "Title" field
1. See that the title field shows up in the breadcrumbs

Before:
![Pasted_Image_7_19_19__10_16_AM](https://user-images.githubusercontent.com/4482263/61553065-5f800400-aa0e-11e9-8e73-2cd02eb1028c.png)

After:
![Bobstores_com](https://user-images.githubusercontent.com/4482263/61553086-70307a00-aa0e-11e9-8c87-e9f9d6869367.png)

