### PR TITLE
Fix: Perform old password validation

### DIFF
--- a/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
+++ b/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
@@ -69,7 +69,7 @@ Template.loginFormChangePassword.events({
     const password = passwordInput.val().trim();
 
     // We only check if it exists, just incase we"ve change the password strength and want the
-    // user to have an oppurtinity to update to a stronger password
+    // user to have an opportunity to update to a stronger password
     const validatedOldPassword = LoginFormValidation.password(oldPassword, { validationLevel: "exists" });
     const validatedPassword = LoginFormValidation.password(password);
 

--- a/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
+++ b/imports/plugins/core/accounts/client/templates/updatePassword/updatePassword.js
@@ -70,7 +70,7 @@ Template.loginFormChangePassword.events({
 
     // We only check if it exists, just incase we"ve change the password strength and want the
     // user to have an oppurtinity to update to a stronger password
-    const validatedOldPassword = LoginFormValidation.password(password, { validationLevel: "exists" });
+    const validatedOldPassword = LoginFormValidation.password(oldPassword, { validationLevel: "exists" });
     const validatedPassword = LoginFormValidation.password(password);
 
     const templateInstance = Template.instance();


### PR DESCRIPTION
Impact: minor
Type: bugfix

Issue
`validatedOldPassword` should validate `oldPassword` instead of new password

Solution
Replace the new password variable(i.e `password`) with old password variable i.e `oldPassword`

Breaking changes
None

Testing
See if the validation works correctly on the password update page
