### PR TITLE
Fix a few 3.0 bugs

### DIFF
--- a/src/core-services/tags/mutations/updateTag.js
+++ b/src/core-services/tags/mutations/updateTag.js
@@ -5,8 +5,14 @@ import getSlug from "@reactioncommerce/api-utils/getSlug.js";
 const inputSchema = new SimpleSchema({
   "slug": String,
   "name": String,
-  "displayTitle": String,
-  "heroMediaUrl": String,
+  "displayTitle": {
+    type: String,
+    optional: true
+  },
+  "heroMediaUrl": {
+    type: String,
+    optional: true
+  },
   "isVisible": Boolean,
   "metafields": { type: Array, optional: true },
   "metafields.$": new SimpleSchema({
@@ -16,7 +22,7 @@ const inputSchema = new SimpleSchema({
   }),
   "featuredProductIds": { type: Array, optional: true },
   "featuredProductIds.$": String
-}, { requiredByDefault: false });
+});
 
 /**
  * @name Mutation.updateTag

--- a/src/core-services/tags/mutations/updateTag.test.js
+++ b/src/core-services/tags/mutations/updateTag.test.js
@@ -22,13 +22,11 @@ test("calls mutations.updateTag and returns the UpdateTagPayload on success", as
   });
 
   const input = {
-    input: {
-      shopId: testShopId,
-      tagId: testTagId,
-      isVisible: true,
-      name: "shirts",
-      displayTitle: "Shirts"
-    }
+    shopId: testShopId,
+    tagId: testTagId,
+    isVisible: true,
+    name: "shirts",
+    displayTitle: "Shirts"
   };
   const result = await updateTag(mockContext, input);
 

--- a/src/core-services/tags/schemas/addTag.graphql
+++ b/src/core-services/tags/schemas/addTag.graphql
@@ -4,7 +4,7 @@ input AddTagInput {
   clientMutationId: String
 
   "Title to display to customers"
-  displayTitle: String!
+  displayTitle: String
 
   "Hero media URL"
   heroMediaUrl: String

--- a/src/core-services/tags/schemas/updateTag.graphql
+++ b/src/core-services/tags/schemas/updateTag.graphql
@@ -5,7 +5,7 @@ input UpdateTagInput {
   clientMutationId: String
 
   "Title to display to customers"
-  displayTitle: String!
+  displayTitle: String
 
   "A list of the IDs of top products in this tag"
   featuredProductIds: [ID]

--- a/src/plugins/navigation/mutations/updateNavigationItem.js
+++ b/src/plugins/navigation/mutations/updateNavigationItem.js
@@ -19,7 +19,7 @@ export default async function updateNavigationItem(context, input) {
 
   await checkPermissions(["core"], shopId);
 
-  const existingNavigationItem = await NavigationItems.findOne({ navigationItemId });
+  const existingNavigationItem = await NavigationItems.findOne({ _id: navigationItemId, shopId });
   if (!existingNavigationItem) {
     throw new ReactionError("navigation-item-not-found", "Navigation item was not found");
   }

--- a/src/plugins/navigation/resolvers/Mutation/createNavigationItem.js
+++ b/src/plugins/navigation/resolvers/Mutation/createNavigationItem.js
@@ -1,3 +1,5 @@
+import { decodeShopOpaqueId } from "../../xforms/id.js";
+
 /**
  * @name Mutation.createNavigationItem
  * @method
@@ -17,7 +19,10 @@ export default async function createNavigationItem(parentResult, { input }, cont
   } = input;
 
   const newNavigationItem = await context.mutations.createNavigationItem(context, {
-    navigationItem
+    navigationItem: {
+      ...navigationItem,
+      shopId: decodeShopOpaqueId(navigationItem.shopId)
+    }
   });
 
   return {

--- a/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.js
+++ b/src/plugins/navigation/resolvers/Mutation/updateNavigationItem.js
@@ -26,7 +26,10 @@ export default async function updateNavigationItem(parentResult, { input }, cont
 
   const updatedNavigationItem = await context.mutations.updateNavigationItem(context, {
     navigationItemId,
-    navigationItem,
+    navigationItem: {
+      ...navigationItem,
+      shopId: decodeShopOpaqueId(navigationItem.shopId)
+    },
     shopId
   });
 

--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -280,6 +280,9 @@ input NavigationItemInput {
 
   "An object storing additional metadata about the navigation item (such as its related tag)"
   metadata: JSONObject
+
+  "Shop ID of the navigation item"
+  shopId: ID!
 }
 
 "NavigationItemData input"

--- a/src/plugins/navigation/xforms/xformNavigationTreeItem.js
+++ b/src/plugins/navigation/xforms/xformNavigationTreeItem.js
@@ -15,6 +15,16 @@ export default async function xformNavigationTreeItem(context, language, item) {
   let { items = [] } = item;
 
   const navigationItem = await NavigationItems.findOne({ _id: navigationItemId });
+  if (!navigationItem) {
+    return {
+      navigationItem: null,
+      expanded,
+      isVisible,
+      isPrivate,
+      isSecondary,
+      items
+    };
+  }
 
   // Add translated content value
   const { draftData, data } = navigationItem;


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

Fixes some 3.0.0 bugs I found while doing https://github.com/reactioncommerce/reaction-admin/pull/89

- `updateTag` mutation required `displayTitle` whereas `createTag` did not, leading to errors, particularly when the tag was originally created from the product edit page, and then you tried to edit it from Tag page
- There were some inconsistencies with IDs and how input was being passed around for some nav item mutations. These were introduced recently in #5802

## Testing
Either test in conjunction with https://github.com/reactioncommerce/reaction-admin/pull/89 or just review the code.