### PR TITLE
refactor: add tag permissions to allow non-owner to edit

### DIFF
--- a/imports/plugins/core/tags/server/no-meteor/mutations/updateTag.js
+++ b/imports/plugins/core/tags/server/no-meteor/mutations/updateTag.js
@@ -33,7 +33,7 @@ export default async function updateTag(context, input) {
   const { shopId, tagId, slug: slugInput } = input;
 
   // Check for owner or admin permissions from the user before allowing the mutation
-  if (!userHasPermission(["owner", "admin"], shopId)) {
+  if (!userHasPermission(["owner", "admin", "tag/admin", "tag/edit"], shopId)) {
     throw new ReactionError("access-denied", "User does not have permission");
   }
 

--- a/imports/plugins/core/tags/server/no-meteor/queries/productsByTagId.js
+++ b/imports/plugins/core/tags/server/no-meteor/queries/productsByTagId.js
@@ -18,7 +18,7 @@ export default async function productsByTagId(context, params) {
   const { Products, Tags } = collections;
 
   // Check for owner or admin permissions from the user before allowing the query
-  if (!userHasPermission(["owner", "admin"], shopId)) {
+  if (!userHasPermission(["owner", "admin", "tag/admin", "tag/edit"], shopId)) {
     throw new ReactionError("access-denied", "User does not have permission");
   }
 

--- a/imports/plugins/core/tags/server/no-meteor/register.js
+++ b/imports/plugins/core/tags/server/no-meteor/register.js
@@ -46,6 +46,16 @@ export default async function register(app) {
           dashboardSize: "md"
         }
       }
+    }, {
+      route: "tag/admin",
+      label: "Tag Admin",
+      permission: "tagAdmin",
+      name: "tag/admin"
+    }, {
+      route: "tag/edit",
+      label: "Edit Tag",
+      permission: "tagEdit",
+      name: "tag/edit"
     }],
     layout: [{
       layout: "coreLayout",


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

## Issue
Operators that didnt' have full `admin` or `owner` permissions could not edit tags.

## Solution
Add two new permissions which will granulize tag permissions to allow other users the ability to edit tags.

## Breaking changes
None. These are new permissions that won't affect existing permissions

## Testing
1. Create a non-admin / owner (Shop Manager) account
1. See that you can edit tags if the correct permissions are turned on
![Accounts](https://user-images.githubusercontent.com/4482263/62657443-5acab380-b91b-11e9-80de-b73580433528.png)