### PR TITLE
Ensure sharp native addon can find ZLIB_1.2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM reactioncommerce/base:v1.8.0.2-meteor as meteor-dev
 LABEL maintainer="Reaction Commerce <architecture@reactioncommerce.com>"
 
 ENV PATH $PATH:/home/node/.meteor:$APP_SOURCE_DIR/node_modules/.bin
+ENV LD_LIBRARY_PATH=/opt/reaction/src/node_modules/sharp/vendor/lib:/lib/x86_64-linux-gnu:/usr/lib
 
 COPY --chown=node package-lock.json $APP_SOURCE_DIR/
 COPY --chown=node package.json $APP_SOURCE_DIR/


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
In some cases reaction was failing to start with the `sharp` npm package failing to load while trying to dynamically link from its native add-on to ZLIB_1.2.9.  Our base OS image is debian stretch which includes ZLIB_1.2.8 only. `sharp` bundles (vendors) its own version so it ends up on disk but was not being linked in properly.

## Solution

Place the directory containing the sharp vendored libz files first on the `LD_LIBRARY_PATH` environment variable.

**NOTE** I don't believe this is strictly necessary to merge into reaction core as we've only seen issues in combination with particular customer plugins. However, I think it is prudent for us to do so.

Also note there are at least 3 places we could do this:

1. In the reactiocommerce/base docker image `Dockerfile`
2. In the reactioncommerce/reaction `docker-compose.yml`
3. In the reactioncommerce/reaction `Dockerfile` (what this PR changes). I think this is the right place but it's debatable.



## Breaking changes

I don't believe this will break anything, especially not in core & included plugins but because this env var is a key piece of dynamic linking it has potential to affect many things on the system including any node packages with native-addons including any third-party reaction plugin dependencies.

## Testing

Start reaction and run a normal regression test. If it works without crashing, this fix is verified.