### PR TITLE
fix: properly destructure shopId as part of data object, not paramete…

### DIFF
--- a/imports/plugins/included/email-templates/server/mutations/renderEmail.js
+++ b/imports/plugins/included/email-templates/server/mutations/renderEmail.js
@@ -11,7 +11,8 @@ import getTemplateConfig from "../util/getTemplateConfig";
  * @param {String} templateName Template name
  * @returns {Object} An object with rendered content in properties `html` and `subject`
  */
-export default async function renderEmail(context, { data, shopId, templateName }) {
+export default async function renderEmail(context, { data, templateName }) {
+  const { shopId } = data;
   const { template, subject } = await getTemplateConfig(context, shopId, templateName);
 
   const renderSubject = Handlebars.compile(subject);


### PR DESCRIPTION
Resolves #5312 
Impact: **major**  
Type: **bugfix**

## Issue
There is no parameter `shopId` passed into `renderEmail` function from `sendEmail`.
`shopId` is passed as `data.shopId` so field of `data` parameter.

## Solution
Properly destructure shopId as it comes from data parameter, not first parameter itself.

## Breaking changes
No breaking changes. 

## Testing
TBD