### PR TITLE
Add graphql equivalent of addUserPermissions

### DIFF
--- a/src/core-services/account/mutations/addUserPermissions.js
+++ b/src/core-services/account/mutations/addUserPermissions.js
@@ -51,6 +51,8 @@ export default async function addUserPermissions(context, input) {
           $each: groups
         }
       }
+    }, {
+      returnOriginal: false
     }
   );
 

--- a/src/core-services/account/mutations/addUserPermissions.js
+++ b/src/core-services/account/mutations/addUserPermissions.js
@@ -54,10 +54,6 @@ export default async function addUserPermissions(context, input) {
     }
   );
 
-  if (!updatedAccount) {
-    throw new ReactionError("server-error", "Unable to update account groups");
-  }
-
   // Create an array which contains all fields that have changed
   // This is used for search, to determine if we need to re-index
   const updatedFields = ["groups"];

--- a/src/core-services/account/mutations/addUserPermissions.js
+++ b/src/core-services/account/mutations/addUserPermissions.js
@@ -54,6 +54,10 @@ export default async function addUserPermissions(context, input) {
     }
   );
 
+  if (!updatedAccount) {
+    throw new ReactionError("server-error", "Unable to update account groups. Account not found");
+  }
+
   // Create an array which contains all fields that have changed
   // This is used for search, to determine if we need to re-index
   const updatedFields = ["groups"];

--- a/src/core-services/account/mutations/addUserPermissions.js
+++ b/src/core-services/account/mutations/addUserPermissions.js
@@ -1,0 +1,72 @@
+import SimpleSchema from "simpl-schema";
+import ReactionError from "@reactioncommerce/reaction-error";
+
+const inputSchema = new SimpleSchema({
+  "accountId": String,
+  "groups": {
+    type: Array, // groupIds that user belongs to
+    minCount: 1
+  },
+  "groups.$": {
+    type: String
+  }
+});
+
+/**
+ * @name accounts/addUserPermissions
+ * @memberof Mutations/Accounts
+ * @summary Adds a group to an account (user) group. This addition to an account  group effectively
+ * adds permissions to account (user)
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Necessary input for mutation. See SimpleSchema.
+ * @param {Object} input.groups - groups to append to
+ * @param {String} input.accountId - the decoded account ID of account on which entry should be updated
+ * @returns {Promise<Object>} with updated account
+ */
+export default async function addUserPermissions(context, input) {
+  const itemsToValidate = { accountId: input.accountId, groups: input.groups };
+  inputSchema.validate(itemsToValidate);
+  const { appEvents, collections, userId: userIdFromContext } = context;
+  const { Accounts } = collections;
+  const { groups, accountId } = input;
+
+
+  const account = await Accounts.findOne({ _id: accountId });
+
+  if (!account) throw new ReactionError("not-found", "No account found");
+
+  if (!context.isInternalCall) {
+    await context.validatePermissions("reaction:accounts", "update", { shopId: account.shopId, legacyRoles: ["reaction-accounts"] });
+  }
+
+  // Update the Reaction Accounts collection with new groups info
+  // This
+  const { value: updatedAccount } = await Accounts.findOneAndUpdate(
+    {
+      _id: accountId
+    },
+    {
+      $addToSet: {
+        groups: {
+          $each: groups
+        }
+      }
+    }
+  );
+
+  if (!updatedAccount) {
+    throw new ReactionError("server-error", "Unable to update account groups");
+  }
+
+  // Create an array which contains all fields that have changed
+  // This is used for search, to determine if we need to re-index
+  const updatedFields = ["groups"];
+
+  await appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: userIdFromContext,
+    updatedFields
+  });
+
+  return updatedAccount;
+}

--- a/src/core-services/account/mutations/index.js
+++ b/src/core-services/account/mutations/index.js
@@ -12,6 +12,7 @@ import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 import createAccountGroup from "./createAccountGroup.js";
+import addUserPermissions from "./addUserPermissions.js";
 
 export default {
   addressBookAdd,
@@ -27,5 +28,6 @@ export default {
   setAccountProfileCurrency,
   setAccountProfileLanguage,
   updateAccountAddressBookEntry,
-  createAccountGroup
+  createAccountGroup,
+  addUserPermissions
 };

--- a/src/core-services/account/resolvers/Mutation/addUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/addUserPermissions.js
@@ -1,0 +1,18 @@
+import setUserPermissions from "./setUserPermissions.js";
+
+/**
+ * @name Mutation/addUserPermissions
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver to add user permissions. This is an alias to {@link setUserPermissions.js}
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} args.input.groups - The groups the user is to be added to
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} args.context.userId - the userId of user to add to the given group
+ * @param {Object} args.context.accountId - the userId of account to add to the given groups
+ * @returns {Object} - object
+ */
+export default async function addUserPermissions(_, { input }, context) {
+  return setUserPermissions(_, { input }, context);
+}

--- a/src/core-services/account/resolvers/Mutation/addUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/addUserPermissions.js
@@ -1,18 +1,25 @@
-import setUserPermissions from "./setUserPermissions.js";
+import { decodeShopOpaqueId, decodeAccountOpaqueId } from "../../xforms/id.js";
 
 /**
  * @name Mutation/addUserPermissions
  * @method
  * @memberof Accounts/GraphQL
- * @summary resolver to add user permissions. This is an alias to {@link setUserPermissions.js}
+ * @summary resolver to add user permissions
  * @param {Object} _ - unused
- * @param {Object} args.input - an object of all mutation arguments that were sent by the client
- * @param {String} args.input.groups - The groups the user is to be added to
+ * @param {Object} input - an object of all mutation arguments that were sent by the client
+ * @param {String} input.groups - The group the user is to be added to
+ * @param {String} input.accountId - the userId of user to add to the given group
+ * @param {String} input.shopId - the shopId of the user to add to the given group
+ * @param {String} input.clientMutationId - the client mutation Id  i.e. string identifying the mutation call,
+ * which will be returned in the response payload
  * @param {Object} context - an object containing the per-request state
- * @param {Object} args.context.userId - the userId of user to add to the given group
- * @param {Object} args.context.accountId - the userId of account to add to the given groups
  * @returns {Object} - object
  */
 export default async function addUserPermissions(_, { input }, context) {
-  return setUserPermissions(_, { input }, context);
+  const { shopId, accountId, clientMutationId } = input;
+  const decodedShopId = decodeShopOpaqueId(shopId);
+  const decodedAccountId = decodeAccountOpaqueId(accountId);
+  const transformedInput = { ...input, shopId: decodedShopId, accountId: decodedAccountId };
+  const result = await context.mutations.addUserPermissions(context, transformedInput);
+  return { account: result, clientMutationId };
 }

--- a/src/core-services/account/resolvers/Mutation/addUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/addUserPermissions.test.js
@@ -1,0 +1,47 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import addUserPermissions from "./addUserPermissions.js";
+import setUserPermissions from "./setUserPermissions.js";
+
+jest.mock("./setUserPermissions.js");
+test("addUserPermissionsTests correctly passes through to internal setUserPermissions resolver function", async () => {
+  const groups = ["test-group-id"];
+
+  const fakeResult = {
+    _id: "3vx5cqBZsymCfHbpf",
+    acceptsMarketing: false,
+    createdAt: "2019-11-05T16:34:49.644Z",
+    emails: [
+      {
+        address: "admin@localhost",
+        verified: true,
+        provides: "default"
+      }
+    ],
+    shopId: "test-shop-id",
+    state: "new",
+    userId: "3vx5cqBZsymCfHbpf",
+    accountId: "3vx5cqBZsymCfHbpf",
+    groups: [
+      "test-group-id"
+    ]
+  };
+
+  setUserPermissions.mockReturnValueOnce(Promise.resolve(fakeResult));
+
+  const result = await addUserPermissions(null, {
+    input: {
+      groups
+    }
+  }, mockContext);
+
+  expect(setUserPermissions).toHaveBeenCalledWith(
+    null, {
+      input: {
+        groups: ["test-group-id"]
+      }
+    },
+    mockContext
+  );
+
+  expect(result).toEqual(fakeResult);
+});

--- a/src/core-services/account/resolvers/Mutation/index.js
+++ b/src/core-services/account/resolvers/Mutation/index.js
@@ -9,6 +9,7 @@ import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 import createAccountGroup from "./createAccountGroup.js";
+import addUserPermissions from "./addUserPermissions.js";
 
 export default {
   addAccountAddressBookEntry,
@@ -21,5 +22,6 @@ export default {
   setAccountProfileCurrency,
   setAccountProfileLanguage,
   updateAccountAddressBookEntry,
-  createAccountGroup
+  createAccountGroup,
+  addUserPermissions
 };

--- a/src/core-services/account/schemas/account.graphql
+++ b/src/core-services/account/schemas/account.graphql
@@ -136,6 +136,18 @@ input RemoveAccountEmailRecordInput {
   email: Email!
 }
 
+"Defines groups to add given user / account to thereby giving that user certain permissions"
+input AddUserPermissionsInput {
+  "The accountId of the user whose permissions are to be set"
+  accountId: String!
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+  "the groups to add a user / account to"
+  groups: [String!]!
+  "the opaque shopId of the shop"
+  shopId: String!
+}
+
 "Per-account tax exemption settings used by the Avalara plugin"
 type TaxSettings {
   "Customer usage type. A value matching the `code` field of one TaxEntityCode, or any custom string."
@@ -349,6 +361,14 @@ type SetAccountProfileLanguagePayload {
   clientMutationId: String
 }
 
+"The response from the `addUserPermissions` mutation"
+type AddUserPermissionsPayload {
+  "The updated account"
+  account: Account!
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+}
+
 extend type Shop {
   """
   Returns a list of administrators for this shop, as a Relay-compatible connection.
@@ -429,6 +449,12 @@ extend type Mutation {
     "Mutation input"
     input: UpdateAccountAddressBookEntryInput!
   ): UpdateAccountAddressBookEntryPayload
+
+  "Adds an account to a group. The user id / account id must be set in the context"
+  addUserPermissions(
+    "Mutation input"
+    input: AddUserPermissionsInput!
+  ): AddUserPermissionsPayload
 }
 
 extend type Query {

--- a/tests/integration/api/mutations/addUserPermissions/__snapshots__/addUserPermissions.test.js.snap
+++ b/tests/integration/api/mutations/addUserPermissions/__snapshots__/addUserPermissions.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`anyone without the required permissions should be denied access to add group to an account 1`] = `
+exports[`addUserPermissions anyone without the required permissions should be denied access to add group to an account 1`] = `
 Object {
   "extensions": Object {
     "code": "FORBIDDEN",
@@ -25,7 +25,7 @@ Object {
 }
 `;
 
-exports[`should throw if there is an empty list of groups provided in the input 1`] = `
+exports[`addUserPermissions should throw if there is an empty list of groups provided in the input 1`] = `
 Object {
   "extensions": Object {
     "code": "BAD_USER_INPUT",

--- a/tests/integration/api/mutations/addUserPermissions/__snapshots__/addUserPermissions.test.js.snap
+++ b/tests/integration/api/mutations/addUserPermissions/__snapshots__/addUserPermissions.test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`anyone without the required permissions should be denied access to add group to an account 1`] = `
+Object {
+  "extensions": Object {
+    "code": "FORBIDDEN",
+    "exception": Object {
+      "details": Object {},
+      "error": "access-denied",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Access Denied",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Access Denied",
+  "path": Array [
+    "addUserPermissions",
+  ],
+}
+`;
+
+exports[`should throw if there is an empty list of groups provided in the input 1`] = `
+Object {
+  "extensions": Object {
+    "code": "BAD_USER_INPUT",
+    "exception": Object {
+      "details": Array [
+        Object {
+          "message": "You must specify at least 1 values",
+          "minCount": 1,
+          "name": "groups",
+          "type": "minCount",
+          "value": Array [],
+        },
+      ],
+      "error": "validation-error",
+      "errorType": "ClientError",
+      "name": "ClientError",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "You must specify at least 1 values",
+  "path": Array [
+    "addUserPermissions",
+  ],
+}
+`;

--- a/tests/integration/api/mutations/addUserPermissions/addUserPermissions.test.js
+++ b/tests/integration/api/mutations/addUserPermissions/addUserPermissions.test.js
@@ -92,7 +92,7 @@ beforeEach(async () => {
   });
 });
 
-test("anyone can with the required permissions can add group to an account", async () => {
+test("addUserPermissions anyone can with the required permissions can add group to an account", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);
 
   const groupName = "test-group-1";
@@ -113,7 +113,7 @@ test("anyone can with the required permissions can add group to an account", asy
 });
 
 
-test("anyone without the required permissions should be denied access to add group to an account", async () => {
+test("addUserPermissions anyone without the required permissions should be denied access to add group to an account", async () => {
   await testApp.setLoggedInUser(mockOtherAccount);
 
   const groupName = "test-group-1";
@@ -136,7 +136,7 @@ test("anyone without the required permissions should be denied access to add gro
   expect(err[0]).toMatchSnapshot();
 });
 
-test("should throw if there is an empty list of groups provided in the input", async () => {
+test("addUserPermissions should throw if there is an empty list of groups provided in the input", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);
 
   let err = null;

--- a/tests/integration/api/mutations/addUserPermissions/addUserPermissions.test.js
+++ b/tests/integration/api/mutations/addUserPermissions/addUserPermissions.test.js
@@ -1,0 +1,150 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const AddUserPermissionsMutation = importAsString("./addUserPermissionsMutation.graphql");
+
+jest.setTimeout(300000);
+
+let addUserPermissions;
+let customerGroup;
+let mockAdminAccount;
+let mockAdminAccountIdOpaque;
+let mockOtherAccount;
+let mockOtherAccountIdOpaque;
+let shopId;
+let shopManagerGroup;
+let shopOpaqueId;
+let testApp;
+
+const mockAdminAccountId = "mockAdminAccount";
+const mockOtherAccountId = "mockOtherAccount";
+const clientMutationId = "SOME_CLIENT_MUTATION_ID";
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  shopId = await testApp.insertPrimaryShop();
+
+  mockAdminAccount = Factory.Account.makeOne({
+    _id: mockAdminAccountId,
+    roles: {
+      [shopId]: ["admin", "reaction-accounts"]
+    },
+    shopId
+  });
+  await testApp.createUserAndAccount(mockAdminAccount);
+
+
+  mockOtherAccount = Factory.Account.makeOne({
+    _id: mockOtherAccountId,
+    groups: [],
+    roles: {},
+    shopId
+  });
+  await testApp.createUserAndAccount(mockOtherAccount);
+
+  shopManagerGroup = Factory.Group.makeOne({
+    createdBy: null,
+    name: "shop manager",
+    permissions: ["admin", "shopManagerGroupPermission"],
+    slug: "shop manager",
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(shopManagerGroup);
+
+  customerGroup = Factory.Group.makeOne({
+    createdBy: null,
+    name: "customer",
+    permissions: ["customerGroupPermission"],
+    slug: "customer",
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(customerGroup);
+
+  shopOpaqueId = encodeOpaqueId("reaction/shop", shopId);
+  mockAdminAccountIdOpaque = encodeOpaqueId("reaction/account", mockAdminAccountId);
+  mockOtherAccountIdOpaque = encodeOpaqueId("reaction/account", mockOtherAccountId);
+
+  addUserPermissions = testApp.mutate(AddUserPermissionsMutation);
+});
+
+afterAll(async () => {
+  testApp.collections.Accounts.deleteMany({});
+  testApp.collections.Shops.deleteMany({});
+  testApp.collections.users.deleteMany({});
+  testApp.collections.Groups.deleteMany({});
+  await testApp.stop();
+});
+
+beforeEach(async () => {
+  await testApp.collections.Accounts.updateOne({ _id: mockOtherAccount._id }, {
+    $set: {
+      groups: []
+    }
+  });
+
+  await testApp.collections.users.updateOne({ _id: mockOtherAccount._id }, {
+    $set: {
+      roles: {}
+    }
+  });
+});
+
+test("anyone can with the required permissions can add group to an account", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  const groupName = "test-group-1";
+  // The group that is to be added tp th  account
+  const testGroup1 = Factory.Group.makeOne({
+    createdBy: null,
+    name: groupName,
+    permissions: ["test-group-1-permission"],
+    slug: groupName,
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(testGroup1);
+
+  const result = await addUserPermissions({ groups: ["test-group-1"], shopId: shopOpaqueId, accountId: mockOtherAccountIdOpaque, clientMutationId });
+  const dbResult = await testApp.collections.Accounts.findOne({ _id: mockOtherAccountId });
+  expect(result.addUserPermissions.clientMutationId).toEqual(clientMutationId);
+  expect(dbResult.groups).toEqual(expect.arrayContaining(["test-group-1"]));
+});
+
+
+test("anyone without the required permissions should be denied access to add group to an account", async () => {
+  await testApp.setLoggedInUser(mockOtherAccount);
+
+  const groupName = "test-group-1";
+  // The group that is to be added tp th  account
+  const testGroup1 = Factory.Group.makeOne({
+    createdBy: null,
+    name: groupName,
+    permissions: ["test-group-1-permission"],
+    slug: groupName,
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(testGroup1);
+  let err = null;
+  try {
+    await addUserPermissions({ groups: ["test-group-1"], shopId: shopOpaqueId, accountId: mockAdminAccountIdOpaque, clientMutationId });
+  } catch (errors) {
+    err = errors;
+  }
+  expect(err).toBeTruthy();
+  expect(err[0]).toMatchSnapshot();
+});
+
+test("should throw if there is an empty list of groups provided in the input", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  let err = null;
+  try {
+    await addUserPermissions({ groups: [], shopId: shopOpaqueId, accountId: mockOtherAccountIdOpaque, clientMutationId });
+  } catch (errors) {
+    err = errors;
+  }
+  expect(err).toBeTruthy();
+  expect(err[0]).toMatchSnapshot();
+});

--- a/tests/integration/api/mutations/addUserPermissions/addUserPermissionsMutation.graphql
+++ b/tests/integration/api/mutations/addUserPermissions/addUserPermissionsMutation.graphql
@@ -1,0 +1,22 @@
+mutation addUserPermissions($accountId: String!, $shopId: String!, $groups: [String!]!, $clientMutationId: String ) {
+
+  addUserPermissions (input: {
+    shopId: $shopId
+    accountId: $accountId
+    groups: $groups
+    clientMutationId: $clientMutationId
+  }) {
+    account {
+      groups {
+        nodes {
+          _id
+          description
+          name
+          permissions
+        }
+      }
+    }
+    clientMutationId
+  }
+
+}


### PR DESCRIPTION
Resolves: #5828  
Impact: **major**  
Type: **feature**

## Issue
 
We need to add a GraphQL equivalent of the `addUserPermissions` found in `reaction-admin` at  https://github.com/reactioncommerce/reaction-admin/blob/trunk/imports/plugins/core/accounts/server/methods/addUserPermissions.js into reaction. This will allow for adding permissions (_which is equivalent of `policies` in `reaction-authorization`. A point of explanation: At the moment, in `reaction-authorization` we dont add policies per user. We apply policies to roles which users are members of_)  to an account in reaction v3.0.0. This will also help our demeteorization efforts and also help transition to reaction-authorization service. 

We also need to add integration tests and unit tests for the newly created equivalent

## Solution

- Add GraphQL equivalent of `addUserPermissions` found in `reaction-admin` to `reaction` (resolver function and mutation functions)
- Add integration and unit tests for the newly created GQL `addUserPermissions`

## Breaking changes

none

## Testing

1. Tests should pass on CI
2. integration tests are found at 
 - **tests/integration/api/mutations/addUserPermissions/addUserPermissions.test.js**
3. unit tests are found at 
 - `src/core-services/account/resolvers/Mutation/addUserPermissions.test.js`
4. run the tests with `npm run test`
 