### PR TITLE
refactor: only update fulfillment group for which id is provided

### DIFF
--- a/imports/node-app/core-services/orders/mutations/updateOrderFulfillmentGroup.test.js
+++ b/imports/node-app/core-services/orders/mutations/updateOrderFulfillmentGroup.test.js
@@ -161,16 +161,19 @@ test("updates an order fulfillment group", async () => {
     },
     {
       $set: {
-        "shipping.$.tracking": "TRACK_REF",
-        "shipping.$.trackingUrl": "http://track.me/TRACK_REF",
-        "shipping.$.updatedAt": jasmine.any(Date),
-        "shipping.$.workflow.status": "NEW_STATUS",
+        "shipping.$[group].tracking": "TRACK_REF",
+        "shipping.$[group].trackingUrl": "http://track.me/TRACK_REF",
+        "shipping.$[group].updatedAt": jasmine.any(Date),
+        "shipping.$[group].workflow.status": "NEW_STATUS",
         "updatedAt": jasmine.any(Date)
       },
       $push: {
-        "shipping.$.workflow.workflow": "NEW_STATUS"
+        "shipping.$[group].workflow.workflow": "NEW_STATUS"
       }
     },
-    { returnOriginal: false }
+    {
+      arrayFilters: [{ "group._id": "group1" }],
+      returnOriginal: false
+    }
   );
 });


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

## Issue
If there are more than one fulfillment groups, this mutation will update the workflow of all the groups.

## Solution
Adding arrayFilters to the collection update to make sure only the group, for which the id is provided, gets updated. Had to remove the schema modifier validation due to this: https://github.com/aldeed/meteor-collection2/issues/387

## Breaking changes
none

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
