### PR TITLE
fix: add shopId argument into getMailConfig function call

### DIFF
--- a/imports/plugins/included/email-smtp/server/no-meteor/util/sendSMTPEmail.js
+++ b/imports/plugins/included/email-smtp/server/no-meteor/util/sendSMTPEmail.js
@@ -1,5 +1,6 @@
 import Logger from "@reactioncommerce/logger";
 import nodemailer from "@reactioncommerce/nodemailer";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 import getMailConfig from "./getMailConfig";
 
 /**
@@ -12,7 +13,8 @@ import getMailConfig from "./getMailConfig";
  * @returns {undefined} Calls one of the callbacks with a return
  */
 export default async function sendSMTPEmail(context, { job, sendEmailCompleted, sendEmailFailed }) {
-  const config = await getMailConfig(context);
+  const shopId = Reaction.getShopId();
+  const config = await getMailConfig(context, shopId);
   if (config.direct) {
     sendEmailFailed(job, "SMTP mail settings not configured");
     return;


### PR DESCRIPTION
Resolves #5566  
Impact: **minor**  
Type: **bugfix**

## Issue
`getMailConfig` is called  without second argument `shopId`.

## Solution
Adds `shopId` as second argument to `getMailConfig` call.

## Breaking changes
None

## Testing
TBD
