### PR TITLE
feat(product table): show Action dropdown, even if no products are selected

### DIFF
--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -215,78 +215,76 @@ class ProductGrid extends Component {
           </Menu>
         </Toolbar>
       );
-    // eslint-disable-next-line no-else-return
-    } else {
-      return (
-        <Toolbar>
-          <Button
-            aria-owns={bulkActionMenuAnchorEl ? "bulk-actions-menu" : undefined}
-            aria-haspopup="true"
-            onClick={this.handleShowBulkActions}
-            variant="outlined"
-          >
-            {i18next.t("admin.productTable.bulkActions.actions")}
-            <ChevronDownIcon />
-          </Button>
-          <Menu
-            id="bulk-actions-menu"
-            anchorEl={bulkActionMenuAnchorEl}
-            open={Boolean(bulkActionMenuAnchorEl)}
-            onClose={this.handleCloseBulkActions}
-          >
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.publishTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.publishMessage")}
-              onConfirm={this.handleBulkActionPublish}
-            >
-              {({ openDialog }) => (
-                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.publish")}</MenuItem>
-              )}
-            </ConfirmDialog>
-
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.makeVisibleTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.makeVisibleMessage")}
-              onConfirm={this.handleBulkActionMakeVisible}
-            >
-              {({ openDialog }) => (
-                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeVisible")}</MenuItem>
-              )}
-            </ConfirmDialog>
-
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.makeHiddenTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.makeHiddenMessage")}
-              onConfirm={this.handleBulkActionMakeHidden}
-            >
-              {({ openDialog }) => (
-                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeHidden")}</MenuItem>
-              )}
-            </ConfirmDialog>
-
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.duplicateTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.duplicateMessage")}
-              onConfirm={this.handleBulkActionDuplicate}
-            >
-              {({ openDialog }) => (
-                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.duplicate")}</MenuItem>
-              )}
-            </ConfirmDialog>
-
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
-              onConfirm={this.handleBulkActionArchive}
-            >
-              {({ openDialog }) => (
-                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
-              )}
-            </ConfirmDialog>
-          </Menu>
-        </Toolbar>
-      );
     }
+    return (
+      <Toolbar>
+        <Button
+          aria-owns={bulkActionMenuAnchorEl ? "bulk-actions-menu" : undefined}
+          aria-haspopup="true"
+          onClick={this.handleShowBulkActions}
+          variant="outlined"
+        >
+          {i18next.t("admin.productTable.bulkActions.actions")}
+          <ChevronDownIcon />
+        </Button>
+        <Menu
+          id="bulk-actions-menu"
+          anchorEl={bulkActionMenuAnchorEl}
+          open={Boolean(bulkActionMenuAnchorEl)}
+          onClose={this.handleCloseBulkActions}
+        >
+          <ConfirmDialog
+            title={i18next.t("admin.productTable.bulkActions.publishTitle", { count })}
+            message={i18next.t("admin.productTable.bulkActions.publishMessage")}
+            onConfirm={this.handleBulkActionPublish}
+          >
+            {({ openDialog }) => (
+              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.publish")}</MenuItem>
+            )}
+          </ConfirmDialog>
+
+          <ConfirmDialog
+            title={i18next.t("admin.productTable.bulkActions.makeVisibleTitle", { count })}
+            message={i18next.t("admin.productTable.bulkActions.makeVisibleMessage")}
+            onConfirm={this.handleBulkActionMakeVisible}
+          >
+            {({ openDialog }) => (
+              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeVisible")}</MenuItem>
+            )}
+          </ConfirmDialog>
+
+          <ConfirmDialog
+            title={i18next.t("admin.productTable.bulkActions.makeHiddenTitle", { count })}
+            message={i18next.t("admin.productTable.bulkActions.makeHiddenMessage")}
+            onConfirm={this.handleBulkActionMakeHidden}
+          >
+            {({ openDialog }) => (
+              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeHidden")}</MenuItem>
+            )}
+          </ConfirmDialog>
+
+          <ConfirmDialog
+            title={i18next.t("admin.productTable.bulkActions.duplicateTitle", { count })}
+            message={i18next.t("admin.productTable.bulkActions.duplicateMessage")}
+            onConfirm={this.handleBulkActionDuplicate}
+          >
+            {({ openDialog }) => (
+              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.duplicate")}</MenuItem>
+            )}
+          </ConfirmDialog>
+
+          <ConfirmDialog
+            title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
+            message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
+            onConfirm={this.handleBulkActionArchive}
+          >
+            {({ openDialog }) => (
+              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
+            )}
+          </ConfirmDialog>
+        </Menu>
+      </Toolbar>
+    );
   }
 
   render() {

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -144,78 +144,7 @@ class ProductGrid extends Component {
     const { selectedProductIds } = this.props;
     const { bulkActionMenuAnchorEl } = this.state;
     const count = selectedProductIds.length;
-
-    if (Array.isArray(selectedProductIds) && selectedProductIds.length) {
-      return (
-        <Toolbar>
-          <Button
-            aria-owns={bulkActionMenuAnchorEl ? "bulk-actions-menu" : undefined}
-            aria-haspopup="true"
-            onClick={this.handleShowBulkActions}
-            variant="outlined"
-          >
-            {i18next.t("admin.productTable.bulkActions.actions")}
-            <ChevronDownIcon />
-          </Button>
-          <Menu
-            id="bulk-actions-menu"
-            anchorEl={bulkActionMenuAnchorEl}
-            open={Boolean(bulkActionMenuAnchorEl)}
-            onClose={this.handleCloseBulkActions}
-          >
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.publishTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.publishMessage")}
-              onConfirm={this.handleBulkActionPublish}
-            >
-              {({ openDialog }) => (
-                <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.publish")}</MenuItem>
-              )}
-            </ConfirmDialog>
-
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.makeVisibleTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.makeVisibleMessage")}
-              onConfirm={this.handleBulkActionMakeVisible}
-            >
-              {({ openDialog }) => (
-                <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeVisible")}</MenuItem>
-              )}
-            </ConfirmDialog>
-
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.makeHiddenTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.makeHiddenMessage")}
-              onConfirm={this.handleBulkActionMakeHidden}
-            >
-              {({ openDialog }) => (
-                <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeHidden")}</MenuItem>
-              )}
-            </ConfirmDialog>
-
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.duplicateTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.duplicateMessage")}
-              onConfirm={this.handleBulkActionDuplicate}
-            >
-              {({ openDialog }) => (
-                <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.duplicate")}</MenuItem>
-              )}
-            </ConfirmDialog>
-
-            <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
-              onConfirm={this.handleBulkActionArchive}
-            >
-              {({ openDialog }) => (
-                <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
-              )}
-            </ConfirmDialog>
-          </Menu>
-        </Toolbar>
-      );
-    }
+    const isEnabled = !(Array.isArray(selectedProductIds) && selectedProductIds.length);
     return (
       <Toolbar>
         <Button
@@ -239,7 +168,7 @@ class ProductGrid extends Component {
             onConfirm={this.handleBulkActionPublish}
           >
             {({ openDialog }) => (
-              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.publish")}</MenuItem>
+              <MenuItem onClick={openDialog} disabled={!isEnabled}>{i18next.t("admin.productTable.bulkActions.publish")}</MenuItem>
             )}
           </ConfirmDialog>
 
@@ -249,7 +178,7 @@ class ProductGrid extends Component {
             onConfirm={this.handleBulkActionMakeVisible}
           >
             {({ openDialog }) => (
-              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeVisible")}</MenuItem>
+              <MenuItem onClick={openDialog} disabled={!isEnabled}>{i18next.t("admin.productTable.bulkActions.makeVisible")}</MenuItem>
             )}
           </ConfirmDialog>
 
@@ -259,7 +188,7 @@ class ProductGrid extends Component {
             onConfirm={this.handleBulkActionMakeHidden}
           >
             {({ openDialog }) => (
-              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeHidden")}</MenuItem>
+              <MenuItem onClick={openDialog} disabled={!isEnabled}>{i18next.t("admin.productTable.bulkActions.makeHidden")}</MenuItem>
             )}
           </ConfirmDialog>
 
@@ -269,7 +198,7 @@ class ProductGrid extends Component {
             onConfirm={this.handleBulkActionDuplicate}
           >
             {({ openDialog }) => (
-              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.duplicate")}</MenuItem>
+              <MenuItem onClick={openDialog} disabled={!isEnabled}>{i18next.t("admin.productTable.bulkActions.duplicate")}</MenuItem>
             )}
           </ConfirmDialog>
 
@@ -279,7 +208,7 @@ class ProductGrid extends Component {
             onConfirm={this.handleBulkActionArchive}
           >
             {({ openDialog }) => (
-              <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
+              <MenuItem onClick={openDialog} disabled={!isEnabled}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
             )}
           </ConfirmDialog>
         </Menu>

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -144,7 +144,7 @@ class ProductGrid extends Component {
     const { selectedProductIds } = this.props;
     const { bulkActionMenuAnchorEl } = this.state;
     const count = selectedProductIds.length;
-    const isEnabled = !(Array.isArray(selectedProductIds) && selectedProductIds.length);
+    const isEnabled = Array.isArray(selectedProductIds) && selectedProductIds.length;
     return (
       <Toolbar>
         <Button

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -204,17 +204,18 @@ class ProductGrid extends Component {
             </ConfirmDialog>
 
             <ConfirmDialog
-                title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
-                message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
-                onConfirm={this.handleBulkActionArchive}
-              >
-                {({ openDialog }) => (
-                  <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
-                )}
-              </ConfirmDialog>
+              title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
+              message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
+              onConfirm={this.handleBulkActionArchive}
+            >
+              {({ openDialog }) => (
+                <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
+              )}
+            </ConfirmDialog>
           </Menu>
         </Toolbar>
       );
+    // eslint-disable-next-line no-else-return
     } else {
       return (
         <Toolbar>
@@ -274,14 +275,14 @@ class ProductGrid extends Component {
             </ConfirmDialog>
 
             <ConfirmDialog
-                title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
-                message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
-                onConfirm={this.handleBulkActionArchive}
-              >
-                {({ openDialog }) => (
-                  <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
-                )}
-              </ConfirmDialog>
+              title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
+              message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
+              onConfirm={this.handleBulkActionArchive}
+            >
+              {({ openDialog }) => (
+                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
+              )}
+            </ConfirmDialog>
           </Menu>
         </Toolbar>
       );

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -163,7 +163,6 @@ class ProductGrid extends Component {
             open={Boolean(bulkActionMenuAnchorEl)}
             onClose={this.handleCloseBulkActions}
           >
-
             <ConfirmDialog
               title={i18next.t("admin.productTable.bulkActions.publishTitle", { count })}
               message={i18next.t("admin.productTable.bulkActions.publishMessage")}
@@ -173,7 +172,6 @@ class ProductGrid extends Component {
                 <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.publish")}</MenuItem>
               )}
             </ConfirmDialog>
-
 
             <ConfirmDialog
               title={i18next.t("admin.productTable.bulkActions.makeVisibleTitle", { count })}
@@ -205,22 +203,89 @@ class ProductGrid extends Component {
               )}
             </ConfirmDialog>
 
-
             <ConfirmDialog
-              title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
-              message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
-              onConfirm={this.handleBulkActionArchive}
+                title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
+                message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
+                onConfirm={this.handleBulkActionArchive}
+              >
+                {({ openDialog }) => (
+                  <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
+                )}
+              </ConfirmDialog>
+          </Menu>
+        </Toolbar>
+      );
+    } else {
+      return (
+        <Toolbar>
+          <Button
+            aria-owns={bulkActionMenuAnchorEl ? "bulk-actions-menu" : undefined}
+            aria-haspopup="true"
+            onClick={this.handleShowBulkActions}
+            variant="outlined"
+          >
+            {i18next.t("admin.productTable.bulkActions.actions")}
+            <ChevronDownIcon />
+          </Button>
+          <Menu
+            id="bulk-actions-menu"
+            anchorEl={bulkActionMenuAnchorEl}
+            open={Boolean(bulkActionMenuAnchorEl)}
+            onClose={this.handleCloseBulkActions}
+          >
+            <ConfirmDialog
+              title={i18next.t("admin.productTable.bulkActions.publishTitle", { count })}
+              message={i18next.t("admin.productTable.bulkActions.publishMessage")}
+              onConfirm={this.handleBulkActionPublish}
             >
               {({ openDialog }) => (
-                <MenuItem onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
+                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.publish")}</MenuItem>
               )}
             </ConfirmDialog>
+
+            <ConfirmDialog
+              title={i18next.t("admin.productTable.bulkActions.makeVisibleTitle", { count })}
+              message={i18next.t("admin.productTable.bulkActions.makeVisibleMessage")}
+              onConfirm={this.handleBulkActionMakeVisible}
+            >
+              {({ openDialog }) => (
+                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeVisible")}</MenuItem>
+              )}
+            </ConfirmDialog>
+
+            <ConfirmDialog
+              title={i18next.t("admin.productTable.bulkActions.makeHiddenTitle", { count })}
+              message={i18next.t("admin.productTable.bulkActions.makeHiddenMessage")}
+              onConfirm={this.handleBulkActionMakeHidden}
+            >
+              {({ openDialog }) => (
+                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.makeHidden")}</MenuItem>
+              )}
+            </ConfirmDialog>
+
+            <ConfirmDialog
+              title={i18next.t("admin.productTable.bulkActions.duplicateTitle", { count })}
+              message={i18next.t("admin.productTable.bulkActions.duplicateMessage")}
+              onConfirm={this.handleBulkActionDuplicate}
+            >
+              {({ openDialog }) => (
+                <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.duplicate")}</MenuItem>
+              )}
+            </ConfirmDialog>
+
+            <ConfirmDialog
+                title={i18next.t("admin.productTable.bulkActions.archiveTitle", { count })}
+                message={i18next.t("admin.productTable.bulkActions.archiveMessage")}
+                onConfirm={this.handleBulkActionArchive}
+              >
+                {({ openDialog }) => (
+                  <MenuItem disabled onClick={openDialog}>{i18next.t("admin.productTable.bulkActions.archive")}</MenuItem>
+                )}
+              </ConfirmDialog>
           </Menu>
         </Toolbar>
       );
     }
-
-    return null;
   }
 
   render() {


### PR DESCRIPTION
Resolves #5388  
Impact: **minor**  
Type: **feature**

## Issue
In the new Bulk Product/Tag action flow, it's required that the Action dropdown menu be available to click - even if products are not selected.

## Solution
This PR changes the `renderToolbar()` method to 1) always show the dropdown, but 2) `disable` the action options if there are no products selected. 

<img width="438" alt="Screen Shot 2019-07-30 at 11 13 51 PM" src="https://user-images.githubusercontent.com/3673236/62187934-c3180480-b31f-11e9-844c-16e19304f798.png">

## Breaking changes
None

## Testing
0. http://localhost:3000/operator/products
1. Select 0 products and click the dropdown. Options should be disabled.
1. Select several products and click the dropdown. Try archiving, make-hidden-ing some things. Make sure the count is correct.