### PR TITLE
docs(readme): introducing the Storefront Component Library to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Follow the documentation to install Reaction with [Reaction Platform](https://do
 - [Docs: Introduction to Reaction:  Concepts](https://docs.reactioncommerce.com/docs/concepts-intro)
 - [Swag Shop Tutorial](https://docs.reactioncommerce.com/docs/swag-shop-1)
 - [Storefront UI Development Tutorial](https://docs.reactioncommerce.com/docs/storefront-intro)
-- [Reaction Design System](http://designsystem.reactioncommerce.com/)
+- [Storefront Component Library](http://designsystem.reactioncommerce.com/)
 - [API documentation](http://api.docs.reactioncommerce.com)
 - [Engineering blog posts](https://blog.reactioncommerce.com/tag/engineering/)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Reaction v2.0.0 is built as a truly headless commerce platform that decouples the Reaction backend services from the frontend. We’ve decoupled the storefront application from the API. Reaction platform consists of this `reaction` project - which is now primarily our GraphQL API (and for the time being also our operator UI and our identity provider) - alongside our new-to-2.0 [Example Storefront](https://github.com/reactioncommerce/example-storefront), which connects with the Reaction application via GraphQL API to provide a customer-facing storefront.
 
-![3-up-Catalyst-UI-lg](https://user-images.githubusercontent.com/20409254/61161477-bb033c80-a4b8-11e9-9c5e-4f4f6a68b8d0.png)
+![Reaction Admin](https://user-images.githubusercontent.com/20409254/61161477-bb033c80-a4b8-11e9-9c5e-4f4f6a68b8d0.png)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Reaction](http://reactioncommerce.com) is an API-first, headless commerce platform built using Node.js, React, and GraphQL. It plays nicely with npm, Docker and Kubernetes.
 
-Reaction v2.0.0 is built as a truly headless commerce platform that decouples the Reaction backend services from the frontend. We’ve decoupled the storefront application from the API. Reaction platform consists of this `reaction` project - which is now primarily our GraphQL API (and for the time being also our operator UI and our identity provider) - alongside our new-to-2.0 [Example Storefront](https://github.com/reactioncommerce/example-storefront), which connects with the Reaction application via GraphQL API to provide a customer-facing storefront.
+Reaction v2.0.0 is built as a truly headless commerce platform that decouples the Reaction backend services from the frontend. We’ve decoupled the storefront application from the API. Reaction platform consists of this `reaction` project - which is now primarily our GraphQL API (and for the time being Reaction Admin and our identity provider) - alongside our new-to-2.0 [Example Storefront](https://github.com/reactioncommerce/example-storefront), which connects with the Reaction application via GraphQL API to provide a customer-facing storefront.
 
 ![Reaction Admin](https://user-images.githubusercontent.com/20409254/61161477-bb033c80-a4b8-11e9-9c5e-4f4f6a68b8d0.png)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Reaction](http://reactioncommerce.com) is an API-first, headless commerce platform built using Node.js, React, and GraphQL. It plays nicely with npm, Docker and Kubernetes.
 
-Reaction v2.0.0 is built as a truly headless commerce platform that decouples the Reaction backend services from the frontend. We’ve decoupled the storefront application from the API. Reaction platform consists of this `reaction` project - which is now primarily our GraphQL API (and for the time being also our operator UI and our identity provider) - alongside our new to 2.0 [Example Storefront](https://github.com/reactioncommerce/example-storefront) - which connects with the Reaction application via GraphQL API to provide a customer-facing storefront.
+Reaction v2.0.0 is built as a truly headless commerce platform that decouples the Reaction backend services from the frontend. We’ve decoupled the storefront application from the API. Reaction platform consists of this `reaction` project - which is now primarily our GraphQL API (and for the time being also our operator UI and our identity provider) - alongside our new-to-2.0 [Example Storefront](https://github.com/reactioncommerce/example-storefront), which connects with the Reaction application via GraphQL API to provide a customer-facing storefront.
 
 ![3-up-Catalyst-UI-lg](https://user-images.githubusercontent.com/20409254/61161477-bb033c80-a4b8-11e9-9c5e-4f4f6a68b8d0.png)
 


### PR DESCRIPTION
Impact: **minor**  
Type: **docs|chore**

## Issue
- The Reaction Component Library is dead. Reaction Design System is dead. Long live the Example Storefront Component Library
- The Operator UI is dead. Long live Reaction Admin.

## Solution
- Rename both Reaction Component Library/Reaction Design System, Reaction Operator UI in the README. Use their real names.
- Ignore the CHANGELOG.md for now. It feels weird/bad/unethical to change the changelog, as it's like rewriting history. This new name will live from here on out.

## Breaking changes
- None

## Testing
1. Read the README
1. Click the links

