### PR TITLE
Add indices on updatedAt for CDC (Products & SimpleInventory)

### DIFF
--- a/imports/plugins/core/product/server/no-meteor/register.js
+++ b/imports/plugins/core/product/server/no-meteor/register.js
@@ -22,7 +22,9 @@ export default async function register(app) {
           [{ handle: 1 }, { name: "c2_handle" }],
           [{ hashtags: 1 }, { name: "c2_hashtags" }],
           [{ shopId: 1 }, { name: "c2_shopId" }],
-          [{ "workflow.status": 1 }, { name: "c2_workflow.status" }]
+          [{ "workflow.status": 1 }, { name: "c2_workflow.status" }],
+          // Use _id as second sort to force full stability
+          [{ updatedAt: 1, _id: 1 }]
         ]
       }
     },

--- a/imports/plugins/included/simple-inventory/server/no-meteor/register.js
+++ b/imports/plugins/included/simple-inventory/server/no-meteor/register.js
@@ -25,7 +25,9 @@ export default async function register(app) {
       SimpleInventory: {
         name: "SimpleInventory",
         indexes: [
-          [{ "productConfiguration.productVariantId": 1, "shopId": 1 }, { unique: true }]
+          [{ "productConfiguration.productVariantId": 1, "shopId": 1 }, { unique: true }],
+          // Use _id as second sort to force full stability
+          [{ updatedAt: 1, _id: 1 }]
         ]
       }
     },


### PR DESCRIPTION
Impact: **minor**  
Type: **feature|performance**

## Issue

As we add Change Data Capture (CDC) to our mix of data streaming paradigms, our kafka connect mongo source needs to load full collections sorted by `updatedAt` when it's doing its initial sync before switching over to oplog tailing. These indices on SimpleInventory and Products facilitate that. 

## Solution

Define the indices as part of plugin registration using the existing mechanism.

## Breaking changes
N/A

## Testing
1. Make sure reaction core starts cleanly without new errors
2. Confirm the 2 new indices exist