### PR TITLE
fix: red textfields

### DIFF
--- a/imports/plugins/core/ui/client/components/textfield/textfield.js
+++ b/imports/plugins/core/ui/client/components/textfield/textfield.js
@@ -22,16 +22,19 @@ class TextField extends Component {
 
   /**
    * Getter: isValid
-   * @return {Boolean} true/false if field is valid from props.isValid or props.validation[this.props.name].isValid
+   * @return {Boolean|undefined} true/false if field is valid from props.isValid or props.validation[this.props.name].isValid
    */
   get isValid() {
     const { isValid } = this.props;
 
+    // Return a boolean if this field is valid, or invalid
     if (typeof isValid === "boolean") {
       return isValid;
     }
 
-    return false;
+    // Return undefined if the field has not yet been validated
+    // eslint-disable-next-line consistent-return
+    return undefined;
   }
 
   get isHelpMode() {


### PR DESCRIPTION
Impact: **critical**  
Type: **bugfix**

## Issue

Some text fields have the red error state, even though they contain valid data.

## Solution

`isValid` can be true for success, false for error, and undefined for the default state.

## Breaking changes

none

## Testing
1. Visit forms around the app, namely the product/variant editor form and see that they aren't red
2. add valid/invalid data and ensure they have the correct error/success states where available
