### PR TITLE
refactor(card): use CardHeader with Catalyst defaults for Product Table

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -19,12 +19,7 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(1)
   },
   helpText: {
-    marginLeft: "20px",
-    letterSpacing: "0.28px",
-    fontWeight: theme.typography.fontWeightRegular
-  },
-  cardHeaderTitle: {
-    letterSpacing: "0.3px"
+    marginLeft: "20px"
   },
   cardContainer: {
     alignItems: "center"
@@ -225,7 +220,7 @@ function ProductTable({ onCreateProduct }) {
                     <ImportIcon className={classes.leftIcon}/>
                     {i18next.t("admin.importCard.import")}
                   </Button>
-                  <Typography variant="h5" display="inline" className={classes.helpText}>
+                  <Typography variant="caption" display="inline" className={classes.helpText}>
                     {i18next.t("admin.importCard.importHelpText")}
                   </Typography>
                 </Grid>

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -138,7 +138,7 @@ class ProductGrid extends Component {
   }
 
   renderFilteredCount() {
-    const { selectedProductIds, totalProductCount, classes } = this.props;
+    const { selectedProductIds, totalProductCount } = this.props;
     const selectedCount = selectedProductIds.length;
     const filterByProductIds = Session.get("filterByProductIds");
     const totalCount = i18next.t("admin.productTable.bulkActions.totalCount", { count: totalProductCount });
@@ -148,7 +148,7 @@ class ProductGrid extends Component {
       return (
         <CardHeader
           title={i18next.t("admin.productTable.bulkActions.filteredProducts")}
-          subheader={ selected }
+          subheader={selected}
         />
       );
     }

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -6,6 +6,7 @@ import { Session } from "meteor/session";
 import { i18next } from "/client/api";
 import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
+import CardHeader from "@material-ui/core/CardHeader";
 import CardContent from "@material-ui/core/CardContent";
 import Checkbox from "@material-ui/core/Checkbox";
 import Menu from "@material-ui/core/Menu";
@@ -20,7 +21,6 @@ import TablePagination from "@material-ui/core/TablePagination";
 import TableRow from "@material-ui/core/TableRow";
 import ChevronDownIcon from "mdi-material-ui/ChevronDown";
 import ConfirmDialog from "@reactioncommerce/catalyst/ConfirmDialog";
-import Typography from "@material-ui/core/Typography";
 import Chip from "@reactioncommerce/catalyst/Chip";
 import withStyles from "@material-ui/core/styles/withStyles";
 
@@ -31,25 +31,13 @@ const styles = (theme) => ({
   },
   toolbar: {
     marginBottom: theme.spacing(2),
-    minHeight: "65px",
+    minHeight: theme.spacing(5),
     paddingLeft: 0,
     paddingRight: 0,
     [theme.breakpoints.up("sm")]: {
       paddingLeft: 0,
       paddingRight: 0
     }
-  },
-  filterCountContainer: {
-    paddingLeft: theme.spacing(2),
-    paddingTop: theme.spacing(3)
-  },
-  filterCountText: {
-    paddingLeft: theme.spacing(2),
-    fontWeight: theme.typography.fontWeightRegular,
-    letterSpacing: "0.5px"
-  },
-  productsTitle: {
-    letterSpacing: "0.3px"
   },
   actionDropdownTrigger: {
     border: `1px solid ${theme.palette.colors.coolGrey}`,
@@ -158,26 +146,18 @@ class ProductGrid extends Component {
 
     if (filterByProductIds) {
       return (
-        <div className={classes.filterCountContainer}>
-          <Typography variant="h4" display="inline" className={classes.productsTitle}>
-            {i18next.t("admin.productTable.bulkActions.filteredProducts")}
-          </Typography>
-          <Typography variant="h5" display="inline" className={classes.filterCountText}>
-            { selected }
-          </Typography>
-        </div>
+        <CardHeader
+          title={i18next.t("admin.productTable.bulkActions.filteredProducts")}
+          subheader={ selected }
+        />
       );
     }
 
     return (
-      <div className={classes.filterCountContainer}>
-        <Typography variant="h4" display="inline" className={classes.productsTitle}>
-          {i18next.t("admin.productTable.bulkActions.allProducts")}
-        </Typography>
-        <Typography variant="h5" display="inline" className={classes.filterCountText}>
-          {(selectedCount > 0) ? selected : totalCount}
-        </Typography>
-      </div>
+      <CardHeader
+        title={i18next.t("admin.productTable.bulkActions.allProducts")}
+        subheader={(selectedCount > 0) ? selected : totalCount}
+      />
     );
   }
 


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Resolves #issueNumber  
Impact: **minor**  
Type: **bugfix|refactor**

## Issue
The Product Table uses a Material-UI Card, and the top padding is off. The Card's CardHeader's secondaryText font color is also off. These will be addressed in an upcoming Catalyst release, and when https://github.com/reactioncommerce/catalyst/pull/94 is released, this ticket can also be tested and merged.

## Solution
- Update Catalyst to latest
- Use a <CardHeader>

<img width="623" alt="Screen Shot 2019-08-30 at 2 33 45 PM" src="https://user-images.githubusercontent.com/3673236/64052620-13a79b00-cb34-11e9-8e7b-a2637305c5e6.png">


## Breaking changes
none


## Testing
1. List the steps needed for testing your change in this section.
2. Assume that testers already know how to start the app, and do the basic setup tasks.
3. Be detailed enough that someone can work through it without being too granular

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
