### PR TITLE
[3.0.0] Check Node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5471,8 +5471,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5493,14 +5492,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5515,20 +5512,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5645,8 +5639,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5658,7 +5651,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5673,7 +5665,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5681,14 +5672,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5707,7 +5696,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5788,8 +5776,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5801,7 +5788,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5887,8 +5873,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5924,7 +5909,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5944,7 +5928,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5988,14 +5971,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "object-hash": "~1.3.1",
     "querystring": "~0.2.0",
     "ramda": "~0.26.1",
+    "semver": "~6.3.0",
     "sharp": "~0.23.1",
     "simpl-schema": "~1.5.6",
     "stripe": "~5.10.0"
@@ -85,11 +86,12 @@
   },
   "scripts": {
     "start": "node --experimental-modules ./src/index.js",
-    "start:dev": "NODE_ENV=development NODE_OPTIONS='--experimental-modules' nodemon ./src/index.js",
+    "start:dev": "npm run check-node-version && NODE_ENV=development NODE_OPTIONS='--experimental-modules' nodemon ./src/index.js",
     "inspect": "NODE_ENV=development node --experimental-modules --inspect ./src/index.js",
     "inspect-brk": "NODE_ENV=development node --experimental-modules --inspect-brk ./src/index.js",
     "inspect:docker": "NODE_ENV=development node --experimental-modules --inspect=0.0.0.0:9229 ./src/index.js",
     "inspect-brk:docker": "NODE_ENV=development node --experimental-modules --inspect-brk=0.0.0.0:9229 ./src/index.js",
+    "check-node-version": "node ./src/checkNodeVersion.js",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "REACTION_LOG_LEVEL=ERROR jest --maxWorkers=4 --testPathIgnorePatterns /tests/integration/",
     "test:unit:watch": "REACTION_LOG_LEVEL=ERROR jest --maxWorkers=4 --testPathIgnorePatterns /tests/integration/ --watch",

--- a/src/checkNodeVersion.js
+++ b/src/checkNodeVersion.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-undef */
+
+// This must not be an ES module because we want
+// this check to work on older Node versions that
+// do not support ES modules.
+
+const semver = require("semver");
+const packageJson = require("../package.json");
+
+const requiredNodeVersion = packageJson.engines.node;
+if (!semver.satisfies(process.version, requiredNodeVersion)) {
+  throw new Error(`Required node version ${requiredNodeVersion} not satisfied with current version ${process.version}.` +
+    " Did you forget to run 'nvm use'?");
+}

--- a/tests/util/setupJestTests.js
+++ b/tests/util/setupJestTests.js
@@ -1,3 +1,7 @@
+/* eslint-disable no-undef */
+
+require("../../src/checkNodeVersion.js");
+
 process.on("unhandledRejection", (err) => {
   console.error("unhandledRejection:", err); // eslint-disable-line no-console
   process.exit(10); // eslint-disable-line no-process-exit


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Changes
To avoid issues caused by running with the wrong Node version.
- Add `.npmrc`, causing `npm install` command to fail if Node version is wrong
- Add a script that runs when you do `npm run start:dev`, which throws if your Node version isn't high enough
- Add a script that runs when you run Jest tests, which throws if your Node version isn't high enough

## Breaking changes
None

## Testing
1. `nvm use 8` and verify you can't `npm install` or `npm run start:dev` or `npm test`
2. `nvm use` and verify that you now can do these things