### PR TITLE
feat: add support for multilingual email

### DIFF
--- a/imports/collections/schemas/accounts.js
+++ b/imports/collections/schemas/accounts.js
@@ -73,6 +73,11 @@ export const Profile = new SimpleSchema({
     optional: true,
     mockValue: null
   },
+  "language": {
+    label: "User language",
+    type: String,
+    optional: true
+  },
   "preferences": {
     label: "User preferences",
     type: Object,

--- a/imports/collections/schemas/orders.js
+++ b/imports/collections/schemas/orders.js
@@ -488,6 +488,10 @@ export const Order = new SimpleSchema({
     optional: true
   },
   "notes.$": Notes,
+  "ordererPreferredLanguage": {
+    type: String,
+    optional: true
+  },
   "payments": {
     type: Array,
     optional: true

--- a/imports/plugins/core/accounts/server/methods/sendResetPasswordEmail.js
+++ b/imports/plugins/core/accounts/server/methods/sendResetPasswordEmail.js
@@ -1,0 +1,142 @@
+import _ from "lodash";
+import Logger from "@reactioncommerce/logger";
+import Random from "@reactioncommerce/random";
+import { Accounts } from "meteor/accounts-base";
+import { check } from "meteor/check";
+import { Meteor } from "meteor/meteor";
+import { Shops } from "/lib/collections";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
+import ReactionError from "@reactioncommerce/reaction-error";
+
+Accounts.urls.resetPassword = function reset(token) {
+  return Meteor.absoluteUrl(`reset-password/${token}`);
+};
+
+/**
+ * @method sendResetEmail
+ * @memberof Core
+ * @summary Send an email with a link that the user can use to reset their password.
+ * @param {String} userId - The id of the user to send email to.
+ * @param {String} [optionalEmail] Address to send the email to.
+ *                 This address must be in the user's `emails` list.
+ *                 Defaults to the first email in the list.
+ * @param {String} language - user prefered language i18n
+ * @returns {Job} - returns a sendEmail Job instance
+ */
+async function sendResetEmail(userId, optionalEmail, language) {
+  // Make sure the user exists, and email is one of their addresses.
+  const user = Meteor.users.findOne(userId);
+
+  if (!user) {
+    Logger.error("sendResetPasswordEmail - User not found");
+    throw new ReactionError("not-found", "User not found");
+  }
+
+  let email = optionalEmail;
+
+  // pick the first email if we weren't passed an email.
+  if (!optionalEmail && user.emails && user.emails[0]) {
+    email = user.emails[0].address;
+  }
+
+  // make sure we have a valid email
+  if (!email || !user.emails || !user.emails.map((mailInfo) => mailInfo.address).includes(email)) {
+    Logger.error("sendResetPasswordEmail - Email not found");
+    throw new ReactionError("not-found", "Email not found");
+  }
+
+  // Create token for password reset
+  const token = Random.secret();
+  const when = new Date();
+  const tokenObj = { token, email, when };
+
+  Meteor.users.update(userId, {
+    $set: {
+      "services.password.reset": tokenObj
+    }
+  });
+
+  Meteor._ensure(user, "services", "password").reset = tokenObj;
+
+  // Get shop data for email display
+  const shop = Shops.findOne(Reaction.getShopId());
+  const copyrightDate = new Date().getFullYear();
+
+  const dataForEmail = {
+    // Shop Data
+    shop,
+    contactEmail: shop.emails[0].address,
+    homepage: Reaction.absoluteUrl(),
+    copyrightDate,
+    legalName: _.get(shop, "addressBook[0].company"),
+    physicalAddress: {
+      address: `${_.get(shop, "addressBook[0].address1")} ${_.get(shop, "addressBook[0].address2")}`,
+      city: _.get(shop, "addressBook[0].city"),
+      region: _.get(shop, "addressBook[0].region"),
+      postal: _.get(shop, "addressBook[0].postal")
+    },
+    shopName: shop.name,
+    socialLinks: {
+      display: true,
+      facebook: {
+        display: true,
+        icon: `${Reaction.absoluteUrl()}resources/email-templates/facebook-icon.png`,
+        link: "https://www.facebook.com"
+      },
+      googlePlus: {
+        display: true,
+        icon: `${Reaction.absoluteUrl()}resources/email-templates/google-plus-icon.png`,
+        link: "https://plus.google.com"
+      },
+      twitter: {
+        display: true,
+        icon: `${Reaction.absoluteUrl()}resources/email-templates/twitter-icon.png`,
+        link: "https://www.twitter.com"
+      }
+    },
+    // Account Data
+    passwordResetUrl: Accounts.urls.resetPassword(token),
+    user
+  };
+
+  const context = Promise.await(getGraphQLContextInMeteorMethod(Reaction.getUserId()));
+  return Promise.await(context.mutations.sendEmail(context, {
+    data: dataForEmail,
+    fromShop: shop,
+    templateName: "accounts/resetPassword",
+    language,
+    to: email
+  }));
+}
+
+/**
+ * @name accounts/sendResetPasswordEmail
+ * @memberof Accounts/Methods
+ * @method
+ * @example Meteor.call("accounts/sendResetPasswordEmail", options)
+ * @summary Send reset password email
+ * @param {Object} options Options object
+ * @param {String} options.email - email of user
+ * @returns {undefined}
+ */
+export default function sendResetPasswordEmail(options) {
+  check(options, {
+    email: String
+  });
+
+  const user = Accounts.findUserByEmail(options.email);
+
+  if (!user) {
+    Logger.error("accounts/sendResetPasswordEmail - User not found");
+    throw new ReactionError("not-found", "User not found");
+  }
+
+  const language = user.profile && user.profile.language;
+
+  const emails = _.map(user.emails || [], "address");
+
+  const caseInsensitiveEmail = _.find(emails, (email) => email.toLowerCase() === options.email.toLowerCase());
+
+  sendResetEmail(user._id, caseInsensitiveEmail, language);
+}

--- a/imports/plugins/core/accounts/server/no-meteor/mutations/index.js
+++ b/imports/plugins/core/accounts/server/no-meteor/mutations/index.js
@@ -5,6 +5,7 @@ import removeAccountAddressBookEntry from "./removeAccountAddressBookEntry";
 import removeAccountFromGroup from "./removeAccountFromGroup";
 import sendResetAccountPasswordEmail from "./sendResetAccountPasswordEmail";
 import setAccountProfileCurrency from "./setAccountProfileCurrency";
+import setAccountProfileLanguage from "./setAccountProfileLanguage";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry";
 
 export default {
@@ -15,5 +16,6 @@ export default {
   removeAccountFromGroup,
   sendResetAccountPasswordEmail,
   setAccountProfileCurrency,
+  setAccountProfileLanguage,
   updateAccountAddressBookEntry
 };

--- a/imports/plugins/core/accounts/server/no-meteor/mutations/sendResetAccountPasswordEmail.js
+++ b/imports/plugins/core/accounts/server/no-meteor/mutations/sendResetAccountPasswordEmail.js
@@ -93,9 +93,13 @@ async function sendResetEmail(context, account, email) {
     user
   };
 
+  // get account profile language for email
+  const language = account.profile && account.profile.language;
+
   return context.mutations.sendEmail(context, {
     data: dataForEmail,
     fromShop: shop,
+    language,
     templateName: "accounts/resetPassword",
     to: email
   });

--- a/imports/plugins/core/accounts/server/no-meteor/mutations/setAccountProfileLanguage.js
+++ b/imports/plugins/core/accounts/server/no-meteor/mutations/setAccountProfileLanguage.js
@@ -1,0 +1,69 @@
+import SimpleSchema from "simpl-schema";
+import ReactionError from "@reactioncommerce/reaction-error";
+
+const inputSchema = new SimpleSchema({
+  language: String,
+  accountId: {
+    type: String,
+    optional: true
+  }
+});
+
+/**
+ * @name accounts/setAccountProfileLanguage
+ * @memberof Mutations/Accounts
+ * @summary Sets users profile language
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Necessary input for mutation. See SimpleSchema.
+ * @param {String} input.language- i18n language code to add to user profile
+ * @param {String} [input.accountId] - optional decoded ID of account on which entry should be updated
+ * @returns {Object} Account document with updated profile language
+ */
+export default async function setAccountProfileLanguage(context, input) {
+  inputSchema.validate(input);
+  const { appEvents, collections, userHasPermission, userId: userIdFromContext } = context;
+  const { Accounts, Shops } = collections;
+  const { language, accountId: providedAccountId } = input;
+  const accountId = providedAccountId || userIdFromContext;
+
+  if (!accountId) throw new ReactionError("access-denied", "You must be logged in to set profile language");
+
+  const account = Accounts.findOne({ _id: accountId }, { fields: { shopId: 1 } });
+  if (!account) throw new ReactionError("not-found", "No account found");
+
+  if (!context.isInternalCall && userIdFromContext !== providedAccountId) {
+    if (!userHasPermission(["reaction-accounts"], account.shopId)) throw new ReactionError("access-denied", "Access denied");
+  }
+
+  // Make sure this language is in the related shop languages list
+  const shop = await Shops.findOne({ _id: account.shopId }, { languages: 1 });
+  if (!shop || !shop.languages || !isLanguageEnabled(shop.languages, language)) {
+    throw new ReactionError("invalid-argument", `Shop does not define any enabled language with code "${language}"`);
+  }
+
+  const { value: updatedAccount } = await Accounts.findOneAndUpdate(
+    { _id: accountId },
+    { $set: { "profile.language": language } },
+    { returnOriginal: false }
+  );
+
+  await appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: accountId,
+    updatedFields: ["profile.language"]
+  });
+
+  return updatedAccount;
+}
+
+/**
+ * @summary Checks whether language is in languages and is enabled
+ * @param {Object[]} languages - shop languages
+ * @param {Boolean} languages[].enabled - true if enabled false if disabled
+ * @param {String} languages[].i18n - code of language
+ * @param {String} language - i18n code of language
+ * @returns {Boolean} - true if language is enabled exists in languages array
+ */
+function isLanguageEnabled(languages, language) {
+  return !!languages.find(({ enabled, i18n }) => enabled === true && i18n === language);
+}

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/index.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Account/index.js
@@ -11,6 +11,7 @@ export default {
   emailRecords: (account) => account.emails,
   firstName: (account) => account.profile.firstName,
   lastName: (account) => account.profile.lastName,
+  language: (account) => account.profile.language,
   name: (account) => account.profile.name,
   preferences: (account) => get(account, "profile.preferences"),
   primaryEmailAddress: (account) => {

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/index.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/index.js
@@ -5,6 +5,7 @@ import removeAccountAddressBookEntry from "./removeAccountAddressBookEntry";
 import removeAccountFromGroup from "./removeAccountFromGroup";
 import sendResetAccountPasswordEmail from "./sendResetAccountPasswordEmail";
 import setAccountProfileCurrency from "./setAccountProfileCurrency";
+import setAccountProfileLanguage from "./setAccountProfileLanguage";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry";
 
 export default {
@@ -15,5 +16,6 @@ export default {
   removeAccountFromGroup,
   sendResetAccountPasswordEmail,
   setAccountProfileCurrency,
+  setAccountProfileLanguage,
   updateAccountAddressBookEntry
 };

--- a/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/setAccountProfileLanguage.js
+++ b/imports/plugins/core/accounts/server/no-meteor/resolvers/Mutation/setAccountProfileLanguage.js
@@ -1,0 +1,29 @@
+import { decodeAccountOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/account";
+
+/**
+ * @name Mutation.setAccountProfileLanguage
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver for the setAccountProfileLanguage GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} [args.input.accoundId] - The account ID, which defaults to the viewer account
+ * @param {String} args.input.language- The languageto add to user profile
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @return {Promise<Object>} setAccountProfileLanguage
+ */
+export default async function setAccountProfileLanguage(_, { input }, context) {
+  const { accountId, language, clientMutationId = null } = input;
+  const decodedAccountId = decodeAccountOpaqueId(accountId);
+
+  const updatedAccount = await context.mutations.setAccountProfileLanguage(context, {
+    language,
+    accountId: decodedAccountId
+  });
+
+  return {
+    account: updatedAccount,
+    clientMutationId
+  };
+}

--- a/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
+++ b/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
@@ -310,7 +310,7 @@ type SetAccountProfileCurrencyPayload {
 "The response from the `setAccountProfileLanguage` mutation"
 type SetAccountProfileLanguagePayload {
   "The updated account"
-  account: Account
+  account: Account!
 
   "The same string you sent with the mutation params, for matching mutation calls with their responses"
   clientMutationId: String
@@ -383,7 +383,7 @@ extend type Mutation {
   setAccountProfileLanguage(
     "Mutation input"
     input: SetAccountProfileLanguageInput!
-  ): SetAccountProfileLanguagePayload
+  ): SetAccountProfileLanguagePayload!
 
   "Remove an address that exists in the `addressBook` field for an account"
   updateAccountAddressBookEntry(

--- a/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
+++ b/imports/plugins/core/accounts/server/no-meteor/schemas/account.graphql
@@ -76,6 +76,18 @@ input SetAccountProfileCurrencyInput {
   currencyCode: String!
 }
 
+"Describes an account profile language change"
+input SetAccountProfileLanguageInput {
+ "The account ID, which defaults to the viewer account"
+ accountId: ID
+
+ "An optional string identifying the mutation call, which will be returned in the response payload"
+ clientMutationId: String
+
+ "The i18n language code value"
+ language: String!
+}
+
 "Defines a new Email and the account to which it should be added"
 input AddAccountEmailRecordInput {
   "The account ID, which defaults to the viewer account"
@@ -161,6 +173,9 @@ type Account implements Node {
     "By default, groups are sorted by when they were created, oldest first. Set this to sort by one of the other allowed fields"
     sortBy: GroupSortByField = createdAt
   ): GroupConnection
+
+  "The preferred language used by this account"
+  language: String
 
   "The last name of the person this account represents, if known"
   lastName: String
@@ -292,6 +307,15 @@ type SetAccountProfileCurrencyPayload {
   clientMutationId: String
 }
 
+"The response from the `setAccountProfileLanguage` mutation"
+type SetAccountProfileLanguagePayload {
+  "The updated account"
+  account: Account
+
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+}
+
 extend type Shop {
   """
   Returns a list of administrators for this shop, as a Relay-compatible connection.
@@ -354,6 +378,12 @@ extend type Mutation {
     "Mutation input"
     input: SetAccountProfileCurrencyInput!
   ): SetAccountProfileCurrencyPayload
+
+  "Set the preferred language for an account"
+  setAccountProfileLanguage(
+    "Mutation input"
+    input: SetAccountProfileLanguageInput!
+  ): SetAccountProfileLanguagePayload
 
   "Remove an address that exists in the `addressBook` field for an account"
   updateAccountAddressBookEntry(

--- a/imports/plugins/core/accounts/server/util/sendVerificationEmail.js
+++ b/imports/plugins/core/accounts/server/util/sendVerificationEmail.js
@@ -25,6 +25,7 @@ export default async function sendVerificationEmail({
 }) {
   // Make sure the user exists, and email is one of their addresses.
   const user = Meteor.users.findOne({ _id: userId });
+  const account = Meteor.users.findOne({ _id: userId });
 
   if (!user) throw new ReactionError("not-found", `User ${userId} not found`);
 
@@ -96,11 +97,14 @@ export default async function sendVerificationEmail({
     userEmailAddress: address
   };
 
+  const language = account && account.profile && account.profile.language;
+
   const context = Promise.await(getGraphQLContextInMeteorMethod(Reaction.getUserId()));
   return Promise.await(context.mutations.sendEmail(context, {
     data: dataForEmail,
     fromShopId: Reaction.getShopId(),
     templateName: bodyTemplate,
+    language,
     to: address
   }));
 }

--- a/imports/plugins/core/accounts/server/util/sendVerificationEmail.js
+++ b/imports/plugins/core/accounts/server/util/sendVerificationEmail.js
@@ -25,7 +25,7 @@ export default async function sendVerificationEmail({
 }) {
   // Make sure the user exists, and email is one of their addresses.
   const user = Meteor.users.findOne({ _id: userId });
-  const account = Meteor.users.findOne({ _id: userId });
+  const account = Accounts.findOne({  userId });
 
   if (!user) throw new ReactionError("not-found", `User ${userId} not found`);
 

--- a/imports/plugins/core/accounts/server/util/sendVerificationEmail.js
+++ b/imports/plugins/core/accounts/server/util/sendVerificationEmail.js
@@ -25,7 +25,7 @@ export default async function sendVerificationEmail({
 }) {
   // Make sure the user exists, and email is one of their addresses.
   const user = Meteor.users.findOne({ _id: userId });
-  const account = Accounts.findOne({  userId });
+  const account = Accounts.findOne({ userId });
 
   if (!user) throw new ReactionError("not-found", `User ${userId} not found`);
 

--- a/imports/plugins/core/accounts/server/util/sendWelcomeEmail.js
+++ b/imports/plugins/core/accounts/server/util/sendWelcomeEmail.js
@@ -64,12 +64,14 @@ export default function sendWelcomeEmail(shopId, userId, token) {
   dataForEmail.verificationUrl = MeteorAccounts.urls.verifyEmail(token);
 
   const userEmail = account.emails[0].address;
+  const language = account && account.profile && account.profile.language;
 
   const context = Promise.await(getGraphQLContextInMeteorMethod(null));
   Promise.await(context.mutations.sendEmail(context, {
     data: dataForEmail,
     fromShop: shop,
     templateName: "accounts/sendWelcomeEmail",
+    language,
     to: userEmail
   }));
 

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.js
@@ -170,6 +170,7 @@ export default async function placeOrder(context, input) {
     customFields: customFieldsFromClient,
     email,
     fulfillmentGroups,
+    ordererPreferredLanguage,
     shopId
   } = orderInput;
   const { accountId, account, collections, getFunctionsOfType, userId } = context;
@@ -259,6 +260,7 @@ export default async function placeOrder(context, input) {
     currencyCode,
     discounts,
     email,
+    ordererPreferredLanguage: ordererPreferredLanguage || null,
     payments,
     shipping: finalFulfillmentGroups,
     shopId,

--- a/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.test.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/placeOrder.test.js
@@ -59,6 +59,7 @@ test("places an anonymous $0 order with no cartId and no payments", async () => 
     cartId: null,
     currencyCode: "USD",
     email: "valid@email.address",
+    ordererPreferredLanguage: "en",
     fulfillmentGroups: Factory.orderFulfillmentGroupInputSchema.makeMany(1, {
       items: Factory.orderItemInputSchema.makeMany(1, {
         quantity: 1,
@@ -88,6 +89,7 @@ test("places an anonymous $0 order with no cartId and no payments", async () => 
     customFields: {},
     discounts: [],
     email: orderInput.email,
+    ordererPreferredLanguage: "en",
     payments: [],
     referenceId: jasmine.any(String),
     shipping: [

--- a/imports/plugins/core/orders/server/no-meteor/mutations/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/no-meteor/mutations/sendOrderEmail.js
@@ -12,6 +12,10 @@ const inputSchema = new SimpleSchema({
   to: {
     type: String
   },
+  language: {
+    type: String,
+    optional: true
+  },
   dataForEmail: {
     type: Object,
     blackbox: true
@@ -28,7 +32,7 @@ const inputSchema = new SimpleSchema({
 export default async function sendOrderEmail(context, input) {
   inputSchema.validate(input);
 
-  const { action, dataForEmail, fromShop, to } = input;
+  const { action, dataForEmail, fromShop, language, to } = input;
 
   // Compile email
   let templateName;
@@ -47,6 +51,7 @@ export default async function sendOrderEmail(context, input) {
     data: dataForEmail,
     fromShop,
     templateName,
+    language,
     to
   });
 }

--- a/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
+++ b/imports/plugins/core/orders/server/no-meteor/simpleSchemas.js
@@ -227,6 +227,10 @@ export const orderInputSchema = new SimpleSchema({
     minCount: 1
   },
   "fulfillmentGroups.$": orderFulfillmentGroupInputSchema,
+  "ordererPreferredLanguage": {
+    type: String,
+    optional: true
+  },
   "shopId": String
 });
 

--- a/imports/plugins/core/orders/server/no-meteor/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/sendOrderEmail.js
@@ -48,11 +48,11 @@ export default async function sendOrderEmail(context, order, action) {
  * @param {Object} order - The order document
  * @returns {String} i18n language code
  */
-async function getLanguageForOrder(context, { language, accountId }) {
+async function getLanguageForOrder(context, { ordererPreferredLanguage, accountId }) {
   const { collections: { Accounts } } = context;
   // if order is anonymous return order language
   if (!accountId) {
-    return language;
+    return ordererPreferredLanguage;
   }
 
   const account = await Accounts.findOne({ _id: accountId }, { "profile.language": 1 });

--- a/imports/plugins/core/orders/server/no-meteor/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/sendOrderEmail.js
@@ -56,5 +56,5 @@ async function getLanguageForOrder(context, { ordererPreferredLanguage, accountI
   }
 
   const account = await Accounts.findOne({ _id: accountId }, { "profile.language": 1 });
-  return (account && account.profile && account.profile.language) || language;
+  return (account && account.profile && account.profile.language) || ordererPreferredLanguage;
 }

--- a/imports/plugins/core/orders/server/no-meteor/util/sendOrderEmail.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/sendOrderEmail.js
@@ -27,13 +27,34 @@ export default async function sendOrderEmail(context, order, action) {
   }
 
   const dataForEmail = await getDataForOrderEmail(context, { order });
+  const language = await getLanguageForOrder(context, order);
 
   await context.mutations.sendOrderEmail(context, {
     action,
     dataForEmail,
     fromShop: dataForEmail.shop,
+    language,
     to
   });
 
   return true;
+}
+
+/**
+ * @summary Returns language to be used for order emails.
+ *          If cart is account based and has set language
+ *          then returns that language, else order language.
+ * @param {Object} context App context
+ * @param {Object} order - The order document
+ * @returns {String} i18n language code
+ */
+async function getLanguageForOrder(context, { language, accountId }) {
+  const { collections: { Accounts } } = context;
+  // if order is anonymous return order language
+  if (!accountId) {
+    return language;
+  }
+
+  const account = await Accounts.findOne({ _id: accountId }, { "profile.language": 1 });
+  return (account && account.profile && account.profile.language) || language;
 }

--- a/imports/plugins/included/email-templates/server/mutations/renderEmail.js
+++ b/imports/plugins/included/email-templates/server/mutations/renderEmail.js
@@ -9,10 +9,11 @@ import getTemplateConfig from "../util/getTemplateConfig";
  * @param {Object} [data] Data that will be used to populate placeholders in the template
  * @param {String} shopId The shop ID, to look up the email template for this shop
  * @param {String} templateName Template name
+ * @param {String} language i18n language of template
  * @returns {Object} An object with rendered content in properties `html` and `subject`
  */
-export default async function renderEmail(context, { data, shopId, templateName }) {
-  const { template, subject } = await getTemplateConfig(context, shopId, templateName);
+export default async function renderEmail(context, { data, shopId, templateName, language }) {
+  const { template, subject } = await getTemplateConfig(context, shopId, templateName, language);
 
   const renderSubject = Handlebars.compile(subject);
   const renderBody = Handlebars.compile(template);

--- a/imports/plugins/included/email-templates/server/util/getTemplateConfig.js
+++ b/imports/plugins/included/email-templates/server/util/getTemplateConfig.js
@@ -3,9 +3,10 @@
  * @param {Object} context App context
  * @param {String} shopId Shop ID
  * @param {String} templateName Email template name
+ * @param {String} language Email language
  * @returns {Object} returns source
  */
-export default async function getTemplateConfig(context, shopId, templateName) {
+export default async function getTemplateConfig(context, shopId, templateName, language) {
   const { Shops, Templates } = context.collections;
 
   const shop = await Shops.findOne({
@@ -17,16 +18,16 @@ export default async function getTemplateConfig(context, shopId, templateName) {
   });
   if (!shop) throw new Error(`Shop with ID ${shopId} not found`);
 
-  const { language } = shop;
+  const { language: shopLanguage } = shop;
 
   // check database for a matching template
   const templateDoc = await Templates.findOne({
-    language,
+    language: language || shopLanguage,
     name: templateName,
     shopId,
     type: "email"
   });
-  if (!templateDoc) throw new Error(`No email template found for language ${language}`);
+  if (!templateDoc) throw new Error(`No email template found for language ${language || shopLanguage}`);
 
   return templateDoc;
 }


### PR DESCRIPTION
Resolves #5555 
Impact: **major**  
Type: **feature**

## Issue
[Previous pull request](https://github.com/reactioncommerce/reaction/pull/5171), which was closed due to significant changes in reaction in this timeframe and different forked repository.

Multilingual emails by shop are not supported, because email language will always be that of `shop.language`. All users will receive email in same language.

## Solution
Added fields `profile.language` to Accounts collection and `ordererPreferredLanguage` to order collection.
Updated graphql queries and mutations to allow for optional language.
This way storefront can supply language and we support multilingual emails.

## Breaking changes
No breaking changes.

## Testing
Tests are not implemented, but code is tested locally.

### Account Profile Language
1. Run graphql mutation `setAccountProfileLanguage`.

### Order language
1. Create order either with or without `orderPreferredLanguage` field.

### Account Emails
1. Set profile language for user.
2. Do an activity which sends email with that user such as reset password, create order etc.
