### PR TITLE
revert change that broke payment capture

### DIFF
--- a/imports/plugins/core/orders/client/graphql/index.js
+++ b/imports/plugins/core/orders/client/graphql/index.js
@@ -20,17 +20,17 @@ export const approveOrderPayments = async ({ orderId, paymentIds, shopId }) => {
     conversionRequests.push({ namespace: "Payment", id: paymentId });
   });
 
-  // const [
-  //   opaqueOrderId,
-  //   opaqueShopId,
-  //   ...opaquePaymentIds
-  // ] = await getOpaqueIds(conversionRequests);
+  const [
+    opaqueOrderId,
+    opaqueShopId,
+    ...opaquePaymentIds
+  ] = await getOpaqueIds(conversionRequests);
 
   return approveOrderPaymentsMutate({
     input: {
-      orderId,
-      paymentIds,
-      shopId
+      orderId: opaqueOrderId,
+      paymentIds: opaquePaymentIds,
+      shopId: opaqueShopId
     }
   });
 };
@@ -46,17 +46,17 @@ export const captureOrderPayments = async ({ orderId, paymentIds, shopId }) => {
     conversionRequests.push({ namespace: "Payment", id: paymentId });
   });
 
-  // const [
-  //   opaqueOrderId,
-  //   opaqueShopId,
-  //   ...opaquePaymentIds
-  // ] = await getOpaqueIds(conversionRequests);
+  const [
+    opaqueOrderId,
+    opaqueShopId,
+    ...opaquePaymentIds
+  ] = await getOpaqueIds(conversionRequests);
 
   return captureOrderPaymentsMutate({
     input: {
-      orderId,
-      paymentIds,
-      shopId
+      orderId: opaqueOrderId,
+      paymentIds: opaquePaymentIds,
+      shopId: opaqueShopId
     }
   });
 };


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issue
Operators could not capture payments because of a previous update which passed unencoded ID's, instead of encoded ID's to `captureOrderPayments`

## Solution
Revert the change, and fix the new code which benefited from the change in #5405 