### PR TITLE
ci: remove snyk as a CI task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,46 +305,6 @@ jobs:
           command: |
             hadolint Dockerfile
 
-  snyk-security:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - restore_cache:
-          keys:
-            - reaction-v2-node-modules-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - reaction-v2-node-modules-{{ .Branch }}
-            - reaction-v2-node-modules-master
-      - run:
-          name: Snyk Test
-          command: |
-            CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" # Determine PR number from pull request link
-            if [[ -v CIRCLE_PR_NUMBER ]] && [ -n ${CIRCLE_PR_NUMBER} ]; then
-              url="https://api.github.com/repos/${DOCKER_REPOSITORY}/pulls/$CIRCLE_PR_NUMBER" # Get PR from github API
-              TARGET_BRANCH=$(curl "$url" | jq '.base.ref' | tr -d '"') # Determine target/base branch from API response
-            fi
-
-            if [ -z "${TARGET_BRANCH}" ] || [  ${TARGET_BRANCH} == "null" ]; then
-              echo "Not a PR. Skipping Snyk."
-              exit 0
-            fi
-
-            # If target branch does not exist or is master, run snyk tests
-            if [ ${TARGET_BRANCH} == "master" ] || [ -z "${TARGET_BRANCH/[ ]*\n/}" ]; then
-              PATH=$PATH:$CIRCLE_WORKING_DIRECTORY/node_modules/.bin && \
-                snyk test
-            else
-              # If package.json is different from the base branch, run snyk
-              if git diff origin/$CIRCLE_BRANCH..origin/$TARGET_BRANCH package.json | grep diff; then
-                echo "package.json different. Running Snyk."
-                PATH=$PATH:$CIRCLE_WORKING_DIRECTORY/node_modules/.bin && \
-                snyk test
-              else
-                echo "package.json identical to target branch. Skipping Snyk."
-              fi
-            fi
-
 workflows:
   version: 2
   build_and_test:
@@ -371,8 +331,6 @@ workflows:
             - build
       - docker-build:
           context: reaction-build-read
-          requires:
-            - snyk-security
       - docker-push:
           context: reaction-publish-docker
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,3 @@ workflows:
           filters:
             branches:
               only: /^master$/
-      - snyk-security:
-          context: reaction-validation
-          requires:
-            - build


### PR DESCRIPTION
Resolves #5327   
Impact: **minor**  
Type: **ci**

## Issue
Snyk issues are timed randomly, with issues thrown when new bugs are reported. This could affect code we've had in the app for a while, and has nothing to do with the current PR. This causes hassle for committing code to Reaction.

## Solution
Remove the CI snyk process, and rely on the daily scanned results sent to those subscribe to snyk. In the future, we can task a scheduled `snyk` check to make sure these are being taken care of.

## Breaking changes
None

## Testing
1. See that `snyk` did not run in CI