### PR TITLE
refactor: use moments calendar format to display time alongside date

### DIFF
--- a/imports/plugins/core/orders/client/components/OrderHeader.js
+++ b/imports/plugins/core/orders/client/components/OrderHeader.js
@@ -27,7 +27,7 @@ function OrderHeader(props) {
   const { classes, moment, order } = props;
   const { createdAt, displayStatus, referenceId, status } = order;
   const orderDate = (moment && moment(createdAt).calendar(null, {
-    sameElse: "DD/MM/YYYY h:mm A"
+    sameElse: "MMMM DD, YYYY h:mm A"
   })) || createdAt.toLocaleString();
   const { payments } = order;
   const paymentStatuses = payments.map((payment) => payment.status);

--- a/imports/plugins/core/orders/client/components/OrderHeader.js
+++ b/imports/plugins/core/orders/client/components/OrderHeader.js
@@ -26,7 +26,9 @@ const styles = (theme) => ({
 function OrderHeader(props) {
   const { classes, moment, order } = props;
   const { createdAt, displayStatus, referenceId, status } = order;
-  const orderDate = (moment && moment(createdAt).format("MM/DD/YYYY")) || createdAt.toLocaleString();
+  const orderDate = (moment && moment(createdAt).calendar(null, {
+    sameElse: "DD/MM/YYYY h:mm A"
+  })) || createdAt.toLocaleString();
   const { payments } = order;
   const paymentStatuses = payments.map((payment) => payment.status);
   const uniqueStatuses = [...new Set(paymentStatuses)];

--- a/imports/plugins/core/orders/client/components/OrderHeader.js
+++ b/imports/plugins/core/orders/client/components/OrderHeader.js
@@ -26,9 +26,7 @@ const styles = (theme) => ({
 function OrderHeader(props) {
   const { classes, moment, order } = props;
   const { createdAt, displayStatus, referenceId, status } = order;
-  const orderDate = (moment && moment(createdAt).calendar(null, {
-    sameElse: "MMMM DD, YYYY h:mm A"
-  })) || createdAt.toLocaleString();
+  const orderDate = (moment && moment(createdAt).format("MMMM DD, YYYY h:mm A")) || createdAt.toLocaleString();
   const { payments } = order;
   const paymentStatuses = payments.map((payment) => payment.status);
   const uniqueStatuses = [...new Set(paymentStatuses)];


### PR DESCRIPTION
Impact: **minor**  
Type: **style|refactor**

## Issue
The new Orders UI only shows the date of an order, but it's been requested that the time is added as it's essential when fulfilling orders.

## Solution
Use `moment`s `calendar()` formatting to add relative timestamp, instead of a date. See the docs here for formatting: https://momentjs.com/docs/#/displaying/calendar-time/

## Breaking changes
None, this is a visual change only

## Testing
1. Create an order
1. See that the timestamp is now present alongside the (now relative) order date
1. In the database, change the date of the order a few times to see past date formats (yesterday, last week, last month)

<img width="709" alt="Order_Details_for_order_reference__jFXML4AW68KHDwT4E" src="https://user-images.githubusercontent.com/4482263/64317275-10654280-cf6c-11e9-8ec1-cb4001942129.png">

<img width="679" alt="Order_Details_for_order_reference__jFXML4AW68KHDwT4E" src="https://user-images.githubusercontent.com/4482263/64317297-21ae4f00-cf6c-11e9-953c-2b7e2cb614a7.png">

<img width="694" alt="Order_Details_for_order_reference__jFXML4AW68KHDwT4E" src="https://user-images.githubusercontent.com/4482263/64317400-74880680-cf6c-11e9-8e05-74e419aa4d57.png">


