### PR TITLE
Correct index migration

### DIFF
--- a/imports/plugins/core/versions/server/migrations/69_make_catalog_product_unique.js
+++ b/imports/plugins/core/versions/server/migrations/69_make_catalog_product_unique.js
@@ -29,9 +29,13 @@ Migrations.add({
   version: 69,
   up() {
     const { Catalog } = rawCollections;
-    Catalog.dropIndex("product.productId", handleError);
-    Catalog.createIndex("product.productId", { unique: true, background: true }, handleError);
-    Catalog.dropIndex("product.product._id", handleError);
-    Catalog.createIndex("product.product._id", { unique: true, background: true }, handleError);
+    Catalog.dropIndex("product.productId", (err) => {
+      if (err) handleError(err);
+      else Catalog.createIndex("product.productId", { unique: true, background: true }, handleError);
+    });
+    Catalog.dropIndex("product.product._id", (err) => {
+      if (err) handleError(err);
+      else Catalog.createIndex("product.product._id", { unique: true, background: true }, handleError);
+    });
   }
 });


### PR DESCRIPTION
Nice


Correctly call the `createIndex` in the callback for `dropIndex` so that the index is always dropped before it's created.
