### PR TITLE
fix(5226): use catalyst button for mediauploader

### DIFF
--- a/imports/plugins/core/ui/client/components/media/mediaUploader.js
+++ b/imports/plugins/core/ui/client/components/media/mediaUploader.js
@@ -92,7 +92,11 @@ function MediaUploader(props) {
   return (
     <div {...getRootProps({ className: "dropzone" })}>
       <input {...getInputProps()} />
-      {isUploading ? <LinearProgress /> : <Button fullWidth size="large" variant="outlined">{i18next.t("reactionUI.components.mediaUploader.dropFiles")}</Button>}
+      {isUploading ?
+        <LinearProgress />
+        :
+        <Button fullWidth size="large" variant="outlined">{i18next.t("reactionUI.components.mediaUploader.dropFiles")}</Button>
+      }
     </div>
   );
 }

--- a/imports/plugins/core/ui/client/components/media/mediaUploader.js
+++ b/imports/plugins/core/ui/client/components/media/mediaUploader.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Meteor } from "meteor/meteor";
 import { useDropzone } from "react-dropzone";
-import Button from "@material-ui/core/Button";
+import Button from "@reactioncommerce/catalyst/Button";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import { FileRecord } from "@reactioncommerce/file-collections";
 import { registerComponent } from "@reactioncommerce/reaction-components";
@@ -92,7 +92,7 @@ function MediaUploader(props) {
   return (
     <div {...getRootProps({ className: "dropzone" })}>
       <input {...getInputProps()} />
-      {isUploading ? <LinearProgress /> : <Button fullWidth size="large">{i18next.t("reactionUI.components.mediaUploader.dropFiles")}</Button>}
+      {isUploading ? <LinearProgress /> : <Button fullWidth size="large" variant="outlined">{i18next.t("reactionUI.components.mediaUploader.dropFiles")}</Button>}
     </div>
   );
 }


### PR DESCRIPTION
Resolves #5526  
Impact: **minor**  
Type: **fix|refactor**

## Issue
- Use Catalyst button for the `mediaUploader`

## Solution
- MediaUploader is used in 2 places so far: Shop Logo, Product Images -

- Product Images:
<img width="858" alt="Screen Shot 2019-09-16 at 2 32 33 PM" src="https://user-images.githubusercontent.com/3673236/64995316-bcbdf780-d88f-11e9-90b8-e4728be1618f.png">
<img width="792" alt="Screen Shot 2019-09-16 at 2 32 27 PM" src="https://user-images.githubusercontent.com/3673236/64995317-bd568e00-d88f-11e9-8cf9-89dd2b5fea30.png">
- Logo:
<img width="1440" alt="Screen Shot 2019-09-16 at 1 47 12 PM" src="https://user-images.githubusercontent.com/3673236/64995319-bd568e00-d88f-11e9-9c48-72d8336881c6.png">
<img width="1158" alt="Screen Shot 2019-09-16 at 2 39 20 PM" src="https://user-images.githubusercontent.com/3673236/64995349-d4957b80-d88f-11e9-81a5-8550a066b6b5.png">


## Breaking changes
none

## Testing
1. Test image upload for shop logo
1. Test image upload for product images