### PR TITLE
fix(card): remove raised shadow

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -177,7 +177,7 @@ function ProductTable({ onCreateProduct }) {
         </Grid>
       ) : null }
       <Grid item sm={12} style={{ display: displayCard }}>
-        <Card raised>
+        <Card>
           <CardHeader
             className={classes.cardHeaderTitle}
             action={


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #5503   
Impact: **minor**  
Type: **bugfix**

## Issue
Filter by File card has wrong shadow.

## Solution
Remove `raised` prop from Card

## Breaking changes
No


## Testing
1. Look @ the card