### PR TITLE
feat: add updateSMTPEmailSettings mutation

### DIFF
--- a/src/plugins/email-smtp/mutations/index.js
+++ b/src/plugins/email-smtp/mutations/index.js
@@ -1,5 +1,7 @@
+import updateSMTPEmailSettings from "./updateSMTPEmailSettings.js";
 import verifySMTPEmailSettings from "./verifySMTPEmailSettings.js";
 
 export default {
+  updateSMTPEmailSettings,
   verifySMTPEmailSettings
 };

--- a/src/plugins/email-smtp/mutations/updateSMTPEmailSettings.js
+++ b/src/plugins/email-smtp/mutations/updateSMTPEmailSettings.js
@@ -1,0 +1,55 @@
+import SimpleSchema from "simpl-schema";
+import Logger from "@reactioncommerce/logger";
+
+const inputSchema = new SimpleSchema({
+  host: {
+    type: String,
+    optional: true
+  },
+  password: String,
+  port: {
+    type: Number,
+    optional: true
+  },
+  service: String,
+  shopId: String,
+  user: String
+});
+
+/**
+ * @name updateSMTPEmailSettings
+ * @param {Object} context - Per request state
+ * @param {Object} input - Mutation arguments sent by the client
+ * @param {String} [input.host] - The host fo the SMTP email service.
+ * @param {String} [input.password] - Password of the SMTP email service account
+ * @param {String} [input.port] - Port of the SMTP email service
+ * @param {String} [input.service] - SMTP email service name
+ * @param {String} [input.shopId] - shopId these settings belong to
+ * @param {String} [input.user] - Username of the SMTP email service account
+ * @returns {Promise<Object>} Updated SMTP mail settings
+ */
+export default async function updateSMTPEmailSettings(context, input) {
+  inputSchema.validate(input);
+
+  const { checkPermissions, collections: { Packages } } = context;
+  const { shopId, ...rest } = input;
+
+  await checkPermissions(["owner", "admin", "dashboard"], shopId);
+
+  await Packages.updateOne(
+    { name: "core", shopId },
+    {
+      $set: {
+        "settings.mail": { ...rest }
+      }
+    }
+  );
+
+  const updatedSMTPSettings = await Packages.findOne({ name: "core", shopId });
+
+  delete input.password;
+  Logger.info("SMTP email settings updated");
+
+  return updatedSMTPSettings.settings.mail;
+}
+

--- a/src/plugins/email-smtp/resolvers/Mutation/index.js
+++ b/src/plugins/email-smtp/resolvers/Mutation/index.js
@@ -1,5 +1,7 @@
+import updateSMTPEmailSettings from "./updateSMTPEmailSettings.js";
 import verifySMTPEmailSettings from "./verifySMTPEmailSettings.js";
 
 export default {
+  updateSMTPEmailSettings,
   verifySMTPEmailSettings
 };

--- a/src/plugins/email-smtp/resolvers/Mutation/updateSMTPEmailSettings.js
+++ b/src/plugins/email-smtp/resolvers/Mutation/updateSMTPEmailSettings.js
@@ -1,0 +1,38 @@
+import decodeOpaqueIdForNamespace from "@reactioncommerce/api-utils/decodeOpaqueIdForNamespace.js";
+
+const decodeShopOpaqueId = decodeOpaqueIdForNamespace("reaction/shop");
+
+/**
+ * @name Mutation/updateSMTPEmailSettings
+ * @method
+ * @summary resolver for the updateSMTPEmailSettings GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} [input.settings.host] - The host of the SMTP email service.
+ * @param {String} input.settings.password - password of SMTP email service account.
+ * @param {String} [input.settings.port] - The port of the SMTP email service.
+ * @param {String} input.settings.service - SMTP email service to use.
+ * @param {String} input.settings.shopId - ShopID this setting belongs to.
+ * @param {String} input.settings.user - username of SMTP email service account.
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @returns {Promise<Object>} verifySMTPEmailSettingsPayload
+ */
+export default async function updateSMTPEmailSettings(_, { input }, context) {
+  const {
+    clientMutationId = null,
+    settings
+  } = input;
+  const { shopId: opaqueShopId, ...passThroughInput } = settings;
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  const updatedSettings = await context.mutations.updateSMTPEmailSettings(context, {
+    shopId,
+    ...passThroughInput
+  });
+
+  return {
+    clientMutationId,
+    settings: updatedSettings
+  };
+}

--- a/src/plugins/email-smtp/resolvers/Mutation/updateSMTPEmailSettings.js
+++ b/src/plugins/email-smtp/resolvers/Mutation/updateSMTPEmailSettings.js
@@ -1,7 +1,5 @@
 import decodeOpaqueIdForNamespace from "@reactioncommerce/api-utils/decodeOpaqueIdForNamespace.js";
 
-const decodeShopOpaqueId = decodeOpaqueIdForNamespace("reaction/shop");
-
 /**
  * @name Mutation/updateSMTPEmailSettings
  * @method
@@ -24,7 +22,7 @@ export default async function updateSMTPEmailSettings(_, { input }, context) {
     settings
   } = input;
   const { shopId: opaqueShopId, ...passThroughInput } = settings;
-  const shopId = decodeShopOpaqueId(opaqueShopId);
+  const shopId = decodeOpaqueIdForNamespace("reaction/shop", opaqueShopId);
 
   const updatedSettings = await context.mutations.updateSMTPEmailSettings(context, {
     shopId,

--- a/src/plugins/email-smtp/schemas/schema.graphql
+++ b/src/plugins/email-smtp/schemas/schema.graphql
@@ -1,13 +1,19 @@
 extend type Mutation {
+  "Update SMTP email settings"
+  updateSMTPEmailSettings(
+    "SMTP settings input"
+    input: UpdateSMTPEmailSettingsInput
+  ) : UpdateSMTPEmailSettingsPayload
+
   "Use this mutation to verify the SMTP email settings"
   verifySMTPEmailSettings(
     "Mutation input"
     input: VerifySMTPEmailSettingsInput!
-    ): VerifySMTPEmailSettingsInputPayload!
+    ): VerifySMTPEmailSettingsPayload!
 }
 
-"Input for an `VerifySMTPEmailSettingsInput`"
-input VerifySMTPEmailSettingsInput {
+"Input for the SMTP Email settings inputs"
+input SMTPEmailSettingsInput {
   "The host of the SMTP email service"
   host: String
 
@@ -27,11 +33,54 @@ input VerifySMTPEmailSettingsInput {
   user: String!
 }
 
+"Input for `verifySMTPEmailSettings` mutation"
+input VerifySMTPEmailSettingsInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  settings: SMTPEmailSettingsInput!
+}
+
+"Input for `updateSMTPEmailSettings` mutation"
+input UpdateSMTPEmailSettingsInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  settings: SMTPEmailSettingsInput!
+}
+
 "Response payload for the verifySMTPEmailSettings mutation"
-type VerifySMTPEmailSettingsInputPayload {
+type VerifySMTPEmailSettingsPayload {
   "The same string you sent with the mutation params, for matching mutation calls with their responses"
   clientMutationId: String
 
   "True if the SMTP connection was made and authentication was successful."
   isVerified: Boolean!
+}
+
+"SMTP Email settings"
+type SMTPSettings {
+  "The host of the SMTP email service"
+  host: String
+
+  "The password of the SMTP email service user"
+  password: String!
+
+  "The port to send email via"
+  port: Int
+
+  "The SMTP email service"
+  service: String!
+
+  "The username of the SMTP email service user"
+  user: String!
+}
+
+"Response payload for `updateSMTPEmailSettings` mutation"
+type UpdateSMTPEmailSettingsPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "Updated settings"
+  settings: SMTPSettings
 }


### PR DESCRIPTION
Resolves #5759  
Impact: minor
Type: feature

## Issue
There needs to exist a GraphQL mutation to update SMTP email settings

```
mutation updateSMTPEmailSettings($input: UpdateSMTPEmailSettingsInput) {
  updateSMTPEmailSettings(input: $input) {
    settings {
      host
      password
      port
      service
      user
    }
  }
}
````
query variables
```
{
  "host": "myhost"
  "password": "password"
  "port": "2525"
  "service": "MY SMTP Service"
  "shopId": "myshopid"
  "user": "myuser"
}
```
## Solution
Add mutation to update SMTP settings

## Breaking changes
None

## Testing
1. Use query above to update SMTP settings
2. Verify settings are correctly  persisted to the database

