### PR TITLE
fix: product medatafield UI issues

### DIFF
--- a/imports/plugins/included/product-admin/client/hocs/withProductForm.js
+++ b/imports/plugins/included/product-admin/client/hocs/withProductForm.js
@@ -123,10 +123,8 @@ const wrapComponent = (Comp) => {
       });
     }
 
-    handleMetaRemove = (event, metafield, index) => {
-      if (this.props.onMetaRemove) {
-        this.props.onMetaRemove(this.product._id, metafield, index);
-      }
+    handleMetaRemove = (event, metafield) => {
+      Meteor.call("products/removeMetaFields", this.product._id, metafield);
     }
 
     get product() {

--- a/imports/plugins/included/product-admin/client/hocs/withProductForm.js
+++ b/imports/plugins/included/product-admin/client/hocs/withProductForm.js
@@ -116,7 +116,7 @@ const wrapComponent = (Comp) => {
       }
 
       this.setState({
-        newMetaField: {
+        newMetafield: {
           key: "",
           value: ""
         }


### PR DESCRIPTION
Resolves #5576   
Impact: **critical**  
Type: **bugfix**

## Issue

- Couldn't delete meta fields
- "new metafield" wouldn't clear input on save

## Solution

- Fix issue of not being able to delete by adding the meteor call to the callback, rather than relying on props

## Breaking changes

none.

## Testing
1. Go to a product
1. Add meta fields
1. See that that the input fields are now cleared on submit
1. Remove meta fields and see that it works as expected
