### PR TITLE
chore(ci): Work more robustly on forks

### DIFF
--- a/.circleci/eslint-changed-files.sh
+++ b/.circleci/eslint-changed-files.sh
@@ -17,9 +17,14 @@ IFS=$'\n\t'
 CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
 if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
   # Get PR from github API
-  url="https://api.github.com/repos/${DOCKER_REPOSITORY}/pulls/${CIRCLE_PR_NUMBER}"
+  org_repo=$(git remote -v |
+    head -1 |
+    awk '{print $2}' |
+    cut -d : -f 2 |
+    sed 's/\.git$//')
+  url="https://api.github.com/repos/${org_repo}/pulls/${CIRCLE_PR_NUMBER}"
   # Determine target/base branch from API response
-  TARGET_BRANCH=$(curl --silent --location --fail --show-error "${url}" | jq -r '.base.ref')
+  TARGET_BRANCH=$(curl --silent --location "${url}" | jq -r '.base.ref' || true)
 fi
 
 if [[ -z "${TARGET_BRANCH}" ]] || [[ ${TARGET_BRANCH} == "null" ]]; then


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
 
CI for forks was breaking because they were missing the `DOCKER_REPOSITORY` env var so the `curl` command that determines the target branch of a PR was breaking due to bad URL 404 error.


## Solution

Compute the github URL to the api for this repo using the output of `git remote -v`.

## Breaking changes
N/A

## Testing
1. Make sure CI passes in this source repo
2. Make sure CI passes in forks of this repo