### PR TITLE
feat: GQL products & product query

### DIFF
--- a/src/core-services/product/index.js
+++ b/src/core-services/product/index.js
@@ -1,4 +1,5 @@
 import mutations from "./mutations/index.js";
+import queries from "./queries/index.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
 import {
@@ -38,6 +39,7 @@ export default async function register(app) {
       schemas
     },
     mutations,
+    queries,
     simpleSchemas: {
       Product,
       ProductVariant,

--- a/src/core-services/product/queries/index.js
+++ b/src/core-services/product/queries/index.js
@@ -1,0 +1,5 @@
+import products from "./products.js";
+
+export default {
+  products
+};

--- a/src/core-services/product/queries/index.js
+++ b/src/core-services/product/queries/index.js
@@ -1,5 +1,7 @@
+import product from "./product.js";
 import products from "./products.js";
 
 export default {
+  product,
   products
 };

--- a/src/core-services/product/queries/product.js
+++ b/src/core-services/product/queries/product.js
@@ -4,7 +4,9 @@
  * @memberof GraphQL/Product
  * @summary Query the Products collection for a single product
  * @param {Object} context - an object containing the per-request state
- * @param {Object} input - ID of Shop to query against
+ * @param {Object} input - Request input
+ * @param {String} input.productId - Product ID
+ * @param {String} input.shopId - Shop ID
  * @returns {Promise<Object>} Product object Promise
  */
 export default async function product(context, input) {

--- a/src/core-services/product/queries/product.js
+++ b/src/core-services/product/queries/product.js
@@ -1,0 +1,21 @@
+/**
+ * @name product
+ * @method
+ * @memberof GraphQL/Product
+ * @summary Query the Products collection for a single product
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} input - ID of Shop to query against
+ * @returns {Promise<Object>} Product object Promise
+ */
+export default async function product(context, input) {
+  const { checkPermissions, collections } = context;
+  const { Products } = collections;
+  const { productId, shopId } = input;
+
+  checkPermissions(["owner", "admin", "createProduct"], shopId);
+
+  return Products.findOne({
+    _id: productId,
+    shopId
+  });
+}

--- a/src/core-services/product/queries/product.js
+++ b/src/core-services/product/queries/product.js
@@ -14,7 +14,7 @@ export default async function product(context, input) {
   const { Products } = collections;
   const { productId, shopId } = input;
 
-  checkPermissions(["owner", "admin", "createProduct"], shopId);
+  await checkPermissions(["owner", "admin", "createProduct"], shopId);
 
   return Products.findOne({
     _id: productId,

--- a/src/core-services/product/queries/products.js
+++ b/src/core-services/product/queries/products.js
@@ -4,7 +4,7 @@ import applyProductFilters from "../utils/applyProductFilters.js";
  * @name products
  * @method
  * @memberof GraphQL/Products
- * @summary Query the Products collection
+ * @summary Query the Products collection for a list of products
  * @param {Object} context - an object containing the per-request state
  * @param {Object} input - ID of Shop to query against
  * @returns {Promise<Object>} Products object Promise

--- a/src/core-services/product/queries/products.js
+++ b/src/core-services/product/queries/products.js
@@ -13,10 +13,10 @@ import applyProductFilters from "../utils/applyProductFilters.js";
  * @param {String} [metafieldValue] - Filter by metafield value
  * @param {Number} [priceMax] - Filter by price range maximum value
  * @param {Number} [priceMin] - Filter by price range minimum value
- * @param {String[]} [productIds] - List of product IDs to filter
+ * @param {String[]} [productIds] - List of product IDs to filter by
  * @param {String} [query] - Regex match query string
  * @param {String[]} shopIds - List of shop IDs to filter by
- * @param {String[]} [tagIds] - List of tag ids to filter
+ * @param {String[]} [tagIds] - List of tag ids to filter by
  * @returns {Promise<Object>} Products object Promise
  */
 export default async function products(context, input) {

--- a/src/core-services/product/queries/products.js
+++ b/src/core-services/product/queries/products.js
@@ -6,13 +6,23 @@ import applyProductFilters from "../utils/applyProductFilters.js";
  * @memberof GraphQL/Products
  * @summary Query the Products collection for a list of products
  * @param {Object} context - an object containing the per-request state
- * @param {Object} input - ID of Shop to query against
+ * @param {Object} input - Request input
+ * @param {Boolean} [isArchived] - Filter by archived
+ * @param {Boolean} [isVisible] - Filter by visibility
+ * @param {String} [metafieldKey] - Filter by metafield key
+ * @param {String} [metafieldValue] - Filter by metafield value
+ * @param {Number} [priceMax] - Filter by price range maximum value
+ * @param {Number} [priceMin] - Filter by price range minimum value
+ * @param {String[]} [productIds] - List of product IDs to filter
+ * @param {String} [query] - Regex match query string
+ * @param {String[]} shopIds - List of shop IDs to filter by
+ * @param {String[]} [tagIds] - List of tag ids to filter
  * @returns {Promise<Object>} Products object Promise
  */
 export default async function products(context, input) {
   const { checkPermissions, collections } = context;
   const { Products } = collections;
-  const { ...productFilters } = input;
+  const productFilters = input;
 
   // Check the permissions for all shop requested
   await Promise.all(productFilters.shopIds.map(async (shopId) => (

--- a/src/core-services/product/queries/products.js
+++ b/src/core-services/product/queries/products.js
@@ -1,0 +1,27 @@
+import applyProductFilters from "../utils/applyProductFilters.js";
+
+/**
+ * @name products
+ * @method
+ * @memberof GraphQL/Products
+ * @summary Query the Products collection
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} input - ID of Shop to query against
+ * @returns {Promise<Object>} Products object Promise
+ */
+export default async function products(context, input) {
+  const { checkPermissions, collections } = context;
+  const { Products } = collections;
+  const { ...productFilters } = input;
+
+  // Check the permissions for all shop requested
+  await Promise.all(productFilters.shopIds.map(async (shopId) => (
+    checkPermissions(["owner", "admin", "createProduct"], shopId)
+  )));
+
+  // Create the mongo selector from the filters
+  const selector = applyProductFilters(context, productFilters);
+
+  // Get the first N (limit) top-level products that match the query
+  return Products.find(selector);
+}

--- a/src/core-services/product/resolvers/Query/index.js
+++ b/src/core-services/product/resolvers/Query/index.js
@@ -1,0 +1,5 @@
+import products from "./products.js";
+
+export default {
+  products
+};

--- a/src/core-services/product/resolvers/Query/index.js
+++ b/src/core-services/product/resolvers/Query/index.js
@@ -1,5 +1,7 @@
+import product from "./product.js";
 import products from "./products.js";
 
 export default {
+  product,
   products
 };

--- a/src/core-services/product/resolvers/Query/product.js
+++ b/src/core-services/product/resolvers/Query/product.js
@@ -1,0 +1,28 @@
+import { decodeProductOpaqueId, decodeShopOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Query/product
+ * @method
+ * @memberof Product/Query
+ * @summary query the Products collection for a single product
+ * @param {Object} _ - unused
+ * @param {Object} args - an object of all arguments that were sent by the client
+ * @param {String} args.productId - Product id
+ * @param {String} args.shopId - Shop id of the product
+ * @param {Object} context - an object containing the per-request state
+ * @returns {Promise<Object>} Products
+ */
+export default async function product(_, args, context) {
+  const {
+    productId: opaqueProductId,
+    shopId: opaqueShopId
+  } = args;
+
+  const productId = decodeProductOpaqueId(opaqueProductId);
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  return context.queries.product(context, {
+    productId,
+    shopId
+  });
+}

--- a/src/core-services/product/resolvers/Query/products.js
+++ b/src/core-services/product/resolvers/Query/products.js
@@ -1,0 +1,56 @@
+import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
+import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
+import { decodeProductOpaqueId, decodeShopOpaqueId, decodeTagOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Query/products
+ * @method
+ * @memberof DiscountCodes/Query
+ * @summary query the Products collection and return user account data
+ * @param {Object} _ - unused
+ * @param {Object} args - an object of all arguments that were sent by the client
+ * @param {String} args.shopId - id of user to query
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} info Info about the GraphQL request
+ * @returns {Promise<Object>} user account object
+ */
+export default async function products(_, args, context, info) {
+  const {
+    productIds: opaqueProductIds,
+    shopIds: opaqueShopIds,
+    tagIds: opaqueTagIds,
+    query: queryString,
+    visibility,
+    metafieldKey,
+    metafieldValue,
+    priceMin,
+    priceMax,
+    weightMin,
+    weightMax,
+    ...connectionArgs
+  } = args;
+
+  const shopIds = opaqueShopIds.map(decodeShopOpaqueId);
+  const productIds = opaqueProductIds && opaqueProductIds.map(decodeProductOpaqueId);
+  const tagIds = opaqueProductIds && opaqueTagIds.map(decodeTagOpaqueId);
+
+  const query = await context.queries.products(context, {
+    productIds,
+    shopIds,
+    tagIds,
+    query: queryString,
+    visibility,
+    metafieldKey,
+    metafieldValue,
+    priceMin,
+    priceMax,
+    weightMin,
+    weightMax
+  });
+
+  return getPaginatedResponse(query, connectionArgs, {
+    includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
+    includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
+    includeTotalCount: wasFieldRequested("totalCount", info)
+  });
+}

--- a/src/core-services/product/resolvers/Query/products.js
+++ b/src/core-services/product/resolvers/Query/products.js
@@ -5,14 +5,14 @@ import { decodeProductOpaqueId, decodeShopOpaqueId, decodeTagOpaqueId } from "..
 /**
  * @name Query/products
  * @method
- * @memberof DiscountCodes/Query
- * @summary query the Products collection and return user account data
+ * @memberof Products/Query
+ * @summary query the Products collection
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client
  * @param {String} args.shopId - id of user to query
  * @param {Object} context - an object containing the per-request state
  * @param {Object} info Info about the GraphQL request
- * @returns {Promise<Object>} user account object
+ * @returns {Promise<Object>} Products
  */
 export default async function products(_, args, context, info) {
   const {

--- a/src/core-services/product/resolvers/Query/products.js
+++ b/src/core-services/product/resolvers/Query/products.js
@@ -20,32 +20,30 @@ export default async function products(_, args, context, info) {
     shopIds: opaqueShopIds,
     tagIds: opaqueTagIds,
     query: queryString,
-    visibility,
+    isArchived,
+    isVisible,
     metafieldKey,
     metafieldValue,
     priceMin,
     priceMax,
-    weightMin,
-    weightMax,
     ...connectionArgs
   } = args;
 
   const shopIds = opaqueShopIds.map(decodeShopOpaqueId);
   const productIds = opaqueProductIds && opaqueProductIds.map(decodeProductOpaqueId);
-  const tagIds = opaqueProductIds && opaqueTagIds.map(decodeTagOpaqueId);
+  const tagIds = opaqueTagIds && opaqueTagIds.map(decodeTagOpaqueId);
 
   const query = await context.queries.products(context, {
     productIds,
     shopIds,
     tagIds,
     query: queryString,
-    visibility,
+    isArchived,
+    isVisible,
     metafieldKey,
     metafieldValue,
     priceMin,
-    priceMax,
-    weightMin,
-    weightMax
+    priceMax
   });
 
   return getPaginatedResponse(query, connectionArgs, {

--- a/src/core-services/product/resolvers/Query/products.js
+++ b/src/core-services/product/resolvers/Query/products.js
@@ -6,7 +6,7 @@ import { decodeProductOpaqueId, decodeShopOpaqueId, decodeTagOpaqueId } from "..
  * @name Query/products
  * @method
  * @memberof Products/Query
- * @summary query the Products collection
+ * @summary Query for a list of products
  * @param {Object} _ - unused
  * @param {Object} args - an object of all arguments that were sent by the client
  * @param {String} args.shopId - id of user to query

--- a/src/core-services/product/resolvers/index.js
+++ b/src/core-services/product/resolvers/index.js
@@ -1,11 +1,15 @@
+import getConnectionTypeResolvers from "@reactioncommerce/api-utils/graphql/getConnectionTypeResolvers.js";
 import ProductConfiguration from "./ProductConfiguration.js";
 import Mutation from "./Mutation/index.js";
+import Query from "./Query/index.js";
 import Product from "./Product/index.js";
 import ProductVariant from "./ProductVariant/index.js";
 
 export default {
   ProductConfiguration,
   Mutation,
+  Query,
   Product,
-  ProductVariant
+  ProductVariant,
+  ...getConnectionTypeResolvers("Product")
 };

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -554,10 +554,10 @@ extend type Query {
     "Filter by metafield value"
     metafieldValue: String
 
-    "Fitler by price range maximun value"
+    "Filter by price range maximum value"
     priceMax: Float
 
-    "Fitler by price range minimun value"
+    "Filter by price range minimum value"
     priceMin: Float
 
     "List of product IDs to filter"

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -549,7 +549,7 @@ extend type Query {
     metafieldKey: String
 
     "Filter by metafield value"
-    metaFieldValue: String
+    metafieldValue: String
 
     "Fitler by price range maximun value"
     priceMax: Float

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -560,7 +560,7 @@ extend type Query {
     "Filter by price range minimum value"
     priceMin: Float
 
-    "List of product IDs to filter"
+    "List of product IDs to filter by"
     productIds: [ID]
 
     "Regex metch query string"

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -569,12 +569,6 @@ extend type Query {
     "List of tag ids to filter by"
     tagIds: [ID]
 
-    "Filter by weight maximun value"
-    weightMax: String
-
-    "Filter by weight minimun value"
-    weightMin: String
-
     "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
     after: ConnectionCursor,
 

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -30,6 +30,9 @@ type Product {
   "Subtitle"
   pageTitle: String
 
+  "Price range"
+  price: ProductPriceRange
+
   "An arbitrary product type value, such as from an external system"
   productType: String
 
@@ -160,6 +163,18 @@ type ProductVariant {
 
   "The width of the product, if it has physical dimensions"
   width: Float
+}
+
+"Product price range"
+type ProductPriceRange {
+  "Maximum price in range"
+  max: Float
+
+  "Minimum price in range"
+  min: Float
+
+  "Price range display"
+  range: String
 }
 
 "Response payload of `archiveProducts` mutation"

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -234,6 +234,40 @@ type UpdateProductVariantPayload  {
   variant: ProductVariant!
 }
 
+"A connection edge in which each node is a `Product` object"
+type ProductEdge {
+  "The cursor that represents this node in the paginated results"
+  cursor: ConnectionCursor!
+
+  "The discount code"
+  node: Product
+}
+
+"""
+Wraps a list of Products`s, providing pagination cursors and information.
+
+For information about what Relay-compatible connections are and how to use them, see the following articles:
+- [Relay Connection Documentation](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections)
+- [Relay Connection Specification](https://facebook.github.io/relay/graphql/connections.htm)
+- [Using Relay-style Connections With Apollo Client](https://www.apollographql.com/docs/react/recipes/pagination.html)
+"""
+type ProductConnection {
+  "The list of nodes that match the query, wrapped in an edge to provide a cursor string for each"
+  edges: [ProductEdge]
+
+  """
+  You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
+  if you know you will not need to paginate the results.
+  """
+  nodes: [Product]
+
+  "Information to help a client request the next or previous page"
+  pageInfo: PageInfo!
+
+  "The total number of nodes that match your query"
+  totalCount: Int!
+}
+
 "Input for the `archiveProducts` mutation"
 input ArchiveProductsInput  {
   "Array of IDs of products to archive"
@@ -479,4 +513,57 @@ extend type Mutation {
     "Mutation input"
     input: UpdateProductVariantInput!
   ): UpdateProductVariantPayload!
+}
+
+extend type Query {
+  "Products query"
+  products(
+    "Filter by visibility"
+    isVisible: Boolean
+
+    "Filter by metafield key"
+    metafieldKey: String
+
+    "Filter by metafield value"
+    metaFieldValue: String
+
+    "Fitler by price range maximun value"
+    priceMax: Float
+
+    "Fitler by price range minimun value"
+    priceMin: Float
+
+    "List of product IDs to filter"
+    productIds: [ID]
+
+    "Regex metch query string"
+    query: String
+
+    "List of shop IDs to filter by"
+    shopIds: [ID]
+
+    "List of tag ids to filter by"
+    tagIds: [ID]
+
+    "Filter by weight maximun value"
+    weightMax: String
+
+    "Filter by weight minimun value"
+    weightMin: String
+
+    "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
+    after: ConnectionCursor,
+
+    "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
+    before: ConnectionCursor,
+
+    "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
+    first: ConnectionLimitInt,
+
+    "Return at most this many results. This parameter may be used with the `before` parameter."
+    last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+  ): ProductConnection
 }

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -567,7 +567,7 @@ extend type Query {
     query: String
 
     "List of shop IDs to filter by"
-    shopIds: [ID]
+    shopIds: [ID]!
 
     "List of tag ids to filter by"
     tagIds: [ID]

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -239,7 +239,7 @@ type ProductEdge {
   "The cursor that represents this node in the paginated results"
   cursor: ConnectionCursor!
 
-  "The discount code"
+  "The product"
   node: Product
 }
 

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -30,9 +30,6 @@ type Product {
   "Subtitle"
   pageTitle: String
 
-  "Price range"
-  price: ProductPriceRange
-
   "An arbitrary product type value, such as from an external system"
   productType: String
 
@@ -163,18 +160,6 @@ type ProductVariant {
 
   "The width of the product, if it has physical dimensions"
   width: Float
-}
-
-"Product price range"
-type ProductPriceRange {
-  "Maximum price in range"
-  max: Float
-
-  "Minimum price in range"
-  min: Float
-
-  "Price range display"
-  range: String
 }
 
 "Response payload of `archiveProducts` mutation"

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -542,6 +542,9 @@ extend type Query {
 
   "Query for a list of Products"
   products(
+    "Filter by archived"
+    isArchived: Boolean
+
     "Filter by visibility"
     isVisible: Boolean
 

--- a/src/core-services/product/schemas/product.graphql
+++ b/src/core-services/product/schemas/product.graphql
@@ -516,7 +516,16 @@ extend type Mutation {
 }
 
 extend type Query {
-  "Products query"
+  "Query for a single Product"
+  product(
+    "Product ID"
+    productId: ID!,
+
+    "Shop ID"
+    shopId: ID!
+  ): Product
+
+  "Query for a list of Products"
   products(
     "Filter by visibility"
     isVisible: Boolean

--- a/src/core-services/product/utils/applyProductFilters.js
+++ b/src/core-services/product/utils/applyProductFilters.js
@@ -20,7 +20,11 @@ const filters = new SimpleSchema({
     type: String,
     optional: true
   },
-  "visibility": {
+  "isArchived": {
+    type: Boolean,
+    optional: true
+  },
+  "isVisible": {
     type: Boolean,
     optional: true
   },
@@ -33,19 +37,11 @@ const filters = new SimpleSchema({
     optional: true
   },
   "priceMin": {
-    type: String,
+    type: Number,
     optional: true
   },
   "priceMax": {
-    type: String,
-    optional: true
-  },
-  "weightMin": {
-    type: String,
-    optional: true
-  },
-  "weightMax": {
-    type: String,
+    type: Number,
     optional: true
   }
 });
@@ -136,10 +132,18 @@ export default function applyProductFilters(context, productFilters) {
     }
 
     // filter by visibility
-    if (productFilters.visibility !== undefined) {
+    if (productFilters.isVisible !== undefined) {
       selector = {
         ...selector,
         isVisible: productFilters.isVisible
+      };
+    }
+
+    // filter by archived
+    if (productFilters.isArchived !== undefined) {
+      selector = {
+        ...selector,
+        isDeleted: productFilters.isArchived
       };
     }
 
@@ -173,43 +177,10 @@ export default function applyProductFilters(context, productFilters) {
       selector = {
         ...selector,
         "price.min": {
-          $lt: priceMax
+          $gte: priceMin
         },
         "price.max": {
-          $gt: priceMin
-        }
-      };
-    }
-
-    // filter by gte minimum weight
-    if (productFilters.weightMin && !productFilters.weightMax) {
-      selector = {
-        ...selector,
-        weight: {
-          $gte: parseFloat(productFilters.weightMin)
-        }
-      };
-    }
-
-    // filter by lte maximum weight
-    if (productFilters.weightMax && !productFilters.weightMin) {
-      selector = {
-        ...selector,
-        weight: {
-          $lte: parseFloat(productFilters.weightMax)
-        }
-      };
-    }
-
-    // filter with a weight range
-    if (productFilters.weightMin && productFilters.weightMax) {
-      const weightMin = parseFloat(productFilters.weightMin);
-      const weightMax = parseFloat(productFilters.weightMax);
-      selector = {
-        ...selector,
-        weight: {
-          $lt: weightMax,
-          $gt: weightMin
+          $lte: priceMax
         }
       };
     }

--- a/src/core-services/product/utils/applyProductFilters.js
+++ b/src/core-services/product/utils/applyProductFilters.js
@@ -171,9 +171,9 @@ export default function applyProductFilters(context, productFilters) {
     if (productFilters.priceMin && productFilters.priceMax) {
       const priceMin = parseFloat(productFilters.priceMin);
       const priceMax = parseFloat(productFilters.priceMax);
-      // where product A has min 12.99 variant and a 19.99 variant
-      // price.min=12.99&price.max=19.98
-      // should return product A
+
+      // Filters a whose min and max price range are within the
+      // range supplied from the filter
       selector = {
         ...selector,
         "price.min": {

--- a/src/core-services/product/utils/applyProductFilters.js
+++ b/src/core-services/product/utils/applyProductFilters.js
@@ -1,0 +1,219 @@
+import SimpleSchema from "simpl-schema";
+
+const filters = new SimpleSchema({
+  "productIds": {
+    type: Array,
+    optional: true
+  },
+  "productIds.$": String,
+  "shopIds": {
+    type: Array,
+    optional: true
+  },
+  "shopIds.$": String,
+  "tagIds": {
+    type: Array,
+    optional: true
+  },
+  "tagIds.$": String,
+  "query": {
+    type: String,
+    optional: true
+  },
+  "visibility": {
+    type: Boolean,
+    optional: true
+  },
+  "metafieldKey": {
+    type: String,
+    optional: true
+  },
+  "metafieldValue": {
+    type: String,
+    optional: true
+  },
+  "priceMin": {
+    type: String,
+    optional: true
+  },
+  "priceMax": {
+    type: String,
+    optional: true
+  },
+  "weightMin": {
+    type: String,
+    optional: true
+  },
+  "weightMax": {
+    type: String,
+    optional: true
+  }
+});
+
+/**
+ * @name applyProductFilters
+ * @summary Builds a selector for Products collection, given a set of filters
+ * @private
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} productFilters - See filters schema above
+ * @returns {Object} Selector
+ */
+export default function applyProductFilters(context, productFilters) {
+  // if there are filter/params that don't match the schema
+  filters.validate(productFilters);
+
+  // Init default selector - Everyone can see products that fit this selector
+  let selector = {
+    ancestors: [], // Lookup top-level products
+    isDeleted: { $ne: true } // by default, we don't publish deleted products
+  };
+
+  if (productFilters) {
+    // filter by productIds
+    if (productFilters.productIds) {
+      selector = {
+        ...selector,
+        _id: {
+          $in: productFilters.productIds
+        }
+      };
+    }
+
+    if (productFilters.shopIds) {
+      selector = {
+        ...selector,
+        shopId: {
+          $in: productFilters.shopIds
+        }
+      };
+    }
+
+    // filter by tags
+    if (productFilters.tagIds) {
+      selector = {
+        ...selector,
+        hashtags: {
+          $in: productFilters.tagIds
+        }
+      };
+    }
+
+    // filter by query
+    if (productFilters.query) {
+      const cond = {
+        $regex: productFilters.query,
+        $options: "i"
+      };
+      selector = {
+        ...selector,
+        $or: [{
+          title: cond
+        }, {
+          pageTitle: cond
+        }, {
+          description: cond
+        }]
+      };
+    }
+
+    // filter by details
+    if (productFilters.metafieldKey && productFilters.metafieldValue) {
+      selector = {
+        ...selector,
+        metafields: {
+          $elemMatch: {
+            key: {
+              $regex: productFilters.metafieldKey,
+              $options: "i"
+            },
+            value: {
+              $regex: productFilters.metafieldValue,
+              $options: "i"
+            }
+          }
+        }
+      };
+    }
+
+    // filter by visibility
+    if (productFilters.visibility !== undefined) {
+      selector = {
+        ...selector,
+        isVisible: productFilters.isVisible
+      };
+    }
+
+    // filter by gte minimum price
+    if (productFilters.priceMin && !productFilters.priceMax) {
+      selector = {
+        ...selector,
+        "price.min": {
+          $gte: parseFloat(productFilters.priceMin)
+        }
+      };
+    }
+
+    // filter by lte maximum price
+    if (productFilters.priceMax && !productFilters.priceMin) {
+      selector = {
+        ...selector,
+        "price.max": {
+          $lte: parseFloat(productFilters.priceMax)
+        }
+      };
+    }
+
+    // filter with a price range
+    if (productFilters.priceMin && productFilters.priceMax) {
+      const priceMin = parseFloat(productFilters.priceMin);
+      const priceMax = parseFloat(productFilters.priceMax);
+      // where product A has min 12.99 variant and a 19.99 variant
+      // price.min=12.99&price.max=19.98
+      // should return product A
+      selector = {
+        ...selector,
+        "price.min": {
+          $lt: priceMax
+        },
+        "price.max": {
+          $gt: priceMin
+        }
+      };
+    }
+
+    // filter by gte minimum weight
+    if (productFilters.weightMin && !productFilters.weightMax) {
+      selector = {
+        ...selector,
+        weight: {
+          $gte: parseFloat(productFilters.weightMin)
+        }
+      };
+    }
+
+    // filter by lte maximum weight
+    if (productFilters.weightMax && !productFilters.weightMin) {
+      selector = {
+        ...selector,
+        weight: {
+          $lte: parseFloat(productFilters.weightMax)
+        }
+      };
+    }
+
+    // filter with a weight range
+    if (productFilters.weightMin && productFilters.weightMax) {
+      const weightMin = parseFloat(productFilters.weightMin);
+      const weightMax = parseFloat(productFilters.weightMax);
+      selector = {
+        ...selector,
+        weight: {
+          $lt: weightMax,
+          $gt: weightMin
+        }
+      };
+    }
+  } // end if productFilters
+
+  return selector;
+}

--- a/src/plugins/simple-pricing/schemas/schema.graphql
+++ b/src/plugins/simple-pricing/schemas/schema.graphql
@@ -68,6 +68,18 @@ type CurrencyExchangeProductPricingInfo {
   price: Float
 }
 
+"Product price range"
+type ProductPriceRange {
+  "Maximum price in range"
+  max: Float
+
+  "Minimum price in range"
+  min: Float
+
+  "Price range display"
+  range: String
+}
+
 extend type CatalogProduct {
   "Price and related information, per currency"
   pricing: [ProductPricingInfo]!
@@ -76,4 +88,9 @@ extend type CatalogProduct {
 extend type CatalogProductVariant {
   "Price and related information, per currency"
   pricing: [ProductPricingInfo]!
+}
+
+extend type Product {
+  "Price range"
+  price: ProductPriceRange
 }

--- a/tests/integration/api/queries/products/product.test.js
+++ b/tests/integration/api/queries/products/product.test.js
@@ -1,0 +1,94 @@
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const productQuery = importAsString("./productQuery.graphql");
+
+jest.setTimeout(300000);
+
+const internalShopId = "123";
+const internalProductId = "999";
+const opaqueProductId = "cmVhY3Rpb24vcHJvZHVjdDo5OTk="; // reaction/product:999
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const internalVariantIds = ["875", "874", "925"];
+
+const shopName = "Test Shop";
+
+const mockProduct = {
+  _id: internalProductId,
+  ancestors: [],
+  title: "Fake Product",
+  shopId: internalShopId,
+  isDeleted: false,
+  isVisible: true,
+  supportedFulfillmentTypes: ["shipping"],
+  type: "simple",
+  createdAt: new Date(),
+  updatedAt: new Date()
+};
+
+const mockVariant = {
+  _id: internalVariantIds[0],
+  ancestors: [internalProductId],
+  attributeLabel: "Variant",
+  title: "Fake Product Variant",
+  shopId: internalShopId,
+  isDeleted: false,
+  isVisible: true,
+  type: "variant"
+};
+
+const mockOptionOne = {
+  _id: internalVariantIds[1],
+  ancestors: [internalProductId, internalVariantIds[0]],
+  attributeLabel: "Option",
+  title: "Fake Product Option One",
+  shopId: internalShopId,
+  isDeleted: false,
+  isVisible: true,
+  type: "variant"
+};
+
+let testApp;
+let queryProduct;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  queryProduct = testApp.query(productQuery);
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+  await testApp.collections.Products.insertOne(mockProduct);
+  await testApp.collections.Products.insertOne(mockVariant);
+  await testApp.collections.Products.insertOne(mockOptionOne);
+
+  await testApp.setLoggedInUser({
+    _id: "123",
+    roles: { [internalShopId]: ["createProduct"] }
+  });
+});
+
+afterAll(async () => {
+  await testApp.collections.Shops.deleteOne({ _id: internalShopId });
+  await testApp.collections.Products.deleteOne({ _id: internalProductId });
+  await testApp.collections.Products.deleteOne({ _id: internalVariantIds[0] });
+  await testApp.collections.Products.deleteOne({ _id: internalVariantIds[1] });
+  await testApp.clearLoggedInUser();
+  await testApp.stop();
+});
+
+test("expect a single product", async () => {
+  let result;
+
+  try {
+    result = await queryProduct({
+      productId: opaqueProductId,
+      shopId: opaqueShopId
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.product.title).toEqual("Fake Product");
+  expect(result.product.variants[0].title).toEqual("Fake Product Variant");
+  expect(result.product.variants[0].options[0].title).toEqual("Fake Product Option One");
+});

--- a/tests/integration/api/queries/products/productQuery.graphql
+++ b/tests/integration/api/queries/products/productQuery.graphql
@@ -1,0 +1,20 @@
+query Product(
+  $productId: ID!
+  $shopId: ID!
+) {
+  product(
+    productId: $productId
+    shopId: $shopId
+  ) {
+    _id
+    title
+    variants {
+      _id
+      title
+      options {
+        _id
+        title
+      }
+    }
+  }
+}

--- a/tests/integration/api/queries/products/products.test.js
+++ b/tests/integration/api/queries/products/products.test.js
@@ -1,0 +1,133 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const productQuery = importAsString("./productQuery.graphql");
+const productsQuery = importAsString("./productsQuery.graphql");
+
+jest.setTimeout(300000);
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const productDocuments = [];
+const shopName = "Test Shop";
+
+for (let index = 100; index < 136; index += 1) {
+  const productId = `product-${index}`;
+  const variantId = `variant-${index}`;
+  const optionId = `option-${index}`;
+
+  const mockProduct = {
+    _id: productId,
+    ancestors: [],
+    title: `Fake Product ${index}`,
+    shopId: internalShopId,
+    isDeleted: false,
+    isVisible: true,
+    supportedFulfillmentTypes: ["shipping"],
+    type: "simple",
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  const mockVariant = {
+    _id: variantId,
+    ancestors: [productId],
+    attributeLabel: "Variant",
+    title: `Fake Product Variant ${index}`,
+    shopId: internalShopId,
+    isDeleted: false,
+    isVisible: true,
+    type: "variant"
+  };
+
+  const mockOption = {
+    _id: optionId,
+    ancestors: [productId, variantId],
+    attributeLabel: "Option",
+    title: `Fake Product Option ${index}`,
+    shopId: internalShopId,
+    isDeleted: false,
+    isVisible: true,
+    type: "variant"
+  };
+
+  productDocuments.push(mockProduct);
+  productDocuments.push(mockVariant);
+  productDocuments.push(mockOption);
+}
+
+let testApp;
+let queryProducts;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  queryProducts = testApp.query(productsQuery);
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+
+  await Promise.all(productDocuments.map((doc) => (
+    testApp.collections.Products.insertOne(doc)
+  )));
+
+  await testApp.setLoggedInUser({
+    _id: "123",
+    roles: { [internalShopId]: ["createProduct"] }
+  });
+});
+
+afterAll(async () => {
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.collections.Products.deleteMany({});
+  await testApp.clearLoggedInUser();
+  await testApp.stop();
+});
+
+test("expect a list of products", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      first: 10
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(10);
+  expect(result.products.nodes[0].title).toEqual("Fake Product 100");
+  expect(result.products.nodes[0].variants[0].title).toEqual("Fake Product Variant 100");
+  expect(result.products.nodes[0].variants[0].options[0].title).toEqual("Fake Product Option 100");
+
+  expect(result.products.nodes[9].title).toEqual("Fake Product 109");
+  expect(result.products.nodes[9].variants[0].title).toEqual("Fake Product Variant 109");
+  expect(result.products.nodes[9].variants[0].options[0].title).toEqual("Fake Product Option 109");
+});
+
+test("expect a list of products on the second page", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      first: 10,
+      offset: 10
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(10);
+  expect(result.products.nodes[0].title).toEqual("Fake Product 110");
+  expect(result.products.nodes[0].variants[0].title).toEqual("Fake Product Variant 110");
+  expect(result.products.nodes[0].variants[0].options[0].title).toEqual("Fake Product Option 110");
+
+  expect(result.products.nodes[9].title).toEqual("Fake Product 119");
+  expect(result.products.nodes[9].variants[0].title).toEqual("Fake Product Variant 119");
+  expect(result.products.nodes[9].variants[0].options[0].title).toEqual("Fake Product Option 119");
+});
+

--- a/tests/integration/api/queries/products/products.test.js
+++ b/tests/integration/api/queries/products/products.test.js
@@ -1,3 +1,4 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
 import importAsString from "@reactioncommerce/api-utils/importAsString.js";
 import TestApp from "/tests/util/TestApp.js";
 
@@ -18,10 +19,27 @@ for (let index = 100; index < 136; index += 1) {
   const mockProduct = {
     _id: productId,
     ancestors: [],
+    hashtags: [
+      `tag-${index}-0`,
+      `tag-${index}-1`,
+      `tag-${index}-2`
+    ],
     title: `Fake Product ${index}`,
     shopId: internalShopId,
     isDeleted: false,
     isVisible: true,
+    price: {
+      min: index,
+      max: index + 50,
+      range: `${index} - ${index + 50}`
+    },
+    weight: {
+      min: index,
+      max: index + 10
+    },
+    metafields: [
+      { key: "index", value: `${index}` }
+    ],
     supportedFulfillmentTypes: ["shipping"],
     type: "simple",
     createdAt: new Date(),
@@ -128,3 +146,173 @@ test("expect a list of products on the second page", async () => {
   expect(result.products.nodes[9].variants[0].options[0].title).toEqual("Fake Product Option 119");
 });
 
+test("expect a list of products filtered by product ids", async () => {
+  const productId1 = encodeOpaqueId("reaction/product", "product-100");
+  const productId2 = encodeOpaqueId("reaction/product", "product-110");
+  const productId3 = encodeOpaqueId("reaction/product", "product-119");
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      productIds: [productId1, productId2, productId3]
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(3);
+  expect(result.products.nodes[0]._id).toEqual(productId1);
+  expect(result.products.nodes[1]._id).toEqual(productId2);
+  expect(result.products.nodes[2]._id).toEqual(productId3);
+});
+
+test("expect a list of products filtered by a minimum price", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      priceMin: 132
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(4);
+  expect(result.products.nodes[0].price.max).toEqual(182);
+  expect(result.products.nodes[3].price.max).toEqual(185);
+});
+
+test("expect a list of products filtered by a maximum price", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      priceMax: 151
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(2);
+  expect(result.products.nodes[0].price.max).toEqual(150);
+  expect(result.products.nodes[1].price.max).toEqual(151);
+});
+
+test("expect a list of products filtered by a price range", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      priceMin: 110,
+      priceMax: 163
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(4);
+  expect(result.products.nodes[0].price.min).toEqual(110);
+  expect(result.products.nodes[0].price.max).toEqual(160);
+  expect(result.products.nodes[3].price.min).toEqual(113);
+  expect(result.products.nodes[3].price.max).toEqual(163);
+});
+
+test("expect a list of products filtered by tags", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      tagIds: [
+        encodeOpaqueId("reaction/tag", "tag-100-0"),
+        encodeOpaqueId("reaction/tag", "tag-120-2"),
+        encodeOpaqueId("reaction/tag", "tag-130-1"),
+        encodeOpaqueId("reaction/tag", "tag-110-0")
+      ]
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(4);
+  expect(result.products.nodes[0].title).toEqual("Fake Product 100");
+  expect(result.products.nodes[1].title).toEqual("Fake Product 110");
+  expect(result.products.nodes[2].title).toEqual("Fake Product 120");
+  expect(result.products.nodes[3].title).toEqual("Fake Product 130");
+});
+
+test("expect a list of products filtered by a metafield", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      metafieldKey: "index",
+      metafieldValue: "110"
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(1);
+  expect(result.products.nodes[0].title).toEqual("Fake Product 110");
+});
+
+test("expect a single of product filtered by a search query", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      query: "Fake Product 130"
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(1);
+  expect(result.products.nodes[0].title).toEqual("Fake Product 130");
+});
+
+test("expect an empty list of products filtered by a visibility", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      isVisible: false
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(0);
+});
+
+test("expect an empty list of products filtered by a archived", async () => {
+  let result;
+
+  try {
+    result = await queryProducts({
+      shopIds: [opaqueShopId],
+      isArchived: true
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.products.nodes.length).toEqual(0);
+});

--- a/tests/integration/api/queries/products/products.test.js
+++ b/tests/integration/api/queries/products/products.test.js
@@ -1,9 +1,6 @@
-import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
 import importAsString from "@reactioncommerce/api-utils/importAsString.js";
-import Factory from "/tests/util/factory.js";
 import TestApp from "/tests/util/TestApp.js";
 
-const productQuery = importAsString("./productQuery.graphql");
 const productsQuery = importAsString("./productsQuery.graphql");
 
 jest.setTimeout(300000);

--- a/tests/integration/api/queries/products/productsQuery.graphql
+++ b/tests/integration/api/queries/products/productsQuery.graphql
@@ -1,12 +1,30 @@
 query Products(
+  $isArchived: Boolean
+  $isVisible: Boolean
+  $metafieldKey: String
+  $metafieldValue: String
+  $priceMax: Float
+  $priceMin: Float
+  $productIds: [ID]
+  $query: String
+  $tagIds: [ID]
   $shopIds: [ID]
-  $first: ConnectionLimitInt,
-  $last:  ConnectionLimitInt,
-  $before: ConnectionCursor,
-  $after: ConnectionCursor,
+  $first: ConnectionLimitInt
+  $last:  ConnectionLimitInt
+  $before: ConnectionCursor
+  $after: ConnectionCursor
   $offset: Int
 ) {
   products(
+    isArchived: $isArchived
+    isVisible: $isVisible
+    metafieldKey: $metafieldKey
+    metafieldValue: $metafieldValue
+    priceMax: $priceMax
+    priceMin: $priceMin
+    productIds: $productIds
+    query: $query
+    tagIds: $tagIds
     shopIds: $shopIds
     first: $first
     last: $last
@@ -17,6 +35,10 @@ query Products(
     nodes {
       _id
       title
+      price {
+        min
+        max
+      }
       shop {
         _id
       }

--- a/tests/integration/api/queries/products/productsQuery.graphql
+++ b/tests/integration/api/queries/products/productsQuery.graphql
@@ -1,0 +1,33 @@
+query Products(
+  $shopIds: [ID]
+  $first: ConnectionLimitInt,
+  $last:  ConnectionLimitInt,
+  $before: ConnectionCursor,
+  $after: ConnectionCursor,
+  $offset: Int
+) {
+  products(
+    shopIds: $shopIds
+    first: $first
+    last: $last
+    before: $before
+    after: $after
+    offset: $offset
+  ) {
+    nodes {
+      _id
+      title
+      shop {
+        _id
+      }
+      variants {
+        _id
+        title
+        options {
+          _id
+          title
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/api/queries/products/productsQuery.graphql
+++ b/tests/integration/api/queries/products/productsQuery.graphql
@@ -8,7 +8,7 @@ query Products(
   $productIds: [ID]
   $query: String
   $tagIds: [ID]
-  $shopIds: [ID]
+  $shopIds: [ID]!
   $first: ConnectionLimitInt
   $last:  ConnectionLimitInt
   $before: ConnectionCursor


### PR DESCRIPTION
Resolves #5817  
Impact: **major**  
Type: **feature**

## Issue

No queries for `products` or `product`

## Solution

Add queries for  `products` or `product`

## Breaking changes

none

## Testing
1. Query for products with various filters
2. Query for a single product

```graphql
# List of products
query Products(
  $shopIds: [ID]
  $first: ConnectionLimitInt,
  $last:  ConnectionLimitInt,
  $before: ConnectionCursor,
  $after: ConnectionCursor,
  $offset: Int
) {
  products(
    shopIds: $shopIds
    first: $first
    last: $last
    before: $before
    after: $after
    offset: $offset
  ) {
    nodes {
      _id
      title
      shop {
        _id
      }
      variants {
        _id
        title
        options {
          _id
          title
        }
      }
    }
  }
}

# Single product
query Product(
  $productId: ID!
  $shopId: ID!
) {
  product(
    productId: $productId
    shopId: $shopId
  ) {
    _id
    title
    variants {
      _id
      title
      options {
        _id
        title
      }
    }
  }
}

```
