### PR TITLE
FIX: Remove cart items should return updated cart

### DIFF
--- a/imports/plugins/core/cart/server/no-meteor/mutations/__snapshots__/removeCartItems.test.js.snap
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/__snapshots__/removeCartItems.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`throws when no account and no token passed 1`] = `"A token is required when updating an anonymous cart"`;
+exports[`throws when no account and no token passed 1`] = `"Cart not found"`;

--- a/imports/plugins/core/cart/server/no-meteor/mutations/removeCartItems.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/removeCartItems.js
@@ -1,6 +1,5 @@
 import SimpleSchema from "simpl-schema";
 import ReactionError from "@reactioncommerce/reaction-error";
-import hashLoginToken from "/imports/node-app/core/util/hashLoginToken";
 import getCartById from "../util/getCartById";
 
 const inputSchema = new SimpleSchema({

--- a/imports/plugins/core/cart/server/no-meteor/mutations/removeCartItems.test.js
+++ b/imports/plugins/core/cart/server/no-meteor/mutations/removeCartItems.test.js
@@ -8,14 +8,18 @@ const dbCart = {
 
 const cartItemIds = ["cartItemId1", "cartItemId2"];
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 test("removes multiple items from account cart", async () => {
+  mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(dbCart));
   mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(dbCart));
 
   const result = await removeCartItems(mockContext, { cartId: "cartId", cartItemIds });
 
   expect(mockContext.collections.Cart.updateOne).toHaveBeenCalledWith({
-    _id: "cartId",
-    accountId: "FAKE_ACCOUNT_ID"
+    _id: "cartId"
   }, {
     $pull: {
       items: {
@@ -23,20 +27,23 @@ test("removes multiple items from account cart", async () => {
           $in: cartItemIds
         }
       }
+    },
+    $set: {
+      updatedAt: jasmine.any(Date)
     }
   });
 
   expect(mockContext.collections.Cart.findOne).toHaveBeenCalledWith({
-    _id: "cartId",
-    accountId: "FAKE_ACCOUNT_ID"
+    _id: "cartId"
   });
 
   expect(result).toEqual({ cart: dbCart });
 });
 
-test("updates the quantity of multiple items in anonymous cart", async () => {
+test("removes multiple items from anonymous cart", async () => {
   const hashedToken = "+YED6SF/CZIIVp0pXBsnbxghNIY2wmjIVLsqCG4AN80=";
 
+  mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(dbCart));
   mockContext.collections.Cart.findOne.mockReturnValueOnce(Promise.resolve(dbCart));
 
   const cachedAccountId = mockContext.accountId;
@@ -49,8 +56,7 @@ test("updates the quantity of multiple items in anonymous cart", async () => {
   mockContext.accountId = cachedAccountId;
 
   expect(mockContext.collections.Cart.updateOne).toHaveBeenCalledWith({
-    _id: "cartId",
-    anonymousAccessToken: hashedToken
+    _id: "cartId"
   }, {
     $pull: {
       items: {
@@ -58,6 +64,9 @@ test("updates the quantity of multiple items in anonymous cart", async () => {
           $in: cartItemIds
         }
       }
+    },
+    $set: {
+      updatedAt: jasmine.any(Date)
     }
   });
 


### PR DESCRIPTION
Resolves N/A
Impact: **critical**  
Type: **bugfix**

## Issue
The cart returned when items are removed from cart does not have the correct taxes.

## Solution
Wait for the `afterCartUpdate` updates to finish before returning the cart to the client.

My code changes are based on how `updateCartItemsQuantity` mutation handled returning the updated cart.

## Breaking changes
None

## Testing
Go to checkout with multiple items in cart. Enter a shipping address that will result to taxes and enter shipping method. Go back to cart page. Remove an item in the cart. See that the tax is updated in the summary.