### PR TITLE
fix: filter products by file on Windows

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -98,7 +98,6 @@ function ProductTable({ history }) {
     onDrop,
     multiple: true,
     disablePreview: true,
-    accept: "text/csv",
     disableClick: true
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17029,30 +17029,13 @@
       }
     },
     "react-dropzone": {
-      "version": "10.1.7",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-10.1.7.tgz",
-      "integrity": "sha512-PT4DHJCQrY/2vVljupveqnlwzVRQGK7U6mhoO0ox6kSJV0EK6W1ZmZpRyHMA1S6/KUOzN+1pASUMSqV/4uAIXg==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-10.1.10.tgz",
+      "integrity": "sha512-vcLBdkYo7wgZpw1o4cz7uk8/Mmm+sYHeiTfFSshA/EGthz/TjjrTOrKwvFHm3o1p1LPk+x+KbDDlw5OeIo6eYA==",
       "requires": {
         "attr-accept": "^1.1.3",
         "file-selector": "^0.1.11",
         "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "react-is": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
-        }
       }
     },
     "react-event-listener": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-dnd": "^7.0.1",
     "react-dnd-html5-backend": "^7.0.1",
     "react-dom": "16.8.6",
-    "react-dropzone": "^10.1.7",
+    "react-dropzone": "^10.1.10",
     "react-helmet": "^5.2.0",
     "react-image-magnify": "^2.7.4",
     "react-loadable": "^5.5.0",


### PR DESCRIPTION
Impact: minor
Type: fix

## Issue
On Windows, an uploaded file type is not always determined correctly, which causes Dropzode to fail to detect an uploaded file.  

## Solution
Remove file type restriction/validation from dropzone configuration. There is currently no other known way to ensure a file will always upload correctly on Windows.

## Breaking changes
None

## Testing
1. Filter products using a file on a Mac using Chrome/Firefox
2. Filter products using a file on a Windows 10/8 machine using Chrome/Firefox
