### PR TITLE
feat: editable tag slug

### DIFF
--- a/imports/plugins/core/tags/client/components/TagForm.js
+++ b/imports/plugins/core/tags/client/components/TagForm.js
@@ -151,20 +151,26 @@ class TagForm extends Component {
       });
     }
 
-    const result = await mutation({
-      refetchQueries,
-      variables: {
-        input
+    this.setState({ error: null });
+    try {
+      const result = await mutation({
+        refetchQueries,
+        variables: {
+          input
+        }
+      });
+
+      if (result.data.addTag) {
+        this.props.onCreate(result.data.addTag.tag);
+      } else {
+        this.props.onUpdate(result.data.updateTag.tag);
       }
-    });
 
-    if (result.data.addTag) {
-      this.props.onCreate(result.data.addTag.tag);
-    } else {
-      this.props.onUpdate(result.data.updateTag.tag);
+      return result;
+    } catch (error) {
+      this.setState({ error });
+      return {};
     }
-
-    return result;
   }
 
   handleRemove(id, mutation) {
@@ -385,6 +391,12 @@ class TagForm extends Component {
               validator={getRequiredValidator("name", "displayTitle")}
               value={tag}
             >
+              {this.state.error &&
+                <InlineAlert
+                  alertType="error"
+                  message={this.state.error.message}
+                />
+              }
               {(this.previousSlug && tag.slug && this.previousSlug !== tag.slug) &&
                 <InlineAlert
                   isDismissable

--- a/imports/plugins/core/tags/client/components/TagForm.js
+++ b/imports/plugins/core/tags/client/components/TagForm.js
@@ -347,7 +347,7 @@ class TagForm extends Component {
   render() {
     const tag = this.tagData;
     const { shopId } = this.props;
-    const { currentTab } = this.state;
+    const { currentTab, error } = this.state;
     const nameInputId = `name_${this.uniqueInstanceIdentifier}`;
     const slugInputId = `slug_${this.uniqueInstanceIdentifier}`;
     const heroMediaUrlInputId = `heroMediaUrl_${this.uniqueInstanceIdentifier}`;
@@ -389,12 +389,12 @@ class TagForm extends Component {
               onChange={this.handleFormChange}
               onSubmit={(data) => this.handleSubmit(data, mutationFunc)}
               validator={getRequiredValidator("name", "displayTitle")}
-              value={tag}
+              value={error ? this.formValue : tag}
             >
-              {this.state.error &&
+              {error &&
                 <InlineAlert
                   alertType="error"
-                  message={this.state.error.message}
+                  message={error.message}
                 />
               }
               {(this.previousSlug && tag.slug && this.previousSlug !== tag.slug) &&

--- a/imports/plugins/core/tags/client/components/TagForm.js
+++ b/imports/plugins/core/tags/client/components/TagForm.js
@@ -561,7 +561,7 @@ class TagForm extends Component {
                     />
                   }
 
-                  <CardActions disableActionSpacing>
+                  <CardActions disableSpacing>
                     <Button actionType="secondary" onClick={this.handleSubmitForm}>
                       {i18next.t("admin.tags.form.save")}
                     </Button>

--- a/imports/plugins/core/tags/client/components/TagForm.js
+++ b/imports/plugins/core/tags/client/components/TagForm.js
@@ -10,6 +10,7 @@ import Button from "@reactioncommerce/components/Button/v1";
 import Checkbox from "@reactioncommerce/components/Checkbox/v1";
 import ErrorsBlock from "@reactioncommerce/components/ErrorsBlock/v1";
 import Field from "@reactioncommerce/components/Field/v1";
+import InlineAlert from "@reactioncommerce/components/InlineAlert/v1";
 import TextInput from "@reactioncommerce/components/TextInput/v1";
 import Grid from "@material-ui/core/Grid";
 import Tabs from "@material-ui/core/Tabs";
@@ -19,6 +20,7 @@ import Divider from "@material-ui/core/Divider";
 import CardContent from "@material-ui/core/CardContent";
 import MUICardActions from "@material-ui/core/CardActions";
 import Typography from "@material-ui/core/Typography";
+import CloseIcon from "mdi-material-ui/Close";
 import { i18next } from "/client/api";
 import { tagListingQuery, tagProductsQuery } from "../../lib/queries";
 import { addTagMutation, updateTagMutation, removeTagMutation, setTagHeroMediaMutation } from "../../lib/mutations";
@@ -91,6 +93,8 @@ class TagForm extends Component {
   uniqueInstanceIdentifier = uniqueId("URLRedirectEditForm");
 
   async handleSubmit(data, mutation) {
+    this.previousSlug = this.tagData.slug;
+
     const { shopId } = this.props;
     const isNew = !data._id;
 
@@ -104,6 +108,7 @@ class TagForm extends Component {
     const input = {
       id: data._id,
       name: data.name,
+      slug: data.slug,
       displayTitle: data.displayTitle,
       isVisible: data.isVisible || false,
       shopId,
@@ -369,7 +374,7 @@ class TagForm extends Component {
                   title={title}
                   onDelete={() => { this.handleRemove(tag._id, removeMutationFunc); }}
                   onCancel={this.handleCancel}
-                  onSave={this.handleSave}
+                  onSave={this.handleSubmitForm}
                 />
               )}
             </Mutation>
@@ -380,6 +385,16 @@ class TagForm extends Component {
               validator={getRequiredValidator("name", "displayTitle")}
               value={tag}
             >
+              {(this.previousSlug && tag.slug && this.previousSlug !== tag.slug) &&
+                <InlineAlert
+                  isDismissable
+                  components={{
+                    iconDismiss: <CloseIcon fontSize="small" />
+                  }}
+                  alertType="information"
+                  message={`Slug changed from ${this.previousSlug} to ${tag.slug}`}
+                />
+              }
               <ContentGroup>
                 <PaddedField
                   name="name"
@@ -424,7 +439,7 @@ class TagForm extends Component {
                           label={i18next.t("admin.tags.form.slug")}
                           labelFor={slugInputId}
                         >
-                          <TextInput id={slugInputId} isReadOnly name="slug" placeholder={i18next.t("admin.tags.form.slugPlaceholder")} />
+                          <TextInput id={slugInputId} name="slug" placeholder={i18next.t("admin.tags.form.slugPlaceholder")} />
                           <ErrorsBlock names={["slug"]} />
                         </PaddedField>
 

--- a/imports/plugins/core/tags/client/components/TagToolbar.js
+++ b/imports/plugins/core/tags/client/components/TagToolbar.js
@@ -38,7 +38,7 @@ TagToolbar.propTypes = {
   isNew: PropTypes.bool,
   onCancel: PropTypes.func,
   onDelete: PropTypes.func,
-  onSave: PropTypes.func.props,
+  onSave: PropTypes.func,
   title: PropTypes.string
 };
 

--- a/imports/plugins/core/tags/server/i18n/en.json
+++ b/imports/plugins/core/tags/server/i18n/en.json
@@ -33,7 +33,7 @@
               "displayTitleHelpText": "The tag display title for product listing pages.",
               "displayTitlePlaceholder": "i.e. Women's Shoes",
               "slug": "Slug",
-              "slugHelpText": "Tag slug is automatically generated using the tag name.",
+              "slugHelpText": "Tag slug is automatically converted into a URL-safe slug on save. Defaults to the tag name if left blank.",
               "slugPlaceholder": "womens-shoes",
               "formTitleNew": "Create a tag",
               "formTitleUpdate": "Edit Tag",

--- a/imports/plugins/core/tags/server/no-meteor/mutations/addTag.js
+++ b/imports/plugins/core/tags/server/no-meteor/mutations/addTag.js
@@ -14,12 +14,17 @@ import getSlug from "/imports/plugins/core/core/server/Reaction/getSlug";
  */
 export default async function addTag(context, input) {
   // Check for owner or admin permissions from the user before allowing the mutation
-  const { shopId, name, isVisible, displayTitle, metafields, heroMediaUrl } = input;
+  const { shopId, name, isVisible, displayTitle, metafields, heroMediaUrl, slug: slugInput } = input;
   const { appEvents, collections, userHasPermission } = context;
   const { Tags } = collections;
 
   if (!userHasPermission(["owner", "admin"], shopId)) {
     throw new ReactionError("access-denied", "User does not have permission");
+  }
+
+  let slug = name;
+  if (typeof slugInput === "string" && slugInput.trim().length > 0) {
+    slug = slugInput;
   }
 
   const now = new Date();
@@ -28,7 +33,7 @@ export default async function addTag(context, input) {
     isDeleted: false,
     isTopLevel: false,
     isVisible,
-    slug: getSlug(name),
+    slug: getSlug(slug),
     metafields,
     name,
     displayTitle,

--- a/imports/plugins/core/tags/server/no-meteor/mutations/updateTag.js
+++ b/imports/plugins/core/tags/server/no-meteor/mutations/updateTag.js
@@ -30,7 +30,7 @@ const inputSchema = new SimpleSchema({
 export default async function updateTag(context, input) {
   const { appEvents, collections, userHasPermission } = context;
   const { Tags } = collections;
-  const { shopId, tagId } = input;
+  const { shopId, tagId, slug: slugInput } = input;
 
   // Check for owner or admin permissions from the user before allowing the mutation
   if (!userHasPermission(["owner", "admin"], shopId)) {
@@ -46,8 +46,13 @@ export default async function updateTag(context, input) {
     }
   });
 
+  let slug = input.name;
+  if (typeof slugInput === "string" && slugInput.trim().length > 0) {
+    slug = slugInput;
+  }
+
   const params = {
-    slug: getSlug(input.name),
+    slug: getSlug(slug),
     name: input.name,
     displayTitle: input.displayTitle,
     isVisible: input.isVisible,

--- a/imports/plugins/core/tags/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/tags/server/no-meteor/schemas/schema.graphql
@@ -20,6 +20,9 @@ input AddTagInput {
 
   "The shop that owns the tag"
   shopId: ID!
+
+  "The tag slug. If left blank, the name will be slugified and saved as the slug"
+  slug: String
 }
 
 "Response payload for `addTag` mutation"
@@ -107,6 +110,9 @@ input UpdateTagInput {
 
   "The shop that owns the tag"
   shopId: ID!
+
+  "The tag slug. If left blank, the name will be slugified and saved as the slug"
+  slug: String
 }
 
 "Response payload for `updateTag` mutation"


### PR DESCRIPTION
Resolves #5380   
Impact: **major**  
Type: **feature**

## Issue

- Tag slug is not editable
- Tags slug changes ever time the `Tag name` changes

## Solution

- Make slug editable
- Default slug to a slugified `Tag name` if slug is left blank
- Notify the user if they change the slug (with an info inline alert)
- Bonus: show errors as an inline alert
- Bonus: fixed a broken save button

![Reaction](https://user-images.githubusercontent.com/42217/62083036-e7ce8800-b20a-11e9-987a-60ebb4fd648a.png)

![Reaction](https://user-images.githubusercontent.com/42217/62083063-f61ca400-b20a-11e9-8e9d-82cff07e7fe5.png)

(we need to revisit error message in another PR, but for now, at least it's more human-readable than it was before)

## Breaking changes

none

## Testing

### Create new
1. Create a tag, leave the slug **blank**
2. Save
3. See the slug default to the slugified tag name

### Create new
1. Create a tag, fill in the slug with normally (like you would a title, with capitalizations, punctuation etc.)
2. Save
3. See the slug is now the slugified version of your input

### Update
1. Change the `Tag name`
2. Save
3. See the slug is still the same
4. Update the slug
5. Save
6. See the slug has updated. (refresh to verify)
7. Delete the contents of the slug field
8. Save
9. See the slug is now the slugified `Tag name`

X. Try to break it.
