### PR TITLE
feat(producttable): add isvisible/hidden icons

### DIFF
--- a/imports/plugins/included/product-variant/components/productGridItems.js
+++ b/imports/plugins/included/product-variant/components/productGridItems.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { formatPriceString, i18next } from "/client/api";
-import { TableCell, TableRow, Checkbox, IconButton, withStyles } from "@material-ui/core"
+import { TableCell, TableRow, Checkbox, IconButton, withStyles } from "@material-ui/core";
 import PencilIcon from "mdi-material-ui/Pencil";
 import CircleIcon from "mdi-material-ui/CheckboxBlankCircle";
 
@@ -87,7 +87,7 @@ class ProductGridItems extends Component {
     if (product.isVisible) {
       return (
         <div style={{ display: "flex" }}>
-          <CircleIcon className={classes.isVisible}></CircleIcon>
+          <CircleIcon className={classes.isVisible}/>
           <span>{i18next.t("admin.tags.visible")}</span>
         </div>
       );
@@ -95,7 +95,7 @@ class ProductGridItems extends Component {
 
     return (
       <div style={{ display: "flex" }}>
-        <CircleIcon className={classes.isHidden}></CircleIcon>
+        <CircleIcon className={classes.isHidden}/>
         <span>{i18next.t("admin.tags.hidden")}</span>
       </div>
     );

--- a/imports/plugins/included/product-variant/components/productGridItems.js
+++ b/imports/plugins/included/product-variant/components/productGridItems.js
@@ -2,14 +2,26 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { formatPriceString, i18next } from "/client/api";
-import TableCell from "@material-ui/core/TableCell";
-import TableRow from "@material-ui/core/TableRow";
-import Checkbox from "@material-ui/core/Checkbox";
-import IconButton from "@material-ui/core/IconButton";
+import { TableCell, TableRow, Checkbox, IconButton, withStyles } from "@material-ui/core"
 import PencilIcon from "mdi-material-ui/Pencil";
+import CircleIcon from "mdi-material-ui/CheckboxBlankCircle";
+
+const styles = (theme) => ({
+  isVisible: {
+    color: theme.palette.colors.forestGreen300,
+    fontSize: theme.typography.fontSize * 1.25,
+    marginRight: theme.spacing(1)
+  },
+  isHidden: {
+    color: theme.palette.colors.black40,
+    fontSize: theme.typography.fontSize * 1.25,
+    marginRight: theme.spacing(1)
+  }
+});
 
 class ProductGridItems extends Component {
   static propTypes = {
+    classes: PropTypes.object,
     displayPrice: PropTypes.func,
     isSearch: PropTypes.bool,
     isSelected: PropTypes.func,
@@ -69,13 +81,32 @@ class ProductGridItems extends Component {
     );
   }
 
+  renderStatusIcon() {
+    const { product, classes } = this.props;
+
+    if (product.isVisible) {
+      return (
+        <div style={{ display: "flex" }}>
+          <CircleIcon className={classes.isVisible}></CircleIcon>
+          <span>{i18next.t("admin.tags.visible")}</span>
+        </div>
+      );
+    }
+
+    return (
+      <div style={{ display: "flex" }}>
+        <CircleIcon className={classes.isHidden}></CircleIcon>
+        <span>{i18next.t("admin.tags.hidden")}</span>
+      </div>
+    );
+  }
+
   handleSelect = (event) => {
     this.props.onSelect(event.target.checked, this.props.product);
   }
 
   render() {
     const { isSelected, product } = this.props;
-
     const productItem = (
       <TableRow className={`product-table-row-item ${isSelected() ? "active" : ""}`}>
         <TableCell padding="checkbox">
@@ -97,7 +128,7 @@ class ProductGridItems extends Component {
           {this.renderPublishStatus()}
         </TableCell>
         <TableCell>
-          {i18next.t(product.isVisible ? "admin.tags.visible" : "admin.tags.hidden")}
+          {this.renderStatusIcon()}
         </TableCell>
         <TableCell padding="checkbox">
           <IconButton onClick={this.handleDoubleClick}>
@@ -111,4 +142,4 @@ class ProductGridItems extends Component {
   }
 }
 
-export default ProductGridItems;
+export default withStyles(styles)(ProductGridItems);


### PR DESCRIPTION
Resolves #5392   
Impact: **minor**  
Type: **feature**

## Issue
#5392 

## Solution
<img width="1440" alt="Screen Shot 2019-08-01 at 11 19 56 PM" src="https://user-images.githubusercontent.com/3673236/62348930-1d959a00-b4b3-11e9-9304-7421f8b9ac1c.png">
<img width="695" alt="Screen Shot 2019-08-01 at 11 22 42 PM" src="https://user-images.githubusercontent.com/3673236/62349003-487fee00-b4b3-11e9-9ff9-c96c7b069674.png">
- use https://github.com/TeamWertarbyte/mdi-material-ui icon, like the Tag table does
- but use MUI styling, rather than Styled-Components (which is what the Tag table does)

## Breaking changes
No


## Testing
1. http://localhost:3000/operator/products - desktop
1. http://localhost:3000/operator/products - mobile

