### PR TITLE
feat: add addAccountEmailRecord mutation and corresponding integration

### DIFF
--- a/src/core-services/account/mutations/addAccountEmailRecord.js
+++ b/src/core-services/account/mutations/addAccountEmailRecord.js
@@ -1,0 +1,85 @@
+import SimpleSchema from "simpl-schema";
+import ReactionError from "@reactioncommerce/reaction-error";
+import sendVerificationEmail from "../util/sendVerificationEmail.js";
+
+const inputSchema = new SimpleSchema({
+  accountId: String,
+  email: SimpleSchema.RegEx.Email
+});
+
+/**
+ * @name accounts/addAccountEmailRecord
+ * @memberof Mutations/Accounts
+ * @summary adds a new email to the user's profile
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Necessary input for mutation. See SimpleSchema.
+ * @param {String} input.accountId - decoded ID of account on which entry should be added
+ * @param {String} input.email - the email to add to the account
+ * @returns {Promise<Object>} account with addd email
+ */
+export default async function addAccountEmailRecord(context, input) {
+  inputSchema.validate(input);
+  const { appEvents, checkPermissions, collections, userId: userIdFromContext } = context;
+  const { Accounts, users } = collections;
+  const {
+    accountId,
+    email
+  } = input;
+
+  const account = await Accounts.findOne({ _id: accountId });
+  if (!account) throw new ReactionError("not-found", "Account not Found");
+
+  const user = await users.findOne({ _id: account.userId });
+  if (!user) throw new ReactionError("not-found", "User not Found");
+
+  if (!context.isInternalCall && userIdFromContext !== account.userId) {
+    await checkPermissions(["reaction-accounts"], account.shopId);
+  }
+
+  // add email to user
+  const { value: updatedUser } = await users.findOneAndUpdate(
+    { _id: user._id },
+    {
+      $addToSet: {
+        emails: {
+          address: email,
+          provides: "default",
+          verified: false
+        }
+      }
+    },
+    {
+      returnOriginal: false
+    }
+  );
+
+  if (!updatedUser) throw new ReactionError("server-error", "Unable to update User");
+
+  // add email to Account
+  const { value: updatedAccount } = await Accounts.findOneAndUpdate(
+    { _id: accountId },
+    {
+      $set: {
+        emails: updatedUser.emails
+      }
+    },
+    {
+      returnOriginal: false
+    }
+  );
+
+  if (!updatedAccount) throw new ReactionError("server-error", "Unable to update Account");
+
+  sendVerificationEmail(context, {
+    bodyTemplate: "accounts/verifyUpdatedEmail",
+    userId: user._id
+  });
+
+  await appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: accountId,
+    updatedFields: ["emails"]
+  });
+
+  return updatedAccount;
+}

--- a/src/core-services/account/mutations/index.js
+++ b/src/core-services/account/mutations/index.js
@@ -1,4 +1,5 @@
 import addressBookAdd from "./addressBookAdd.js";
+import addAccountEmailRecord from "./addAccountEmailRecord.js";
 import addAccountToGroup from "./addAccountToGroup.js";
 import addAccountToGroupBySlug from "./addAccountToGroupBySlug.js";
 import createAccount from "./createAccount.js";
@@ -13,6 +14,7 @@ import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 
 export default {
   addressBookAdd,
+  addAccountEmailRecord,
   addAccountToGroup,
   addAccountToGroupBySlug,
   createAccount,

--- a/src/core-services/account/resolvers/Mutation/addAccountEmailRecord.js
+++ b/src/core-services/account/resolvers/Mutation/addAccountEmailRecord.js
@@ -23,7 +23,7 @@ export default async function addAccountEmailRecord(_, { input }, context) {
   });
 
   return {
-    emailRecord: updatedAccount.emails.pop(),
+    account: updatedAccount,
     clientMutationId
   };
 }

--- a/src/core-services/account/resolvers/Mutation/addAccountEmailRecord.js
+++ b/src/core-services/account/resolvers/Mutation/addAccountEmailRecord.js
@@ -1,0 +1,29 @@
+import { decodeAccountOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Mutation/addAccountEmailRecord
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver for the addAccountEmailRecord GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} args.input.accountId - The account ID
+ * @param {String} args.input.email - The email to add
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @returns {Object} addAccountEmailRecordPayload
+ */
+export default async function addAccountEmailRecord(_, { input }, context) {
+  const { accountId, email, clientMutationId = null } = input;
+  const decodedAccountId = decodeAccountOpaqueId(accountId);
+
+  const updatedAccount = await context.mutations.addAccountEmailRecord(context, {
+    accountId: decodedAccountId,
+    email
+  });
+
+  return {
+    emailRecord: updatedAccount.emails.pop(),
+    clientMutationId
+  };
+}

--- a/src/core-services/account/resolvers/Mutation/index.js
+++ b/src/core-services/account/resolvers/Mutation/index.js
@@ -1,4 +1,5 @@
 import addAccountAddressBookEntry from "./addAccountAddressBookEntry.js";
+import addAccountEmailRecord from "./addAccountEmailRecord.js";
 import addAccountToGroup from "./addAccountToGroup.js";
 import inviteShopMember from "./inviteShopMember.js";
 import removeAccountAddressBookEntry from "./removeAccountAddressBookEntry.js";
@@ -10,6 +11,7 @@ import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 
 export default {
   addAccountAddressBookEntry,
+  addAccountEmailRecord,
   addAccountToGroup,
   inviteShopMember,
   removeAccountAddressBookEntry,

--- a/src/core-services/account/schemas/account.graphql
+++ b/src/core-services/account/schemas/account.graphql
@@ -282,8 +282,8 @@ type AddAccountEmailRecordPayload {
   "The same string you sent with the mutation params, for matching mutation calls with their responses"
   clientMutationId: String
 
-  "The added email record"
-  emailRecord: EmailRecord
+  "The account, with updated `emailRecords`"
+  account: Account
 }
 
 "The response from the `createAccount` mutation"

--- a/src/core-services/account/schemas/account.graphql
+++ b/src/core-services/account/schemas/account.graphql
@@ -279,11 +279,11 @@ type AddAccountAddressBookEntryPayload {
 
 "The response from the `addAccountEmailRecord` mutation"
 type AddAccountEmailRecordPayload {
-  "The same string you sent with the mutation params, for matching mutation calls with their responses"
-  clientMutationId: String
-
   "The account, with updated `emailRecords`"
   account: Account
+
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
 }
 
 "The response from the `createAccount` mutation"

--- a/src/core-services/account/simpleSchemas.js
+++ b/src/core-services/account/simpleSchemas.js
@@ -250,7 +250,7 @@ export const Profile = new SimpleSchema({
  * @property {String} address required
  * @property {Boolean} verified optional
  */
-const Email = new SimpleSchema({
+export const Email = new SimpleSchema({
   provides: {
     type: String,
     defaultValue: "default",

--- a/tests/integration/api/mutations/addAccountEmailRecord/AddAccountEmailRecordMutation.graphql
+++ b/tests/integration/api/mutations/addAccountEmailRecord/AddAccountEmailRecordMutation.graphql
@@ -1,9 +1,11 @@
 mutation ($accountId: ID!, $email: Email!) {
   addAccountEmailRecord(input: { accountId: $accountId, email: $email }) {
-    emailRecord {
-      address
-      provides
-      verified
+    account {
+      emailRecords {
+        address
+        provides
+        verified
+      }
     }
   }
 }

--- a/tests/integration/api/mutations/addAccountEmailRecord/AddAccountEmailRecordMutation.graphql
+++ b/tests/integration/api/mutations/addAccountEmailRecord/AddAccountEmailRecordMutation.graphql
@@ -1,0 +1,9 @@
+mutation ($accountId: ID!, $email: Email!) {
+  addAccountEmailRecord(input: { accountId: $accountId, email: $email }) {
+    emailRecord {
+      address
+      provides
+      verified
+    }
+  }
+}

--- a/tests/integration/api/mutations/addAccountEmailRecord/addAccountEmailRecord.test.js
+++ b/tests/integration/api/mutations/addAccountEmailRecord/addAccountEmailRecord.test.js
@@ -1,0 +1,58 @@
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const AddAccountEmailRecordMutation = importAsString("./AddAccountEmailRecordMutation.graphql");
+
+jest.setTimeout(300000);
+
+let testApp;
+let addAccountEmailRecord;
+let shopId;
+let mockUserAccount;
+let accountOpaqueId;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  shopId = await testApp.insertPrimaryShop();
+  addAccountEmailRecord = testApp.mutate(AddAccountEmailRecordMutation);
+
+  mockUserAccount = Factory.Account.makeOne({
+    _id: "mockUserId",
+    groups: [],
+    roles: {},
+    shopId
+  });
+
+  accountOpaqueId = encodeOpaqueId("reaction/account", mockUserAccount._id);
+
+  await testApp.createUserAndAccount(mockUserAccount);
+});
+
+afterAll(async () => {
+  await testApp.collections.Accounts.deleteMany({});
+  await testApp.collections.users.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.stop();
+});
+
+test("user can add an email to their own account", async () => {
+  await testApp.setLoggedInUser(mockUserAccount);
+
+  const email = Factory.Email.makeOne();
+
+  // _id is set by the server, true
+  delete email._id;
+
+  let result;
+  try {
+    result = await addAccountEmailRecord({ accountId: accountOpaqueId, email: email.address });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.addAccountEmailRecord.emailRecord).toEqual(email);
+});

--- a/tests/integration/api/mutations/addAccountEmailRecord/addAccountEmailRecord.test.js
+++ b/tests/integration/api/mutations/addAccountEmailRecord/addAccountEmailRecord.test.js
@@ -54,5 +54,5 @@ test("user can add an email to their own account", async () => {
     return;
   }
 
-  expect(result.addAccountEmailRecord.emailRecord).toEqual(email);
+  expect(result.addAccountEmailRecord.account.emailRecords.pop()).toEqual(email);
 });

--- a/tests/util/factory.js
+++ b/tests/util/factory.js
@@ -41,6 +41,7 @@ import {
 import {
   Account,
   AccountProfileAddress,
+  Email,
   Group
 } from "../../src/core-services/account/simpleSchemas.js";
 
@@ -83,6 +84,7 @@ const schemasToAddToFactory = {
   CommonOrder,
   CommonOrderItem,
   Discounts,
+  Email,
   Group,
   Order,
   OrderAddress,


### PR DESCRIPTION
Resolves #5643  
Impact: minor
Type: feature

## Issue
There was no GraphQL mutation to add an email to a user's account

## Solution
Add `addAccountEmailRecord` mutation and corresponding integration test.

```
mutation {
  addAccountEmailRecord(input: {
    accountId: "cmVhY3Rpb24vYWNjb3VudDpOR242R1I4TDdEZlduZkdDaA==",
    email: "test@gmail.com"
  }){
    account {
      emailRecords {
        address
        provides
        verified
      }
    }
  }
}
```

## Testing
1. Add a new email to an existing account by executing the mutation above
2. Verify new email was added correctly
