### PR TITLE
refactor: remove Reaction.Email

### DIFF
--- a/imports/plugins/core/core/server/Reaction/index.js
+++ b/imports/plugins/core/core/server/Reaction/index.js
@@ -1,5 +1,4 @@
 import Log from "@reactioncommerce/logger";
-import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
 import Core from "./core";
 import { Fixture, Importer } from "./importer";
 import getSlug from "./getSlug";
@@ -12,26 +11,6 @@ export default {
   ...Core,
   ...accountUtils,
   Collections,
-
-  /**
-   * @deprecated Reaction.Email should no longer be used
-   */
-  Email: {
-    /**
-     * @summary Backwards compatible email sending function
-     * @deprecated Call `context.mutations.sendEmail` directly instead
-     * @param {Object} options See `sendEmail`
-     * @returns {undefined}
-     */
-    send(options) {
-      const context = Promise.await(getGraphQLContextInMeteorMethod(accountUtils.getUserId()));
-
-      if (!options.fromShopId) options.fromShopId = Core.getShopId();
-
-      return Promise.await(context.mutations.sendEmail(context, options));
-    }
-  },
-
   Fixture,
   getSlug,
   Importer,


### PR DESCRIPTION
Resolves parts of #5529
Impact: breaking|minor
Type: refactor

## Issue
Reaction.Email was [deprecated in February of 2019](https://github.com/reactioncommerce/reaction/blame/refactor-kieckhafer-removeSendResetPasswordEmailMeteorMethod/imports/plugins/core/core/server/Reaction/index.js#L17), over 7 months ago, and prior to our `v2.0.0` release. This is one of the last pieces of code that uses `getGraphQLContextInMeteorMethod`, which we are removing.

## Solution
Given the time this has been deprecated since before `v2.0.0`, and the fact that there are `0` instances of using `Reaction.Email` inside core code, I believe this can be removed. It might be best to not merge until we make a `v3.0.0` release branch, so it's included in the other breaking changes.

## Breaking changes
Any custom code using `Reaction.Email` will need to be updated to call `context.mutations.sendEmail`.

## Testing
1. Make sure the app starts