### PR TITLE
Feat #5366 show filter count

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -20,7 +20,7 @@ function ProductTable({ onCreateProduct }) {
           onClick={onCreateProduct}
           variant="contained"
         >
-          {i18next.t("admin.createProduct") || "Create Product"}
+          {i18next.t("admin.createProduct") || "Create product"}
         </Button>
       </Grid>
       <Grid item sm={12}>

--- a/imports/plugins/included/product-admin/server/i18n/en.json
+++ b/imports/plugins/included/product-admin/server/i18n/en.json
@@ -43,7 +43,9 @@
             "duplicate": "Duplicate",
             "duplicateTitle": "Duplicate {{count}} product?",
             "duplicateTitle_plural": "Duplicate {{count}} products?",
-            "duplicateMessage": "Duplicate selected products and their variants."
+            "duplicateMessage": "Duplicate selected products and their variants.",
+            "filteredProducts": "Filtered products",
+            "selectedCount": "{{count}} selected"
           }
         },
         "products": "Products",

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -30,7 +30,8 @@ const styles = (theme) => ({
     paddingTop: theme.spacing(3)
   },
   filterCountText: {
-    paddingLeft: theme.spacing(2)
+    paddingLeft: theme.spacing(2),
+    fontWeight: 400
   }
 });
 

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -21,7 +21,18 @@ import TableRow from "@material-ui/core/TableRow";
 import ChevronDownIcon from "mdi-material-ui/ChevronDown";
 import ConfirmDialog from "@reactioncommerce/catalyst/ConfirmDialog";
 import Typography from "@material-ui/core/Typography";
+import withStyles from "@material-ui/core/styles/withStyles";
 
+
+const styles = (theme) => ({
+  filterCountContainer: {
+    paddingLeft: theme.spacing(2),
+    paddingTop: theme.spacing(3)
+  },
+  filterCountText: {
+    paddingLeft: theme.spacing(2)
+  }
+});
 
 class ProductGrid extends Component {
   static propTypes = {
@@ -83,17 +94,17 @@ class ProductGrid extends Component {
   }
 
   renderFilteredCount() {
-    const { selectedProductIds } = this.props;
+    const { selectedProductIds, classes } = this.props;
     const count = selectedProductIds.length;
     const filterByProductIds = Session.get("filterByProductIds");
 
     if (filterByProductIds) {
       return (
-        <div style={{ paddingTop: "24px", paddingLeft: "8px" }}>
-          <Typography variant="h4" style={{ display: "inline" }}>
+        <div className={classes.filterCountContainer}>
+          <Typography variant="h4" display="inline">
             {i18next.t("admin.productTable.bulkActions.filteredProducts")}
           </Typography>
-          <Typography variant="h5" style={{ display: "inline", paddingLeft: "16px" }}>
+          <Typography variant="h5" display="inline" className={classes.filterCountText}>
             {i18next.t("admin.productTable.bulkActions.selectedCount", { count })}
           </Typography>
         </div>
@@ -285,4 +296,4 @@ class ProductGrid extends Component {
   }
 }
 
-export default ProductGrid;
+export default withStyles(styles)(ProductGrid);

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -20,6 +20,7 @@ import TablePagination from "@material-ui/core/TablePagination";
 import TableRow from "@material-ui/core/TableRow";
 import ChevronDownIcon from "mdi-material-ui/ChevronDown";
 import ConfirmDialog from "@reactioncommerce/catalyst/ConfirmDialog";
+import Typography from "@material-ui/core/Typography";
 
 
 class ProductGrid extends Component {
@@ -78,6 +79,23 @@ class ProductGrid extends Component {
     } else {
       // Reset selection
       onSelectAllProducts(false);
+    }
+  }
+
+  renderFilteredCount() {
+    const { selectedProductIds } = this.props;
+    const count = selectedProductIds.length;
+    const filterByProductIds = Session.get("filterByProductIds");
+
+    if(filterByProductIds) {
+      return (
+        <div style={{ paddingTop: "24px", paddingLeft: "8px" }}>
+          <Typography variant="h4" style={{ display: "inline" }}>{i18next.t("admin.productTable.bulkActions.filteredProducts")}</Typography>
+          <Typography variant="h5" style={{ display: "inline", paddingLeft: "16px" }}>{i18next.t("admin.productTable.bulkActions.selectedCount", { count })}</Typography>
+        </div>
+      );
+    } else {
+      return "";
     }
   }
 
@@ -222,6 +240,7 @@ class ProductGrid extends Component {
 
     return (
       <Card>
+        {this.renderFilteredCount()}
         {this.renderToolbar()}
         <CardContent>
           <Table>

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -87,16 +87,19 @@ class ProductGrid extends Component {
     const count = selectedProductIds.length;
     const filterByProductIds = Session.get("filterByProductIds");
 
-    if(filterByProductIds) {
+    if (filterByProductIds) {
       return (
         <div style={{ paddingTop: "24px", paddingLeft: "8px" }}>
-          <Typography variant="h4" style={{ display: "inline" }}>{i18next.t("admin.productTable.bulkActions.filteredProducts")}</Typography>
-          <Typography variant="h5" style={{ display: "inline", paddingLeft: "16px" }}>{i18next.t("admin.productTable.bulkActions.selectedCount", { count })}</Typography>
+          <Typography variant="h4" style={{ display: "inline" }}>
+            {i18next.t("admin.productTable.bulkActions.filteredProducts")}
+          </Typography>
+          <Typography variant="h5" style={{ display: "inline", paddingLeft: "16px" }}>
+            {i18next.t("admin.productTable.bulkActions.selectedCount", { count })}
+          </Typography>
         </div>
       );
-    } else {
-      return "";
     }
+    return "";
   }
 
   renderProductGridItems() {

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -36,6 +36,7 @@ const styles = (theme) => ({
 
 class ProductGrid extends Component {
   static propTypes = {
+    classes: PropTypes.object,
     onArchiveProducts: PropTypes.func,
     onChangePage: PropTypes.func,
     onChangeRowsPerPage: PropTypes.func,

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -31,7 +31,7 @@ const styles = (theme) => ({
   },
   filterCountText: {
     paddingLeft: theme.spacing(2),
-    fontWeight: 400
+    fontWeight: theme.typography.fontWeightRegular
   }
 });
 


### PR DESCRIPTION
Resolves #5366   
Impact: **minor**  
Type: **feature**

## Issue
#5366 

## Solution
Uses Session.get("filterByProductIds") to get filter results; Uses i18n strings to represent text, which is rendered inside MUI Typography components. Also fixes a minor issue wherein the capitalization of the letter 'P' in 'Create product' changes as the page renders.

## Breaking changes
N/A


## Testing
1. Navigate to the /operator/products page
2. Use the console to execute: ```Session.set("filterByProductIds", ["BCTMZ6HTxFSppJESk"])``` (or any other array of known productIds from the currently loaded dataset). Observe that the filter message appears.
3. Check and un-check items. Observe that the selected count changes.
4. Observe that everything is properly formatted.
