### PR TITLE
Update URLs for Hydra OAuth flow to support reaction-hydra moving to 1.0.0

### DIFF
--- a/imports/plugins/core/hydra-oauth/server/util/hydra.js
+++ b/imports/plugins/core/hydra-oauth/server/util/hydra.js
@@ -18,16 +18,19 @@ if (process.env.MOCK_TLS_TERMINATION) {
  * @param  {String} challenge To fetch information about the login/consent
  * @returns {Object|String} API res
  */
-function get(flow, challenge) {
-  return fetch(`${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}/${challenge}`)
-    .then(async (res) => {
-      if (res.status < 200 || res.status > 302) {
-        const json = await res.json();
-        Logger.error(`An error occurred while making GET ${flow}-${challenge} HTTP request to Hydra: `, json.error_description);
-        return Promise.reject(new Error(json.error_description));
-      }
-      return res.json();
-    });
+const get = async (flow, challenge) => {
+  try{
+    const res = await fetch(`${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}?${flow}_challenge=${challenge}`);
+    console.log({ res });
+    if (res.status < 200 || res.status > 302) {
+      const json = await res.json();
+      Logger.error(`An error occurred while making GET ${flow}-${challenge} HTTP request to Hydra: `, json.error_description);
+      return Promise.reject(new Error(json.error_description));
+    }
+    return res.json();
+  } catch (err) {
+    Logger.error(`An error occurred while making GET ${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}?${flow}_challenge=${challenge} HTTP request to Hydra: `, err);
+  }
 }
 
 /**
@@ -40,23 +43,25 @@ function get(flow, challenge) {
  * @param  {String} body Request body
  * @returns {Object|String} API res
  */
-function put(flow, action, challenge, body) {
-  return fetch(`${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}/${challenge}/${action}`, {
-    method: "PUT",
-    body: JSON.stringify(body),
-    headers: {
-      "Content-Type": "application/json",
-      ...mockTlsTermination
-    }
-  })
-    .then(async (res) => {
-      if (res.status < 200 || res.status > 302) {
-        const json = await res.json();
-        Logger.error(`An error occurred while making PUT ${flow}-${challenge} request to Hydra: `, json.error_description);
-        return Promise.reject(new Error(json.error_description));
+const put = async (flow, action, challenge, body) => {
+  try {
+    const res = await fetch(`${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}/${action}?${flow}_challenge=${challenge}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+      headers: {
+        "Content-Type": "application/json",
+        ...mockTlsTermination
       }
-      return res.json();
-    });
+    })
+    if (res.status < 200 || res.status > 302) {
+      const json = await res.json();
+      Logger.error(`An error occurred while making PUT ${flow}-${challenge} request to Hydra: `, json.error_description);
+      return Promise.reject(new Error(json.error_description));
+    }
+    return res.json();
+  } catch (err){
+    Logger.error(`An error occurred while making PUT  ${flow}-${challenge} request to Hydra`, json.error_description);
+  }
 }
 
 /**


### PR DESCRIPTION
Resolves: https://github.com/reactioncommerce/reaction-feature-requests/issues/112#issue-484468960
Impact: **minor**  
Type: **chore**

## Issue
This PR updates the auth URLs that were changed as part of the hydra project moving away from the 1.0.0-beta to the stable release

## Solution
change GET and PUT urls for login flow under the hydra plugin to conform to the expected url as specified [here](https://github.com/ory/hydra/blob/master/CHANGELOG.md#v100-2019-06-24)

## Breaking changes
this solution will only work if the reaction-hydra project has an update to use the stable version of hydra as opposed to the currently used 1.0.0-beta


## Testing
1. run `make`
2. navigate to the `docker-compose.yaml` of the reaction-hydra project
3. update image of hydra to `oryd/hydra:1.0.0`
4. run through authentication steps as usual
