### PR TITLE
(fix) Make catalog indexes unique for product

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/register.js
+++ b/imports/plugins/core/catalog/server/no-meteor/register.js
@@ -25,7 +25,7 @@ export default async function register(app) {
           [{ shopId: 1 }],
           [{ "product._id": 1 }, { unique: true }],
           [{ "product.productId": 1 }, { unique: true }],
-          [{ "product.slug": 1 }, { unique: true }],
+          [{ "product.slug": 1 }],
           [{ "product.tagIds": 1 }]
         ]
       }

--- a/imports/plugins/core/catalog/server/no-meteor/register.js
+++ b/imports/plugins/core/catalog/server/no-meteor/register.js
@@ -23,9 +23,9 @@ export default async function register(app) {
           [{ createdAt: 1, _id: 1 }],
           [{ updatedAt: 1, _id: 1 }],
           [{ shopId: 1 }],
-          [{ "product._id": 1 }],
-          [{ "product.productId": 1 }],
-          [{ "product.slug": 1 }],
+          [{ "product._id": 1 }, { unique: true }],
+          [{ "product.productId": 1 }, { unique: true }],
+          [{ "product.slug": 1 }, { unique: true }],
           [{ "product.tagIds": 1 }]
         ]
       }

--- a/imports/plugins/core/product/server/no-meteor/register.js
+++ b/imports/plugins/core/product/server/no-meteor/register.js
@@ -18,7 +18,7 @@ export default async function register(app) {
           // with indexes created by the aldeed:schema-index Meteor package.
           [{ ancestors: 1 }, { name: "c2_ancestors" }],
           [{ createdAt: 1 }, { name: "c2_createdAt" }],
-          [{ handle: 1 }, { name: "c2_handle" }],
+          [{ handle: 1 }, { name: "c2_handle" }, { unique: true }],
           [{ hashtags: 1 }, { name: "c2_hashtags" }],
           [{ shopId: 1 }, { name: "c2_shopId" }],
           [{ "workflow.status": 1 }, { name: "c2_workflow.status" }]

--- a/imports/plugins/core/product/server/no-meteor/register.js
+++ b/imports/plugins/core/product/server/no-meteor/register.js
@@ -18,7 +18,7 @@ export default async function register(app) {
           // with indexes created by the aldeed:schema-index Meteor package.
           [{ ancestors: 1 }, { name: "c2_ancestors" }],
           [{ createdAt: 1 }, { name: "c2_createdAt" }],
-          [{ handle: 1 }, { name: "c2_handle" }, { unique: true }],
+          [{ handle: 1 }, { name: "c2_handle" }],
           [{ hashtags: 1 }, { name: "c2_hashtags" }],
           [{ shopId: 1 }, { name: "c2_shopId" }],
           [{ "workflow.status": 1 }, { name: "c2_workflow.status" }]

--- a/tests/integration/api/queries/catalogItems/catalogItemsByTag.test.js
+++ b/tests/integration/api/queries/catalogItems/catalogItemsByTag.test.js
@@ -37,7 +37,10 @@ const mockCatalogItemsWithFeatured = Factory.Catalog.makeMany(30, {
 });
 
 const mockCatalogItemsWithoutFeatured = Factory.Catalog.makeMany(50, {
-  product: Factory.CatalogProduct.makeOne({
+  _id: (iterator) => (iterator + 500).toString(),
+  product: (iterator) => Factory.CatalogProduct.makeOne({
+    _id: (iterator + 500).toString(),
+    productId: (iterator + 500).toString(),
     isDeleted: false,
     isVisible: true,
     tagIds: [mockTagWithoutFeatured._id],


### PR DESCRIPTION
Resolves #5349
Impact: **breaking|minor**  
Type: **bugfix**

## Issue
The system current allows for more than one Catalog record per top-level product. This causes all sort of problems and should never happen

## Solution
Creates a unique index on product fields where there should always be only one of them. I guess this got overlooked when the Catalog collection was originally created.

## Breaking changes
In order for this change to take place you must drop the existing indexes on `product._id`and `product.productId`. We currently have no system for modifying indexes in code.


## Testing
1. Drop the indexes on `Catalog.product._id, Catalog.product.productId and Catalog.product.slug`
1. Start the system
1. Verify that the new indexes are created as unique indexes.
