### PR TITLE
Rewrite addAccountToGroup to not call through to Meteor method

### DIFF
--- a/imports/node-app/core/util/getErrorFormatter.js
+++ b/imports/node-app/core/util/getErrorFormatter.js
@@ -23,6 +23,7 @@ function getErrorFormatter() {
       const eventObj = {
         errorId: err.errorId,
         path: err.path,
+        stack: originalError.stack,
         ...(originalError.eventData || {})
       };
 

--- a/imports/plugins/core/accounts/server/no-meteor/mutations/addAccountToGroup.js
+++ b/imports/plugins/core/accounts/server/no-meteor/mutations/addAccountToGroup.js
@@ -1,0 +1,90 @@
+import ReactionError from "@reactioncommerce/reaction-error";
+import { difference } from "lodash";
+import SimpleSchema from "simpl-schema";
+import ensureRoles from "../util/ensureRoles";
+
+const inputSchema = new SimpleSchema({
+  accountId: String,
+  groupId: String
+});
+
+/**
+ * @name accounts/addAccountToGroup
+ * @memberof Mutations/Accounts
+ * @method
+ * @summary Add an account to a group
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Input arguments
+ * @param {String} input.accountId - The account ID
+ * @param {String} input.groupId - The group ID
+ * @return {Promise<Object>} with updated address
+ */
+export default async function addAccountToGroup(context, input) {
+  inputSchema.validate(input);
+
+  const { accountId, groupId } = input;
+  const {
+    appEvents,
+    collections: {
+      Accounts,
+      Groups,
+      users
+    },
+    user
+  } = context;
+
+  const group = await Groups.findOne({ _id: groupId });
+  if (!group) throw new ReactionError("not-found", "No group found with that ID");
+
+  const { permissions: groupPermissions = [], shopId } = group;
+
+  // An account can add another account to a group as long as the person adding
+  // has all permissions granted by that group.
+  // We can't use `userHasPermission` here because we want to make sure they
+  // have ALL the permissions rather than ANY.
+  if (difference(groupPermissions, user.roles[shopId] || []).length > 0) {
+    throw new ReactionError("access-denied", "Access Denied");
+  }
+
+  const account = await Accounts.findOne({ _id: accountId });
+  if (!account) throw new ReactionError("not-found", "No account found with that ID");
+
+  // Add all group roles to the user
+  await ensureRoles(context, groupPermissions);
+  await users.updateOne({
+    _id: account.userId
+  }, {
+    $addToSet: {
+      [`roles.${shopId}`]: {
+        $each: groupPermissions
+      }
+    }
+  });
+
+  // Save updated groups list, making sure user only belongs to one group per shop
+  const allGroupsInShop = await Groups.find({
+    shopId
+  }, {
+    projection: {
+      _id: 1
+    }
+  }).toArray();
+  const allGroupIDsInShop = allGroupsInShop.map((grp) => grp._id);
+  const newGroups = (account.groups || []).filter((grp) => allGroupIDsInShop.indexOf(grp) === -1);
+  newGroups.push(groupId);
+  await Accounts.updateOne({ _id: accountId }, { $set: { groups: newGroups } });
+
+  const updatedAccount = {
+    ...account,
+    groups: newGroups
+  };
+
+  await appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: user._id,
+    updatedFields: ["groups"]
+  });
+
+  // Return the group the account was added to
+  return Groups.findOne({ _id: groupId });
+}

--- a/imports/plugins/core/accounts/server/no-meteor/mutations/index.js
+++ b/imports/plugins/core/accounts/server/no-meteor/mutations/index.js
@@ -1,5 +1,7 @@
 import addressBookAdd from "./addressBookAdd";
+import addAccountToGroup from "./addAccountToGroup";
 
 export default {
-  addressBookAdd
+  addressBookAdd,
+  addAccountToGroup
 };

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/addAccountToGroup.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/addAccountToGroup.js
@@ -14,11 +14,17 @@ import { decodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/g
  * @param {Object} context - an object containing the per-request state
  * @return {Object} AddAccountToGroupPayload
  */
-export default function addAccountToGroup(parentResult, { input }, context) {
-  const { accountId, groupId, clientMutationId = null } = input;
-  const dbAccountId = decodeAccountOpaqueId(accountId);
-  const dbGroupId = decodeGroupOpaqueId(groupId);
-  const group = context.callMeteorMethod("group/addUser", dbAccountId, dbGroupId);
+export default async function addAccountToGroup(parentResult, { input }, context) {
+  const { accountId: opaqueAccountId, groupId: opaqueGroupId, clientMutationId = null } = input;
+
+  const accountId = decodeAccountOpaqueId(opaqueAccountId);
+  const groupId = decodeGroupOpaqueId(opaqueGroupId);
+
+  const group = await context.mutations.addAccountToGroup(context, {
+    accountId,
+    groupId
+  });
+
   return {
     group,
     clientMutationId

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/addAccountToGroup.test.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/addAccountToGroup.test.js
@@ -1,29 +1,28 @@
 import { encodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
 import { encodeGroupOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/group";
+import mockContext from "/imports/test-utils/helpers/mockContext";
 import addAccountToGroup from "./addAccountToGroup";
 
-test("correctly passes through to group/addUser method", () => {
+mockContext.mutations.addAccountToGroup = jest.fn().mockName("mutations.addAccountToGroup");
+
+test("correctly passes through to internal mutation function", async () => {
   const accountId = encodeAccountOpaqueId("1");
   const groupId = encodeGroupOpaqueId("g1");
   const group = { name: "customer" };
 
   const fakeResult = { _id: "g1", ...group };
 
-  const mockMethod = jest.fn().mockName("group/addUser method");
-  mockMethod.mockReturnValueOnce(fakeResult);
-  const context = {
-    callMeteorMethod: mockMethod
-  };
+  mockContext.mutations.addAccountToGroup.mockReturnValueOnce(Promise.resolve(fakeResult));
 
-  const result = addAccountToGroup(null, {
+  const result = await addAccountToGroup(null, {
     input: {
       accountId,
       groupId,
       clientMutationId: "clientMutationId"
     }
-  }, context);
+  }, mockContext);
 
-  expect(mockMethod).toHaveBeenCalledWith("group/addUser", "1", "g1");
+  expect(mockContext.mutations.addAccountToGroup).toHaveBeenCalledWith(mockContext, { accountId: "1", groupId: "g1" });
 
   expect(result).toEqual({
     group: fakeResult,

--- a/tests/integration/api/mutations/addAccountToGroup/AddAccountToGroupMutation.graphql
+++ b/tests/integration/api/mutations/addAccountToGroup/AddAccountToGroupMutation.graphql
@@ -1,7 +1,19 @@
-query ($accountId: ID!, $groupId: ID!) {
+mutation ($accountId: ID!, $groupId: ID!) {
   addAccountToGroup(input: { accountId: $accountId, groupId: $groupId }) {
     group {
       _id
+      createdAt
+      createdBy {
+        _id
+      }
+      description
+      name
+      permissions
+      shop {
+        _id
+      }
+      slug
+      updatedAt
     }
   }
 }

--- a/tests/integration/api/mutations/addAccountToGroup/__snapshots__/addAccountToGroup.test.js.snap
+++ b/tests/integration/api/mutations/addAccountToGroup/__snapshots__/addAccountToGroup.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`anyone cannot add account to group if they do not have ALL the group permissions 1`] = `[GraphQLError: Access Denied]`;


### PR DESCRIPTION
Resolves #5336   
Impact: **minor**  
Type: **refactor**

## Changes
Rewrites `addAccountToGroup` GraphQL resolver to not use `context.callMeteorMethod`. Adds `addAccountToGroup` internal mutation function and calls that.

## Breaking changes
None

## Testing
Covered by integration tests, but you can manually test `addAccountToGroup` mutation. The UI still uses the Meteor method.