### PR TITLE
fix: restore Add/Remove menu item in products page

### DIFF
--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -116,6 +116,7 @@ class ProductGrid extends Component {
     onArchiveProducts: PropTypes.func,
     onChangePage: PropTypes.func,
     onChangeRowsPerPage: PropTypes.func,
+    onDisplayTagSelector: PropTypes.func,
     onDuplicateProducts: PropTypes.func,
     onPublishProducts: PropTypes.func,
     onSelectAllProducts: PropTypes.func,

--- a/imports/plugins/included/product-variant/components/productGrid.js
+++ b/imports/plugins/included/product-variant/components/productGrid.js
@@ -131,11 +131,11 @@ class ProductGrid extends Component {
   }
 
   static defaultProps = {
-    onArchiveProducts() {},
-    onDuplicateProducts() {},
-    onPublishProducts() {},
-    onSelectAllProducts() {},
-    onSetProductVisibility() {},
+    onArchiveProducts() { },
+    onDuplicateProducts() { },
+    onPublishProducts() { },
+    onSelectAllProducts() { },
+    onSetProductVisibility() { },
     productMediaById: {}
   };
 
@@ -186,7 +186,7 @@ class ProductGrid extends Component {
             {i18next.t("admin.productTable.bulkActions.filteredProducts")}
           </Typography>
           <Typography variant="h5" display="inline" className={classes.filterCountText}>
-            { selected }
+            {selected}
           </Typography>
         </div>
       );
@@ -231,9 +231,14 @@ class ProductGrid extends Component {
     );
   }
 
+  handleDisplayTagSelector = () => {
+    this.handleCloseBulkActions();
+    this.props.onDisplayTagSelector(true);
+  }
+
   handleShowFilterByFile = () => {
     this.handleCloseBulkActions();
-    this.props.onShowFilterByFile();
+    this.props.onShowFilterByFile(true);
   }
 
   handleShowBulkActions = (event) => {
@@ -324,6 +329,14 @@ class ProductGrid extends Component {
           >
             Actions
           </MenuItem>
+          <MenuItem
+            onClick={this.handleDisplayTagSelector}
+            variant="default"
+            disabled={!isEnabled}
+            className={classes.actionDropdownMenuItem}
+          >
+            {i18next.t("admin.productTable.bulkActions.addRemoveTags")}
+          </MenuItem>
 
           <MenuItem
             onClick={this.handleShowFilterByFile}
@@ -352,10 +365,10 @@ class ProductGrid extends Component {
                   )}
                 </ConfirmDialog>
                 <span>
-                  { error &&
+                  {error &&
                     Alerts.toast(error.message, "error")
                   }
-                  { data &&
+                  {data &&
                     Alerts.toast(i18next.t("admin.catalogProductPublishSuccess", { defaultValue: "Product published to catalog" }), "success")
                   }
                 </span>


### PR DESCRIPTION
Impact: minor
Type: bugfix

## Issue
The Add/Remove tags menu item was removed accidentally, perhaps in a merge. The filter by file functionality was also broken; this PR restores that too.

## Solution
Restore menu item and ensure filter by file works correctly.

# Testing
1. Start app
2. Filter products using a `csv` file that contains product ids
3. Add tags to 1 or more product
