### PR TITLE
feat: add new setting to allow / disallow custom user locale lookup

### DIFF
--- a/imports/collections/schemas/shops.js
+++ b/imports/collections/schemas/shops.js
@@ -568,6 +568,11 @@ export const Shop = new SimpleSchema({
     type: StorefrontUrls,
     optional: true,
     defaultValue: {}
+  },
+  "allowCustomUserLocale": {
+    type: Boolean,
+    defaultValue: true,
+    label: "Allow custom user locale"
   }
 });
 

--- a/imports/collections/schemas/shops.js
+++ b/imports/collections/schemas/shops.js
@@ -572,6 +572,7 @@ export const Shop = new SimpleSchema({
   "allowCustomUserLocale": {
     type: Boolean,
     defaultValue: true,
+    optional: true,
     label: "Allow custom user locale"
   }
 });

--- a/imports/plugins/core/core/server/methods/shop/getLocale.js
+++ b/imports/plugins/core/core/server/methods/shop/getLocale.js
@@ -17,7 +17,6 @@ import GeoCoder from "../../util/geocoder";
 export default function getLocale() {
   this.unblock();
   let clientAddress;
-  const geo = new GeoCoder();
   const result = {};
   let defaultCountryCode = "US";
   let localeCurrency = "USD";
@@ -32,6 +31,7 @@ export default function getLocale() {
   const shop = Shops.findOne(Reaction.getShopId(), {
     fields: {
       addressBook: 1,
+      allowCustomUserLocale: 1,
       locales: 1,
       currencies: 1,
       currency: 1
@@ -50,8 +50,14 @@ export default function getLocale() {
       }
     }
   }
+
+  // If custom user locales are allowed,
   // geocode reverse ip lookup
-  const geoCountryCode = geo.geoip(clientAddress).country_code;
+  let geoCountryCode;
+  if (shop && shop.allowCustomUserLocale === true) {
+    const geo = new GeoCoder();
+    geoCountryCode = geo.geoip(clientAddress).country_code;
+  }
 
   // countryCode either from geo or defaults
   const countryCode = (geoCountryCode || defaultCountryCode).toUpperCase();

--- a/imports/plugins/core/dashboard/client/containers/packageListContainer.js
+++ b/imports/plugins/core/dashboard/client/containers/packageListContainer.js
@@ -41,6 +41,12 @@ function handleOpenShortcut(event, app) {
   Reaction.showActionView(app);
 }
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   const audience = Roles.getRolesForUser(Reaction.getUserId(), Reaction.getShopId());
   const settings = Reaction.Apps({ provides: "settings", enabled: true, audience }) || [];

--- a/imports/plugins/core/hydra-oauth/client/containers/auth.js
+++ b/imports/plugins/core/hydra-oauth/client/containers/auth.js
@@ -150,6 +150,12 @@ class OAuthFormContainer extends Component {
   }
 }
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   onData(null, { currentRoute: Router.current() });
 }

--- a/imports/plugins/core/i18n/client/components/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/components/localizationSettings.js
@@ -199,6 +199,9 @@ class LocalizationSettings extends Component {
               language: {
                 type: "select",
                 options: this.props.enabledLanguages
+              },
+              allowCustomUserLocale: {
+                type: "boolean",
               }
             }}
             name="localization"

--- a/imports/plugins/core/i18n/client/components/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/components/localizationSettings.js
@@ -201,7 +201,7 @@ class LocalizationSettings extends Component {
                 options: this.props.enabledLanguages
               },
               allowCustomUserLocale: {
-                type: "boolean",
+                type: "boolean"
               }
             }}
             name="localization"

--- a/imports/plugins/core/i18n/client/containers/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/containers/localizationSettings.js
@@ -45,7 +45,8 @@ const wrapComponent = (Comp) => (
           currency: doc.currency,
           baseUOM: doc.baseUOM,
           baseUOL: doc.baseUOL,
-          language: doc.language
+          language: doc.language,
+          allowCustomUserLocale: doc.allowCustomUserLocale
         }
       });
     }

--- a/imports/plugins/core/i18n/client/containers/localizationSettings.js
+++ b/imports/plugins/core/i18n/client/containers/localizationSettings.js
@@ -99,6 +99,12 @@ const wrapComponent = (Comp) => (
   }
 );
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   const languages = [];
   const shop = Shops.findOne();

--- a/imports/plugins/core/layout/client/containers/adminContainer.js
+++ b/imports/plugins/core/layout/client/containers/adminContainer.js
@@ -1,6 +1,12 @@
 import { composeWithTracker } from "@reactioncommerce/reaction-components";
 import { Reaction } from "/client/api";
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   const shortcuts = Reaction.Apps({ provides: "shortcut", enabled: true });
   const items = [];
@@ -38,6 +44,11 @@ function composer(props, onData) {
   });
 }
 
+/**
+ * @private
+ * @param {Component} component component to wrap
+ * @returns {Component} wrapped component
+ */
 export default function AdminContainer(component) {
   return composeWithTracker(composer)(component);
 }

--- a/imports/plugins/core/layout/client/containers/quickMenuContainer.js
+++ b/imports/plugins/core/layout/client/containers/quickMenuContainer.js
@@ -3,6 +3,12 @@ import { composeWithTracker } from "@reactioncommerce/reaction-components";
 import { QuickMenu } from "../components";
 import { Reaction } from "/client/api";
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   const shortcuts = Reaction.Apps({ provides: "shortcut", enabled: true });
   const items = [];

--- a/imports/plugins/core/layout/lib/reactionLayout.js
+++ b/imports/plugins/core/layout/lib/reactionLayout.js
@@ -112,6 +112,12 @@ ReactionLayout.propTypes = {
   layoutProps: PropTypes.object
 };
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   const sub = Meteor.subscribe("Templates");
 

--- a/imports/plugins/core/ui/client/containers/alerts.js
+++ b/imports/plugins/core/ui/client/containers/alerts.js
@@ -17,6 +17,12 @@ const handlers = {
   }
 };
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   const alerts = ReactionAlerts.collection_.find({
     "options.placement": props.placement || "",

--- a/imports/plugins/core/ui/client/containers/tagListContainer.js
+++ b/imports/plugins/core/ui/client/containers/tagListContainer.js
@@ -222,6 +222,12 @@ const wrapComponent = (Comp) => (
   }
 );
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   let { tags } = props;
 

--- a/imports/plugins/core/ui/client/providers/adminContextProvider.js
+++ b/imports/plugins/core/ui/client/providers/adminContextProvider.js
@@ -23,6 +23,12 @@ class AdminContextProvider extends Component {
   }
 }
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   onData(null, {
     adminContext: {

--- a/imports/plugins/core/ui/client/providers/translationProvider.js
+++ b/imports/plugins/core/ui/client/providers/translationProvider.js
@@ -24,6 +24,12 @@ TranslationProvider.propTypes = {
   translations: PropTypes.object.isRequired
 };
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   i18nextDep.depend();
 

--- a/imports/plugins/core/versions/server/migrations/71_add_allow_custom_user_locale.js
+++ b/imports/plugins/core/versions/server/migrations/71_add_allow_custom_user_locale.js
@@ -1,0 +1,9 @@
+import { Migrations } from "meteor/percolate:migrations";
+import { Shops } from "/lib/collections";
+
+Migrations.add({
+  version: 71,
+  up() {
+    Shops.update({}, { $set: { allowCustomUserLocale: true } }, { multi: true });
+  }
+});

--- a/imports/plugins/core/versions/server/migrations/index.js
+++ b/imports/plugins/core/versions/server/migrations/index.js
@@ -69,3 +69,4 @@ import "./67_order_tokens";
 import "./68_add_is_sold_out_to_variants_and_options";
 import "./69_make_catalog_product_unique";
 import "./70_remove_shop_app_version";
+import "./71_add_allow_custom_user_locale";

--- a/imports/plugins/included/notifications/client/containers/notification.js
+++ b/imports/plugins/included/notifications/client/containers/notification.js
@@ -5,6 +5,12 @@ import { Notifications } from "/lib/collections";
 import { Reaction } from "/client/api";
 import { Notification } from "../components";
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   if (Meteor.subscribe("Notification", Reaction.getUserId()).ready()) {
     const notificationList = Notifications.find({}, { sort: { timeSent: -1 }, limit: 5 }).fetch();

--- a/imports/plugins/included/notifications/client/containers/notificationRoute.js
+++ b/imports/plugins/included/notifications/client/containers/notificationRoute.js
@@ -14,6 +14,12 @@ const handlers = {
   }
 };
 
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   if (Meteor.subscribe("Notification", Reaction.getUserId()).ready()) {
     const notificationList = Notifications.find({}, { sort: { timeSent: -1 } }).fetch();

--- a/imports/plugins/included/product-detail-simple/client/containers/publish.js
+++ b/imports/plugins/included/product-detail-simple/client/containers/publish.js
@@ -50,7 +50,12 @@ class ProductPublishContainer extends Component {
   }
 }
 
-
+/**
+ * @private
+ * @param {Object} props Props
+ * @param {Function} onData Call this to update props
+ * @returns {undefined}
+ */
 function composer(props, onData) {
   const product = ReactionProduct.selectedProduct();
   let revisonDocumentIds;


### PR DESCRIPTION
Same as #5442 but hopefully with all the commits that weren't being seen in that PR.

Impact: **minor**  
Type: **feature|refactor**

## Issue
When checking a users locale, we hit an external server every time the app refreshes, which can be taxing on performance, and cost.

## Solution
Add an option to not allow custom user locales, which will skip this check and use the default store locale. This can be beneficial for any shop which doesn't wish to take the performance hit of the constant external server hit, and also for shops which only have one language / currency and a locale check is not needed.

## Breaking changes
None. By default, the old settings of checking the locale are enable.

## Testing
Since we [don't have an IP address that's locale based](https://github.com/reactioncommerce/reaction/blob/refactor-kieckhafer-customUserLocaleOption/imports/plugins/core/core/server/util/geocoder.js#L113) when developing locally, the easiest way to test is to `console.log` inside of this check, and see that the log shows / doesn't show depending on the settings: https://github.com/reactioncommerce/reaction/blob/refactor-kieckhafer-customUserLocaleOption/imports/plugins/core/core/server/methods/shop/getLocale.js#L57