### PR TITLE
Use checkPermissions in getOrderQuery

### DIFF
--- a/src/core-services/orders/util/getOrderQuery.js
+++ b/src/core-services/orders/util/getOrderQuery.js
@@ -13,10 +13,10 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @returns {Object} A mongo selector
  */
 export function getOrderQuery(context, selector, shopId, token) {
-  const { accountId: contextAccountId, userHasPermission } = context;
+  const { accountId: contextAccountId, checkPermissions } = context;
   const newSelector = { ...selector, shopId };
 
-  if (userHasPermission(["orders", "order/fulfillment", "order/view"], shopId)) {
+  if (checkPermissions(["orders", "order/fulfillment", "order/view"], shopId)) {
     // admins with orders permissions can see any order in the shop
     // admins with order/fulfillment and order/view permissions can also view order
     // with further permission checks in each component to limit functionality where needed
@@ -27,8 +27,6 @@ export function getOrderQuery(context, selector, shopId, token) {
   } else if (token) {
     // If you have an anonymous access token for this order, OK to see it
     newSelector["anonymousAccessTokens.hashedToken"] = hashToken(token);
-  } else {
-    throw new ReactionError("access-denied", "Access Denied");
   }
   return newSelector;
 }

--- a/src/core-services/orders/util/getOrderQuery.js
+++ b/src/core-services/orders/util/getOrderQuery.js
@@ -1,5 +1,4 @@
 import hashToken from "@reactioncommerce/api-utils/hashToken.js";
-import ReactionError from "@reactioncommerce/reaction-error";
 
 /**
  * @name getOrderQuery


### PR DESCRIPTION
Resolves N.A.
Impact: **minor**  
Type: **feature|refactor**

## Issue
`getOrderQuery` is still using `userHasPermission` method to check and throw access denied error explicitly. 

## Solution
Use `checkPermissions` method to avoid throwing an error explicitly.

## Testing
Check if `orderById` Graphql query works as expected.