### PR TITLE
chore: use file extensions for node 12 compatibility

### DIFF
--- a/.reaction/scripts/appSetup.mjs
+++ b/.reaction/scripts/appSetup.mjs
@@ -1,7 +1,7 @@
-import Log from "./logger";
-import loadPlugins from "./loadPlugins";
-import loadStyles from "./loadStyles";
-import provisionAssets from "./provisionAssets";
+import Log from "./logger.mjs";
+import loadPlugins from "./loadPlugins.mjs";
+import loadStyles from "./loadStyles.mjs";
+import provisionAssets from "./provisionAssets.mjs";
 
 export default function appSetup() {
   let start, sec, ns;

--- a/.reaction/scripts/build.mjs
+++ b/.reaction/scripts/build.mjs
@@ -1,3 +1,3 @@
-import appSetup from "./appSetup";
+import appSetup from "./appSetup.mjs";
 
 appSetup();

--- a/.reaction/scripts/fs.mjs
+++ b/.reaction/scripts/fs.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import Log from './logger';
+import Log from './logger.mjs';
 
 /**
  * Synchronously check if a file or directory exists

--- a/.reaction/scripts/loadPlugins.mjs
+++ b/.reaction/scripts/loadPlugins.mjs
@@ -2,9 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import childProcess from 'child_process';
 import _ from 'lodash';
-import Log from './logger';
-import { exists, getDirectories } from './fs';
-import pluginConfig from "../pluginConfig";
+import Log from './logger.mjs';
+import { exists, getDirectories } from './fs.mjs';
+import pluginConfig from "../pluginConfig.js";
 
 // add a message to the top of the plugins import file
 const importFileMessage = `

--- a/.reaction/scripts/loadStyles.mjs
+++ b/.reaction/scripts/loadStyles.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import Log from './logger';
-import { exists, getDirectories } from './fs';
+import Log from './logger.mjs';
+import { exists, getDirectories } from './fs.mjs';
 
 // add a message to the top of the plugins import file
 const importFileMessage = `

--- a/.reaction/scripts/provisionAssets.mjs
+++ b/.reaction/scripts/provisionAssets.mjs
@@ -1,8 +1,8 @@
 import fs  from 'fs-extra';
 import path from 'path';
 import rimraf from 'rimraf';
-import Log from './logger';
-import { exists, getDirectories } from './fs';
+import Log from './logger.mjs';
+import { exists, getDirectories } from './fs.mjs';
 
 
 /**

--- a/.reaction/scripts/run.mjs
+++ b/.reaction/scripts/run.mjs
@@ -1,8 +1,8 @@
 // Assumes Node 8.x
 import _ from "lodash";
 import childProcess from "child_process";
-import Log from "./logger";
-import appSetup from "./appSetup";
+import Log from "./logger.mjs";
+import appSetup from "./appSetup.mjs";
 
 function run() {
   appSetup();


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
Running `npm run dev` with Node 12 throws errors about invalid imports.

Node 12 no longer auto-adds file extensions to import paths in ES modules. Although the app currently runs on Node 8.x, we want to avoid confusion for people using 12 and be ready for the future.

Ref: https://nodejs.org/api/esm.html#esm_mandatory_file_extensions

## Solution
In the build scripts, added explicit extensions to all imports.

## Breaking changes
None

## Testing
Switch to Node 12.x (latest) and `npm run dev`. Verify that the app starts without errors.