### PR TITLE
Add csv file type validation for all platforms

### DIFF
--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -25,6 +25,18 @@ mutation createProduct($input: CreateProductInput!) {
 }
 `;
 
+const CSV_FILE_TYPES = [
+  "text/csv",
+  "text/plain",
+  "text/x-csv",
+  "application/vnd.ms-excel",
+  "application/csv",
+  "application/x-csv",
+  "text/comma-separated-values",
+  "text/x-comma-separated-values",
+  "text/tab-separated-values"
+];
+
 /**
  * ProductTable component
  * @param {Object} props Component props
@@ -98,7 +110,7 @@ function ProductTable({ history }) {
     onDrop,
     multiple: true,
     disablePreview: true,
-    accept: "text/csv, text/plain, text/x-csv, application/vnd.ms-excel, application/csv, application/x-csv, text/comma-separated-values, text/x-comma-separated-values, text/tab-separated-values",
+    accept: CSV_FILE_TYPES.join(", "),
     disableClick: true
   });
 

--- a/imports/plugins/included/product-admin/client/components/ProductTable.js
+++ b/imports/plugins/included/product-admin/client/components/ProductTable.js
@@ -98,6 +98,7 @@ function ProductTable({ history }) {
     onDrop,
     multiple: true,
     disablePreview: true,
+    accept: "text/csv, text/plain, text/x-csv, application/vnd.ms-excel, application/csv, application/x-csv, text/comma-separated-values, text/x-comma-separated-values, text/tab-separated-values",
     disableClick: true
   });
 


### PR DESCRIPTION
Resolves N.A.
Impact: **minor**  
Type: **bugfix**

## Issue
Products filter by .csv file doesn't have file validation which makes any type of files to  be uploaded causing the following error on browser console:
<img width="1275" alt="Screenshot 2019-11-06 at 5 43 40 PM" src="https://user-images.githubusercontent.com/22974490/68297474-03281980-00bd-11ea-81b4-a8593d2aac0a.png"> 

## Solution
Adding following MIME type for csv validation works on all platforms
```
text/plain
text/x-csv
application/vnd.ms-excel
application/csv
application/x-csv
text/csv
text/comma-separated-values
text/x-comma-separated-values
text/tab-separated-values
```
ref: https://www.christianwood.net/csv-file-upload-validation/


## Testing
1. Go to products page 
2. Click on `Actions` dropdown and now click on `Filter by file` option
3. Upload non-csv file and see the browser console after clicking on `Filter Products`
