### PR TITLE
feat: GQL Tags (core/tags)

### DIFF
--- a/src/core-services/catalog/queries/tags.js
+++ b/src/core-services/catalog/queries/tags.js
@@ -37,8 +37,7 @@ export default async function tags(
 
   // Use `filter` to filter out results on the server
   if (filter) {
-    query.name = { $regex: _.escapeRegExp(filter), $options: "i" };
-    regexMatch = { $regex: escapeRegExp(filter), $options: "i" };
+    regexMatch = { $regex: _.escapeRegExp(filter), $options: "i" };
     searchFieldFilter = {
       $or: [{
         name: regexMatch,

--- a/src/core-services/catalog/queries/tags.js
+++ b/src/core-services/catalog/queries/tags.js
@@ -39,10 +39,10 @@ export default async function tags(
   if (filter) {
     regexMatch = { $regex: _.escapeRegExp(filter), $options: "i" };
     searchFieldFilter = {
-      $or: [{
-        name: regexMatch,
-        slug: regexMatch
-      }]
+      $or: [
+        { name: regexMatch },
+        { slug: regexMatch }
+      ]
     };
   }
 

--- a/src/core-services/tags/resolvers/Query/tags.js
+++ b/src/core-services/tags/resolvers/Query/tags.js
@@ -1,6 +1,7 @@
 import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
 import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
-import { decodeShopOpaqueId } from "../../xforms/id.js";
+import { decodeShopOpaqueId, decodeTagOpaqueId } from "../../xforms/id.js";
+
 
 /**
  * Arguments passed by the client for a tags query
@@ -26,11 +27,19 @@ import { decodeShopOpaqueId } from "../../xforms/id.js";
  * @returns {Promise<Object[]>} Promise that resolves with array of Tag objects
  */
 export default async function tags(_, connectionArgs, context, info) {
-  const { shopId } = connectionArgs;
+  const { shopId, excludedTagIds } = connectionArgs;
 
   const dbShopId = decodeShopOpaqueId(shopId);
+  let dbExcludedTagIds;
 
-  const query = await context.queries.tags(context, dbShopId, connectionArgs);
+  if (Array.isArray(excludedTagIds)) {
+    dbExcludedTagIds = excludedTagIds.map(decodeTagOpaqueId);
+  }
+
+  const query = await context.queries.tags(context, dbShopId, {
+    ...connectionArgs,
+    excludedTagIds: dbExcludedTagIds
+  });
 
   return getPaginatedResponse(query, connectionArgs, {
     includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),

--- a/src/core-services/tags/schemas/tags.graphql
+++ b/src/core-services/tags/schemas/tags.graphql
@@ -111,6 +111,9 @@ extend type Query {
     "If provided, this query will do a regex search using the provided filter data, and return only tags that match"
     filter: String
 
+    "Tags to exclude from results"
+    excludedTagIds: [ID]
+
     "If set, the query will return only top-level tags or only non-top-level tags. By default, both types of tags are returned."
     isTopLevel: Boolean,
 


### PR DESCRIPTION
Resolves #5755  
Impact: **major**  
Type: **refactor**

## Issue
De-meteorize core `tags/getBySlug` (used by products UI to fuzzy match tags for adding to product)

## Solution
- Update existing [`tags`](https://github.com/reactioncommerce/reaction/blob/release-3.0.0/src/core-services/catalog/queries/tags.js#L27) queries to use tag name and slug for fuzzy search
- Replace `getBySlug` by [tag](https://github.com/reactioncommerce/reaction/blob/release-3.0.0/src/core-services/catalog/queries/tags.js#L27) 

## Breaking changes

## Testing

1. Visit PDP as admin
2. Click edit icon next to tags
3. Start typing a new tag name, confirm no console errors
4. Edit tag nav, start typing an existing tag name, confirm suggestions still work