### PR TITLE
Make "Create product" button visible by default

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -148,6 +148,17 @@ function ProductTable({ onCreateProduct }) {
         setVisibility={setTagSelectorVisible}
         selectedProductIds={selectedProductIds}
       />
+      {(!isFiltered && !isTagSelectorVisible && !isFilterByFileVisible) && (
+        <Grid item sm={12} >
+          <Button
+            color="primary"
+            onClick={onCreateProduct}
+            variant="contained"
+          >
+            {i18next.t("admin.createProduct") || "Create product"}
+          </Button>
+        </Grid>
+      )}
       {isFiltered && (
         <Grid item sm={12} >
           {noProductsFoundError && (
@@ -157,15 +168,6 @@ function ProductTable({ onCreateProduct }) {
               isDismissable
               message={i18next.t("admin.noProductsFoundText")}
             />
-          )}
-          {(!isFiltered && !isTagSelectorVisible && !isFilterByFileVisible) && (
-            <Button
-              color="primary"
-              onClick={onCreateProduct}
-              variant="contained"
-            >
-              {i18next.t("admin.createProduct") || "Create product"}
-            </Button>
           )}
           {isFiltered && (
             <InlineAlert


### PR DESCRIPTION
Impact: minor
Type:  fix

## Issue
The "Create product" button on the products table was not visible by default.

## Resolution
Make button visible
