### PR TITLE
chore: remove unused shop.appVersion

### DIFF
--- a/imports/collections/schemas/shops.js
+++ b/imports/collections/schemas/shops.js
@@ -318,7 +318,6 @@ registerSchema("StorefrontUrls", StorefrontUrls);
  * @property {Layout[]} layout optional
  * @property {ShopTheme} theme optional
  * @property {BrandAsset[]} brandAssets optional
- * @property {String} appVersion optional
  * @property {Date} createdAt optional
  * @property {Date} updatedAt optional
  * @property {Object[]} paymentMethods blackbox, default value: `[]`
@@ -525,10 +524,6 @@ export const Shop = new SimpleSchema({
   },
   "brandAssets.$": {
     type: BrandAsset
-  },
-  "appVersion": {
-    type: String,
-    optional: true
   },
   "createdAt": {
     type: Date,

--- a/imports/plugins/core/core/server/Reaction/core.js
+++ b/imports/plugins/core/core/server/Reaction/core.js
@@ -1,5 +1,4 @@
 import Logger from "@reactioncommerce/logger";
-import packageJson from "/package.json";
 import _ from "lodash";
 import { Meteor } from "meteor/meteor";
 import { check } from "meteor/check";
@@ -673,28 +672,6 @@ export default {
       return marketplace.settings;
     }
     return {};
-  },
-
-  /**
-   * @name getAppVersion
-   * @method
-   * @memberof Core
-   * @return {String} App version
-   */
-  getAppVersion() {
-    return Shops.findOne().appVersion;
-  },
-
-  /**
-   * @name setAppVersion
-   * @method
-   * @memberof Core
-   * @return {undefined} no return value
-   */
-  setAppVersion() {
-    const { version } = packageJson;
-    Logger.info(`Reaction Version: ${version}`);
-    Shops.update({}, { $set: { appVersion: version } }, { multi: true });
   },
 
   /**

--- a/imports/plugins/core/core/server/startup/index.js
+++ b/imports/plugins/core/core/server/startup/index.js
@@ -25,8 +25,6 @@ export default function startup() {
 
   Reaction.whenAppInstanceReady(register);
 
-  Reaction.setAppVersion();
-
   importAllTranslations();
 
   CollectionSecurity();

--- a/imports/plugins/core/system-info/server/no-meteor/queries/systemInformation.js
+++ b/imports/plugins/core/system-info/server/no-meteor/queries/systemInformation.js
@@ -11,7 +11,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
  **/
 export default async function systemInformation(context, shopId) {
   const { userHasPermission, app: { db } } = context;
-  // sensitive information should be accesible to admins only
+  // sensitive information should be accessible to admins only
   if (!userHasPermission(["admin"], shopId)) throw new ReactionError("access-denied", "User does not have permission");
 
   const mongoAdmin = await db.admin();

--- a/imports/plugins/core/versions/server/migrations/70_remove_shop_app_version.js
+++ b/imports/plugins/core/versions/server/migrations/70_remove_shop_app_version.js
@@ -1,0 +1,9 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Shops } from "/lib/collections";
+
+Migrations.add({
+  version: 70,
+  up() {
+    Shops.update({}, { $unset: { appVersion: "" } }, { multi: true });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -68,3 +68,4 @@ import "./66_attribute_labels";
 import "./67_order_tokens";
 import "./68_add_is_sold_out_to_variants_and_options";
 import "./69_make_catalog_product_unique";
+import "./70_remove_shop_app_version";


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

Part of epic #4996

## Issue
Startup code is setting `appVersion` property on every Shop document. Nothing uses this. It's accessible from the `systemInformation` GraphQL query if needed.

## Solution
- Remove `appVersion` from shop schema
- Remove code that was setting it
- Migration to delete `appVersion` property from the database

## Breaking changes
If custom code is relying on `shop.appVersion`, it will need to be updated to use the `systemInformation` GraphQL query.

## Testing
- Verify app starts
- Look at Shops collection in database and verify shops do not have `appVersion` field. Logging should also show that migration 70 ran successfully.