### PR TITLE
Fix popover z-index

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/variables.less
+++ b/imports/plugins/included/default-theme/client/styles/variables.less
@@ -523,7 +523,7 @@
 
 @zindex-navbar:            1000;
 @zindex-dropdown:          1000;
-@zindex-popover:           1060;
+@zindex-popover:           1200;
 @zindex-tooltip:           1070;
 @zindex-navbar-fixed:      1030;
 @zindex-modal-background:  1040;


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
Buttons with popovers (ie the Group selector in the Add Admin User form) aren't working properly because their z-index is 1060 whereas the Mui Drawers on the left and right hand sides are using the default of 1200.

## Solution
Increase z-index of popovers to 1200

## Testing
Visit `operator/accounts`
Click `Manage Groups`
Observe the behavior of the dropdown that selects User Group. The Popover (dropdown menu) should be visible.
![image](https://user-images.githubusercontent.com/492653/62659036-552f9680-b938-11e9-90ec-51ab7d64a672.png)


