### PR TITLE
feat: add redirect on graphql-alpha to default path

### DIFF
--- a/imports/node-app/core/createApolloServer.js
+++ b/imports/node-app/core/createApolloServer.js
@@ -85,6 +85,12 @@ export default function createApolloServer(options = {}) {
     tokenMiddleware(contextFromOptions)
   );
 
+  // Redirect for graphql-alpha route
+  app.get("/graphql-alpha", (req, res) => {
+    // Redirect to path once graphql-alpha is received
+    res.redirect(path);
+  });
+
   apolloServer.applyMiddleware({ app, cors: true, path });
 
   return {

--- a/imports/node-app/core/createApolloServer.js
+++ b/imports/node-app/core/createApolloServer.js
@@ -86,7 +86,7 @@ export default function createApolloServer(options = {}) {
   );
 
   // Redirect for graphql-alpha route
-  app.get("/graphql-alpha", (req, res) => {
+  app.all("/graphql-alpha", (req, res) => {
     // Redirect to path once graphql-alpha is received
     res.redirect(path);
   });


### PR DESCRIPTION
Resolves #5293   
Impact: **minor**  
Type: **feature**

## Issue
Developers have bookmarks, tools like postman, muscle memory around /graphql-alpha being where you go for graphql and graphiql. A redirect to the new URL is requested so developers don't hit a dead end.

## Solution
I have added another route redirect to the Express server once a get has been to `"/graphql-alpha"`. On `get` the Express server will redirect towards the current selected base path. This is by default set to `"/graphql-beta"`

## Testing
1. Visit the URL `localhost:3000/graphql-alpha`.

## Result
1. Page will be redirected to URL `localhost:3000/graphql-beta`
