### PR TITLE
fix(product table): style the product table as close as possible

### DIFF
--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -47,22 +47,43 @@ const styles = (theme) => ({
   },
   actionDropdownTrigger: {
     border: `1px solid ${theme.palette.colors.coolGrey}`,
-    fontSize: "16px",
+    fontSize: theme.typography.fontSize,
     letterSpacing: "0.3px",
-    fontWeight: 600,
-    color: theme.palette.colors.coolGrey500
+    fontWeight: theme.typography.fontWeightSemiBold,
+    color: theme.palette.colors.coolGrey500,
+    lineHeight: 1.5
   },
   actionDropdownMenuList: {
     border: `1px solid ${theme.palette.colors.black10}`,
-    fontSize: "16px",
+    fontSize: theme.typography.fontSize,
     letterSpacing: "0.3px"
   },
   actionDropdownMenuItem: {
-    "fontSize": "16px",
-    "letterSpacing": "0.3px",
-    "&:hover": {
-      backgroundColor: "#EBF7FC"
+    "fontSize": theme.typography.fontSize,
+    "letterSpacing": "0.3px"
+  },
+  tableBody: {
+    "& tr:nth-child(odd)": {
+      backgroundColor: theme.palette.colors.black02
     }
+  },
+  tableHead: {
+    "& tr th": {
+      borderBottom: "none",
+      fontWeight: theme.typography.fontWeightSemiBold,
+      letterSpacing: "0.5px",
+      padding: 0,
+      color: theme.palette.colors.coolGrey500
+    },
+    "& tr th:first-child": {
+      padding: "7px 0 1px 4px"
+    }
+  },
+  pagination: {
+    borderBottom: "none",
+    color: theme.palette.colors.coolGrey500,
+    letterSpacing: "0.28px",
+    paddingTop: theme.spacing(2)
   }
 });
 
@@ -367,7 +388,7 @@ class ProductGrid extends Component {
   }
 
   render() {
-    const { totalProductCount, page, productsPerPage, onChangePage, onChangeRowsPerPage } = this.props;
+    const { totalProductCount, page, productsPerPage, onChangePage, onChangeRowsPerPage, classes } = this.props;
     const { isAllSelected } = this.state;
     this.props.setFilteredProductIdsCount(totalProductCount);
 
@@ -378,9 +399,9 @@ class ProductGrid extends Component {
           {this.renderToolbar()}
           {this.renderFiles()}
           <Table>
-            <TableHead>
+            <TableHead className={classes.tableHead}>
               <TableRow>
-                <TableCell padding="checkbox">
+                <TableCell>
                   <Checkbox
                     onClick={this.handleSelectAll}
                     checked={isAllSelected}
@@ -388,24 +409,28 @@ class ProductGrid extends Component {
                 </TableCell>
                 <TableCell />
                 <TableCell>Title</TableCell>
+                <TableCell>Product ID</TableCell>
                 <TableCell>Price</TableCell>
                 <TableCell>Published</TableCell>
-                <TableCell>Visible</TableCell>
+                <TableCell>Status</TableCell>
                 <TableCell />
               </TableRow>
             </TableHead>
-            <TableBody id="product-grid-list">
+            <TableBody id="product-grid-list" className={classes.tableBody}>
               {this.renderProductGridItems()}
             </TableBody>
             <TableFooter>
               <TableRow>
                 <TablePagination
+                  className={classes.pagination}
                   count={totalProductCount}
                   page={page}
                   rowsPerPage={productsPerPage}
                   rowsPerPageOptions={[10, 24, 50, 100]}
                   onChangePage={onChangePage}
                   onChangeRowsPerPage={onChangeRowsPerPage}
+                  labelRowsPerPage={""}
+                  labelDisplayedRows={({ page, count }) => `Page ${page+1} of ${count}`}
                 />
               </TableRow>
             </TableFooter>

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -59,8 +59,8 @@ const styles = (theme) => ({
     letterSpacing: "0.3px"
   },
   actionDropdownMenuItem: {
-    "fontSize": theme.typography.fontSize,
-    "letterSpacing": "0.3px"
+    fontSize: theme.typography.fontSize,
+    letterSpacing: "0.3px"
   },
   tableBody: {
     "& tr:nth-child(odd)": {

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -429,8 +429,6 @@ class ProductGrid extends Component {
                   rowsPerPageOptions={[10, 24, 50, 100]}
                   onChangePage={onChangePage}
                   onChangeRowsPerPage={onChangeRowsPerPage}
-                  labelRowsPerPage={""}
-                  labelDisplayedRows={({ page, count }) => `Page ${page+1} of ${count}`}
                 />
               </TableRow>
             </TableFooter>

--- a/imports/plugins/included/product-variant/components/productGridItems.js
+++ b/imports/plugins/included/product-variant/components/productGridItems.js
@@ -16,6 +16,21 @@ const styles = (theme) => ({
     color: theme.palette.colors.black40,
     fontSize: theme.typography.fontSize * 1.25,
     marginRight: theme.spacing(1)
+  },
+  tableRow: {
+    "& td": {
+      borderBottom: "none",
+      letterSpacing: "0.28px",
+      padding: 0,
+      color: theme.palette.colors.coolGrey500
+    },
+    "& td:first-child": {
+      padding: "4px",
+      width: "50px"
+    },
+    "& td:nth-child(2)": {
+      width: "60px"
+    }
   }
 });
 
@@ -106,11 +121,11 @@ class ProductGridItems extends Component {
   }
 
   render() {
-    const { isSelected, product } = this.props;
+    const { isSelected, product, classes } = this.props;
     const isChecked = isSelected() === "active" || false;
     const productItem = (
-      <TableRow className={`product-table-row-item ${isSelected() ? "active" : ""}`}>
-        <TableCell padding="checkbox">
+      <TableRow className={`product-table-row-item ${isSelected() ? "active" : ""} ${classes.tableRow}`}>
+        <TableCell>
           <Checkbox
             onClick={this.handleSelect}
             checked={isChecked}
@@ -123,6 +138,9 @@ class ProductGridItems extends Component {
           <Link to={`/operator/products/${product._id}`}>{product.title}</Link>
         </TableCell>
         <TableCell>
+          {product._id}
+        </TableCell>
+        <TableCell>
           {formatPriceString(this.props.displayPrice())}
         </TableCell>
         <TableCell>
@@ -131,7 +149,7 @@ class ProductGridItems extends Component {
         <TableCell>
           {this.renderStatusIcon()}
         </TableCell>
-        <TableCell padding="checkbox">
+        <TableCell>
           <IconButton onClick={this.handleDoubleClick}>
             <PencilIcon />
           </IconButton>


### PR DESCRIPTION
Resolves #5389  
Impact: **minor**  
Type: **style**

## Issue
_With only CSS_, make the Product Table as close to the mocks as possible.

## Solution
- Add a Product ID column
- Rename "Visible" to "Status" in table header
- Add CSS style overrides to existing MUI components to:
1. The table now has striped backgrounds
1. The letter spacing is all correct everywhere
1. The padding is changed for the checkbox
1. The pagination area now doesn't have that border-top and has more padding in between the pagination area and the table

<img width="1426" alt="Screen Shot 2019-08-19 at 1 52 09 PM" src="https://user-images.githubusercontent.com/3673236/63299964-e9c8bb80-c28b-11e9-8a4e-ae00d9ef65ed.png">
<img width="1437" alt="Screen Shot 2019-08-19 at 11 47 51 AM" src="https://user-images.githubusercontent.com/3673236/63299968-edf4d900-c28b-11e9-8ed0-b2c99ff0b09f.png">
<img width="1096" alt="Screen Shot 2019-08-19 at 2 26 23 PM" src="https://user-images.githubusercontent.com/3673236/63300586-63ad7480-c28d-11e9-9852-4cf37614e41d.png">

## Future changes
- Note: Once I work on the Typography/Letterspacing PR for Catalyst, I'll change all the hardcoded values (like "0.28px") to the appropriate variables.

## Breaking changes
None

## Testing
1. Look at the Table w/ images
1. Look at the Table w/o images
1. Look at the Table in various desktop sizes