### PR TITLE
chore: add redirect for blank route

### DIFF
--- a/imports/plugins/core/ui/client/components/app/app.js
+++ b/imports/plugins/core/ui/client/components/app/app.js
@@ -99,7 +99,7 @@ class App extends Component {
     const { currentRoute } = this.props;
 
     // Since we currently don't have any content on `/`, forward to /operator when landing on `/`
-    if (currentRoute.route.fullPath === "/") {
+    if (currentRoute && currentRoute.route && currentRoute.route.fullPath === "/") {
       window.location.replace("/operator");
     }
 

--- a/imports/plugins/core/ui/client/components/app/app.js
+++ b/imports/plugins/core/ui/client/components/app/app.js
@@ -97,6 +97,12 @@ class App extends Component {
     });
 
     const { currentRoute } = this.props;
+
+    // Since we currently don't have any content on `/`, forward to /operator when landing on `/`
+    if (currentRoute.route.fullPath === "/") {
+      window.location.replace("/operator");
+    }
+
     const layout = currentRoute && currentRoute.route && currentRoute.route.options && currentRoute.route.options.layout;
     if (this.isAdminApp && layout !== "printLayout" && !this.noAdminControls) {
       if (currentRoute.route.path.startsWith("/operator")) {


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
`localhost:3000` /  the `/` route of the app has no content on it, so when you log into that page, you see a blank page.

## Solution
Check to see if the browser is on `/`, and if so, redirect to `/operator` where our content lives.

## Breaking changes
No breaking changes for our core code. If anyone has custom packages use the `/` route, this will break their page and redirect to `/operator`.

## Testing
1. Login to Reaction Admin
1. See you are redirected to `/operator`
1. Directly type `localhost:3000` in the browser
1. See it redirects to `/operator`
1. See other routes work