### PR TITLE
Replace context.queries.primaryShopId shopId with client shopId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1380,7 +1380,7 @@
     },
     "@types/accepts": {
       "version": "1.3.5",
-      "resolved": "http://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "requires": {
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1380,7 +1380,7 @@
     },
     "@types/accepts": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "http://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "requires": {
         "@types/node": "*"

--- a/src/core-services/catalog/queries/tag.js
+++ b/src/core-services/catalog/queries/tag.js
@@ -4,8 +4,9 @@
  * @memberof Catalog/NoMeteorQueries
  * @summary query the Tags collection and return a tag by tag ID or slug
  * @param {Object} context - an object containing the per-request state
- * @param {String} slugOrId - ID or slug of tag to query
- * @param {String} shopId - shopId of tag
+ * @param {Object} input input of tag query
+ * @param {String} input.shopId - shopId of tag
+ * @param {String} input.slugOrId - ID or slug of tag to query
  * @param {Boolean} [params.shouldIncludeInvisible] - Whether or not to include `isVisible=true` tags. Default is `false`
  * @returns {Object} - A Tag document if one was found
  */

--- a/src/core-services/catalog/queries/tag.js
+++ b/src/core-services/catalog/queries/tag.js
@@ -5,21 +5,22 @@
  * @summary query the Tags collection and return a tag by tag ID or slug
  * @param {Object} context - an object containing the per-request state
  * @param {String} slugOrId - ID or slug of tag to query
+ * @param {String} shopId - shopId of tag
  * @param {Boolean} [params.shouldIncludeInvisible] - Whether or not to include `isVisible=true` tags. Default is `false`
  * @returns {Object} - A Tag document if one was found
  */
-export default async function tag(context, slugOrId, { shouldIncludeInvisible = false } = {}) {
+export default async function tag(context, { slugOrId, shopId }, { shouldIncludeInvisible = false } = {}) {
   const { collections, userHasPermission } = context;
   const { Tags } = collections;
   let query = {
     $and: [
       { isVisible: true },
+      { shopId },
       { $or: [{ _id: slugOrId }, { slug: slugOrId }] }
     ]
   };
 
   if (shouldIncludeInvisible === true) {
-    const shopId = await context.queries.primaryShopId(context);
     if (userHasPermission(["owner", "admin"], shopId)) {
       query = { $or: [{ _id: slugOrId }, { slug: slugOrId }] };
     }

--- a/src/core-services/catalog/queries/tag.js
+++ b/src/core-services/catalog/queries/tag.js
@@ -7,12 +7,13 @@
  * @param {Object} input input of tag query
  * @param {String} input.shopId - shopId of tag
  * @param {String} input.slugOrId - ID or slug of tag to query
- * @param {Boolean} [params.shouldIncludeInvisible] - Whether or not to include `isVisible=true` tags. Default is `false`
+ * @param {Boolean} [input.shouldIncludeInvisible] - Whether or not to include `isVisible=true` tags. Default is `false`
  * @returns {Object} - A Tag document if one was found
  */
-export default async function tag(context, { slugOrId, shopId }, { shouldIncludeInvisible = false } = {}) {
+export default async function tag(context, input) {
   const { collections, userHasPermission } = context;
   const { Tags } = collections;
+  const { slugOrId, shopId, shouldIncludeInvisible = false } = input;
   let query = {
     $and: [
       { isVisible: true },

--- a/src/core-services/catalog/queries/tag.test.js
+++ b/src/core-services/catalog/queries/tag.test.js
@@ -1,0 +1,56 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import tagQuery from "./tag.js";
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test("default - includes shopId and tag._id", async () => {
+  const shopId = "s1";
+  const slugOrId = "t1";
+  const tag = {
+    _id: "t1",
+    shopId,
+    isVisible: true,
+    name: "shirts",
+    displayTitle: "Shirts"
+  };
+  const query = {
+    $and: [
+      { isVisible: true },
+      { shopId },
+      { $or: [{ _id: slugOrId }, { slug: slugOrId }] }
+    ]
+  };
+  mockContext.collections.Tags.findOne.mockReturnValueOnce(tag);
+
+  const result = await tagQuery(mockContext, { shopId, slugOrId });
+
+  expect(mockContext.collections.Tags.findOne).toHaveBeenCalledWith(query);
+  expect(result).toBe(tag);
+});
+
+test("default - includes shopId and tag.slug", async () => {
+  const shopId = "s1";
+  const slugOrId = "slug1";
+  const tag = {
+    shopId,
+    slug: slugOrId,
+    isVisible: true,
+    name: "shirts",
+    displayTitle: "Shirts"
+  };
+  const query = {
+    $and: [
+      { isVisible: true },
+      { shopId },
+      { $or: [{ _id: slugOrId }, { slug: slugOrId }] }
+    ]
+  };
+  mockContext.collections.Tags.findOne.mockReturnValueOnce(tag);
+
+  const result = await tagQuery(mockContext, { shopId, slugOrId });
+
+  expect(mockContext.collections.Tags.findOne).toHaveBeenCalledWith(query);
+  expect(result).toBe(tag);
+});

--- a/src/core-services/tags/resolvers/Query/tag.js
+++ b/src/core-services/tags/resolvers/Query/tag.js
@@ -1,4 +1,4 @@
-import { decodeTagOpaqueId } from "../../xforms/id.js";
+import { decodeShopOpaqueId, decodeTagOpaqueId } from "../../xforms/id.js";
 
 /**
  * Arguments passed by the client for a tags query
@@ -20,15 +20,17 @@ import { decodeTagOpaqueId } from "../../xforms/id.js";
  * @returns {Promise<Object[]>} Promise that resolves with array of Tag objects
  */
 export default async function tag(_, connectionArgs, context) {
-  const { slugOrId } = connectionArgs;
+  const { slugOrId: opaqueSlugOrId, shopId: opaqueShopId } = connectionArgs;
 
-  let dbTagId;
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  let slugOrId;
 
   try {
-    dbTagId = decodeTagOpaqueId(slugOrId);
+    slugOrId = decodeTagOpaqueId(opaqueSlugOrId);
   } catch (error) {
-    dbTagId = slugOrId;
+    slugOrId = opaqueSlugOrId;
   }
 
-  return context.queries.tag(context, dbTagId, connectionArgs);
+  return context.queries.tag(context, { slugOrId, shopId }, connectionArgs);
 }

--- a/src/core-services/tags/resolvers/Query/tag.js
+++ b/src/core-services/tags/resolvers/Query/tag.js
@@ -32,5 +32,5 @@ export default async function tag(_, connectionArgs, context) {
     slugOrId = opaqueSlugOrId;
   }
 
-  return context.queries.tag(context, { slugOrId, shopId }, connectionArgs);
+  return context.queries.tag(context, { ...connectionArgs, slugOrId, shopId });
 }

--- a/src/core-services/tags/resolvers/Query/tag.test.js
+++ b/src/core-services/tags/resolvers/Query/tag.test.js
@@ -1,0 +1,38 @@
+import { encodeShopOpaqueId, encodeTagOpaqueId } from "../../xforms/id.js";
+import tagQuery from "./tag.js";
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test("calls Query.tag and returns the tag on success", async () => {
+  const shopId = encodeShopOpaqueId("s1");
+  const tagId = encodeTagOpaqueId("t1");
+  const tag = {
+    _id: "t1",
+    shopId: "s1",
+    isVisible: true,
+    name: "shirts",
+    displayTitle: "Shirts"
+  };
+
+  const fakeResult = { _id: tagId, shopId, ...tag };
+  const mockMutation = jest.fn().mockName("queries.tag");
+  mockMutation.mockReturnValueOnce(Promise.resolve(fakeResult));
+
+  const context = {
+    queries: {
+      tag: mockMutation
+    }
+  };
+
+  const result = await tagQuery(null, {
+    input: {
+      shopId,
+      tagId,
+      clientMutationId: "clientMutationId"
+    }
+  }, context);
+
+  expect(result).toEqual(tag);
+});

--- a/src/core-services/tags/schemas/tag.graphql
+++ b/src/core-services/tags/schemas/tag.graphql
@@ -53,7 +53,10 @@ extend type Query {
   "Returns a tag from a provided tag ID or slug. Tags with isVisible set to false are excluded by default."
   tag(
     "Slug or ID of Tag"
-    slugOrId: String,
+    slugOrId: String!,
+
+    "The shop to which this tag belongs"
+    shopId: ID!
 
     "Set to true if you want to include tags that have isVisible set to false"
     shouldIncludeInvisible: Boolean = false

--- a/src/plugins/navigation/mutations/deleteNavigationItem.js
+++ b/src/plugins/navigation/mutations/deleteNavigationItem.js
@@ -5,23 +5,23 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @summary Deletes a navigation item
  * @param {Object} context An object containing the per-request state
  * @param {Object} input An object of all mutation arguments that were sent by the client
- * @param {String} input._id ID of the navigation item to delete
+ * @param {String} input.navigationItemId ID of the navigation item to delete
  * @param {String} input.shopId ID of the shop navigation item belongs
  * @returns {Promise<Object>} Deleted navigation item
  */
 export default async function deleteNavigationItem(context, input) {
   const { checkPermissions, collections } = context;
   const { NavigationItems } = collections;
-  const { _id, shopId } = input;
+  const { navigationItemId, shopId } = input;
 
   await checkPermissions(["core"], shopId);
 
-  const navigationItem = await NavigationItems.findOne({ _id });
+  const navigationItem = await NavigationItems.findOne({ _id: navigationItemId });
   if (!navigationItem) {
     throw new ReactionError("navigation-item-not-found", "Navigation item was not found");
   }
 
-  await NavigationItems.deleteOne({ _id });
+  await NavigationItems.deleteOne({ _id: navigationItemId });
 
   return navigationItem;
 }

--- a/src/plugins/navigation/mutations/publishNavigationChanges.js
+++ b/src/plugins/navigation/mutations/publishNavigationChanges.js
@@ -6,8 +6,9 @@ import getNavigationTreeItemIds from "../util/getNavigationTreeItemIds.js";
  * @method publishNavigationChanges
  * @summary Publishes changes for a navigation tree and its items
  * @param {Object} context An object containing the per-request state
- * @param {String} input input of navigation tree to publish
- * @param {String} shopId shopId of navigation tree to publish
+ * @param {String} input Input of publishNavigationChanges mutation
+ * @param {String} input._id ID of navigation tree to publish
+ * @param {String} input.shopId shopId of navigation tree to publish
  * @returns {Promise<Object>} Updated navigation tree
  */
 export default async function publishNavigationChanges(context, input) {

--- a/src/plugins/navigation/mutations/publishNavigationChanges.js
+++ b/src/plugins/navigation/mutations/publishNavigationChanges.js
@@ -7,20 +7,20 @@ import getNavigationTreeItemIds from "../util/getNavigationTreeItemIds.js";
  * @summary Publishes changes for a navigation tree and its items
  * @param {Object} context An object containing the per-request state
  * @param {String} input Input of publishNavigationChanges mutation
- * @param {String} input._id ID of navigation tree to publish
+ * @param {String} input.navigationTreeId ID of navigation tree to publish
  * @param {String} input.shopId shopId of navigation tree to publish
  * @returns {Promise<Object>} Updated navigation tree
  */
 export default async function publishNavigationChanges(context, input) {
   const { checkPermissions, collections } = context;
   const { NavigationItems, NavigationTrees } = collections;
-  const { _id, shopId } = input;
+  const { navigationTreeId, shopId } = input;
 
   if (!context.isInternalCall) {
     await checkPermissions(["core"], shopId);
   }
 
-  const treeSelector = { _id, shopId };
+  const treeSelector = { _id: navigationTreeId, shopId };
   const navigationTree = await NavigationTrees.findOne(treeSelector);
   if (!navigationTree) {
     throw new ReactionError("navigation-tree-not-found", "No navigation tree was found");

--- a/src/plugins/navigation/mutations/publishNavigationChanges.js
+++ b/src/plugins/navigation/mutations/publishNavigationChanges.js
@@ -6,19 +6,20 @@ import getNavigationTreeItemIds from "../util/getNavigationTreeItemIds.js";
  * @method publishNavigationChanges
  * @summary Publishes changes for a navigation tree and its items
  * @param {Object} context An object containing the per-request state
- * @param {String} _id _id of navigation tree to publish
+ * @param {String} input input of navigation tree to publish
  * @param {String} shopId shopId of navigation tree to publish
  * @returns {Promise<Object>} Updated navigation tree
  */
-export default async function publishNavigationChanges(context, _id, shopId) {
+export default async function publishNavigationChanges(context, input) {
   const { checkPermissions, collections } = context;
   const { NavigationItems, NavigationTrees } = collections;
+  const { _id, shopId } = input;
 
   if (!context.isInternalCall) {
     await checkPermissions(["core"], shopId);
   }
 
-  const treeSelector = { _id };
+  const treeSelector = { _id, shopId };
   const navigationTree = await NavigationTrees.findOne(treeSelector);
   if (!navigationTree) {
     throw new ReactionError("navigation-tree-not-found", "No navigation tree was found");

--- a/src/plugins/navigation/mutations/publishNavigationChanges.js
+++ b/src/plugins/navigation/mutations/publishNavigationChanges.js
@@ -7,13 +7,12 @@ import getNavigationTreeItemIds from "../util/getNavigationTreeItemIds.js";
  * @summary Publishes changes for a navigation tree and its items
  * @param {Object} context An object containing the per-request state
  * @param {String} _id _id of navigation tree to publish
+ * @param {String} shopId shopId of navigation tree to publish
  * @returns {Promise<Object>} Updated navigation tree
  */
-export default async function publishNavigationChanges(context, _id) {
+export default async function publishNavigationChanges(context, _id, shopId) {
   const { checkPermissions, collections } = context;
   const { NavigationItems, NavigationTrees } = collections;
-
-  const shopId = await context.queries.primaryShopId(context);
 
   if (!context.isInternalCall) {
     await checkPermissions(["core"], shopId);

--- a/src/plugins/navigation/mutations/publishNavigationChanges.test.js
+++ b/src/plugins/navigation/mutations/publishNavigationChanges.test.js
@@ -2,6 +2,7 @@ import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import ReactionError from "@reactioncommerce/reaction-error";
 import publishNavigationChangesMutation from "./publishNavigationChanges.js";
 
+const mockInput = { navigationTreeId: "123", shopId: "789" };
 const mockTreeItems = [
   {
     navigationItemId: "uaXXawc5oxy9eR4hP",
@@ -64,7 +65,7 @@ test("Calls NavigationTrees.findOne and updateOne, and NavigationItems.findOne, 
 
   mockContext.queries.primaryShopId = jest.fn().mockName("queries.primaryShopId").mockReturnValueOnce(Promise.resolve("FAKE_SHOP_ID"));
 
-  const navigationTree = await publishNavigationChangesMutation(mockContext, { _id: "123", shopId: "789" });
+  const navigationTree = await publishNavigationChangesMutation(mockContext, mockInput);
 
   expect(mockContext.collections.NavigationTrees.findOne).toHaveBeenCalledTimes(2);
   expect(mockContext.collections.NavigationTrees.updateOne).toHaveBeenCalledTimes(1);
@@ -77,12 +78,12 @@ test("throws an error if the user does not have the core permission", async () =
   mockContext.checkPermissions.mockImplementation(() => {
     throw new ReactionError("access-denied", "Access Denied");
   });
-  const result = publishNavigationChangesMutation(mockContext, { _id: "123", shopId: "789" });
+  const result = publishNavigationChangesMutation(mockContext, mockInput);
   expect(result).rejects.toThrow();
 });
 
 test("throws an error if the navigation tree does not exist", async () => {
   mockContext.collections.NavigationTrees.findOne.mockReturnValueOnce(Promise.resolve(null));
-  const result = publishNavigationChangesMutation(mockContext, { _id: "123", shopId: "789" });
+  const result = publishNavigationChangesMutation(mockContext, mockInput);
   expect(result).rejects.toThrow();
 });

--- a/src/plugins/navigation/mutations/publishNavigationChanges.test.js
+++ b/src/plugins/navigation/mutations/publishNavigationChanges.test.js
@@ -1,6 +1,6 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import ReactionError from "@reactioncommerce/reaction-error";
-import publishNavigationChangesMutation from "./publishNavigationChanges., "789"js";
+import publishNavigationChangesMutation from "./publishNavigationChanges.js";
 
 const mockTreeItems = [
   {
@@ -64,7 +64,7 @@ test("Calls NavigationTrees.findOne and updateOne, and NavigationItems.findOne, 
 
   mockContext.queries.primaryShopId = jest.fn().mockName("queries.primaryShopId").mockReturnValueOnce(Promise.resolve("FAKE_SHOP_ID"));
 
-  const navigationTree = await publishNavigationChangesMutation(mockContext, "123", "789");
+  const navigationTree = await publishNavigationChangesMutation(mockContext, { _id: "123", shopId: "789" });
 
   expect(mockContext.collections.NavigationTrees.findOne).toHaveBeenCalledTimes(2);
   expect(mockContext.collections.NavigationTrees.updateOne).toHaveBeenCalledTimes(1);
@@ -77,12 +77,12 @@ test("throws an error if the user does not have the core permission", async () =
   mockContext.checkPermissions.mockImplementation(() => {
     throw new ReactionError("access-denied", "Access Denied");
   });
-  const result = publishNavigationChangesMutation(mockContext, "123", "789");
+  const result = publishNavigationChangesMutation(mockContext, { _id: "123", shopId: "789" });
   expect(result).rejects.toThrow();
 });
 
 test("throws an error if the navigation tree does not exist", async () => {
   mockContext.collections.NavigationTrees.findOne.mockReturnValueOnce(Promise.resolve(null));
-  const result = publishNavigationChangesMutation(mockContext, "123", "789");
+  const result = publishNavigationChangesMutation(mockContext, { _id: "123", shopId: "789" });
   expect(result).rejects.toThrow();
 });

--- a/src/plugins/navigation/mutations/publishNavigationChanges.test.js
+++ b/src/plugins/navigation/mutations/publishNavigationChanges.test.js
@@ -1,6 +1,6 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import ReactionError from "@reactioncommerce/reaction-error";
-import publishNavigationChangesMutation from "./publishNavigationChanges.js";
+import publishNavigationChangesMutation from "./publishNavigationChanges., "789"js";
 
 const mockTreeItems = [
   {
@@ -64,7 +64,7 @@ test("Calls NavigationTrees.findOne and updateOne, and NavigationItems.findOne, 
 
   mockContext.queries.primaryShopId = jest.fn().mockName("queries.primaryShopId").mockReturnValueOnce(Promise.resolve("FAKE_SHOP_ID"));
 
-  const navigationTree = await publishNavigationChangesMutation(mockContext, "123");
+  const navigationTree = await publishNavigationChangesMutation(mockContext, "123", "789");
 
   expect(mockContext.collections.NavigationTrees.findOne).toHaveBeenCalledTimes(2);
   expect(mockContext.collections.NavigationTrees.updateOne).toHaveBeenCalledTimes(1);
@@ -77,12 +77,12 @@ test("throws an error if the user does not have the core permission", async () =
   mockContext.checkPermissions.mockImplementation(() => {
     throw new ReactionError("access-denied", "Access Denied");
   });
-  const result = publishNavigationChangesMutation(mockContext, "123");
+  const result = publishNavigationChangesMutation(mockContext, "123", "789");
   expect(result).rejects.toThrow();
 });
 
 test("throws an error if the navigation tree does not exist", async () => {
   mockContext.collections.NavigationTrees.findOne.mockReturnValueOnce(Promise.resolve(null));
-  const result = publishNavigationChangesMutation(mockContext, "123");
+  const result = publishNavigationChangesMutation(mockContext, "123", "789");
   expect(result).rejects.toThrow();
 });

--- a/src/plugins/navigation/mutations/updateNavigationItem.js
+++ b/src/plugins/navigation/mutations/updateNavigationItem.js
@@ -5,13 +5,16 @@ import { NavigationItemData } from "../simpleSchemas.js";
  * @method updateNavigationItem
  * @summary Updates a navigation item
  * @param {Object} context An object containing the per-request state
- * @param {String} _id _id of navigation item to update
- * @param {Object} navigationItem Updated navigation item
+ * @param {Object} input Input of updateNavigationItem mutation
+ * @param {String} input._id ID of navigation item to update
+ * @param {String} input.shopId Shop ID of navigation item
+ * @param {String} input.navigationItem Navigation item object to update
  * @returns {Promise<Object>} Updated navigation item
  */
-export default async function updateNavigationItem(context, { _id, shopId, navigationItem }) {
+export default async function updateNavigationItem(context, input) {
   const { checkPermissions, collections } = context;
   const { NavigationItems } = collections;
+  const { _id, shopId, navigationItem } = input;
   const { draftData, metadata } = navigationItem;
 
   await checkPermissions(["core"], shopId);

--- a/src/plugins/navigation/mutations/updateNavigationItem.js
+++ b/src/plugins/navigation/mutations/updateNavigationItem.js
@@ -6,7 +6,7 @@ import { NavigationItemData } from "../simpleSchemas.js";
  * @summary Updates a navigation item
  * @param {Object} context An object containing the per-request state
  * @param {Object} input Input of updateNavigationItem mutation
- * @param {String} input._id ID of navigation item to update
+ * @param {String} input.navigationItemId ID of navigation item to update
  * @param {String} input.shopId Shop ID of navigation item
  * @param {String} input.navigationItem Navigation item object to update
  * @returns {Promise<Object>} Updated navigation item
@@ -14,12 +14,12 @@ import { NavigationItemData } from "../simpleSchemas.js";
 export default async function updateNavigationItem(context, input) {
   const { checkPermissions, collections } = context;
   const { NavigationItems } = collections;
-  const { _id, shopId, navigationItem } = input;
+  const { navigationItemId, shopId, navigationItem } = input;
   const { draftData, metadata } = navigationItem;
 
   await checkPermissions(["core"], shopId);
 
-  const existingNavigationItem = await NavigationItems.findOne({ _id });
+  const existingNavigationItem = await NavigationItems.findOne({ navigationItemId });
   if (!existingNavigationItem) {
     throw new ReactionError("navigation-item-not-found", "Navigation item was not found");
   }
@@ -46,9 +46,9 @@ export default async function updateNavigationItem(context, input) {
     }
   }
 
-  await NavigationItems.updateOne({ _id }, { $set: { ...update } });
+  await NavigationItems.updateOne({ navigationItemId }, { $set: { ...update } });
 
-  const updatedNavigationItem = await NavigationItems.findOne({ _id });
+  const updatedNavigationItem = await NavigationItems.findOne({ navigationItemId });
 
   return updatedNavigationItem;
 }

--- a/src/plugins/navigation/mutations/updateNavigationItem.js
+++ b/src/plugins/navigation/mutations/updateNavigationItem.js
@@ -9,12 +9,10 @@ import { NavigationItemData } from "../simpleSchemas.js";
  * @param {Object} navigationItem Updated navigation item
  * @returns {Promise<Object>} Updated navigation item
  */
-export default async function updateNavigationItem(context, _id, navigationItem) {
+export default async function updateNavigationItem(context, { _id, shopId, navigationItem }) {
   const { checkPermissions, collections } = context;
   const { NavigationItems } = collections;
   const { draftData, metadata } = navigationItem;
-
-  const shopId = await context.queries.primaryShopId(context);
 
   await checkPermissions(["core"], shopId);
 

--- a/src/plugins/navigation/mutations/updateNavigationItem.test.js
+++ b/src/plugins/navigation/mutations/updateNavigationItem.test.js
@@ -38,7 +38,7 @@ test("calls NavigationItems.findOne and updateOne, and returns the updated navig
 
   mockContext.queries.primaryShopId = jest.fn().mockName("queries.primaryShopId").mockReturnValueOnce(Promise.resolve("FAKE_SHOP_ID"));
 
-  const result = await updateNavigationItemMutation(mockContext, {...mockInput, navigationItem: mockValidNavigationItemInput });
+  const result = await updateNavigationItemMutation(mockContext, { ...mockInput, navigationItem: mockValidNavigationItemInput });
 
   expect(mockContext.collections.NavigationItems.findOne).toHaveBeenCalledTimes(2);
   expect(mockContext.collections.NavigationItems.updateOne).toHaveBeenCalled();
@@ -60,6 +60,6 @@ test("throws an error if the navigation item does not exist", async () => {
 });
 
 test("throws an error if invalid JSON metadata is passed", async () => {
-  const result = updateNavigationItemMutation(mockContext, {...mockInput, navigationItem: mockInvalidNavigationItemInput });
+  const result = updateNavigationItemMutation(mockContext, { ...mockInput, navigationItem: mockInvalidNavigationItemInput });
   expect(result).rejects.toThrow();
 });

--- a/src/plugins/navigation/mutations/updateNavigationItem.test.js
+++ b/src/plugins/navigation/mutations/updateNavigationItem.test.js
@@ -2,6 +2,15 @@ import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import ReactionError from "@reactioncommerce/reaction-error";
 import updateNavigationItemMutation from "./updateNavigationItem.js";
 
+const mockInput = {
+  _id: "n1",
+  shopId: "123",
+  navigationItem: {}
+};
+
+const mockValidNavigationItemInput = { metadata: "{ \"tagId\": \"t1\" }" };
+const mockInvalidNavigationItemInput = { metadata: "INVALID_JSON" };
+
 const mockNavigationItem = {
   _id: "n1",
   createdAt: new Date(),
@@ -29,7 +38,7 @@ test("calls NavigationItems.findOne and updateOne, and returns the updated navig
 
   mockContext.queries.primaryShopId = jest.fn().mockName("queries.primaryShopId").mockReturnValueOnce(Promise.resolve("FAKE_SHOP_ID"));
 
-  const result = await updateNavigationItemMutation(mockContext, "n1", { metadata: "{ \"tagId\": \"t1\" }" });
+  const result = await updateNavigationItemMutation(mockContext, {...mockInput, navigationItem: mockValidNavigationItemInput });
 
   expect(mockContext.collections.NavigationItems.findOne).toHaveBeenCalledTimes(2);
   expect(mockContext.collections.NavigationItems.updateOne).toHaveBeenCalled();
@@ -40,17 +49,17 @@ test("throws an error if the user does not have the core permission", async () =
   mockContext.checkPermissions.mockImplementation(() => {
     throw new ReactionError("access-denied", "Access Denied");
   });
-  const result = updateNavigationItemMutation(mockContext, "n1", {});
+  const result = updateNavigationItemMutation(mockContext, mockInput);
   expect(result).rejects.toThrow();
 });
 
 test("throws an error if the navigation item does not exist", async () => {
   mockContext.collections.NavigationItems.findOne.mockReturnValueOnce(null);
-  const result = updateNavigationItemMutation(mockContext, "n1", {});
+  const result = updateNavigationItemMutation(mockContext, mockInput);
   expect(result).rejects.toThrow();
 });
 
 test("throws an error if invalid JSON metadata is passed", async () => {
-  const result = updateNavigationItemMutation(mockContext, "n1", { metadata: "INVALID_JSON" });
+  const result = updateNavigationItemMutation(mockContext, {...mockInput, navigationItem: mockInvalidNavigationItemInput });
   expect(result).rejects.toThrow();
 });

--- a/src/plugins/navigation/mutations/updateNavigationItem.test.js
+++ b/src/plugins/navigation/mutations/updateNavigationItem.test.js
@@ -3,7 +3,7 @@ import ReactionError from "@reactioncommerce/reaction-error";
 import updateNavigationItemMutation from "./updateNavigationItem.js";
 
 const mockInput = {
-  _id: "n1",
+  navigationItemId: "n1",
   shopId: "123",
   navigationItem: {}
 };

--- a/src/plugins/navigation/mutations/updateNavigationTree.js
+++ b/src/plugins/navigation/mutations/updateNavigationTree.js
@@ -7,17 +7,16 @@ import { NavigationTree as NavigationTreeSchema } from "../simpleSchemas.js";
  * @method updateNavigationTree
  * @summary Updates a navigation tree
  * @param {Object} context An object containing the per-request state
- * @param {String} _id _id of navigation tree to update
- * @param {Object} navigationTree Updated navigation tree
+ * @param {Object} input Input of updateNavigationTree mutation
+ * @param {String} input._id ID of navigation tree to update
+ * @param {String} input.shopId Shop ID of navigation tree
+ * @param {Object} input.navigationTree Navigation tree object to update
  * @returns {Promise<Object>} Updated navigation tree
  */
-export default async function updateNavigationTree(context, {
-  _id,
-  shopId,
-  navigationTree
-}) {
+export default async function updateNavigationTree(context, input) {
   const { checkPermissions, collections } = context;
   const { NavigationTrees } = collections;
+  const { _id, shopId, navigationTree } = input;
 
   const {
     shouldNavigationTreeItemsBeAdminOnly,

--- a/src/plugins/navigation/mutations/updateNavigationTree.js
+++ b/src/plugins/navigation/mutations/updateNavigationTree.js
@@ -11,11 +11,14 @@ import { NavigationTree as NavigationTreeSchema } from "../simpleSchemas.js";
  * @param {Object} navigationTree Updated navigation tree
  * @returns {Promise<Object>} Updated navigation tree
  */
-export default async function updateNavigationTree(context, _id, navigationTree) {
+export default async function updateNavigationTree(context, {
+  _id,
+  shopId,
+  navigationTree
+}) {
   const { checkPermissions, collections } = context;
   const { NavigationTrees } = collections;
 
-  const shopId = await context.queries.primaryShopId(context);
   const {
     shouldNavigationTreeItemsBeAdminOnly,
     shouldNavigationTreeItemsBePubliclyVisible,
@@ -44,7 +47,8 @@ export default async function updateNavigationTree(context, _id, navigationTree)
 
   await checkPermissions(["core"], shopId);
 
-  const existingNavigationTree = await NavigationTrees.findOne({ _id });
+  const treeSelector = { _id, shopId };
+  const existingNavigationTree = await NavigationTrees.findOne(treeSelector);
   if (!existingNavigationTree) {
     throw new ReactionError("navigation-tree-not-found", "No navigation tree was found");
   }
@@ -62,7 +66,7 @@ export default async function updateNavigationTree(context, _id, navigationTree)
 
   await NavigationTrees.updateOne({ _id }, { $set: { ...update } });
 
-  const updatedNavigationTree = await NavigationTrees.findOne({ _id });
+  const updatedNavigationTree = await NavigationTrees.findOne(treeSelector);
 
   return updatedNavigationTree;
 }

--- a/src/plugins/navigation/mutations/updateNavigationTree.js
+++ b/src/plugins/navigation/mutations/updateNavigationTree.js
@@ -8,7 +8,7 @@ import { NavigationTree as NavigationTreeSchema } from "../simpleSchemas.js";
  * @summary Updates a navigation tree
  * @param {Object} context An object containing the per-request state
  * @param {Object} input Input of updateNavigationTree mutation
- * @param {String} input._id ID of navigation tree to update
+ * @param {String} input.navigationTreeId ID of navigation tree to update
  * @param {String} input.shopId Shop ID of navigation tree
  * @param {Object} input.navigationTree Navigation tree object to update
  * @returns {Promise<Object>} Updated navigation tree
@@ -16,7 +16,7 @@ import { NavigationTree as NavigationTreeSchema } from "../simpleSchemas.js";
 export default async function updateNavigationTree(context, input) {
   const { checkPermissions, collections } = context;
   const { NavigationTrees } = collections;
-  const { _id, shopId, navigationTree } = input;
+  const { navigationTreeId, shopId, navigationTree } = input;
 
   const {
     shouldNavigationTreeItemsBeAdminOnly,
@@ -46,7 +46,7 @@ export default async function updateNavigationTree(context, input) {
 
   await checkPermissions(["core"], shopId);
 
-  const treeSelector = { _id, shopId };
+  const treeSelector = { _id: navigationTreeId, shopId };
   const existingNavigationTree = await NavigationTrees.findOne(treeSelector);
   if (!existingNavigationTree) {
     throw new ReactionError("navigation-tree-not-found", "No navigation tree was found");
@@ -63,7 +63,7 @@ export default async function updateNavigationTree(context, input) {
     update.name = name;
   }
 
-  await NavigationTrees.updateOne({ _id }, { $set: { ...update } });
+  await NavigationTrees.updateOne({ _id: navigationTreeId }, { $set: { ...update } });
 
   const updatedNavigationTree = await NavigationTrees.findOne(treeSelector);
 

--- a/src/plugins/navigation/mutations/updateNavigationTree.test.js
+++ b/src/plugins/navigation/mutations/updateNavigationTree.test.js
@@ -39,6 +39,11 @@ const mockNavigationTree = {
   hasUnpublishedChanges: false
 };
 
+const mockInput = {
+  _id: mockNavigationTreeId,
+  shopId: "123"
+};
+
 test("calls NavigationTrees.findOne and updateOne, and returns the updated tree", async () => {
   mockContext.collections.NavigationTrees.findOne
     .mockReturnValueOnce(Promise.resolve(mockNavigationTree))
@@ -51,7 +56,10 @@ test("calls NavigationTrees.findOne and updateOne, and returns the updated tree"
     shouldNavigationTreeItemsBePubliclyVisible: false
   }));
 
-  const updatedNavigationTree = await updateNavigationTreeMutation(mockContext, mockNavigationTreeId, mockNavigationTreeInput);
+  const updatedNavigationTree = await updateNavigationTreeMutation(mockContext, {
+    ...mockInput,
+    navigationTree: mockNavigationTreeInput
+  });
 
   expect(mockContext.collections.NavigationTrees.findOne).toHaveBeenCalledTimes(2);
   expect(mockContext.collections.NavigationTrees.updateOne).toHaveBeenCalled();
@@ -63,12 +71,12 @@ test("throws an error if the user does not have the core permission", async () =
   mockContext.checkPermissions.mockImplementation(() => {
     throw new ReactionError("access-denied", "Access Denied");
   });
-  const result = updateNavigationTreeMutation(mockContext, "123");
+  const result = updateNavigationTreeMutation(mockContext, mockInput);
   expect(result).rejects.toThrow();
 });
 
 test("throws an error if the navigation tree does not exist", async () => {
   mockContext.collections.NavigationTrees.findOne.mockReturnValueOnce(Promise.resolve(null));
-  const result = updateNavigationTreeMutation(mockContext, "123");
+  const result = updateNavigationTreeMutation(mockContext, mockInput);
   expect(result).rejects.toThrow();
 });

--- a/src/plugins/navigation/mutations/updateNavigationTree.test.js
+++ b/src/plugins/navigation/mutations/updateNavigationTree.test.js
@@ -40,7 +40,7 @@ const mockNavigationTree = {
 };
 
 const mockInput = {
-  _id: mockNavigationTreeId,
+  navigationTreeId: mockNavigationTreeId,
   shopId: "123"
 };
 

--- a/src/plugins/navigation/resolvers/Mutation/deleteNavigationItem.js
+++ b/src/plugins/navigation/resolvers/Mutation/deleteNavigationItem.js
@@ -7,7 +7,7 @@ import { decodeNavigationItemOpaqueId, decodeShopOpaqueId } from "../../xforms/i
  * @summary resolver for deleteNavigation GraphQL mutation
  * @param {Object} parentResult Unused
  * @param {Object} args.input An object of all mutation arguments that were sent by the client
- * @param {String} args.input._id ID of the navigation item to delete
+ * @param {String} args.input.id ID of the navigation item to delete
  * @param {String} args.input.shopId ID of the shop navigation item belongs
  * @param {String} [args.input.clientMutationId] An optional string identifying the mutation call
  * @param {Object} context An object containing the per-request state
@@ -16,13 +16,16 @@ import { decodeNavigationItemOpaqueId, decodeShopOpaqueId } from "../../xforms/i
 export default async function deleteNavigationItem(parentResult, { input }, context) {
   const {
     clientMutationId = null,
-    _id,
-    shopId
+    id: opaqueNavigationItemId,
+    shopId: opaqueShopId
   } = input;
 
+  const navigationItemId = decodeNavigationItemOpaqueId(opaqueNavigationItemId);
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
   const deletedNavigationItem = await context.mutations.deleteNavigationItem(context, {
-    _id: decodeNavigationItemOpaqueId(_id),
-    shopId: decodeShopOpaqueId(shopId)
+    navigationItemId,
+    shopId
   });
 
   return {

--- a/src/plugins/navigation/resolvers/Mutation/deleteNavigationItem.test.js
+++ b/src/plugins/navigation/resolvers/Mutation/deleteNavigationItem.test.js
@@ -1,7 +1,7 @@
 import deleteNavigationItemMutation from "./deleteNavigationItem.js";
 
 const mockInput = {
-  _id: "cmVhY3Rpb24vbmF2aWdhdGlvbkl0ZW06dWFYWGF3YzVveHk5ZVI0aFA="
+  id: "cmVhY3Rpb24vbmF2aWdhdGlvbkl0ZW06dWFYWGF3YzVveHk5ZVI0aFA="
 };
 const mockNavigationItemResult = {
   _id: "wYWSrwT2bWDE9aHLg",

--- a/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
+++ b/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
@@ -7,19 +7,19 @@ import { decodeNavigationTreeOpaqueId, decodeShopOpaqueId } from "../../xforms/i
  * @summary resolver for publishNavigationChanges GraphQL mutation
  * @param {Object} parentResult Unused
  * @param {Object} args.input An object of all mutation arguments that were sent by the client
- * @param {String} args.input._id ID of the navigation tree to publish changes
+ * @param {String} args.input.id ID of the navigation tree to publish changes
  * @param {String} args.input.shopId Shop ID of the navigation tree to publish changes
  * @param {String} [args.input.clientMutationId] An optional string identifying the mutation call
  * @param {Object} context An object containing the per-request state
  * @returns {Promise<Object>} publishNavigationChangesPayload
  */
 export default async function publishNavigationChanges(parentResult, { input }, context) {
-  const { clientMutationId = null, _id, shopId: opaqueShopId } = input;
+  const { clientMutationId = null, id: opaqueNavigationTreeId, shopId: opaqueShopId } = input;
 
-  const decodedId = decodeNavigationTreeOpaqueId(_id);
+  const decodedId = decodeNavigationTreeOpaqueId(opaqueNavigationTreeId);
   const shopId = decodeShopOpaqueId(opaqueShopId);
   const publishedNavigationTree = context.mutations.publishNavigationChanges(context, {
-    _id: decodedId,
+    navigationTreeId: decodedId,
     shopId
   });
 

--- a/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
+++ b/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
@@ -22,7 +22,7 @@ export default async function publishNavigationChanges(parentResult, { input }, 
   const decodedId = decodeNavigationTreeOpaqueId(_id);
   const shopId = decodeShopOpaqueId(opaqueShopId);
   const publishedNavigationTree = context.mutations.publishNavigationChanges(context, {
-    decodedId,
+    _id: decodedId,
     shopId
   });
 

--- a/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
+++ b/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
@@ -1,4 +1,4 @@
-import { decodeNavigationTreeOpaqueId } from "../../xforms/id.js";
+import { decodeNavigationTreeOpaqueId, decodeShopOpaqueId } from "../../xforms/id.js";
 
 /**
  * @name Mutation.publishNavigationChanges
@@ -15,12 +15,13 @@ import { decodeNavigationTreeOpaqueId } from "../../xforms/id.js";
 export default async function publishNavigationChanges(parentResult, { input }, context) {
   const {
     clientMutationId = null,
-    _id
+    _id,
+    shopId: opaqueShopId
   } = input;
 
   const decodedId = decodeNavigationTreeOpaqueId(_id);
-
-  const publishedNavigationTree = context.mutations.publishNavigationChanges(context, decodedId);
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+  const publishedNavigationTree = context.mutations.publishNavigationChanges(context, decodedId, shopId);
 
   return {
     clientMutationId,

--- a/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
+++ b/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
@@ -21,7 +21,10 @@ export default async function publishNavigationChanges(parentResult, { input }, 
 
   const decodedId = decodeNavigationTreeOpaqueId(_id);
   const shopId = decodeShopOpaqueId(opaqueShopId);
-  const publishedNavigationTree = context.mutations.publishNavigationChanges(context, decodedId, shopId);
+  const publishedNavigationTree = context.mutations.publishNavigationChanges(context, {
+    decodedId,
+    shopId
+  });
 
   return {
     clientMutationId,

--- a/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
+++ b/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.js
@@ -8,16 +8,13 @@ import { decodeNavigationTreeOpaqueId, decodeShopOpaqueId } from "../../xforms/i
  * @param {Object} parentResult Unused
  * @param {Object} args.input An object of all mutation arguments that were sent by the client
  * @param {String} args.input._id ID of the navigation tree to publish changes
+ * @param {String} args.input.shopId Shop ID of the navigation tree to publish changes
  * @param {String} [args.input.clientMutationId] An optional string identifying the mutation call
  * @param {Object} context An object containing the per-request state
- * @returns {Promise<Object>} PublishNavigationTreePayload
+ * @returns {Promise<Object>} publishNavigationChangesPayload
  */
 export default async function publishNavigationChanges(parentResult, { input }, context) {
-  const {
-    clientMutationId = null,
-    _id,
-    shopId: opaqueShopId
-  } = input;
+  const { clientMutationId = null, _id, shopId: opaqueShopId } = input;
 
   const decodedId = decodeNavigationTreeOpaqueId(_id);
   const shopId = decodeShopOpaqueId(opaqueShopId);

--- a/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.test.js
+++ b/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.test.js
@@ -1,7 +1,10 @@
 import publishNavigationChangesMutation from "./publishNavigationChanges.js";
 
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM=";
+
 const mockInput = {
-  _id: "cmVhY3Rpb24vbmF2aWdhdGlvblRyZWU6cGtNVFdBRUhKcnNpTnpZMmE="
+  _id: "cmVhY3Rpb24vbmF2aWdhdGlvblRyZWU6cGtNVFdBRUhKcnNpTnpZMmE=",
+  shopId: opaqueShopId
 };
 const mockNavigationTreeItems = [
   {

--- a/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.test.js
+++ b/src/plugins/navigation/resolvers/Mutation/publishNavigationChanges.test.js
@@ -3,7 +3,7 @@ import publishNavigationChangesMutation from "./publishNavigationChanges.js";
 const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM=";
 
 const mockInput = {
-  _id: "cmVhY3Rpb24vbmF2aWdhdGlvblRyZWU6cGtNVFdBRUhKcnNpTnpZMmE=",
+  id: "cmVhY3Rpb24vbmF2aWdhdGlvblRyZWU6cGtNVFdBRUhKcnNpTnpZMmE=",
   shopId: opaqueShopId
 };
 const mockNavigationTreeItems = [

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.js
@@ -7,7 +7,7 @@ import { decodeNavigationItemOpaqueId, decodeShopOpaqueId } from "../../xforms/i
  * @summary resolver for updateNavigationItem GraphQL mutation
  * @param {Object} parentResult Unused
  * @param {Object} args.input An object of all mutation arguments that were sent by the client
- * @param {String} args.input._id ID of the navigation item to update
+ * @param {String} args.input.id ID of the navigation item to update
  * @param {String} args.input.navigationItem The updated navigation item
  * @param {String} [args.input.clientMutationId] An optional string identifying the mutation call
  * @param {Object} context An object containing the per-request state
@@ -16,16 +16,16 @@ import { decodeNavigationItemOpaqueId, decodeShopOpaqueId } from "../../xforms/i
 export default async function updateNavigationItem(parentResult, { input }, context) {
   const {
     clientMutationId = null,
-    _id,
+    id: opaqueNavigationItemId,
     shopId: opaqueShopId,
     navigationItem
   } = input;
 
-  const decodedId = decodeNavigationItemOpaqueId(_id);
+  const navigationItemId = decodeNavigationItemOpaqueId(opaqueNavigationItemId);
   const shopId = decodeShopOpaqueId(opaqueShopId);
 
   const updatedNavigationItem = await context.mutations.updateNavigationItem(context, {
-    _id: decodedId,
+    navigationItemId,
     navigationItem,
     shopId
   });

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.js
@@ -1,4 +1,4 @@
-import { decodeNavigationItemOpaqueId } from "../../xforms/id.js";
+import { decodeNavigationItemOpaqueId, decodeShopOpaqueId } from "../../xforms/id.js";
 
 /**
  * @name Mutation.updateNavigationItem
@@ -17,12 +17,18 @@ export default async function updateNavigationItem(parentResult, { input }, cont
   const {
     clientMutationId = null,
     _id,
+    shopId: opaqueShopId,
     navigationItem
   } = input;
 
   const decodedId = decodeNavigationItemOpaqueId(_id);
+  const shopId = decodeShopOpaqueId(opaqueShopId);
 
-  const updatedNavigationItem = await context.mutations.updateNavigationItem(context, decodedId, navigationItem);
+  const updatedNavigationItem = await context.mutations.updateNavigationItem(context, {
+    _id: decodedId,
+    navigationItem,
+    shopId
+  });
 
   return {
     clientMutationId,

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.test.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.test.js
@@ -1,5 +1,6 @@
 import updateNavigationItemMutation from "./updateNavigationItem.js";
 
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM=";
 const mockData = {
   content: [
     {
@@ -29,7 +30,7 @@ test("calls mutations.updateNavigationItem and returns the updated item", async 
     .mockName("mutations.updateNavigationItem")
     .mockReturnValueOnce(mockNavigationItemResult);
 
-  const mockArgs = { input: { navigationItem: mockNavigationItemInput } };
+  const mockArgs = { input: { navigationItem: mockNavigationItemInput, shopId: opaqueShopId } };
   const { navigationItem } = await updateNavigationItemMutation({}, mockArgs, {
     mutations: { updateNavigationItem }
   });

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.test.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.test.js
@@ -14,7 +14,7 @@ const mockData = {
   classNames: "home-link"
 };
 const mockNavigationItemInput = {
-  _id: "cmVhY3Rpb24vbmF2aWdhdGlvbkl0ZW06dWFYWGF3YzVveHk5ZVI0aFA=",
+  id: "cmVhY3Rpb24vbmF2aWdhdGlvbkl0ZW06dWFYWGF3YzVveHk5ZVI0aFA=",
   draftData: mockData,
   metadata: "{ \"tagId\": \"t1\" }"
 };

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.js
@@ -8,6 +8,7 @@ import { decodeNavigationTreeOpaqueId, decodeShopOpaqueId } from "../../xforms/i
  * @param {Object} parentResult Unused
  * @param {Object} args.input An object of all mutation arguments that were sent by the client
  * @param {String} args.input._id ID of the navigation tree to update
+ * @param {String} args.input.shopId Shop ID of the navigation tree to publish changes
  * @param {String} args.input.navigationTree The updated navigation tree
  * @param {Object} context An object containing the per-request state
  * @param {String} [args.input.clientMutationId] An optional string identifying the mutation call

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.js
@@ -7,7 +7,7 @@ import { decodeNavigationTreeOpaqueId, decodeShopOpaqueId } from "../../xforms/i
  * @summary resolver for updateNavigationTree GraphQL mutation
  * @param {Object} parentResult Unused
  * @param {Object} args.input An object of all mutation arguments that were sent by the client
- * @param {String} args.input._id ID of the navigation tree to update
+ * @param {String} args.input.id ID of the navigation tree to update
  * @param {String} args.input.shopId Shop ID of the navigation tree to publish changes
  * @param {String} args.input.navigationTree The updated navigation tree
  * @param {Object} context An object containing the per-request state
@@ -17,16 +17,16 @@ import { decodeNavigationTreeOpaqueId, decodeShopOpaqueId } from "../../xforms/i
 export default async function updateNavigationTree(parentResult, { input }, context) {
   const {
     clientMutationId = null,
-    _id,
+    id: opaqueNavigationTreeId,
     shopId: opaqueShopId,
     navigationTree
   } = input;
 
-  const decodedId = decodeNavigationTreeOpaqueId(_id);
+  const navigationTreeId = decodeNavigationTreeOpaqueId(opaqueNavigationTreeId);
   const shopId = decodeShopOpaqueId(opaqueShopId);
   const updatedNavigationTree = await context.mutations.updateNavigationTree(context, {
     shopId,
-    _id: decodedId,
+    navigationTreeId,
     navigationTree
   });
 

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.js
@@ -1,4 +1,4 @@
-import { decodeNavigationTreeOpaqueId } from "../../xforms/id.js";
+import { decodeNavigationTreeOpaqueId, decodeShopOpaqueId } from "../../xforms/id.js";
 
 /**
  * @name Mutation.updateNavigationTree
@@ -17,12 +17,17 @@ export default async function updateNavigationTree(parentResult, { input }, cont
   const {
     clientMutationId = null,
     _id,
+    shopId: opaqueShopId,
     navigationTree
   } = input;
 
   const decodedId = decodeNavigationTreeOpaqueId(_id);
-
-  const updatedNavigationTree = await context.mutations.updateNavigationTree(context, decodedId, navigationTree);
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+  const updatedNavigationTree = await context.mutations.updateNavigationTree(context, {
+    shopId,
+    _id: decodedId,
+    navigationTree
+  });
 
   return {
     clientMutationId,

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.test.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.test.js
@@ -15,7 +15,7 @@ const mockNavigationTreeItems = [
   }
 ];
 const mockInput = {
-  _id: "cmVhY3Rpb24vbmF2aWdhdGlvblRyZWU6cGtNVFdBRUhKcnNpTnpZMmE=",
+  id: "cmVhY3Rpb24vbmF2aWdhdGlvblRyZWU6cGtNVFdBRUhKcnNpTnpZMmE=",
   shopId: opaqueShopId,
   navigationTree: {
     draftItems: mockNavigationTreeItems,

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.test.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationTree.test.js
@@ -1,5 +1,6 @@
 import updateNavigationTreeMutation from "./updateNavigationTree.js";
 
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM=";
 const mockNavigationTreeItems = [
   {
     navigationItemId: "uaXXawc5oxy9eR4hP",
@@ -15,6 +16,7 @@ const mockNavigationTreeItems = [
 ];
 const mockInput = {
   _id: "cmVhY3Rpb24vbmF2aWdhdGlvblRyZWU6cGtNVFdBRUhKcnNpTnpZMmE=",
+  shopId: opaqueShopId,
   navigationTree: {
     draftItems: mockNavigationTreeItems,
     name: "Main Menu"

--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -256,6 +256,9 @@ input UpdateNavigationTreeInput {
 
   "The field updates to apply"
   navigationTree: NavigationTreeInput!
+
+  "The ID of the shop navigation item belongs to"
+  shopId: ID!
 }
 
 "Input for the `publishNavigationChanges` mutation"

--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -229,6 +229,9 @@ input UpdateNavigationItemInput {
 
   "The field updates to apply"
   navigationItem: NavigationItemInput!
+
+  "The ID of the shop navigation item belongs to"
+  shopId: ID!
 }
 
 "Input for the `deleteNavigationItem` mutation"

--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -237,7 +237,7 @@ input UpdateNavigationItemInput {
 "Input for the `deleteNavigationItem` mutation"
 input DeleteNavigationItemInput {
   "The ID of the navigation item to delete"
-  _id: ID!
+  id: ID!
 
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String

--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -221,11 +221,11 @@ input CreateNavigationItemInput {
 
 "Input for the `updateNavigationItem` mutation"
 input UpdateNavigationItemInput {
-  "The ID of the navigation item to update"
-  id: ID!
-
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
+
+  "The ID of the navigation item to update"
+  id: ID!
 
   "The field updates to apply"
   navigationItem: NavigationItemInput!
@@ -236,11 +236,11 @@ input UpdateNavigationItemInput {
 
 "Input for the `deleteNavigationItem` mutation"
 input DeleteNavigationItemInput {
-  "The ID of the navigation item to delete"
-  id: ID!
-
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
+
+  "The ID of the navigation item to delete"
+  id: ID!
 
   "The ID of the shop navigation item belongs to"
   shopId: ID!

--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -248,11 +248,11 @@ input DeleteNavigationItemInput {
 
 "Input for the `updateNavigationTree` mutation"
 input UpdateNavigationTreeInput {
-  "The ID of the navigation tree to update"
-  _id: ID!
-
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
+
+  "The ID of the navigation tree to update"
+  id: ID!
 
   "The field updates to apply"
   navigationTree: NavigationTreeInput!
@@ -263,11 +263,11 @@ input UpdateNavigationTreeInput {
 
 "Input for the `publishNavigationChanges` mutation"
 input PublishNavigationChangesInput {
-  "The ID of the navigation tree"
-  _id: ID!
-
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
+
+  "The ID of the navigation tree"
+  id: ID!
 
   "Shop ID of the navigation tree"
   shopId: ID!

--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -262,6 +262,9 @@ input PublishNavigationChangesInput {
 
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
+
+  "Shop ID of the navigation tree"
+  shopId: ID!
 }
 
 "NavigationItem input"

--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -222,7 +222,7 @@ input CreateNavigationItemInput {
 "Input for the `updateNavigationItem` mutation"
 input UpdateNavigationItemInput {
   "The ID of the navigation item to update"
-  _id: ID!
+  id: ID!
 
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String

--- a/src/plugins/navigation/util/createDefaultNavigationTreeForShop.js
+++ b/src/plugins/navigation/util/createDefaultNavigationTreeForShop.js
@@ -75,7 +75,13 @@ export default async function createDefaultNavigationTreeForShop(context, shop) 
     shopId
   });
 
-  await context.mutations.publishNavigationChanges({ ...context, isInternalCall: true }, navigationTreeId);
+  await context.mutations.publishNavigationChanges({
+    ...context,
+    isInternalCall: true
+  }, {
+    _id: navigationTreeId,
+    shopId
+  });
 
   await Shops.updateOne({ _id: shopId }, { $set: { defaultNavigationTreeId: navigationTreeId } });
 

--- a/src/plugins/navigation/util/createDefaultNavigationTreeForShop.js
+++ b/src/plugins/navigation/util/createDefaultNavigationTreeForShop.js
@@ -79,7 +79,7 @@ export default async function createDefaultNavigationTreeForShop(context, shop) 
     ...context,
     isInternalCall: true
   }, {
-    _id: navigationTreeId,
+    navigationTreeId,
     shopId
   });
 

--- a/src/plugins/sitemap-generator/mutations/generateSitemaps.js
+++ b/src/plugins/sitemap-generator/mutations/generateSitemaps.js
@@ -4,8 +4,8 @@
  * @method
  * @summary Regenerates sitemap files for primary shop
  * @param {Object} context - GraphQL execution context
- * @param {String} input input of generateSitemaps
- * @param {String} input.shopId shopId to generate sitemap for
+ * @param {String} input Input of generateSitemaps
+ * @param {String} input.shopId Shop ID to generate sitemap for
  * @returns {undefined} schedules immediate sitemap generation job
  */
 export default async function generateSitemaps(context, input) {

--- a/src/plugins/sitemap-generator/mutations/generateSitemaps.js
+++ b/src/plugins/sitemap-generator/mutations/generateSitemaps.js
@@ -4,12 +4,13 @@
  * @method
  * @summary Regenerates sitemap files for primary shop
  * @param {Object} context - GraphQL execution context
+ * @param {String} input input of generateSitemaps
+ * @param {String} input.shopId shopId to generate sitemap for
  * @returns {undefined} schedules immediate sitemap generation job
  */
-export default async function generateSitemaps(context) {
+export default async function generateSitemaps(context, input) {
   const { checkPermissions, userId } = context;
-
-  const shopId = await context.queries.primaryShopId(context);
+  const { shopId } = input;
 
   await checkPermissions(["admin"], shopId);
 

--- a/src/plugins/sitemap-generator/resolvers/Mutation/generateSitemaps.js
+++ b/src/plugins/sitemap-generator/resolvers/Mutation/generateSitemaps.js
@@ -1,17 +1,23 @@
+import { decodeShopOpaqueId } from "../../xforms/id.js";
+
 /**
  * @name Mutation.generateSitemaps
  * @method
  * @memberof Sitemap/GraphQL
  * @summary resolver for the generateSitemaps GraphQL mutation
  * @param {Object} parentResult - unused
- * @param {Object} args - unused
+ * @param {Object} args.input An object of all mutation arguments that were sent by the client
+ * @param {String} args.input.shopId shopId to generate sitemap for
+ * @param {String} [args.input.clientMutationId] An optional string identifying the mutation call
  * @param {Object} context - an object containing the per-request state
  * @returns {Promise<Boolean>} true on success
  */
 export default async function generateSitemaps(parentResult, { input = {} }, context) {
-  const { clientMutationId = null } = input;
+  const { clientMutationId = null, shopId: opaqueShopId } = input;
 
-  await context.mutations.generateSitemaps(context);
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  await context.mutations.generateSitemaps(context, { shopId });
 
   return {
     wasJobScheduled: true,

--- a/src/plugins/sitemap-generator/schemas/schema.graphql
+++ b/src/plugins/sitemap-generator/schemas/schema.graphql
@@ -10,6 +10,9 @@ extend type Mutation {
 input GenerateSitemapsInput {
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
+
+  "The ID of the shop to generate sitemap for"
+  shopId: ID!
 }
 
 "Response for the `generateSitemaps` mutation"

--- a/src/plugins/sitemap-generator/xforms/id.js
+++ b/src/plugins/sitemap-generator/xforms/id.js
@@ -1,3 +1,4 @@
+import decodeOpaqueIdForNamespace from "@reactioncommerce/api-utils/decodeOpaqueIdForNamespace.js";
 import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
 
 const namespaces = {
@@ -5,3 +6,5 @@ const namespaces = {
 };
 
 export const encodeShopOpaqueId = encodeOpaqueId(namespaces.Shop);
+
+export const decodeShopOpaqueId = decodeOpaqueIdForNamespace(namespaces.Shop);


### PR DESCRIPTION
Resolves #5801 
Impact: **minor**  
Type: **refactor**

## Issue
context.queries.primaryShopId is used in several places. These need to be updated to have client pass in a shopId.

## Solution
Remove `context.queries.primaryShopId` from following mutations/queries:

- [x] [publishNavigationChanges](https://github.com//reactioncommerce/reaction/blob/dba6fa1980f06f04a4d17afbf06ddb1fcfbccda9/src/plugins/navigation/mutations/publishNavigationChanges.js#L17)
- [x] [updateNavigationItem](https://github.com//reactioncommerce/reaction/blob/d2080cfdf7527de36851592e1d96d40feb52fd19/src/plugins/navigation/mutations/updateNavigationItem.js#L17)
- [x] [updateNavigationTree](https://github.com//reactioncommerce/reaction/blob/d2080cfdf7527de36851592e1d96d40feb52fd19/src/plugins/navigation/mutations/updateNavigationTree.js#L18)
- [x] [catalog/queries/tag](https://github.com//reactioncommerce/reaction/blob/fd09b9e88d0c6e23fcaba2bae3701b66ed09ee86/src/core-services/catalog/queries/tag.js) 
- [x] [generateSitemaps](https://github.com//reactioncommerce/reaction/blob/d2080cfdf7527de36851592e1d96d40feb52fd19/src/plugins/sitemap-generator/mutations/generateSitemaps.js#L12)

- [x] Add test for tag query and api