### PR TITLE
Fix console warnings

### DIFF
--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -165,11 +165,12 @@ class ProductGrid extends Component {
 
   renderProductGridItems() {
     const { productMediaById, products } = this.props;
+    const { classes, ...notClasses } = this.props;
 
     if (Array.isArray(products) && products.length > 0) {
       return products.map((product, index) => (
         <Components.ProductGridItems
-          {...this.props}
+          {...notClasses}
           product={product}
           productMedia={productMediaById[product._id]}
           key={index}

--- a/imports/plugins/included/product-variant/components/products.js
+++ b/imports/plugins/included/product-variant/components/products.js
@@ -16,7 +16,7 @@ import { getTagIds as getIds } from "/lib/selectors/tags";
 class Products extends Component {
   static propTypes = {
     canLoadMoreProducts: PropTypes.bool,
-    files: PropTypes.arrayOf(PropTypes.file),
+    files: PropTypes.arrayOf(PropTypes.object),
     handleDelete: PropTypes.func,
     isFiltered: PropTypes.bool,
     isProductsSubscriptionReady: PropTypes.bool,


### PR DESCRIPTION
Resolves #5462 
Impact: **minor**  
Type: **bugfix**

## Issue
#5462 

## Solution
Stopped passing `classes` down to ProductGridItems. Also fixed an invalid PropType that caused an unrelated console error.

## Breaking changes
N/A


## Testing
Load /operator/products, watch JS console, verify that material-ui warnings as well as invalid PropType warning are resolved.
