### PR TITLE
feat: filter products by id in products table

### DIFF
--- a/imports/plugins/core/core/server/publications/collections/products.js
+++ b/imports/plugins/core/core/server/publications/collections/products.js
@@ -14,6 +14,11 @@ import Reaction from "/imports/plugins/core/core/server/Reaction";
 // params supplied to the products publication
 //
 const filters = new SimpleSchema({
+  "productIds": {
+    type: Array,
+    optional: true
+  },
+  "productIds.$": String,
   "shops": {
     type: Array,
     optional: true
@@ -170,6 +175,15 @@ function filterProducts(productFilters) {
   if (!selector) return false;
 
   if (productFilters) {
+    // filter by productIds
+    if (productFilters.productIds) {
+      _.extend(selector, {
+        _id: {
+          $in: productFilters.productIds
+        }
+      });
+    }
+
     // filter by tags
     if (productFilters.tags) {
       _.extend(selector, {

--- a/imports/plugins/included/product-variant/containers/productsContainerAdmin.js
+++ b/imports/plugins/included/product-variant/containers/productsContainerAdmin.js
@@ -83,6 +83,10 @@ const wrapComponent = (Comp) => (
       return isProductsSubscriptionReady;
     }
 
+    filterByProductIds = (productIds) => {
+      Session.set("filterByProductIds", productIds);
+    }
+
     loadProducts = (event) => {
       event.preventDefault();
       this.setState({
@@ -97,6 +101,7 @@ const wrapComponent = (Comp) => (
           {...this.props}
           isReady={this.isReady}
           loadProducts={this.loadProducts}
+          filterByProductIds={this.filterByProductIds}
         />
       );
     }
@@ -113,6 +118,14 @@ function composer(props, onData) {
   window.prerenderReady = false;
 
   const queryParams = Object.assign({}, Reaction.Router.current().query);
+
+  const filterByProductIds = Session.get("filterByProductIds");
+
+  if (Array.isArray(filterByProductIds) && filterByProductIds.length) {
+    queryParams.productIds = filterByProductIds;
+  } else if (queryParams.productIds) {
+    queryParams.productIds = queryParams.productIds.split(",").map((id) => id.trim());
+  }
 
   // Filter by tag
   const tagIdOrSlug = Reaction.Router.getParam("slug");


### PR DESCRIPTION
Resolves part of #5385  
Impact: **minor**  
Type: **feature**

## Issue

Add ability to filter products list by product id.

## Solution

**Necessary evils have been committed in order to push this feature forward. This will need to be revisited at some point to addGraphQL queries for the entire products table/product detail admin panels**

- Add filter for product id in publication
- Add Session var "filterByProductIds"

## Breaking changes

none.

## Testing
1. Using a large data set (you know the one) use the following URL
1. http://localhost:3000/operator/products?productIds=1284997,1286853
1. See the product filter in the table
1. http://localhost:3000/operator/products?productIds=OTHER_PRODUCT_IDS
1. See the product filter in the table
1. From the console do `Session.set("filterByProductIds", ["1284997", "1286853"])`
1. See the list filter by product ids
1. Try using different ids. The Session var overrides the URL query string
