### PR TITLE
fix: integration test in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
     - DOCKER_NAMESPACE: "reactioncommerce"
     - DOCKER_NAME: "reaction"
     - GLOBAL_CACHE_VERSION: "v2"
-    - TOOL_NODE_FLAGS: "--max-old-space-size=4096"
+    - TOOL_NODE_FLAGS: "--max-old-space-size=4000"
   working_directory: ~/reaction-app
   docker:
     - image: circleci/node:8-stretch
@@ -96,7 +96,7 @@ jobs:
           name: Docker build
           command: |
             docker build \
-              --build-arg TOOL_NODE_FLAGS="--max-old-space-size=4096" \
+              --build-arg TOOL_NODE_FLAGS="--max-old-space-size=4000" \
               -t "$DOCKER_REPOSITORY:$CIRCLE_SHA1" .
             mkdir -p docker-cache
             docker save \

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "test:app:watch": "MONGO_URL='' SKIP_FIXTURES=true TEST_CLIENT=0 TEST_WATCH=1 meteor test --no-release-check --full-app --driver-package meteortesting:mocha",
     "test:unit": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 REACTION_LOG_LEVEL=ERROR jest --maxWorkers=4 --testPathIgnorePatterns /tests/integration/",
     "test:unit:watch": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 REACTION_LOG_LEVEL=ERROR jest --maxWorkers=4 --testPathIgnorePatterns /tests/integration/ --watch",
-    "test:integration": "NODE_ENV=jesttest JEST_MONGO=1 BABEL_DISABLE_CACHE=1 SKIP_FIXTURES=true REACTION_WORKERS_ENABLED=false REACTION_LOG_LEVEL=ERROR jest --no-cache --forceExit --maxWorkers=3 /tests/integration/",
+    "test:integration": "NODE_ENV=jesttest JEST_MONGO=1 BABEL_DISABLE_CACHE=1 SKIP_FIXTURES=true REACTION_WORKERS_ENABLED=false REACTION_LOG_LEVEL=ERROR node --max-old-space-size=4000 ./node_modules/.bin/jest --no-cache --forceExit --runInBand /tests/integration/",
     "test:integration:watch": "NODE_ENV=jesttest JEST_MONGO=1 BABEL_DISABLE_CACHE=1 SKIP_FIXTURES=true REACTION_WORKERS_ENABLED=false REACTION_LOG_LEVEL=ERROR jest --runInBand --watch /tests/integration/",
     "test:file": "NODE_ENV=jesttest JEST_MONGO=1 REACTION_LOG_LEVEL=ERROR jest --runInBand --watch",
     "docs": "jsdoc . --configure .reaction/jsdoc/jsdoc.json --readme .reaction/jsdoc/templates/static/README.md",


### PR DESCRIPTION
Resolves #5779
Impact: **minor**  
Type: **performance|test**

## Issue
maxWorkers for jest integration test was set to 3 which increased the CPU and RAM consumption of CI container

## Solution
bring back --runInBand and reduce node memory limit for jest integration script to 4000 MB so that there some memory for other processes.
Refer:
- https://github.com/integrations/slack/pull/895/files
Note: Although in the reference, global.gc is invoked before each test, it wasn't required here.
- https://developer.ibm.com/articles/nodejs-memory-management-in-container-environments/

## Breaking changes
none
