### PR TITLE
fix: add check against missing riskLevel field, and missing string in capitalization function

### DIFF
--- a/imports/plugins/core/orders/client/components/OrderPayment.js
+++ b/imports/plugins/core/orders/client/components/OrderPayment.js
@@ -106,7 +106,7 @@ function OrderPayment(props) {
         <Typography paragraph variant="h4">
           {displayName}
         </Typography>
-        {riskLevel !== "normal" && payment.mode !== "captured" &&
+        {riskLevel && riskLevel !== "normal" && payment.mode !== "captured" &&
           <Typography className={classes.dangerText} variant="body2">
             Payment risk level: {capitalizeString(riskLevel)}
           </Typography>

--- a/imports/utils/capitalizeString.js
+++ b/imports/utils/capitalizeString.js
@@ -9,7 +9,7 @@
  * @returns {String} original string, transformed with capitalizations
  */
 export default function capitalizeString(string, options) {
-  // if (!string) return null;
+  if (!string) return null;
 
   if (options && options.titleCase) {
     const str = string.toLowerCase().split(" ");

--- a/imports/utils/capitalizeString.js
+++ b/imports/utils/capitalizeString.js
@@ -9,6 +9,8 @@
  * @returns {String} original string, transformed with capitalizations
  */
 export default function capitalizeString(string, options) {
+  // if (!string) return null;
+
   if (options && options.titleCase) {
     const str = string.toLowerCase().split(" ");
     for (let i = 0; i < str.length; i++) { // eslint-disable-line


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issue
Based on using `Stripe` and the example payment method for testing, where `riskLevel` always exists, we missed the possibility that `riskLevel` did not exist on another payment type. Because of this, when another payment provider is used, and `riskLevel` isn't present, the orders ui throws an error and shows a blank screen as we are missing data.

## Solution
- Add a check to make sure `riskLevel` exists before trying to display it
- Add a check to make sure a string exists inside a function that is capitalizing said string

## Breaking changes
None


## Testing
1. Create an order
1. Go into the database, and manually delete the `riskLevel` field from the payment on the order
1. Go to the Orders admin, click on an order
1. Add `-beta` into the URL to see the new UI - http://localhost:3000/operator/orders-beta/{order-id} 
1. see that the page still loads even with the missing field