### PR TITLE
feat: add various filters to the main orders query

### DIFF
--- a/imports/plugins/core/orders/server/no-meteor/queries/orders.js
+++ b/imports/plugins/core/orders/server/no-meteor/queries/orders.js
@@ -18,21 +18,20 @@ export default async function orders(context, { filters, shopIds } = {}) {
   const { Orders } = collections;
 
   const query = {};
-  let dateRangeFilter = {};
+  let createdAtFilter = {};
   let fulfillmentStatusFilter = {};
   let paymentStatusFilter = {};
   let searchFieldFilter = {};
   let statusFilter = {};
 
-
   // Add a date range filter if provided, the filter will be
   // applied to the createdAt database field.
-  if (filters.dateRange && filters.dateRange.createdAt) {
-    const { createdAt } = filters.dateRange;
+  if (filters.createdAt) {
+    const { createdAt } = filters;
     // Both fields are optional
     const gteProp = createdAt.gte ? { $gte: createdAt.gte } : {};
     const ltProp = createdAt.lt ? { $lte: createdAt.lt } : {};
-    dateRangeFilter = {
+    createdAtFilter = {
       createdAt: {
         ...gteProp,
         ...ltProp
@@ -98,7 +97,7 @@ export default async function orders(context, { filters, shopIds } = {}) {
 
   // Build the final query
   query.$and = [{
-    ...dateRangeFilter,
+    ...createdAtFilter,
     ...fulfillmentStatusFilter,
     ...paymentStatusFilter,
     ...searchFieldFilter,

--- a/imports/plugins/core/orders/server/no-meteor/queries/orders.js
+++ b/imports/plugins/core/orders/server/no-meteor/queries/orders.js
@@ -30,11 +30,11 @@ export default async function orders(context, { filters, shopIds } = {}) {
     const { createdAt } = filters;
     // Both fields are optional
     const gteProp = createdAt.gte ? { $gte: createdAt.gte } : {};
-    const ltProp = createdAt.lt ? { $lte: createdAt.lt } : {};
+    const lteProp = createdAt.lte ? { $lte: createdAt.lte } : {};
     createdAtFilter = {
       createdAt: {
         ...gteProp,
-        ...ltProp
+        ...lteProp
       }
     };
   }

--- a/imports/plugins/core/orders/server/no-meteor/queries/orders.js
+++ b/imports/plugins/core/orders/server/no-meteor/queries/orders.js
@@ -26,7 +26,7 @@ export default async function orders(context, { filters, shopIds } = {}) {
 
   // Add a date range filter if provided, the filter will be
   // applied to the createdAt database field.
-  if (filters.createdAt) {
+  if (filters && filters.createdAt) {
     const { createdAt } = filters;
     // Both fields are optional
     const gteProp = createdAt.gte ? { $gte: createdAt.gte } : {};
@@ -55,7 +55,7 @@ export default async function orders(context, { filters, shopIds } = {}) {
   }
 
   // Add fulfillment status if provided
-  if (filters.fulfillmentStatus) {
+  if (filters && filters.fulfillmentStatus) {
     const prefix = filters.fulfillmentStatus === "new" ? "" : "coreOrderWorkflow/";
     fulfillmentStatusFilter = {
       "shipping.workflow.status": `${prefix}${filters.fulfillmentStatus}`
@@ -63,14 +63,14 @@ export default async function orders(context, { filters, shopIds } = {}) {
   }
 
   // Add payment status filters if provided
-  if (filters.paymentStatus) {
+  if (filters && filters.paymentStatus) {
     paymentStatusFilter = {
       "payments.status": filters.paymentStatus
     };
   }
 
   // Add order status filter if provided
-  if (filters.status) {
+  if (filters && filters.status) {
     const prefix = filters.fulfillmentStatus === "new" ? "" : "coreOrderWorkflow/";
     statusFilter = {
       "workflow.status": { $eq: `${prefix}${filters.status}` }
@@ -78,7 +78,7 @@ export default async function orders(context, { filters, shopIds } = {}) {
   }
 
   // Use `filters` to filters out results on the server
-  if (filters.searchField) {
+  if (filters && filters.searchField) {
     const { searchField } = filters;
     const regexMatch = { $regex: escapeRegExp(searchField), $options: "i" };
     searchFieldFilter = {

--- a/imports/plugins/core/orders/server/no-meteor/queries/orders.js
+++ b/imports/plugins/core/orders/server/no-meteor/queries/orders.js
@@ -71,7 +71,7 @@ export default async function orders(context, { filters, shopIds } = {}) {
 
   // Add order status filter if provided
   if (filters && filters.status) {
-    const prefix = filters.fulfillmentStatus === "new" ? "" : "coreOrderWorkflow/";
+    const prefix = filters.status === "new" ? "" : "coreOrderWorkflow/";
     statusFilter = {
       "workflow.status": { $eq: `${prefix}${filters.status}` }
     };

--- a/imports/plugins/core/orders/server/no-meteor/queries/orders.js
+++ b/imports/plugins/core/orders/server/no-meteor/queries/orders.js
@@ -18,10 +18,27 @@ export default async function orders(context, { filters, shopIds } = {}) {
   const { Orders } = collections;
 
   const query = {};
+  let dateRangeFilter = {};
   let fulfillmentStatusFilter = {};
   let paymentStatusFilter = {};
   let searchFieldFilter = {};
   let statusFilter = {};
+
+
+  // Add a date range filter if provided, the filter will be
+  // applied to the createdAt database field.
+  if (filters.dateRange && filters.dateRange.createdAt) {
+    const { createdAt } = filters.dateRange;
+    // Both fields are optional
+    const gteProp = createdAt.gte ? { $gte: createdAt.gte } : {};
+    const ltProp = createdAt.lt ? { $lt: createdAt.lt } : {};
+    dateRangeFilter = {
+      createdAt: {
+        ...gteProp,
+        ...ltProp
+      }
+    };
+  }
 
   // If an admin wants all orders for an account, we force it to be limited to the
   // shops for which they're allowed to see orders.
@@ -81,6 +98,7 @@ export default async function orders(context, { filters, shopIds } = {}) {
 
   // Build the final query
   query.$and = [{
+    ...dateRangeFilter,
     ...fulfillmentStatusFilter,
     ...paymentStatusFilter,
     ...searchFieldFilter,

--- a/imports/plugins/core/orders/server/no-meteor/queries/orders.js
+++ b/imports/plugins/core/orders/server/no-meteor/queries/orders.js
@@ -31,7 +31,7 @@ export default async function orders(context, { filters, shopIds } = {}) {
     const { createdAt } = filters.dateRange;
     // Both fields are optional
     const gteProp = createdAt.gte ? { $gte: createdAt.gte } : {};
-    const ltProp = createdAt.lt ? { $lt: createdAt.lt } : {};
+    const ltProp = createdAt.lt ? { $lte: createdAt.lt } : {};
     dateRangeFilter = {
       createdAt: {
         ...gteProp,

--- a/imports/plugins/core/orders/server/no-meteor/resolvers/Query/orders.js
+++ b/imports/plugins/core/orders/server/no-meteor/resolvers/Query/orders.js
@@ -8,21 +8,19 @@ import { decodeShopOpaqueId } from "@reactioncommerce/reaction-graphql-xforms/sh
  * @summary Get an order by its reference ID
  * @param {Object} parentResult - unused
  * @param {ConnectionArgs} args - An object of all arguments that were sent by the client
- * @param {String} args.filter - filter by _id, referenceId, email and name
- * @param {String} args.orderStatus - workflow status to limit search results
+ * @param {Object} args.filters - An Object of filters to apply
  * @param {String} args.shopIds - shop IDs to check for orders from
  * @param {Object} context - An object containing the per-request state
  * @param {Object} info Info about the GraphQL request
  * @returns {Promise<Object>|undefined} An Order object
  */
 export default async function orders(parentResult, args, context, info) {
-  const { filter, orderStatus, shopIds: opaqueShopIds, ...connectionArgs } = args;
+  const { filters, shopIds: opaqueShopIds, ...connectionArgs } = args;
 
   const shopIds = opaqueShopIds && opaqueShopIds.map(decodeShopOpaqueId);
 
   const query = await context.queries.orders(context, {
-    filter,
-    orderStatus,
+    filters,
     shopIds
   });
 

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -1031,6 +1031,7 @@ input CreatedAtInput {
 
 "Input type for an order date range"
 input OrderDateRangeInput {
+  "The order's create date"
   createdAt: CreatedAtInput 
 }
 

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -13,11 +13,8 @@ extend type Query {
 
   "Get all orders for a single account, optionally limited to certain shop IDs and certain orderStatus"
   orders(
-    "A filter string"
-    filter: String
-
-    "Limit to orders with one of these statuses"
-    orderStatus: [String]
+    "Filters to apply to a list of orders"
+    filters: OrderFilterInput
 
     "Provide a list of shop IDs from which you want to get orders from"
     shopIds: [ID]
@@ -985,4 +982,55 @@ type UpdateOrderFulfillmentGroupPayload {
 
   "The updated order"
   order: Order!
+}
+
+"Order status"
+enum OrderStatus {
+  "A new order that needs processing"
+  new
+  
+  "An order that is being processed"
+  processing
+
+  "A completed order"
+  completed
+
+  "Canceled order"
+  canceled
+}
+
+"Order payment status"
+enum OrderPaymentStatus {
+  "A payment intent has been created"
+  created
+
+  "Payments that have been successfully processed"
+  completed
+}
+
+"Available order fulfillment statuses"
+enum OrderFulfillmentStatus {
+  "Newly created order that needs processing"
+  new
+
+  "An order that is currently being processed"
+  processing
+
+  "An order that has been completed"
+  completed
+}
+
+"Input type for filters to by applied to an Orders list"
+input OrderFilterInput {
+  "An order's fulfillment status"
+  fulfillmentStatus: OrderFulfillmentStatus
+
+  "An order's payment status"
+  paymentStatus: OrderPaymentStatus
+
+  "Keywords typed by the user in the search input field"
+  searchField: String
+
+  "The order's status to filter by"
+  status: OrderStatus
 }

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -984,40 +984,40 @@ type UpdateOrderFulfillmentGroupPayload {
   order: Order!
 }
 
-"Order status"
-enum OrderStatus {
-  "A new order that needs processing"
-  new
-  
-  "An order that is being processed"
-  processing
-
-  "A completed order"
-  completed
-
-  "Canceled order"
-  canceled
-}
-
-"Order payment status"
-enum OrderPaymentStatus {
-  "A payment intent has been created"
-  created
-
-  "Payments that have been successfully processed"
-  completed
-}
-
 "Available order fulfillment statuses"
 enum OrderFulfillmentStatus {
+  "An order that has been completed"
+  completed
+
   "Newly created order that needs processing"
   new
 
   "An order that is currently being processed"
   processing
+}
 
-  "An order that has been completed"
+"Order payment status"
+enum OrderPaymentStatus {
+  "Payments that have been successfully processed"
   completed
+
+  "A payment intent has been created"
+  created
+}
+
+"Order status"
+enum OrderStatus {
+  "Canceled order"
+  canceled
+
+  "A completed order"
+  completed
+
+  "A new order that needs processing"
+  new
+  
+  "An order that is being processed"
+  processing
 }
 
 "Input type for filters to by applied to an Orders list"

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -1020,8 +1020,25 @@ enum OrderStatus {
   processing
 }
 
+"Input for the createdAt database field"
+input CreatedAtInput {
+  "Start date, inclusive"
+  gte: DateTime
+
+  "End date, not inclusive"
+  lt: DateTime
+}
+
+"Input type for an order date range"
+input OrderDateRangeInput {
+  createdAt: CreatedAtInput 
+}
+
 "Input type for filters to by applied to an Orders list"
 input OrderFilterInput {
+  "A date range to filter by"
+  dateRange: OrderDateRangeInput
+
   "An order's fulfillment status"
   fulfillmentStatus: OrderFulfillmentStatus
 

--- a/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
+++ b/imports/plugins/core/orders/server/no-meteor/schemas/schema.graphql
@@ -1025,20 +1025,14 @@ input CreatedAtInput {
   "Start date, inclusive"
   gte: DateTime
 
-  "End date, not inclusive"
-  lt: DateTime
-}
-
-"Input type for an order date range"
-input OrderDateRangeInput {
-  "The order's create date"
-  createdAt: CreatedAtInput 
+  "End date, inclusive"
+  lte: DateTime
 }
 
 "Input type for filters to by applied to an Orders list"
 input OrderFilterInput {
-  "A date range to filter by"
-  dateRange: OrderDateRangeInput
+  "A createdAt date range to filter by"
+  createdAt: CreatedAtInput
 
   "An order's fulfillment status"
   fulfillmentStatus: OrderFulfillmentStatus


### PR DESCRIPTION
# Adds various filters to the main orders query

### Summary
Adds API support to enable users to filter orders by: search keywords (fuzzy search), status, payment status, fulfillment status, date range.

### Testing
1. Create a sample set of orders with varying created dates (edit in DB if necessary)
2. Use sample query below to test all the supported filters
3. Verify orders are filtered correctly

sample query all supported filters
```
{
  orders(
    shopIds: ["cmVhY3Rpb24vc2hvcDpKOEJocTN1VHRkZ3daeDNyeg=="]
    filters: { 
      searchField: "myname"
      status: processing
      paymentStatus:completed
      fulfillmentStatus: completed
      createdAt:{
        gte: "2019-09-16T00:00:00.000Z",
        lte: "2019-09-16T23:59:59.999Z"
      }
    }
  ) {
    nodes {
      _id
      createdAt
      email
      fulfillmentGroups {
      	status
      }
      payments {
        status
        billingAddress {
          fullName
        }
      }
      email
      status
    }
  }
}

```