### PR TITLE
adding sidebar permission control

### DIFF
--- a/imports/client/ui/components/Sidebar/Sidebar.js
+++ b/imports/client/ui/components/Sidebar/Sidebar.js
@@ -18,6 +18,7 @@ import SettingsIcon from "mdi-material-ui/Settings";
 import CloseIcon from "mdi-material-ui/Close";
 import ShopLogoWithData from "../ShopLogoWithData";
 import { Translation } from "/imports/plugins/core/ui/client/components";
+import { Reaction } from "/client/api";
 
 const activeClassName = "nav-item-active";
 
@@ -148,7 +149,9 @@ function Sidebar(props) {
         </Toolbar>
       </AppBar>
       <List disablePadding>
-        {primaryRoutes.map((route) => (
+        {primaryRoutes.filter((route) => {
+          return Reaction.hasPermission(route.permissionRequired);
+        }).map((route) => (
           <NavLink
             activeClassName={!isSettingsOpen ? activeClassName : null}
             className={classes.link}
@@ -200,7 +203,9 @@ function Sidebar(props) {
         </ListItem>
 
         <Collapse in={isSettingsOpen}>
-          {settingRoutes.map((route) => (
+          {settingRoutes.filter((route) => {
+            return Reaction.hasPermission(route.permissionRequired)
+          }).map((route) => (
             <NavLink
               activeClassName={activeClassName}
               className={classes.link}


### PR DESCRIPTION
Impact: **major**  
Type: **feature**

## Issue
RegisterOperatorRoute will not be able to register a route with access control, we want to add a option for `registerOperatorRoute ` to support it.

## Solution
Adding a `permissionRequired` option in `registerOperatorRoute` to check if the current user have one of the permissions provided in `permissionRequired` array

## Example
```sh
registerOperatorRoute({
    permissionRequired: ['companies/list']
    isNavigationLink: true,
    isSetting: false,
    path: "/partners",
    layoutComponent: ContentViewExtraWideLayout,
    mainComponent: PartnerList,
    SidebarIconComponent: (props) => <BriefcaseIcon {...props} />,
    sidebarI18nLabel: "admin.dashboard.partnerLabel"
})
```