### PR TITLE
fix partial product publish error

### DIFF
--- a/imports/plugins/core/catalog/server/no-meteor/mutations/publishProducts.js
+++ b/imports/plugins/core/catalog/server/no-meteor/mutations/publishProducts.js
@@ -39,7 +39,10 @@ export default async function publishProducts(context, productIds) {
   const success = await publishProductsToCatalog(productIds, context);
   if (!success) {
     Logger.error("Some Products could not be published to the Catalog.");
-    throw new ReactionError("server-error", "Some Products could not be published to the Catalog. Make sure your variants are visible.");
+    throw new ReactionError(
+      "server-error",
+      "Some Products could not be published to the Catalog. Make sure the parent product and its variants and options are visible."
+    );
   }
   return Catalog.find({ "product.productId": { $in: productIds } }).toArray();
 }

--- a/imports/plugins/core/inventory/server/no-meteor/utils/publishProductToCatalog.js
+++ b/imports/plugins/core/inventory/server/no-meteor/utils/publishProductToCatalog.js
@@ -8,6 +8,9 @@ import ReactionError from "@reactioncommerce/reaction-error";
  */
 export default async function publishProductToCatalog(catalogProduct, { context }) {
   const { productId, shopId } = catalogProduct;
+  // If the product being published does not have variants, do not
+  // attempt to publish inventory information.
+  if (!catalogProduct.variants.length) return;
 
   // Most inventory information is looked up and included at read time, when
   // preparing a response to a GraphQL query, but we need to store some


### PR DESCRIPTION
Resolves #5414   
Impact: minor
Type: bugfix

## Issue
When attempting to publish a product and itself and variants are invisible, an ambiguous error would occur without notifying the user of the cause.

## Solution
Prevent publishing inventory information when variants are not visible.

# Testing
1. Create a new product with variants + options and leave all set to Invisible
2.  Attempt to publish
3. Observe notification informing user that the product and variants or not visible.
