### PR TITLE
fix(bulktag): info inline alert should autoclose

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -154,7 +154,7 @@ function ProductTable({ onCreateProduct }) {
             isDismissable
             components={iconComponents}
             alertType="error"
-            title={i18next.t("admin.productListIdsNotFound", { missing, all: filterProductIds }) || "Product Ids not found"}
+            title={i18next.t("admin.productListIdsNotFound", { missing, all: filterProductIds }) || "Product Is not found"}
             message={i18next.t("admin.missingFilteredProducts", { count: missing })}
           />
         </Grid>
@@ -246,6 +246,7 @@ function ProductTable({ onCreateProduct }) {
       { isFiltered ? (
         <Grid item sm={12}>
           <InlineAlert
+            isAutoClosing
             isDismissable
             components={iconComponents}
             alertType="information"


### PR DESCRIPTION
Resolves #5491   
Impact: **minor**  
Type: **bugfix**

## Issue
The notification user experience feels clunky when there are 2 inline alerts stacked on top of each other. They will eventually be replaced with toasts #5501, but for now, we are making the information inlinealert `isAutoClosing`.

## Solution
Pass `isAutoClosing` to this blue informational alert:
<img width="1440" alt="Screen Shot 2019-08-29 at 1 53 27 PM" src="https://user-images.githubusercontent.com/3673236/63976180-99104a00-ca65-11e9-937f-a1e03961c52a.png">

## Breaking changes
None


## Testing
1. Test that the alert closes after 10 seconds.