### PR TITLE
chore: update bodyParser to use individual method

### DIFF
--- a/imports/node-app/core/createApolloServer.js
+++ b/imports/node-app/core/createApolloServer.js
@@ -75,7 +75,7 @@ export default function createApolloServer(options = {}) {
     // set a higher limit for data transfer, which can help with GraphQL mutations
     // `express` default is 100kb
     // AWS default is 5mb, which we'll use here
-    bodyParser({ limit: config.BODY_PARSER_SIZE_LIMIT }),
+    bodyParser.json({ limit: config.BODY_PARSER_SIZE_LIMIT }),
     // Enable `cors` to set HTTP response header: Access-Control-Allow-Origin: *
     // Although the `cors: true` option to `applyMiddleware` below does this already
     // for successful requests, we need it to be set here, before tokenMiddleware,


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
`bodyParser()` was presenting a warning on app startup because we were using it in a deprecated way

## Solution
Update the code to conform to their updated standards by calling an individual method on `bodyParser`, instead of the entire `bodyParser` code.

## Breaking changes
None

## Testing
1. Start the app and see that we no longer see the warning

<img width="1014" alt="Screenshot_8_7_19__12_55_PM" src="https://user-images.githubusercontent.com/4482263/62653527-9c0a9580-b912-11e9-9547-502d6de2e056.png">