### PR TITLE
refactor: use Accounts collection instead of Meteor.users to get admin accounts

### DIFF
--- a/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
+++ b/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
@@ -27,6 +27,10 @@ const handlers = {
       return updateMethodCall(groupId);
     };
 
+    /**
+     * @param {String} groupId groupId
+     * @return {undefined} undefined
+     */
     function updateMethodCall(groupId) {
       Meteor.call("group/addUser", account._id, groupId, (err) => {
         if (err) {
@@ -39,6 +43,9 @@ const handlers = {
       });
     }
 
+    /**
+     * @return {Component} Alert component
+     */
     function alertConfirm() {
       let changeOwnerWarn = "changeShopOwnerWarn";
       if (Reaction.getShopId() === Reaction.getPrimaryShopId()) {
@@ -66,6 +73,9 @@ const handlers = {
         })
         .catch(() => false);
 
+      /**
+       * @return {undefined} undefined
+       */
       function removeMethodCall() {
         Meteor.call("group/removeUser", account._id, groupId, (err) => {
           if (err) {
@@ -76,6 +86,9 @@ const handlers = {
       }
     };
 
+    /**
+     * @return {Component} Alert component
+     */
     function alertConfirm() {
       return Alert({
         title: i18next.t("admin.settings.removeUser"),

--- a/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
+++ b/imports/plugins/core/accounts/client/containers/accountsDashboardContainer.js
@@ -105,13 +105,9 @@ const composer = (props, onData) => {
       return admGrps;
     }, []);
 
-    const adminQuery = {
-      [`roles.${shopId}`]: "dashboard"
-    };
+    const adminGroupIds = adminGroups.map((adminGroup) => adminGroup._id);
 
-    const adminUsers = Meteor.users.find(adminQuery, { fields: { _id: 1 } }).fetch();
-    const ids = adminUsers.map((user) => user._id);
-    const accounts = Accounts.find({ userId: { $in: ids } }).fetch();
+    const accounts = Accounts.find({ groups: { $in: adminGroupIds } }).fetch();
 
     onData(null, { accounts, groups, adminGroups });
   }


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
Account management tables were only displaying the current user, and not showing all users that were admins (when permissions allowed). This seemed to stem from removing the publication of the `Meteor.users` collection, as we were trying to get users from that collection.

## Solution
Refactor to get users from the `Accounts collection` instead.

## Breaking changes
None.

## Testing
1. Invite a `Shop manager`
1. As the shop manager, go to the accounts page and see you can only see your own account
1. As the shop admin (`admin@localhost`), see that you can see your own account, in addition to the shop admin account, in the accounts tables
1. Create a new user group, and see you can move the users between groups

![Accounts](https://user-images.githubusercontent.com/4482263/62646640-96f21a00-b903-11e9-8405-b8118b35b900.png)