### PR TITLE
feat: retry initial MongoDB connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4348,6 +4348,11 @@
         "validator": "^10.11.0"
       }
     },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -9739,6 +9744,22 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+      "requires": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+        }
+      }
     },
     "prompts": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mongodb": "~3.3.3",
     "node-fetch": "~2.6.0",
     "object-hash": "~1.3.1",
+    "promise-retry": "^1.1.1",
     "querystring": "~0.2.0",
     "ramda": "~0.26.1",
     "semver": "~6.3.0",

--- a/src/core/ReactionAPI.js
+++ b/src/core/ReactionAPI.js
@@ -11,6 +11,7 @@ import Logger from "@reactioncommerce/logger";
 import appEvents from "./util/appEvents.js";
 import getAbsoluteUrl from "./util/getAbsoluteUrl.js";
 import initReplicaSet from "./util/initReplicaSet.js";
+import mongoConnectWithRetry from "./util/mongoConnectWithRetry.js";
 import config from "./config.js";
 import createApolloServer from "./createApolloServer.js";
 import coreResolvers from "./graphql/resolvers/index.js";
@@ -30,8 +31,6 @@ const {
 } = config;
 
 const debugLevels = ["DEBUG", "TRACE"];
-
-const { MongoClient } = mongodb;
 
 const optionsSchema = new SimpleSchema({
   "httpServer": {
@@ -214,12 +213,7 @@ export default class ReactionAPI {
     const dbUrl = mongoUrl.slice(0, lastSlash);
     const dbName = mongoUrl.slice(lastSlash + 1);
 
-    const client = await MongoClient.connect(dbUrl, {
-      useNewUrlParser: true
-      // Uncomment this after this `mongodb` pkg bug is fixed:
-      // https://jira.mongodb.org/browse/NODE-2249
-      // useUnifiedTopology: true
-    });
+    const client = await mongoConnectWithRetry(dbUrl);
 
     this.mongoClient = client;
     this.setMongoDatabase(client.db(dbName));

--- a/src/core/util/mongoConnectWithRetry.js
+++ b/src/core/util/mongoConnectWithRetry.js
@@ -1,0 +1,45 @@
+import Logger from "@reactioncommerce/logger";
+import mongodb from "mongodb";
+import promiseRetry from "promise-retry";
+
+const { MongoClient } = mongodb;
+
+const mongoInitialConnectRetries = 10;
+
+/**
+ * @summary The MongoDB driver will auto-reconnect but not on the first connect.
+ *   If the first connection fails, it throws. Because we expect to be in a dynamic
+ *   Docker environment in which containers may start and slightly different times,
+ *   we want to try to reconnect for a bit, even on the first connect.
+ * @param {String} url MongoDB URL
+ * @return {Object} Client
+ */
+export default function mongoConnectWithRetry(url) {
+  return promiseRetry((retry, number) => {
+    if (number > 1) {
+      Logger.info(`Retrying connect to MongoDB... (${number - 1} of ${mongoInitialConnectRetries})`);
+    } else {
+      Logger.info("Connecting to MongoDB...");
+    }
+
+    return MongoClient.connect(url, {
+      useNewUrlParser: true
+      // Uncomment this after this `mongodb` pkg bug is fixed:
+      // https://jira.mongodb.org/browse/NODE-2249
+      // useUnifiedTopology: true
+    }).then((client) => {
+      Logger.info("Connected to MongoDB");
+      return client;
+    }).catch((error) => {
+      if (error.name === "MongoNetworkError") {
+        retry(error);
+      } else {
+        throw error;
+      }
+    });
+  }, {
+    factor: 1,
+    minTimeout: 3000,
+    retries: mongoInitialConnectRetries
+  }).catch((error) => { throw error; });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -21,4 +21,7 @@ async function runApp() {
   Logger.info(`GraphQL subscriptions ready at ${app.graphQLServerSubscriptionUrl} (port ${app.serverPort || "unknown"})`);
 }
 
-runApp().catch(Logger.error.bind(Logger));
+runApp().catch((error) => {
+  Logger.error(error);
+  process.exit(1); // eslint-disable-line no-process-exit
+});


### PR DESCRIPTION
Resolves #5806   
Impact: **minor**  
Type: **feature**

## Issue
When spinning up separate API and MongoDB containers, due to timing the API container may try to connect to MongoDB before it is fully ready. Now that API starts up faster in 3.0.0, this is more likely. The MongoDB driver library does not auto-retry connecting on the first connection.

## Solution
Adds our own auto-retry logic for the first connection, as well as better logging about what is happening with db connections.

## Breaking changes
None

## Testing
1. Start `api` service but not `mongo` service. Verify that you see logging about retrying 10 times and it eventually gives up and exits the app with the error. (In a development environment, you'll see this whole series of connection logs twice because it first tries to auto-init the replica set.)
2. Start `api` service but not `mongo` service. While it's showing the retrying log messages in API logs, start the `mongo` service. You'll have about 30 seconds window to do so. Verify in the API logs that it eventually shows a successful db connection before it fully times out.
3. Start both `api` and `mongo` services normally. Verify that it shows a successful db connection in the logs on the first or second try.