### PR TITLE
add email templates query

### DIFF
--- a/src/plugins/discount-codes/resolvers/Query/discountCodes.js
+++ b/src/plugins/discount-codes/resolvers/Query/discountCodes.js
@@ -9,10 +9,10 @@ import { decodeShopOpaqueId } from "../../xforms/id.js";
  * @summary query the Discount codes collection and return user account data
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client
- * @param {String} args.shopId - id of user to query
+ * @param {String} args.shopId - id of the shop
  * @param {Object} context - an object containing the per-request state
  * @param {Object} info Info about the GraphQL request
- * @returns {Promise<Object>} user account object
+ * @returns {Promise<Object>} An array of discount codes
  */
 export default async function discountCodes(_, args, context, info) {
   const { shopId: opaqueShopId, ...connectionArgs } = args;

--- a/src/plugins/discount-codes/schemas/schema.graphql
+++ b/src/plugins/discount-codes/schemas/schema.graphql
@@ -367,7 +367,7 @@ type DeleteDiscountCodePayload {
 extend type Query {
   "Gets discount codes"
   discountCodes(
-    "Provide a shp ID from which you want to get discount codes"
+    "Provide a shop ID from which you want to get discount codes"
     shopId: ID!
 
     "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."

--- a/src/plugins/email-templates/index.js
+++ b/src/plugins/email-templates/index.js
@@ -1,3 +1,4 @@
+import queries from "./queries/index.js";
 import mutations from "./mutations/index.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
@@ -18,6 +19,7 @@ export default async function register(app) {
       resolvers,
       schemas
     },
+    queries,
     mutations,
     simpleSchemas: {
       EmailTemplates

--- a/src/plugins/email-templates/queries/emailTemplates.js
+++ b/src/plugins/email-templates/queries/emailTemplates.js
@@ -1,0 +1,20 @@
+/**
+ * @name emailTemplates
+ * @method
+ * @memberof GraphQL/Templates
+ * @summary Query the Templates collection for a list of email templates
+ * @param {Object} context - an object containing the per-request state
+ * @param {String} shopId - ID of the shop to query against
+ * @returns {Promise<Object>} Email templates cursor
+ */
+export default async function emailTemplates(context, shopId) {
+  const { checkPermissions, collections } = context;
+  const { Templates } = collections;
+
+  await checkPermissions(["owner", "admin"], shopId);
+
+  return Templates.find({
+    shopId,
+    type: "email"
+  });
+}

--- a/src/plugins/email-templates/queries/index.js
+++ b/src/plugins/email-templates/queries/index.js
@@ -1,0 +1,5 @@
+import emailTemplates from "./emailTemplates.js";
+
+export default {
+  emailTemplates
+};

--- a/src/plugins/email-templates/resolvers/Query/emailTemplates.js
+++ b/src/plugins/email-templates/resolvers/Query/emailTemplates.js
@@ -1,0 +1,28 @@
+import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
+import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
+import { decodeShopOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Query/emailTemplates
+ * @method
+ * @memberof Templates/Query
+ * @param {Object} _ unused
+ * @param {Object} args - an object of all the arguments that were sent by the client
+ * @param {String} args.shopId - id of the shop
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} info - info about the GraphQL request
+ * @returns {Promise<Object>} an array of email templates
+ */
+export default async function emailTemplates(_, args, context, info) {
+  const { shopId: opaqueShopId, ...connectionArgs } = args;
+
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  const query = await context.queries.emailTemplates(context, shopId);
+
+  return getPaginatedResponse(query, connectionArgs, {
+    includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
+    includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
+    includeTotalCount: wasFieldRequested("totalCount", info)
+  });
+}

--- a/src/plugins/email-templates/resolvers/Query/index.js
+++ b/src/plugins/email-templates/resolvers/Query/index.js
@@ -1,0 +1,5 @@
+import emailTemplates from "./emailTemplates.js";
+
+export default {
+  emailTemplates
+};

--- a/src/plugins/email-templates/resolvers/index.js
+++ b/src/plugins/email-templates/resolvers/index.js
@@ -1,7 +1,9 @@
+import Query from "./Query/index.js";
 import Mutation from "./Mutation/index.js";
 import Template from "./Template/index.js";
 
 export default {
+  Query,
   Mutation,
   Template
 };

--- a/src/plugins/email-templates/schemas/schema.graphql
+++ b/src/plugins/email-templates/schemas/schema.graphql
@@ -21,3 +21,60 @@ type Template implements Node {
   "Email template title"
   title: String
 }
+
+"A connection edge in which each node is a `Template` object"
+type TemplateEdge {
+  "The cursor that represents this node in the paginated results"
+  cursor: ConnectionCursor!
+
+  "The email template"
+  node: Template
+}
+
+"""
+Wraps a list of Templates, providing pagination cursors and information.
+
+For information about what Relay-compatible connections are and how to use them, see the following articles:
+- [Relay Connection Documentation](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections)
+- [Relay Connection Specification](https://facebook.github.io/relay/graphql/connections.htm)
+- [Using Relay-style Connections With Apollo Client](https://www.apollographql.com/docs/react/recipes/pagination.html)
+"""
+type TemplateConnection {
+  "The list of nodes that match the query, wrapped in an edge to provide a cursor string for each"
+  edges: [TemplateEdge]
+
+  """
+  You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
+  if you know you will not need to paginate the results.
+  """
+  nodes: [Template]
+
+  "Information to help a client request the next or previous page"
+  pageInfo: PageInfo!
+
+  "The total number of nodes that match your query"
+  totalCount: Int!
+}
+
+extend type Query {
+  "Retrieves a list of email templates"
+  emailTemplates(
+    "The shopId to which email templates belong to"
+    shopId: ID!
+
+    "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
+    after: ConnectionCursor,
+
+    "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
+    before: ConnectionCursor,
+
+    "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
+    first: ConnectionLimitInt,
+
+    "Return at most this many results. This parameter may be used with the `before` parameter."
+    last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+  ) : TemplateConnection
+}

--- a/tests/integration/api/queries/emailTemplates/__snapshots__/emailTemplates.test.js.snap
+++ b/tests/integration/api/queries/emailTemplates/__snapshots__/emailTemplates.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throws access-denied when retrieving email templates if not an admin 1`] = `
+Object {
+  "extensions": Object {
+    "code": "FORBIDDEN",
+    "exception": Object {
+      "details": Object {},
+      "error": "access-denied",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Access Denied",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Access Denied",
+  "path": Array [
+    "emailTemplates",
+  ],
+}
+`;

--- a/tests/integration/api/queries/emailTemplates/emailTemplates.test.js
+++ b/tests/integration/api/queries/emailTemplates/emailTemplates.test.js
@@ -1,0 +1,133 @@
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const emailTemplatesQuery = importAsString("./emailTemplatesQuery.graphql");
+
+jest.setTimeout(300000);
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const shopName = "Test Shop";
+const emailTemplateDocuments = [];
+const template = `
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>This is a test email</title>
+</head>
+<body style="margin:0; padding:0;">
+  <table width="100%" border="0" cellspacing="0" cellpadding="0" class="emailwrapto100pc">
+    <tr>
+      <td align="center" valign="middle">
+        <p>This is a test email template</p>
+      </td>
+    </tr>
+  </table>
+</body>
+`;
+const emailTemplateData = [{
+  name: "orders/new",
+  subject: "Your order is confirmed - {{order.referenceId}}",
+  template,
+  title: "Orders - New Order Placed",
+  type: "email"
+}, {
+  name: "accounts/resetPassword",
+  subject: "{{shop.name}}: Here's your password reset link",
+  template,
+  title: "Accounts - Reset Password",
+  type: "email"
+}, {
+  name: "accounts/verifyEmail",
+  subject: "{{shopName}}: Please verify your email address",
+  template,
+  title: "Accounts - Verify Account",
+  type: "email"
+}];
+
+// Create 10 test email template documents
+for (let index = 0; index < 3; index += 1) {
+  const doc = Factory.EmailTemplates.makeOne({
+    _id: `emailTemplate-${index}`,
+    shopId: internalShopId,
+    enabled: true,
+    language: "en",
+    name: emailTemplateData[index].name,
+    parser: "handlebars",
+    provides: "template",
+    subject: emailTemplateData[index].subject,
+    template: emailTemplateData[index].template,
+    title: emailTemplateData[index].title,
+    type: "email"
+  });
+
+  emailTemplateDocuments.push(doc);
+}
+
+
+const mockAdminAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: ["admin"]
+  },
+  shopId: internalShopId
+});
+
+const mockCustomerAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: []
+  },
+  shopId: internalShopId
+});
+
+let testApp;
+let emailTemplates;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+
+  await Promise.all(emailTemplateDocuments.map((doc) => (
+    testApp.collections.Templates.insertOne(doc)
+  )));
+
+  await testApp.createUserAndAccount(mockAdminAccount);
+  await testApp.createUserAndAccount(mockCustomerAccount);
+
+  emailTemplates = testApp.query(emailTemplatesQuery);
+});
+
+afterAll(async () => {
+  await testApp.collections.Templates.deleteMany({});
+  await testApp.collections.Accounts.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.stop();
+});
+
+test("throws access-denied when retrieving email templates if not an admin", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  try {
+    await emailTemplates({
+      shopId: opaqueShopId
+    });
+  } catch (errors) {
+    expect(errors[0]).toMatchSnapshot();
+  }
+});
+
+test("returns email template records if user is an admin", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  const result = await emailTemplates({
+    shopId: opaqueShopId,
+    first: 3,
+    offset: 0
+  });
+
+  expect(result.emailTemplates.nodes.length).toEqual(3);
+  expect(result.emailTemplates.nodes[0].name).toEqual("orders/new");
+  expect(result.emailTemplates.nodes[2].name).toEqual("accounts/verifyEmail");
+  expect(result.emailTemplates.nodes[2].template).toEqual(template);
+});

--- a/tests/integration/api/queries/emailTemplates/emailTemplatesQuery.graphql
+++ b/tests/integration/api/queries/emailTemplates/emailTemplatesQuery.graphql
@@ -1,0 +1,26 @@
+query emailTemplates(
+  $shopId: ID!,
+  $first: ConnectionLimitInt,
+  $last:  ConnectionLimitInt,
+  $before: ConnectionCursor,
+  $after: ConnectionCursor,
+  $offset: Int
+) {
+  emailTemplates(
+    shopId: $shopId,
+    first: $first,
+    last: $last,
+    before: $before,
+    after: $after,
+    offset: $offset
+  ) {
+		nodes {
+      _id
+      name
+      title
+      subject
+      template
+      shopId
+    }
+  }
+}

--- a/tests/util/factory.js
+++ b/tests/util/factory.js
@@ -66,6 +66,10 @@ import {
 } from "../../src/core-services/taxes/simpleSchemas.js";
 
 import {
+  EmailTemplates
+} from "../../src/plugins/email-templates/simpleSchemas.js";
+
+import {
   extendSimplePricingSchemas
 } from "../../src/plugins/simple-pricing/simpleSchemas.js";
 
@@ -83,6 +87,7 @@ const schemasToAddToFactory = {
   CommonOrder,
   CommonOrderItem,
   Discounts,
+  EmailTemplates,
   Group,
   Order,
   OrderAddress,


### PR DESCRIPTION
Resolves #5754
Impact: minor
Type: feature

## Issue
There was no GraphQL query to retrieve email templates

## Solution
Add query to retrieve email templates

```
{
  emailTemplates(shopId: "cmVhY3Rpb24vc2hvcDpKOEJocTN1VHRkZ3daeDNyeg==", first: 3) {
    nodes {
      name
      title
      subject
    }
  }
}
```

## Breaking changes
None


## Testing
1. Use query above to retrieve email templates
2. Verify email templates are retrieved correctly
