### PR TITLE
fix(card): remove raised shadow from Quick Edit card

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -177,7 +177,7 @@ function ProductTable({ onCreateProduct }) {
         </Grid>
       ) : null }
       <Grid item sm={12} style={{ display: displayCard }}>
-        <Card raised>
+        <Card>
           <CardHeader
             className={classes.cardHeaderTitle}
             action={


### PR DESCRIPTION
Resolves #5503   
Impact: **minor**  
Type: **bugfix**

## Issue: Quick Edit Card shadow
Shadow is wrong. Shadow should match: https://catalyst.reactioncommerce.com/#/Components/Themed%20Components/Card

## Solution
Remove `raised` from Card props

## Breaking changes
None


## Testing
<img width="1440" alt="Screen Shot 2019-08-29 at 2 34 59 PM" src="https://user-images.githubusercontent.com/3673236/63978272-d3301a80-ca6a-11e9-9369-78bf5143a8b2.png">
