### PR TITLE
Feat bulk actions UI updates

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -136,16 +136,16 @@ function ProductTable({ onCreateProduct }) {
     } else {
       setFilteredProductIdsCount(count);
     }
-    return;
   };
 
   const iconComponents = {
     iconDismiss: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" /><path d="M0 0h24v24H0z" fill="none" /></svg>
   };
 
+  // eslint-disable-next-line react/no-multi-comp
   const renderMissedFilterItems = () => {
     if (!Session.get("filterByProductIds")) {
-      return "";
+      return null;
     }
     const filterProductIds = Session.get("filterByProductIds").length;
     if (isFiltered && filteredProductIdsCount < filterProductIds) {
@@ -162,12 +162,12 @@ function ProductTable({ onCreateProduct }) {
         </Grid>
       );
     }
-    return "";
+    return null;
   };
 
-  const renderNoProductsFoundError = () => {
-    if (noProductsFoundError) {
-      return (
+  return (
+    <Grid container spacing={3}>
+      { noProductsFoundError ? (
         <Grid item sm={12}>
           <InlineAlert
             isDismissable
@@ -177,14 +177,7 @@ function ProductTable({ onCreateProduct }) {
             message={i18next.t("admin.noProductsFoundText")}
           />
         </Grid>
-      );
-    }
-    return "";
-  };
-
-  return (
-    <Grid container spacing={3}>
-      {renderNoProductsFoundError()}
+      ) : null }
       <Grid item sm={12} style={{ display: displayCard }}>
         <Card raised>
           <CardHeader
@@ -253,7 +246,7 @@ function ProductTable({ onCreateProduct }) {
             message={i18next.t("admin.showingFilteredProducts", { count: filteredProductIdsCount })}
           />
         </Grid>
-      ) : "" }
+      ) : null }
       {renderMissedFilterItems()}
       <Grid item sm={12}>
         <Components.ProductsAdmin

--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -8,7 +8,6 @@ import ImportIcon from "mdi-material-ui/Download";
 import { useDropzone } from "react-dropzone";
 import { i18next } from "/client/api";
 import { Session } from "meteor/session";
-import _ from "lodash";
 import Chip from "@reactioncommerce/catalyst/Chip";
 import withCreateProduct from "../hocs/withCreateProduct";
 
@@ -80,8 +79,6 @@ function ProductTable({ onCreateProduct }) {
             Session.set("filterByProductIds", productIds);
             setClosed(true);
             setFiltered(true);
-            const selectedProductIds = _.uniq(productIds);
-            Session.set("productGrid/selectedProducts", selectedProductIds);
           });
       };
       return;
@@ -94,6 +91,7 @@ function ProductTable({ onCreateProduct }) {
     if (newFiles.length === 0) {
       setFiltered(false);
       Session.delete("filterByProductIds");
+      Session.set("productGrid/selectedProducts", []);
     } else if (isFiltered) {
       importFiles(newFiles);
     }
@@ -133,9 +131,9 @@ function ProductTable({ onCreateProduct }) {
       Session.delete("filterByProductIds");
       setFiles([]);
       setNoProductsFoundError(true);
-    } else {
-      setFilteredProductIdsCount(count);
+      Session.set("productGrid/selectedProducts", []);
     }
+    setFilteredProductIdsCount(count);
   };
 
   const iconComponents = {

--- a/imports/plugins/included/product-admin/server/i18n/en.json
+++ b/imports/plugins/included/product-admin/server/i18n/en.json
@@ -9,7 +9,7 @@
         "showingFilteredProducts": "Showing {{count}} found product from imported file(s).",
         "showingFilteredProducts_plural": "Showing {{count}} found products from imported file(s).",
         "productListIdsNotFound": "{{missing}} of {{all}} products not found",
-        "missingFilteredProducts": "{{count}} product IDs could not be found in the catalog.",
+        "missingFilteredProducts": "{{count}} product ID could not be found in the catalog.",
         "missingFilteredProducts_plural": "{{count}} product IDs could not be found in the catalog.",
         "noProductsFoundTitle": "No products found",
         "noProductsFoundText": "No product IDs could be found in the catalog.",

--- a/imports/plugins/included/product-admin/server/i18n/en.json
+++ b/imports/plugins/included/product-admin/server/i18n/en.json
@@ -7,6 +7,10 @@
         "createProduct": "Create product",
         "productListFiltered": "Product list filtered",
         "showingFilteredProducts": "Showing {{count}} found products from imported file(s).",
+        "productListIdsNotFound": "{{missing}} of {{all}} products not found",
+        "missingFilteredProducts": "{{count}} product IDs could not be found in the catalog.",
+        "noProductsFoundTitle": "No products found",
+        "noProductsFoundText": "No product IDs could be found in the catalog.",
         "productAdmin": {
           "details": "Details",
           "metadata": "Metadata",

--- a/imports/plugins/included/product-admin/server/i18n/en.json
+++ b/imports/plugins/included/product-admin/server/i18n/en.json
@@ -6,9 +6,11 @@
       "admin": {
         "createProduct": "Create product",
         "productListFiltered": "Product list filtered",
-        "showingFilteredProducts": "Showing {{count}} found products from imported file(s).",
+        "showingFilteredProducts": "Showing {{count}} found product from imported file(s).",
+        "showingFilteredProducts_plural": "Showing {{count}} found products from imported file(s).",
         "productListIdsNotFound": "{{missing}} of {{all}} products not found",
         "missingFilteredProducts": "{{count}} product IDs could not be found in the catalog.",
+        "missingFilteredProducts_plural": "{{count}} product IDs could not be found in the catalog.",
         "noProductsFoundTitle": "No products found",
         "noProductsFoundText": "No product IDs could be found in the catalog.",
         "productAdmin": {

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -25,6 +25,9 @@ import Chip from "@reactioncommerce/catalyst/Chip";
 import withStyles from "@material-ui/core/styles/withStyles";
 
 const styles = (theme) => ({
+  leftChip: {
+    marginRight: theme.spacing(1)
+  },
   toolbar: {
     paddingLeft: 0,
     paddingRight: 0,
@@ -228,12 +231,12 @@ class ProductGrid extends Component {
   }
 
   renderFiles() {
-    const { files, handleDelete, isFiltered } = this.props;
+    const { files, handleDelete, isFiltered, classes } = this.props;
 
     if (isFiltered) {
       return (
         <div>
-          {files.map((file) => <Chip label={file.name} onDelete={() => handleDelete(file.name)} />)}
+          {files.map((file, idx) => <Chip label={file.name} key={idx} className={classes.leftChip} onDelete={() => handleDelete(file.name)} />)}
         </div>
       );
     }

--- a/imports/plugins/included/product-variant/components/products.js
+++ b/imports/plugins/included/product-variant/components/products.js
@@ -16,7 +16,7 @@ import { getTagIds as getIds } from "/lib/selectors/tags";
 class Products extends Component {
   static propTypes = {
     canLoadMoreProducts: PropTypes.bool,
-    files: PropTypes.arrayOf(PropTypes.file),
+    files: PropTypes.arrayOf(PropTypes.object),
     handleDelete: PropTypes.func,
     isFiltered: PropTypes.bool,
     isProductsSubscriptionReady: PropTypes.bool,

--- a/imports/plugins/included/product-variant/containers/productGridContainer.js
+++ b/imports/plugins/included/product-variant/containers/productGridContainer.js
@@ -156,6 +156,11 @@ function composer(props, onData) {
     };
   });
 
+  if (Session.get("filterByProductIds")) {
+    const selectedProductIds = Object.keys(productMediaById);
+    Session.set("productGrid/selectedProducts", selectedProductIds);
+  }
+
   onData(null, {
     productMediaById,
     page: Session.get("products/page") || 0,


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
This includes the following UI fixes for Bulk Actions:
- Navigational dead end when no products match the uploaded CSVs: Instead the UI is reset and a red (error) InlineAlert is shown saying that no products were found.
- Proper spacing (16px) between filename chips
- If CSV contains some (but not all) product ids that weren't matched, a red (error) InlineAlert is shown after the green one with the count of products not found.
- All filtered products are automatically selected

## Breaking changes
n/a

## Testing
Verify the above are properly implemented and styled
