### PR TITLE
refactor: Fix proptype warning with ReactSortableTree

### DIFF
--- a/imports/plugins/core/navigation/client/components/SortableNodeContentRenderer.js
+++ b/imports/plugins/core/navigation/client/components/SortableNodeContentRenderer.js
@@ -2,15 +2,17 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import { withStyles } from "@material-ui/core/styles";
-import Card from "@material-ui/core/Card";
-import IconButton from "@material-ui/core/IconButton";
-import Typography from "@material-ui/core/Typography";
+import {
+  Card,
+  IconButton,
+  Typography,
+  makeStyles
+} from "@material-ui/core";
 import ChevronRightIcon from "mdi-material-ui/ChevronRight";
 import DragIcon from "mdi-material-ui/Drag";
 import FileOutlineIcon from "mdi-material-ui/FileOutline";
 
-const styles = (theme) => ({
+const useStyles = makeStyles((theme) => ({
   badge: {
     backgroundColor: theme.palette.colors.black05,
     color: theme.palette.colors.black65,
@@ -70,7 +72,7 @@ const styles = (theme) => ({
   subtitleIcon: {
     marginRight: 4
   }
-});
+}));
 
 /**
  * Check if node is a descendant
@@ -86,226 +88,224 @@ function isDescendant(older, younger) {
   );
 }
 
-class SortableNodeContentRenderer extends Component {
-  static propTypes = {
-    buttons: PropTypes.arrayOf(PropTypes.node),
-    canDrag: PropTypes.bool,
-    canDrop: PropTypes.bool,
-    className: PropTypes.string,
-    classes: PropTypes.object,
-    connectDragPreview: PropTypes.func.isRequired,
-    connectDragSource: PropTypes.func.isRequired,
-    didDrop: PropTypes.bool.isRequired, // eslint-disable-line react/boolean-prop-naming
-    draggedNode: PropTypes.shape({}),
-    icons: PropTypes.arrayOf(PropTypes.node),
-    isDragging: PropTypes.bool.isRequired,
-    isOver: PropTypes.bool.isRequired,
-    isSearchFocus: PropTypes.bool,
-    isSearchMatch: PropTypes.bool,
-    listIndex: PropTypes.number.isRequired,
-    lowerSiblingCounts: PropTypes.arrayOf(PropTypes.number).isRequired,
-    node: PropTypes.shape({}).isRequired,
-    parentNode: PropTypes.shape({}), // Needed for dndManager
-    path: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
-    rowDirection: PropTypes.string.isRequired,
-    scaffoldBlockPxWidth: PropTypes.number.isRequired,
-    style: PropTypes.shape({}),
-    subtitle: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-    swapDepth: PropTypes.number,
-    swapFrom: PropTypes.number,
-    swapLength: PropTypes.number,
-    title: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-    toggleChildrenVisibility: PropTypes.func,
-    treeId: PropTypes.string.isRequired,
-    treeIndex: PropTypes.number.isRequired
-  }
+function SortableNodeContentRenderer(props) {
+  const {
+    // ReactSortableTreeProps
+    scaffoldBlockPxWidth,
+    toggleChildrenVisibility,
+    connectDragPreview,
+    connectDragSource,
+    isDragging,
+    canDrop,
+    canDrag,
+    node,
+    title,
+    subtitle,
+    draggedNode,
+    path,
+    treeIndex,
+    isSearchMatch,
+    isSearchFocus,
+    icons,
+    buttons,
+    className,
+    style,
+    didDrop,
+    lowerSiblingCounts,
+    listIndex,
+    swapFrom,
+    swapLength,
+    swapDepth,
+    treeId, // Not needed, but preserved for other renderers
+    isOver, // Not needed, but preserved for other renderers
+    parentNode, // Needed for dndManager
+    rowDirection,
+    // Pull remaining props and apply to the root element
+    ...otherProps
+  } = props;
+  const classes = useStyles();
+  const nodeTitle = title || node.title;
+  const nodeSubtitle = subtitle || node.subtitle;
 
-  static defaultProps = {
-    buttons: [],
-    canDrag: false,
-    canDrop: false,
-    className: "",
-    draggedNode: null,
-    icons: [],
-    isSearchFocus: false,
-    isSearchMatch: false,
-    parentNode: null,
-    style: {},
-    swapDepth: null,
-    swapFrom: null,
-    swapLength: null,
-    title: null,
-    toggleChildrenVisibility: null
-  }
+  const isDraggedDescendant = draggedNode && isDescendant(draggedNode, node);
+  const isLandingPadActive = !didDrop && isDragging;
 
-  render() {
-    const {
-      classes,
+  // Construct the scaffold representing the structure of the tree
+  const scaffold = [];
+  lowerSiblingCounts.forEach((lowerSiblingCount, index) => {
+    scaffold.push((
+      <div
+        key={`pre_${1 + index}`}
+        // style={{ width: scaffoldBlockPxWidth }}
+        className={classes.lineBlock}
+      />
+    ));
 
-      // ReactSortableTreeProps
-      scaffoldBlockPxWidth,
-      toggleChildrenVisibility,
-      connectDragPreview,
-      connectDragSource,
-      isDragging,
-      canDrop,
-      canDrag,
-      node,
-      title,
-      subtitle,
-      draggedNode,
-      path,
-      treeIndex,
-      isSearchMatch,
-      isSearchFocus,
-      icons,
-      buttons,
-      className,
-      style,
-      didDrop,
-      lowerSiblingCounts,
-      listIndex,
-      swapFrom,
-      swapLength,
-      swapDepth,
-      treeId, // Not needed, but preserved for other renderers
-      isOver, // Not needed, but preserved for other renderers
-      parentNode, // Needed for dndManager
-      rowDirection,
-      ...otherProps
-    } = this.props;
-    const nodeTitle = title || node.title;
-    const nodeSubtitle = subtitle || node.subtitle;
+    if (treeIndex !== listIndex && index === swapDepth) {
+      // This row has been shifted, and is at the depth of
+      // the line pointing to the new destination
+      let highlightLineClass = "";
 
-    const isDraggedDescendant = draggedNode && isDescendant(draggedNode, node);
-    const isLandingPadActive = !didDrop && isDragging;
+      if (listIndex === swapFrom + swapLength - 1) {
+        // This block is on the bottom (target) line
+        // This block points at the target block (where the row will go when released)
+        highlightLineClass = classes.highlightBottomLeftCorner;
+      } else if (treeIndex === swapFrom) {
+        // This block is on the top (source) line
+        highlightLineClass = classes.highlightTopLeftCorner;
+      } else {
+        // This block is between the bottom and top
+        highlightLineClass = classes.highlightLineVertical;
+      }
 
-    // Construct the scaffold representing the structure of the tree
-    const scaffold = [];
-    lowerSiblingCounts.forEach((lowerSiblingCount, index) => {
       scaffold.push((
         <div
-          key={`pre_${1 + index}`}
-          // style={{ width: scaffoldBlockPxWidth }}
-          className={styles.lineBlock}
+          key={`highlight_${1 + index}`}
+          style={{
+            left: scaffoldBlockPxWidth * index
+          }}
+          className={`${classes.absoluteLineBlock} ${highlightLineClass}`}
         />
       ));
+    }
+  });
 
-      if (treeIndex !== listIndex && index === swapDepth) {
-        // This row has been shifted, and is at the depth of
-        // the line pointing to the new destination
-        let highlightLineClass = "";
+  const nodeContent = (
+    <div
+      style={{
+        marginTop: -2,
+        height: "100%",
+        marginLeft: (lowerSiblingCounts.length) * scaffoldBlockPxWidth,
+        marginRight: scaffoldBlockPxWidth
+      }}
+      {...otherProps}
+    >
+      <Card className={classes.cardContent} elevation={3}>
 
-        if (listIndex === swapFrom + swapLength - 1) {
-          // This block is on the bottom (target) line
-          // This block points at the target block (where the row will go when released)
-          highlightLineClass = styles.highlightBottomLeftCorner;
-        } else if (treeIndex === swapFrom) {
-          // This block is on the top (source) line
-          highlightLineClass = styles.highlightTopLeftCorner;
-        } else {
-          // This block is between the bottom and top
-          highlightLineClass = styles.highlightLineVertical;
-        }
+        <IconButton
+          aria-label="Drag"
+          className={classNames(classes.dragIcon)}
+          disableRipple
+          disableTouchRipple
+        >
+          <DragIcon />
+        </IconButton>
 
-        scaffold.push((
-          <div
-            key={`highlight_${1 + index}`}
-            style={{
-              left: scaffoldBlockPxWidth * index
-            }}
-            className={`${styles.absoluteLineBlock} ${highlightLineClass}`}
-          />
-        ));
-      }
-    });
-
-    const nodeContent = (
-      <div
-        style={{
-          marginTop: -2,
-          height: "100%",
-          marginLeft: (lowerSiblingCounts.length) * scaffoldBlockPxWidth,
-          marginRight: scaffoldBlockPxWidth
-        }}
-        {...otherProps}
-      >
-        <Card className={classes.cardContent} elevation={3}>
-
+        {toggleChildrenVisibility && node.children && node.children.length > 0 && (
           <IconButton
-            aria-label="Drag"
-            className={classNames(classes.dragIcon)}
-            disableRipple
-            disableTouchRipple
+            aria-label={node.expanded ? "Collapse" : "Expand"}
+            className={classNames(classes.expandIcon, {
+              [classes.expanded]: node.expanded
+            })}
+            onClick={() => toggleChildrenVisibility({ node, path, treeIndex })}
           >
-            <DragIcon />
+            <ChevronRightIcon />
           </IconButton>
-
-          {toggleChildrenVisibility && node.children && node.children.length > 0 && (
-            <IconButton
-              aria-label={node.expanded ? "Collapse" : "Expand"}
-              className={classNames(classes.expandIcon, {
-                [classes.expanded]: node.expanded
-              })}
-              onClick={() => toggleChildrenVisibility({ node, path, treeIndex })}
+        )}
+        {/* Set the row preview to be used during drag and drop */}
+        {connectDragPreview((
+          <div style={{ display: "flex", flex: 1 }}>
+            {scaffold}
+            <div
+              className={
+                classNames(classes.row, {
+                  [classes.rowDragDisabled]: !canDrag,
+                  [classes.rowLandingPad]: isLandingPadActive,
+                  [classes.rowCancelPad]: isLandingPadActive && !canDrop,
+                  [classes.rowSearchMatch]: isSearchMatch,
+                  [classes.rowSearchFocus]: isSearchFocus
+                }, className)
+              }
+              style={{
+                opacity: isDraggedDescendant ? 0.5 : 1,
+                ...style
+              }}
             >
-              <ChevronRightIcon />
-            </IconButton>
-          )}
-          {/* Set the row preview to be used during drag and drop */}
-          {connectDragPreview((
-            <div style={{ display: "flex", flex: 1 }}>
-              {scaffold}
-              <div
-                className={
-                  classNames(classes.row, {
-                    [classes.rowDragDisabled]: !canDrag,
-                    [classes.rowLandingPad]: isLandingPadActive,
-                    [classes.rowCancelPad]: isLandingPadActive && !canDrop,
-                    [classes.rowSearchMatch]: isSearchMatch,
-                    [classes.rowSearchFocus]: isSearchFocus
-                  }, className)
-                }
-                style={{
-                  opacity: isDraggedDescendant ? 0.5 : 1,
-                  ...style
-                }}
-              >
-                <div className={classes.rowContent}>
-                  <Typography className={classes.title} variant="subtitle1">
-                    {typeof nodeTitle === "function" ? nodeTitle({ node, path, treeIndex }) : nodeTitle}
-                    {node.isVisible === false && <Typography className={classes.badge} key="isVisible" variant="caption">{"Hide from storefront"}</Typography>}
-                    {node.isPrivate && <Typography className={classes.badge} variant="caption">{"Admin only"}</Typography>}
-                    {node.isSecondary && <Typography className={classes.badge} variant="caption">{"Secondary nav only"}</Typography>}
-                  </Typography>
-                  <Typography className={classes.subtitle} variant="caption">
-                    <FileOutlineIcon className={classes.subtitleIcon} fontSize="inherit" />
-                    {typeof nodeSubtitle === "function" ? nodeSubtitle({ node, path, treeIndex }) : nodeSubtitle}
-                  </Typography>
-                </div>
+              <div className={classes.rowContent}>
+                <Typography className={classes.title} variant="subtitle1">
+                  {typeof nodeTitle === "function" ? nodeTitle({ node, path, treeIndex }) : nodeTitle}
+                  {node.isVisible === false && <Typography className={classes.badge} key="isVisible" variant="caption">{"Hide from storefront"}</Typography>}
+                  {node.isPrivate && <Typography className={classes.badge} variant="caption">{"Admin only"}</Typography>}
+                  {node.isSecondary && <Typography className={classes.badge} variant="caption">{"Secondary nav only"}</Typography>}
+                </Typography>
+                <Typography className={classes.subtitle} variant="caption">
+                  <FileOutlineIcon className={classes.subtitleIcon} fontSize="inherit" />
+                  {typeof nodeSubtitle === "function" ? nodeSubtitle({ node, path, treeIndex }) : nodeSubtitle}
+                </Typography>
+              </div>
 
-                <div className={classes.rowToolbar}>
-                  {buttons.map((button, index) => (
-                    <div
-                      key={index} // eslint-disable-line react/no-array-index-key
-                      className={classes.toolbarButton}
-                    >
-                      {button}
-                    </div>
-                  ))}
-                </div>
+              <div className={classes.rowToolbar}>
+                {buttons.map((button, index) => (
+                  <div
+                    key={index} // eslint-disable-line react/no-array-index-key
+                    className={classes.toolbarButton}
+                  >
+                    {button}
+                  </div>
+                ))}
               </div>
             </div>
-          ))}
-        </Card>
+          </div>
+        ))}
+      </Card>
 
-      </div>
-    );
+    </div>
+  );
 
-    return canDrag
-      ? connectDragSource(nodeContent, { dropEffect: "copy" })
-      : nodeContent;
-  }
+  return canDrag
+    ? connectDragSource(nodeContent, { dropEffect: "copy" })
+    : nodeContent;
 }
 
-export default withStyles(styles, { name: "RuiSortableNodeContentRenderer" })(SortableNodeContentRenderer);
+SortableNodeContentRenderer.propTypes = {
+  buttons: PropTypes.arrayOf(PropTypes.node),
+  canDrag: PropTypes.bool,
+  canDrop: PropTypes.bool,
+  className: PropTypes.string,
+  classes: PropTypes.object,
+  connectDragPreview: PropTypes.func.isRequired,
+  connectDragSource: PropTypes.func.isRequired,
+  didDrop: PropTypes.bool.isRequired, // eslint-disable-line react/boolean-prop-naming
+  draggedNode: PropTypes.shape({}),
+  icons: PropTypes.arrayOf(PropTypes.node),
+  isDragging: PropTypes.bool.isRequired,
+  isOver: PropTypes.bool.isRequired,
+  isSearchFocus: PropTypes.bool,
+  isSearchMatch: PropTypes.bool,
+  listIndex: PropTypes.number.isRequired,
+  lowerSiblingCounts: PropTypes.arrayOf(PropTypes.number).isRequired,
+  node: PropTypes.shape({}).isRequired,
+  parentNode: PropTypes.shape({}), // Needed for dndManager
+  path: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+  rowDirection: PropTypes.string.isRequired,
+  scaffoldBlockPxWidth: PropTypes.number.isRequired,
+  style: PropTypes.shape({}),
+  subtitle: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  swapDepth: PropTypes.number,
+  swapFrom: PropTypes.number,
+  swapLength: PropTypes.number,
+  title: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  toggleChildrenVisibility: PropTypes.func,
+  treeId: PropTypes.string.isRequired,
+  treeIndex: PropTypes.number.isRequired
+};
+
+SortableNodeContentRenderer.defaultProps = {
+  buttons: [],
+  canDrag: false,
+  canDrop: false,
+  className: "",
+  draggedNode: null,
+  icons: [],
+  isSearchFocus: false,
+  isSearchMatch: false,
+  parentNode: null,
+  style: {},
+  swapDepth: null,
+  swapFrom: null,
+  swapLength: null,
+  title: null,
+  toggleChildrenVisibility: null
+};
+
+export default SortableNodeContentRenderer;

--- a/imports/plugins/core/navigation/client/components/SortableNodeContentRenderer.js
+++ b/imports/plugins/core/navigation/client/components/SortableNodeContentRenderer.js
@@ -1,5 +1,5 @@
 // Based on theme: https://github.com/frontend-collective/react-sortable-tree-theme-file-explorer
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import {
@@ -88,6 +88,11 @@ function isDescendant(older, younger) {
   );
 }
 
+/**
+ * SortableNodeContentRenderer
+ * @param {Object} props Component props
+ * @returns {React.Component} A react component
+ */
 function SortableNodeContentRenderer(props) {
   const {
     // ReactSortableTreeProps

--- a/imports/plugins/core/navigation/client/components/SortableTheme.js
+++ b/imports/plugins/core/navigation/client/components/SortableTheme.js
@@ -1,7 +1,7 @@
 import nodeContentRenderer from "./SortableNodeContentRenderer";
 import treeNodeRenderer from "./SortableTreeNodeRenderer";
 
-module.exports = {
+export default {
   nodeContentRenderer,
   treeNodeRenderer,
   scaffoldBlockPxWidth: 65,


### PR DESCRIPTION
Resolves #5548   
Impact: **minor**  
Type: **frefactor**

## Issue
Prop-type warning from ReactSrotableTree
```
backend.js:1 Warning: Failed prop type: Invalid prop `theme.nodeContentRenderer` of type `object` supplied to `ReactSortableTree`, expected `function`.
    in ReactSortableTree (created by Context.Consumer)
    in SortableTreeWithoutDndContext (created by NavigationTreeContainer)
```

## Solution

Refactor SortableNodeContentRenderer into a function component. This fixes an issue with the ReactSortableTree theme as `withStyles` from MUI uses `React.forwardRef`. The propType of components with a forwarded ref is an `object` rather than a `function`, which ReactSortableTree expects.

## Breaking changes

none.

## Testing
1. Use the navigation tree editor http://localhost:3000/operator/navigation
2. Ensure the nodes render and you can add an remove nodes as usual to the tree.
3. Open the console and verify that there are no proptype warnings