### PR TITLE
[3.0.0] fix: parse complicated MONGO_URL properly

### DIFF
--- a/src/core/ReactionAPI.js
+++ b/src/core/ReactionAPI.js
@@ -209,14 +209,11 @@ export default class ReactionAPI {
     connectOptionsSchema.validate(options);
 
     const { mongoUrl = MONGO_URL } = options;
-    const lastSlash = mongoUrl.lastIndexOf("/");
-    const dbUrl = mongoUrl.slice(0, lastSlash);
-    const dbName = mongoUrl.slice(lastSlash + 1);
 
-    const client = await mongoConnectWithRetry(dbUrl);
+    const client = await mongoConnectWithRetry(mongoUrl);
 
     this.mongoClient = client;
-    this.setMongoDatabase(client.db(dbName));
+    this.setMongoDatabase(client.db()); // Uses db name from the connection string
   }
 
   async disconnectFromMongo() {

--- a/src/core/util/initReplicaSet.js
+++ b/src/core/util/initReplicaSet.js
@@ -15,28 +15,6 @@ function sleep(ms) {
 }
 
 /**
- * Connect to mongodb
- *
- * @param {Object} parsedUrl URL to mongodb server and database name, parsed
- * @returns {Promise} a promise resolving to the mongodb db instance
- */
-async function connect(parsedUrl) {
-  const dbName = parsedUrl.pathname.slice(1);
-
-  // clone to remove the DB name
-  const dbParsedUrl = new URL(parsedUrl.toString());
-  dbParsedUrl.pathname = "";
-  const dbUrl = dbParsedUrl.toString();
-
-  const client = await mongoConnectWithRetry(dbUrl);
-
-  return {
-    client,
-    db: client.db(dbName)
-  };
-}
-
-/**
  * Runs the mongo command replSetInitiate,
  * which we need for the oplog for change streams
  *
@@ -51,7 +29,8 @@ export default async function initReplicaSet(mongoUrl) {
   // the process
   const stopped = false;
 
-  const { client, db } = await connect(parsedUrl);
+  const client = await mongoConnectWithRetry(mongoUrl);
+  const db = client.db(); // Uses db name from the connection string
 
   const replSetConfiguration = {
     _id: "rs0",

--- a/src/core/util/mongoConnectWithRetry.js
+++ b/src/core/util/mongoConnectWithRetry.js
@@ -28,7 +28,7 @@ export default function mongoConnectWithRetry(url) {
       // https://jira.mongodb.org/browse/NODE-2249
       // useUnifiedTopology: true
     }).then((client) => {
-      Logger.info("Connected to MongoDB");
+      Logger.info(`Connected to MongoDB. Database name: ${client.db().databaseName}`);
       return client;
     }).catch((error) => {
       if (error.name === "MongoNetworkError") {


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
The 3.0.0 API does not properly parse production MONGO_URLs with more complicated options

## Solution
Refactor the Mongo client and db calls to do none of our own parsing. This is the more modern and correct way of doing it and resolves the issue by letting the MongoDB library do all of the parsing work.

## Breaking changes
None

## Testing
Set `MONGO_URL` to a connection string with `?` and various query string options. Verify the logs show successful connection on startup.