### PR TITLE
chore: updated Dockerfile to change .meteor/ permissions to the node …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY --chown=node package.json $APP_SOURCE_DIR/
 # by root by default, we have to initially create node_modules here with correct owner.
 # Without this NPM cannot write packages into node_modules later, when running in a container.
 RUN mkdir "$APP_SOURCE_DIR/node_modules" && chown node "$APP_SOURCE_DIR/node_modules"
+RUN mkdir -p "$APP_SOURCE_DIR/.meteor/local" && chown node "$APP_SOURCE_DIR/.meteor/local"
 
 RUN meteor npm install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "9229:9229"
     volumes:
       - .:/opt/reaction/src:cached
-      - ./.meteor/local:/opt/reaction/src/.meteor/local:delegated
+      - reaction_meteor_local:/opt/reaction/src/.meteor/local
       - reaction_node_modules:/opt/reaction/src/node_modules # do not link node_modules in, and persist it between dc up runs
 
   mongo:
@@ -52,3 +52,4 @@ services:
 volumes:
   mongo-db:
   reaction_node_modules:
+  reaction_meteor_local:


### PR DESCRIPTION
Resolves #5351   
Impact: **minor**  
Type: **chore**

## Issue
When starting the reaction container on a fresh linux install I was met with permission issues within the container during startup. The issue was the owner of the `.meteor/local` was the `root` user and not the `node` user.

## Solution
Updated the dockerfile to create the `.meteor/local/` directory as well as `chown` it to the `node` user. Also created a new volume within the docker-compose file for the local meteor directory.

If you're solving a UIX related issue, please attach screen-caps or gifs showing how your solution differs from the issue.

## Breaking changes
I think peoples using macOS may need to rebuild their container for this change to work.

## Testing
1. On a Linux or Mac computer checkout this PR branch and do a fresh docker build.
2. Everything should start and you'll become very pleased.
