### PR TITLE
fix: restore loadTranslations fn

### DIFF
--- a/imports/plugins/core/core/server/startup/i18n.js
+++ b/imports/plugins/core/core/server/startup/i18n.js
@@ -3,7 +3,7 @@
  * Delete this when there is a 3.0.0 release.
  */
 import Logger from "@reactioncommerce/logger";
-import mergeResource from "/imports/plugins/core/i18n/server/no-meteor/translations";
+import { mergeResource } from "/imports/plugins/core/i18n/server/no-meteor/translations";
 
 /**
  * @summary Load an array of translation arrays


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
The translation changes in #5514 broke custom plugins that have their own translations.

## Solution
Restore the `loadTranslations` function with a deprecation warning. It will be removed in the next major API release.

## Breaking changes
Quite the contrary

## Testing
Verify that custom plugins calling `loadTranslations` function continue to work, and their translations are found/shown in the Reaction Admin UI.