### PR TITLE
Constant condition bugfix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,9 @@ At Reaction Commerce, we're dedicated to the open source community. In fact, we'
 
 If you'd like to join us, check out our detailed [Contributing Guide](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction).
 
+### Prem Saktheesh Paul Thavittupitchai
+# #hacktoberfest  #infydiaries 
+- Location: India
+- Bio: Program Manager. Open Source Contributor 
+- Github: https://github.com/preminfy
+***

--- a/imports/node-app/plugins/marketplace/util/stripeCapturePayment.js
+++ b/imports/node-app/plugins/marketplace/util/stripeCapturePayment.js
@@ -22,7 +22,7 @@ export default async function stripeCapturePayment(context, paymentMethod) {
   // If discount is 100%, capture 100% and then refund 100% of transaction
   if (captureDetails.amount === accounting.unformat(0)) {
     const voidedAmount = unformatFromStripe(paymentMethod.transactions[0].amount);
-    stripeCaptureCharge(paymentMethod);
+    stripeCaptureCharge(context, paymentMethod); //Fix Nullpointer
 
     return stripeCreateRefund(context, paymentMethod, voidedAmount);
   }

--- a/imports/node-app/plugins/marketplace/util/stripeCapturePayment.js
+++ b/imports/node-app/plugins/marketplace/util/stripeCapturePayment.js
@@ -22,7 +22,7 @@ export default async function stripeCapturePayment(context, paymentMethod) {
   // If discount is 100%, capture 100% and then refund 100% of transaction
   if (captureDetails.amount === accounting.unformat(0)) {
     const voidedAmount = unformatFromStripe(paymentMethod.transactions[0].amount);
-    stripeCaptureCharge(context, paymentMethod); //Fix Nullpointer
+    stripeCaptureCharge(paymentMethod);
 
     return stripeCreateRefund(context, paymentMethod, voidedAmount);
   }

--- a/lib/api/router/metadata.js
+++ b/lib/api/router/metadata.js
@@ -100,7 +100,7 @@ export const MetaData = {
 
     Reaction.DOM.setMetaTag({
       name: "keywords",
-      content: keywords ? keywords.toString() : ""
+      content: keywords.length ? keywords.toString() : ""
     });
 
     // set site defaults


### PR DESCRIPTION
Resolves Constant condition issue
Impact: **minor**  
Type: **bugfix**

## Issue
Condition 'keywords' is always true because it evaluates to an array. Better to check 'keywords.length' instead.

File: lib/api/router/metadata.js

## Solution
Changed to use keywords.length
Code snippet:
Reaction.DOM.setMetaTag({
      name: "keywords",
      content: keywords.length ? keywords.toString() : ""
    });

