### PR TITLE
[WIP] Add removeAccountFromGroups GraphQL mutation (formerly Add graphql equivalent of remove user permissions)

### DIFF
--- a/src/core-services/account/mutations/index.js
+++ b/src/core-services/account/mutations/index.js
@@ -12,6 +12,7 @@ import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 import createAccountGroup from "./createAccountGroup.js";
+import removeUserPermissions from "./removeUserPermissions.js";
 
 export default {
   addressBookAdd,
@@ -27,5 +28,6 @@ export default {
   setAccountProfileCurrency,
   setAccountProfileLanguage,
   updateAccountAddressBookEntry,
-  createAccountGroup
+  createAccountGroup,
+  removeUserPermissions
 };

--- a/src/core-services/account/mutations/removeUserPermissions.js
+++ b/src/core-services/account/mutations/removeUserPermissions.js
@@ -72,5 +72,5 @@ export default async function removeUserPermissions(context, input) {
     updatedFields
   });
 
-  return { account: updatedAccount };
+  return updatedAccount;
 }

--- a/src/core-services/account/mutations/removeUserPermissions.js
+++ b/src/core-services/account/mutations/removeUserPermissions.js
@@ -5,8 +5,7 @@ const inputSchema = new SimpleSchema({
   "accountId": String,
   "groups": {
     type: Array, // groupIds that user belongs to
-    optional: true,
-    defaultValue: []
+    minCount: 1
   },
   "groups.$": {
     type: String

--- a/src/core-services/account/mutations/removeUserPermissions.js
+++ b/src/core-services/account/mutations/removeUserPermissions.js
@@ -38,24 +38,25 @@ export default async function removeUserPermissions(context, input) {
 
   if (!account) throw new ReactionError("not-found", "No account found");
 
-  if (!context.isInternalCall && userIdFromContext !== accountId) {
-    await context.validatePermissions("reaction:accounts", "update", { shopId: account.shopId, legacyRoles: ["reaction-accounts"] });
+  if (!context.isInternalCall) {
+    await context.validatePermissions("reaction:accounts", "update", { shopId, legacyRoles: ["reaction-accounts"] });
   }
 
-  await context.validatePermissions("reaction:accounts", "update", { shopId, legacyRoles: ["admin"] });
 
   // Update the Reaction Accounts collection with new groups info
   // This
   const { value: updatedAccount } = await Accounts.findOneAndUpdate(
+    {
+      _id: accountId
+    },
     {
       $pull: {
         groups: {
           $in: groups
         }
       }
-    },
-    {
-      multi: true
+    }, {
+      returnNewDocument: true
     }
   );
 

--- a/src/core-services/account/mutations/removeUserPermissions.js
+++ b/src/core-services/account/mutations/removeUserPermissions.js
@@ -53,12 +53,12 @@ export default async function removeUserPermissions(context, input) {
         }
       }
     }, {
-      returnNewDocument: true
+      returnOriginal: false
     }
   );
 
   if (!updatedAccount) {
-    throw new ReactionError("server-error", "Unable to update account groups");
+    throw new ReactionError("server-error", "Unable to update account groups. Account not found");
   }
 
   // Create an array which contains all fields that have changed

--- a/src/core-services/account/mutations/removeUserPermissions.js
+++ b/src/core-services/account/mutations/removeUserPermissions.js
@@ -3,7 +3,6 @@ import ReactionError from "@reactioncommerce/reaction-error";
 
 const inputSchema = new SimpleSchema({
   "accountId": String,
-  "userId": String,
   "groups": {
     type: Array, // groupIds that user belongs to
     optional: true,
@@ -22,16 +21,15 @@ const inputSchema = new SimpleSchema({
  * @param {Object} context - GraphQL execution context
  * @param {Object} input - Necessary input for mutation. See SimpleSchema.
  * @param {Object} input.groups - groups to append to
- * @param {String} input.accountId - optional decoded ID of account on which entry should be updated, for admins
+ * @param {String} input.accountId - decoded ID of account on which entry should be updated
  * @returns {Promise<Object>} with updated account
  */
 export default async function removeUserPermissions(context, input) {
-  const itemsToValidate = { accountId: context.accountId, userId: context.userId, groups: input.groups };
+  const itemsToValidate = { accountId: input.accountId, groups: input.groups };
   inputSchema.validate(itemsToValidate);
   const { appEvents, collections, userId: userIdFromContext } = context;
   const { Accounts } = collections;
-  const { accountId } = context;
-  const { groups, shopId } = input;
+  const { groups, shopId, accountId } = input;
 
 
   const account = await Accounts.findOne({ _id: accountId });

--- a/src/core-services/account/mutations/removeUserPermissions.js
+++ b/src/core-services/account/mutations/removeUserPermissions.js
@@ -41,7 +41,6 @@ export default async function removeUserPermissions(context, input) {
 
 
   // Update the Reaction Accounts collection with new groups info
-  // This
   const { value: updatedAccount } = await Accounts.findOneAndUpdate(
     {
       _id: accountId

--- a/src/core-services/account/mutations/removeUserPermissions.js
+++ b/src/core-services/account/mutations/removeUserPermissions.js
@@ -1,0 +1,77 @@
+import SimpleSchema from "simpl-schema";
+import ReactionError from "@reactioncommerce/reaction-error";
+
+const inputSchema = new SimpleSchema({
+  "accountId": String,
+  "userId": String,
+  "groups": {
+    type: Array, // groupIds that user belongs to
+    optional: true,
+    defaultValue: []
+  },
+  "groups.$": {
+    type: String
+  }
+});
+
+/**
+ * @name accounts/removeUserPermissions
+ * @memberof Mutations/Accounts
+ * @summary Removes a group from an account (user) group. This addition to an account  group effectively
+ * removes permissions from account (user)
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Necessary input for mutation. See SimpleSchema.
+ * @param {Object} input.groups - groups to append to
+ * @param {String} input.accountId - optional decoded ID of account on which entry should be updated, for admins
+ * @returns {Promise<Object>} with updated account
+ */
+export default async function removeUserPermissions(context, input) {
+  const itemsToValidate = { accountId: context.accountId, userId: context.userId, groups: input.groups };
+  inputSchema.validate(itemsToValidate);
+  const { appEvents, collections, userId: userIdFromContext } = context;
+  const { Accounts } = collections;
+  const { accountId } = context;
+  const { groups, shopId } = input;
+
+
+  const account = await Accounts.findOne({ _id: accountId });
+
+  if (!account) throw new ReactionError("not-found", "No account found");
+
+  if (!context.isInternalCall && userIdFromContext !== accountId) {
+    await context.validatePermissions("reaction:accounts", "update", { shopId: account.shopId, legacyRoles: ["reaction-accounts"] });
+  }
+
+  await context.validatePermissions("reaction:accounts", "update", { shopId, legacyRoles: ["admin"] });
+
+  // Update the Reaction Accounts collection with new groups info
+  // This
+  const { value: updatedAccount } = await Accounts.findOneAndUpdate(
+    {
+      $pull: {
+        groups: {
+          $in: groups
+        }
+      }
+    },
+    {
+      multi: true
+    }
+  );
+
+  if (!updatedAccount) {
+    throw new ReactionError("server-error", "Unable to update account groups");
+  }
+
+  // Create an array which contains all fields that have changed
+  // This is used for search, to determine if we need to re-index
+  const updatedFields = ["groups"];
+
+  await appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: userIdFromContext,
+    updatedFields
+  });
+
+  return { account: updatedAccount };
+}

--- a/src/core-services/account/resolvers/Mutation/index.js
+++ b/src/core-services/account/resolvers/Mutation/index.js
@@ -9,6 +9,7 @@ import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 import createAccountGroup from "./createAccountGroup.js";
+import removeUserPermissions from "./removeUserPermissions.js";
 
 export default {
   addAccountAddressBookEntry,
@@ -21,5 +22,6 @@ export default {
   setAccountProfileCurrency,
   setAccountProfileLanguage,
   updateAccountAddressBookEntry,
-  createAccountGroup
+  createAccountGroup,
+  removeUserPermissions
 };

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
@@ -1,4 +1,4 @@
-import { decodeShopOpaqueId } from "../../xforms/id.js";
+import { decodeShopOpaqueId, decodeAccountOpaqueId } from "../../xforms/id.js";
 /**
  * @name Mutation/removeUserPermissions
  * @method
@@ -7,15 +7,15 @@ import { decodeShopOpaqueId } from "../../xforms/id.js";
  * @param {Object} _ - unused
  * @param {Object} input - an object of all mutation arguments that were sent by the client
  * @param {String} input.groups - The group the user is to be added to
+ * @param {Object} input.accountId - the accountId of user to remove from the given group
  * @param {Object} context - an object containing the per-request state
- * @param {Object} context.userId - the userId of user to add to the given group
- * @param {Object} context.accountId - the account of user to add to the given
  * @returns {Object} - object
  */
 export default async function removeUserPermissions(_, { input }, context) {
-  const { shopId, clientMutationId } = input;
+  const { shopId, clientMutationId, accountId } = input;
   const decodedShopId = decodeShopOpaqueId(shopId);
-  const transformedInput = { ...input, shopId: decodedShopId };
+  const decodedAccountId = decodeAccountOpaqueId(accountId);
+  const transformedInput = { ...input, shopId: decodedShopId, accountId: decodedAccountId };
   const result = await context.mutations.removeUserPermissions(context, transformedInput);
   return { ...result, clientMutationId };
 }

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
@@ -17,5 +17,5 @@ export default async function removeUserPermissions(_, { input }, context) {
   const decodedAccountId = decodeAccountOpaqueId(accountId);
   const transformedInput = { ...input, shopId: decodedShopId, accountId: decodedAccountId };
   const result = await context.mutations.removeUserPermissions(context, transformedInput);
-  return { ...result, clientMutationId };
+  return { account: result, clientMutationId };
 }

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
@@ -1,19 +1,19 @@
 import AddOrRemoveAccountGroupsOperationType from "../../mutations/AddOrRemoveAccountGroupsOperationType.js";
 
 /**
- * @name Mutation/setUserPermissions
+ * @name Mutation/removeUserPermissions
  * @method
  * @memberof Accounts/GraphQL
- * @summary resolver to add user permissions
+ * @summary resolver to remove user permissions
  * @param {Object} _ - unused
  * @param {Object} input - an object of all mutation arguments that were sent by the client
  * @param {String} input.groups - The group the user is to be added to
  * @param {Object} context - an object containing the per-request state
  * @param {Object} context.userId - the userId of user to add to the given group
- * @param {Object} context.accountId - the userId of user to add to the given group
+ * @param {Object} context.accountId - the accouny of user to add to the given
  * @returns {Object} - object
  */
-export default async function setUserPermissions(_, { input }, context) {
-  await context.validatePermissions("reaction:accounts", "create", { });
-  return context.mutations.addOrRemoveAccountGroups(context, input, AddOrRemoveAccountGroupsOperationType.ADD);
+export default async function removeUserPermissions(_, { input }, context) {
+  await context.validatePermissions("reaction:accounts", "delete", { });
+  return context.mutations.addOrRemoveAccountGroups(context, input, AddOrRemoveAccountGroupsOperationType.DELETE);
 }

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
@@ -12,6 +12,5 @@
  * @returns {Object} - object
  */
 export default async function removeUserPermissions(_, { input }, context) {
-  await context.validatePermissions("reaction:accounts", "delete", { });
   return context.mutations.addOrRemoveAccountGroups(context, input);
 }

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
@@ -1,3 +1,4 @@
+import { decodeShopOpaqueId } from "../../xforms/id.js";
 /**
  * @name Mutation/removeUserPermissions
  * @method
@@ -12,5 +13,9 @@
  * @returns {Object} - object
  */
 export default async function removeUserPermissions(_, { input }, context) {
-  return context.mutations.addOrRemoveAccountGroups(context, input);
+  const { shopId, clientMutationId } = input;
+  const decodedShopId = decodeShopOpaqueId(shopId);
+  const transformedInput = { ...input, shopId: decodedShopId };
+  const result = await context.mutations.removeUserPermissions(context, transformedInput);
+  return { ...result, clientMutationId };
 }

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
@@ -1,0 +1,19 @@
+import AddOrRemoveAccountGroupsOperationType from "../../mutations/AddOrRemoveAccountGroupsOperationType.js";
+
+/**
+ * @name Mutation/setUserPermissions
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver to add user permissions
+ * @param {Object} _ - unused
+ * @param {Object} input - an object of all mutation arguments that were sent by the client
+ * @param {String} input.groups - The group the user is to be added to
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} context.userId - the userId of user to add to the given group
+ * @param {Object} context.accountId - the userId of user to add to the given group
+ * @returns {Object} - object
+ */
+export default async function setUserPermissions(_, { input }, context) {
+  await context.validatePermissions("reaction:accounts", "create", { });
+  return context.mutations.addOrRemoveAccountGroups(context, input, AddOrRemoveAccountGroupsOperationType.ADD);
+}

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.js
@@ -1,5 +1,3 @@
-import AddOrRemoveAccountGroupsOperationType from "../../mutations/AddOrRemoveAccountGroupsOperationType.js";
-
 /**
  * @name Mutation/removeUserPermissions
  * @method
@@ -10,10 +8,10 @@ import AddOrRemoveAccountGroupsOperationType from "../../mutations/AddOrRemoveAc
  * @param {String} input.groups - The group the user is to be added to
  * @param {Object} context - an object containing the per-request state
  * @param {Object} context.userId - the userId of user to add to the given group
- * @param {Object} context.accountId - the accouny of user to add to the given
+ * @param {Object} context.accountId - the account of user to add to the given
  * @returns {Object} - object
  */
 export default async function removeUserPermissions(_, { input }, context) {
   await context.validatePermissions("reaction:accounts", "delete", { });
-  return context.mutations.addOrRemoveAccountGroups(context, input, AddOrRemoveAccountGroupsOperationType.DELETE);
+  return context.mutations.addOrRemoveAccountGroups(context, input);
 }

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -1,0 +1,49 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import AddOrRemoveAccountGroupsOperationType from "../../mutations/AddOrRemoveAccountGroupsOperationType";
+import setUserPermissions from "./setUserPermissions.js";
+
+mockContext.mutations.addOrRemoveAccountGroups = jest.fn().mockName("mutations.addOrRemoveAccountGroups");
+mockContext.validatePermissions = jest.fn().mockName("validatePermissions");
+
+test("correctly passes through to internal mutation function", async () => {
+  const groups = ["test-group-id"];
+
+  const fakeResult = {
+    _id: "3vx5cqBZsymCfHbpf",
+    acceptsMarketing: false,
+    createdAt: "2019-11-05T16:34:49.644Z",
+    emails: [
+      {
+        address: "admin@localhost",
+        verified: true,
+        provides: "default"
+      }
+    ],
+    shopId: "test-shop-id",
+    state: "new",
+    userId: "3vx5cqBZsymCfHbpf",
+    accountId: "3vx5cqBZsymCfHbpf",
+    groups: [
+      "test-group-id"
+    ]
+  };
+
+  mockContext.mutations.addOrRemoveAccountGroups.mockReturnValueOnce(Promise.resolve(fakeResult));
+  mockContext.validatePermissions.mockReturnValueOnce(Promise.resolve({ allow: true }));
+
+  const result = await setUserPermissions(null, {
+    input: {
+      groups
+    }
+  }, mockContext);
+
+  expect(mockContext.mutations.addOrRemoveAccountGroups).toHaveBeenCalledWith(
+    mockContext,
+    { groups: ["test-group-id"] },
+    AddOrRemoveAccountGroupsOperationType.ADD
+  );
+
+  expect(mockContext.validatePermissions).toHaveBeenCalledWith("reaction:accounts", "create", { });
+
+  expect(result).toEqual(fakeResult);
+});

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -1,5 +1,4 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
-import AddOrRemoveAccountGroupsOperationType from "../../mutations/AddOrRemoveAccountGroupsOperationType";
 import removeUserPermissions from "./removeUserPermissions.js";
 
 mockContext.mutations.addOrRemoveAccountGroups = jest.fn().mockName("mutations.addOrRemoveAccountGroups");
@@ -39,8 +38,7 @@ test("removeUserPermissions must correctly passes through to internal addOrRemov
 
   expect(mockContext.mutations.addOrRemoveAccountGroups).toHaveBeenCalledWith(
     mockContext,
-    { groups: ["test-group-id"] },
-    AddOrRemoveAccountGroupsOperationType.DELETE
+    { groups: ["test-group-id"] }
   );
 
   expect(mockContext.validatePermissions).toHaveBeenCalledWith("reaction:accounts", "delete", { });

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -8,12 +8,14 @@ mockContext.validatePermissions = jest.fn().mockName("validatePermissions");
 test("removeUserPermissions must correctly passes through to internal removeUserPermissions mutation function", async () => {
   const groups = ["test-group-id"];
   const clientMutationId = "SOME_CLIENT_MUTATION_ID";
+  const accountId = "3vx5cqBZsymCfHbpf";
   const shopId = "test-shop-id";
   const shopIdOpaque = encodeOpaqueId("reaction/shop", shopId);
+  const accountIdOpaque = encodeOpaqueId("reaction/account", accountId);
 
   const fakeResult = {
     account: {
-      _id: "3vx5cqBZsymCfHbpf",
+      _id: accountId,
       acceptsMarketing: false,
       createdAt: "2019-11-05T16:34:49.644Z",
       emails: [
@@ -40,7 +42,8 @@ test("removeUserPermissions must correctly passes through to internal removeUser
     input: {
       groups,
       clientMutationId,
-      shopId: shopIdOpaque
+      shopId: shopIdOpaque,
+      accountId: accountIdOpaque
     }
   }, mockContext);
 
@@ -48,6 +51,7 @@ test("removeUserPermissions must correctly passes through to internal removeUser
     mockContext,
     {
       groups: ["test-group-id"],
+      accountId,
       clientMutationId,
       shopId
     }

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -1,11 +1,11 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import AddOrRemoveAccountGroupsOperationType from "../../mutations/AddOrRemoveAccountGroupsOperationType";
-import setUserPermissions from "./setUserPermissions.js";
+import removeUserPermissions from "./removeUserPermissions.js";
 
 mockContext.mutations.addOrRemoveAccountGroups = jest.fn().mockName("mutations.addOrRemoveAccountGroups");
 mockContext.validatePermissions = jest.fn().mockName("validatePermissions");
 
-test("correctly passes through to internal mutation function", async () => {
+test("removeUserPermissions must correctly passes through to internal addOrRemoveAccountGroups mutation function", async () => {
   const groups = ["test-group-id"];
 
   const fakeResult = {
@@ -31,7 +31,7 @@ test("correctly passes through to internal mutation function", async () => {
   mockContext.mutations.addOrRemoveAccountGroups.mockReturnValueOnce(Promise.resolve(fakeResult));
   mockContext.validatePermissions.mockReturnValueOnce(Promise.resolve({ allow: true }));
 
-  const result = await setUserPermissions(null, {
+  const result = await removeUserPermissions(null, {
     input: {
       groups
     }
@@ -40,10 +40,10 @@ test("correctly passes through to internal mutation function", async () => {
   expect(mockContext.mutations.addOrRemoveAccountGroups).toHaveBeenCalledWith(
     mockContext,
     { groups: ["test-group-id"] },
-    AddOrRemoveAccountGroupsOperationType.ADD
+    AddOrRemoveAccountGroupsOperationType.DELETE
   );
 
-  expect(mockContext.validatePermissions).toHaveBeenCalledWith("reaction:accounts", "create", { });
+  expect(mockContext.validatePermissions).toHaveBeenCalledWith("reaction:accounts", "delete", { });
 
   expect(result).toEqual(fakeResult);
 });

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -39,7 +39,7 @@ test("removeUserPermissions must correctly passes through to internal removeUser
 
   expect(mockContext.mutations.removeUserPermissions).toHaveBeenCalledWith(
     mockContext,
-    { groups: ["test-group-id"] }
+    { groups: ["test-group-id"], clientMutationId }
   );
 
   expect(mockContext.validatePermissions).toHaveBeenCalledWith("reaction:accounts", "delete", { });

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -29,7 +29,6 @@ test("removeUserPermissions must correctly passes through to internal removeUser
   };
 
   mockContext.mutations.removeUserPermissions.mockReturnValueOnce(Promise.resolve(fakeResult));
-  mockContext.validatePermissions.mockReturnValueOnce(Promise.resolve({ allow: true }));
 
   const result = await removeUserPermissions(null, {
     input: {
@@ -41,8 +40,6 @@ test("removeUserPermissions must correctly passes through to internal removeUser
     mockContext,
     { groups: ["test-group-id"], clientMutationId }
   );
-
-  expect(mockContext.validatePermissions).toHaveBeenCalledWith("reaction:accounts", "delete", { });
 
   expect(result).toEqual(fakeResult);
 });

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -1,4 +1,5 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
 import removeUserPermissions from "./removeUserPermissions.js";
 
 mockContext.mutations.removeUserPermissions = jest.fn().mockName("mutations.removeUserPermissions");
@@ -7,38 +8,49 @@ mockContext.validatePermissions = jest.fn().mockName("validatePermissions");
 test("removeUserPermissions must correctly passes through to internal removeUserPermissions mutation function", async () => {
   const groups = ["test-group-id"];
   const clientMutationId = "SOME_CLIENT_MUTATION_ID";
+  const shopId = "test-shop-id";
+  const shopIdOpaque = encodeOpaqueId("reaction/shop", shopId);
 
   const fakeResult = {
-    _id: "3vx5cqBZsymCfHbpf",
-    acceptsMarketing: false,
-    createdAt: "2019-11-05T16:34:49.644Z",
-    emails: [
-      {
-        address: "admin@localhost",
-        verified: true,
-        provides: "default"
-      }
-    ],
-    shopId: "test-shop-id",
-    state: "new",
-    userId: "3vx5cqBZsymCfHbpf",
-    accountId: "3vx5cqBZsymCfHbpf",
-    groups: [
-      "test-group-id"
-    ]
+    account: {
+      _id: "3vx5cqBZsymCfHbpf",
+      acceptsMarketing: false,
+      createdAt: "2019-11-05T16:34:49.644Z",
+      emails: [
+        {
+          address: "admin@localhost",
+          verified: true,
+          provides: "default"
+        }
+      ],
+      shopId,
+      state: "new",
+      userId: "3vx5cqBZsymCfHbpf",
+      accountId: "3vx5cqBZsymCfHbpf",
+      groups: [
+        "test-group-id"
+      ]
+    },
+    clientMutationId
   };
 
   mockContext.mutations.removeUserPermissions.mockReturnValueOnce(Promise.resolve(fakeResult));
 
   const result = await removeUserPermissions(null, {
     input: {
-      groups, clientMutationId
+      groups,
+      clientMutationId,
+      shopId: shopIdOpaque
     }
   }, mockContext);
 
   expect(mockContext.mutations.removeUserPermissions).toHaveBeenCalledWith(
     mockContext,
-    { groups: ["test-group-id"], clientMutationId }
+    {
+      groups: ["test-group-id"],
+      clientMutationId,
+      shopId
+    }
   );
 
   expect(result).toEqual(fakeResult);

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -1,11 +1,12 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import removeUserPermissions from "./removeUserPermissions.js";
 
-mockContext.mutations.addOrRemoveAccountGroups = jest.fn().mockName("mutations.addOrRemoveAccountGroups");
+mockContext.mutations.removeUserPermissions = jest.fn().mockName("mutations.removeUserPermissions");
 mockContext.validatePermissions = jest.fn().mockName("validatePermissions");
 
-test("removeUserPermissions must correctly passes through to internal addOrRemoveAccountGroups mutation function", async () => {
+test("removeUserPermissions must correctly passes through to internal removeUserPermissions mutation function", async () => {
   const groups = ["test-group-id"];
+  const clientMutationId = "SOME_CLIENT_MUTATION_ID";
 
   const fakeResult = {
     _id: "3vx5cqBZsymCfHbpf",
@@ -27,16 +28,16 @@ test("removeUserPermissions must correctly passes through to internal addOrRemov
     ]
   };
 
-  mockContext.mutations.addOrRemoveAccountGroups.mockReturnValueOnce(Promise.resolve(fakeResult));
+  mockContext.mutations.removeUserPermissions.mockReturnValueOnce(Promise.resolve(fakeResult));
   mockContext.validatePermissions.mockReturnValueOnce(Promise.resolve({ allow: true }));
 
   const result = await removeUserPermissions(null, {
     input: {
-      groups
+      groups, clientMutationId
     }
   }, mockContext);
 
-  expect(mockContext.mutations.addOrRemoveAccountGroups).toHaveBeenCalledWith(
+  expect(mockContext.mutations.removeUserPermissions).toHaveBeenCalledWith(
     mockContext,
     { groups: ["test-group-id"] }
   );

--- a/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeUserPermissions.test.js
@@ -14,26 +14,23 @@ test("removeUserPermissions must correctly passes through to internal removeUser
   const accountIdOpaque = encodeOpaqueId("reaction/account", accountId);
 
   const fakeResult = {
-    account: {
-      _id: accountId,
-      acceptsMarketing: false,
-      createdAt: "2019-11-05T16:34:49.644Z",
-      emails: [
-        {
-          address: "admin@localhost",
-          verified: true,
-          provides: "default"
-        }
-      ],
-      shopId,
-      state: "new",
-      userId: "3vx5cqBZsymCfHbpf",
-      accountId: "3vx5cqBZsymCfHbpf",
-      groups: [
-        "test-group-id"
-      ]
-    },
-    clientMutationId
+    _id: accountId,
+    acceptsMarketing: false,
+    createdAt: "2019-11-05T16:34:49.644Z",
+    emails: [
+      {
+        address: "admin@localhost",
+        verified: true,
+        provides: "default"
+      }
+    ],
+    shopId,
+    state: "new",
+    userId: "3vx5cqBZsymCfHbpf",
+    accountId: "3vx5cqBZsymCfHbpf",
+    groups: [
+      "test-group-id"
+    ]
   };
 
   mockContext.mutations.removeUserPermissions.mockReturnValueOnce(Promise.resolve(fakeResult));
@@ -57,5 +54,6 @@ test("removeUserPermissions must correctly passes through to internal removeUser
     }
   );
 
-  expect(result).toEqual(fakeResult);
+  const expected = { account: fakeResult, clientMutationId };
+  expect(result).toEqual(expected);
 });

--- a/src/core-services/account/schemas/account.graphql
+++ b/src/core-services/account/schemas/account.graphql
@@ -136,6 +136,16 @@ input RemoveAccountEmailRecordInput {
   email: Email!
 }
 
+"Defines groups to be removed from an account group. Removin an group from an account effectively also removes permissions from the account"
+input RemoveUserPermissionsInput {
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+  "the groups to remove from a user / account"
+  groups: [String!]!
+  "the opaque shopId of the shop"
+  shopId: String!
+}
+
 "Per-account tax exemption settings used by the Avalara plugin"
 type TaxSettings {
   "Customer usage type. A value matching the `code` field of one TaxEntityCode, or any custom string."
@@ -349,6 +359,14 @@ type SetAccountProfileLanguagePayload {
   clientMutationId: String
 }
 
+"The response from the `removeUserPermissionsMutation` mutation"
+type RemoveUserPermissionsPayload {
+  "The updated account"
+  account: Account!
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+}
+
 extend type Shop {
   """
   Returns a list of administrators for this shop, as a Relay-compatible connection.
@@ -429,6 +447,12 @@ extend type Mutation {
     "Mutation input"
     input: UpdateAccountAddressBookEntryInput!
   ): UpdateAccountAddressBookEntryPayload
+
+  "Remove one or more groups from the account. The user id / account id must be set in the context"
+  removeUserPermissions(
+    "Mutation input"
+    input: RemoveUserPermissionsInput!
+  ): RemoveUserPermissionsPayload
 }
 
 extend type Query {

--- a/src/core-services/account/schemas/account.graphql
+++ b/src/core-services/account/schemas/account.graphql
@@ -138,6 +138,8 @@ input RemoveAccountEmailRecordInput {
 
 "Defines groups to be removed from an account group. Removin an group from an account effectively also removes permissions from the account"
 input RemoveUserPermissionsInput {
+  "the opaque account Id of the user who is to be removed from the group"
+  accountId: String!
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
   "the groups to remove from a user / account"

--- a/tests/integration/api/mutations/removeUserPermissions/__snapshots__/removeUserPermissions.test.js.snap
+++ b/tests/integration/api/mutations/removeUserPermissions/__snapshots__/removeUserPermissions.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`anyone without the required permissions should be denied access to add group to an account 1`] = `
+exports[`anyone without the required permissions should be denied access to remove group from an account 1`] = `
 Object {
   "extensions": Object {
     "code": "FORBIDDEN",

--- a/tests/integration/api/mutations/removeUserPermissions/__snapshots__/removeUserPermissions.test.js.snap
+++ b/tests/integration/api/mutations/removeUserPermissions/__snapshots__/removeUserPermissions.test.js.snap
@@ -24,3 +24,67 @@ Object {
   ],
 }
 `;
+
+exports[`anyone without the required permissions should be denied access to remove group from an account 2`] = `
+Object {
+  "extensions": Object {
+    "code": "BAD_USER_INPUT",
+    "exception": Object {
+      "details": Array [
+        Object {
+          "message": "You must specify at least 1 values",
+          "minCount": 1,
+          "name": "groups",
+          "type": "minCount",
+          "value": Array [],
+        },
+      ],
+      "error": "validation-error",
+      "errorType": "ClientError",
+      "name": "ClientError",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "You must specify at least 1 values",
+  "path": Array [
+    "removeUserPermissions",
+  ],
+}
+`;
+
+exports[`should throw if a groups array is empty 1`] = `
+Object {
+  "extensions": Object {
+    "code": "BAD_USER_INPUT",
+    "exception": Object {
+      "details": Array [
+        Object {
+          "message": "You must specify at least 1 values",
+          "minCount": 1,
+          "name": "groups",
+          "type": "minCount",
+          "value": Array [],
+        },
+      ],
+      "error": "validation-error",
+      "errorType": "ClientError",
+      "name": "ClientError",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "You must specify at least 1 values",
+  "path": Array [
+    "removeUserPermissions",
+  ],
+}
+`;

--- a/tests/integration/api/mutations/removeUserPermissions/__snapshots__/removeUserPermissions.test.js.snap
+++ b/tests/integration/api/mutations/removeUserPermissions/__snapshots__/removeUserPermissions.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`anyone without the required permissions should be denied access to add group to an account 1`] = `
+Object {
+  "extensions": Object {
+    "code": "FORBIDDEN",
+    "exception": Object {
+      "details": Object {},
+      "error": "access-denied",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Access Denied",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Access Denied",
+  "path": Array [
+    "removeUserPermissions",
+  ],
+}
+`;

--- a/tests/integration/api/mutations/removeUserPermissions/__snapshots__/removeUserPermissions.test.js.snap
+++ b/tests/integration/api/mutations/removeUserPermissions/__snapshots__/removeUserPermissions.test.js.snap
@@ -25,38 +25,6 @@ Object {
 }
 `;
 
-exports[`anyone without the required permissions should be denied access to remove group from an account 2`] = `
-Object {
-  "extensions": Object {
-    "code": "BAD_USER_INPUT",
-    "exception": Object {
-      "details": Array [
-        Object {
-          "message": "You must specify at least 1 values",
-          "minCount": 1,
-          "name": "groups",
-          "type": "minCount",
-          "value": Array [],
-        },
-      ],
-      "error": "validation-error",
-      "errorType": "ClientError",
-      "name": "ClientError",
-    },
-  },
-  "locations": Array [
-    Object {
-      "column": 3,
-      "line": 2,
-    },
-  ],
-  "message": "You must specify at least 1 values",
-  "path": Array [
-    "removeUserPermissions",
-  ],
-}
-`;
-
 exports[`should throw if a groups array is empty 1`] = `
 Object {
   "extensions": Object {

--- a/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
+++ b/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
@@ -169,3 +169,16 @@ test("anyone without the required permissions should be denied access to remove 
   expect(err[0]).toMatchSnapshot();
 });
 
+
+test("should throw if a groups array is empty", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  let err = null;
+  try {
+    await removeUserPermissions({ groups: [], shopId: shopOpaqueId, accountId: mockAdminAccountIdOpaque });
+  } catch (errors) {
+    err = errors;
+  }
+  expect(err).toBeTruthy();
+  expect(err[0]).toMatchSnapshot();
+});

--- a/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
+++ b/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
@@ -1,0 +1,159 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const RemoveUserPermissionsMutation = importAsString("./removeUserPermissionsMutation.graphql");
+
+jest.setTimeout(300000);
+
+let removeUserPermissions;
+let customerGroup;
+let mockAdminAccount;
+let mockOtherAccount;
+let shopId;
+let shopManagerGroup;
+let shopOpaqueId;
+let testApp;
+const shopManagerGroupName = "shop manager";
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  shopId = await testApp.insertPrimaryShop();
+
+  mockAdminAccount = Factory.Account.makeOne({
+    _id: "mockAdminAccount",
+    roles: {
+      [shopId]: ["reaction-accounts"]
+    },
+    groups: [shopManagerGroupName],
+    shopId
+  });
+  await testApp.createUserAndAccount(mockAdminAccount);
+
+  mockOtherAccount = Factory.Account.makeOne({
+    _id: "mockOtherAccount",
+    groups: [],
+    roles: {},
+    shopId
+  });
+  await testApp.createUserAndAccount(mockOtherAccount);
+
+  shopManagerGroup = Factory.Group.makeOne({
+    createdBy: null,
+    name: shopManagerGroupName,
+    permissions: ["admin", "shopManagerGroupPermission"],
+    slug: shopManagerGroupName,
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(shopManagerGroup);
+
+  customerGroup = Factory.Group.makeOne({
+    createdBy: null,
+    name: "customer",
+    permissions: ["customerGroupPermission"],
+    slug: "customer",
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(customerGroup);
+
+  shopOpaqueId = encodeOpaqueId("reaction/shop", shopId);
+
+  removeUserPermissions = testApp.mutate(RemoveUserPermissionsMutation);
+});
+
+afterAll(async () => {
+  testApp.collections.Accounts.deleteMany({});
+  testApp.collections.Shops.deleteMany({});
+  testApp.collections.users.deleteMany({});
+  testApp.collections.Groups.deleteMany({});
+  await testApp.stop();
+});
+
+beforeEach(async () => {
+  await testApp.collections.Accounts.updateOne({ _id: mockOtherAccount._id }, {
+    $set: {
+      groups: []
+    }
+  });
+
+  await testApp.collections.users.updateOne({ _id: mockOtherAccount._id }, {
+    $set: {
+      roles: {}
+    }
+  });
+});
+
+test("anyone can with the required permissions can remove a group(s) to an account", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  const groupName = "test-group-1";
+  // The group that is to be removed from the  account
+  const testGroup1 = Factory.Group.makeOne({
+    createdBy: null,
+    name: groupName,
+    permissions: ["test-group-1-permission"],
+    slug: groupName,
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(testGroup1);
+  const updatedAccountBeforeGroupRemoval = await testApp.collections.Accounts.findOneAndUpdate(
+    {
+      _id: mockAdminAccount._id
+    }, {
+      $addToSet: {
+        groups: {
+          $each: [groupName]
+        }
+      }
+    },
+    { returnOriginal: false }
+  );
+
+
+  await removeUserPermissions({ groups: ["test-group-1"], shopId: shopOpaqueId });
+  const dbResult = await testApp.collections.Accounts.findOne({ _id: mockAdminAccount._id });
+
+  expect(updatedAccountBeforeGroupRemoval.value.groups.length).toEqual(2);
+  expect(updatedAccountBeforeGroupRemoval.value.groups).toEqual(expect.arrayContaining(["test-group-1"]));
+  expect(dbResult.groups).toEqual(expect.not.arrayContaining(["test-group-1"]));
+  expect(dbResult.groups.length).toBe(1);
+});
+
+
+test("anyone without the required permissions should be denied access to add group to an account", async () => {
+  await testApp.setLoggedInUser(mockOtherAccount);
+
+  const groupName = "test-group-1";
+  // The group that is to be added tp th  account
+  const testGroup1 = Factory.Group.makeOne({
+    createdBy: null,
+    name: groupName,
+    permissions: ["test-group-1-permission"],
+    slug: groupName,
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(testGroup1);
+  await testApp.collections.Accounts.findOneAndUpdate(
+    {
+      _id: mockAdminAccount._id
+    }, {
+      $addToSet: {
+        groups: {
+          $each: [groupName]
+        }
+      }
+    },
+    { returnOriginal: false }
+  );
+
+  let err = null;
+  try {
+    await removeUserPermissions({ groups: ["test-group-1"], shopId: shopOpaqueId });
+  } catch (errors) {
+    err = errors;
+  }
+  expect(err).toBeTruthy();
+  expect(err[0]).toMatchSnapshot();
+});
+

--- a/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
+++ b/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
@@ -141,7 +141,9 @@ test("anyone without the required permissions should be denied access to remove 
     slug: groupName,
     shopId
   });
+
   await testApp.collections.Groups.insertOne(testGroup1);
+
   await testApp.collections.Accounts.findOneAndUpdate(
     {
       _id: mockAdminAccount._id
@@ -157,7 +159,7 @@ test("anyone without the required permissions should be denied access to remove 
 
   let err = null;
   try {
-    await removeUserPermissions({ groups: ["test-group-1"], shopId: shopOpaqueId, accountId: mockOtherAccountIdOpaque });
+    await removeUserPermissions({ groups: ["test-group-1"], shopId: shopOpaqueId, accountId: mockAdminAccountId });
   } catch (errors) {
     err = errors;
   }

--- a/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
+++ b/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
@@ -10,6 +10,7 @@ jest.setTimeout(300000);
 let removeUserPermissions;
 let customerGroup;
 let mockAdminAccount;
+let mockAdminAccountIdOpaque;
 let mockOtherAccount;
 let mockOtherAccountIdOpaque;
 let shopId;
@@ -63,6 +64,7 @@ beforeAll(async () => {
   await testApp.collections.Groups.insertOne(customerGroup);
 
   shopOpaqueId = encodeOpaqueId("reaction/shop", shopId);
+  mockAdminAccountIdOpaque = encodeOpaqueId("reaction/account", mockAdminAccountId);
   mockOtherAccountIdOpaque = encodeOpaqueId("reaction/account", mockOtherAccountId);
 
   removeUserPermissions = testApp.mutate(RemoveUserPermissionsMutation);
@@ -159,7 +161,7 @@ test("anyone without the required permissions should be denied access to remove 
 
   let err = null;
   try {
-    await removeUserPermissions({ groups: ["test-group-1"], shopId: shopOpaqueId, accountId: mockAdminAccountId });
+    await removeUserPermissions({ groups: ["test-group-1"], shopId: shopOpaqueId, accountId: mockAdminAccountIdOpaque });
   } catch (errors) {
     err = errors;
   }

--- a/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
+++ b/tests/integration/api/mutations/removeUserPermissions/removeUserPermissions.test.js
@@ -121,7 +121,7 @@ test("anyone can with the required permissions can remove a group(s) to an accou
 });
 
 
-test("anyone without the required permissions should be denied access to add group to an account", async () => {
+test("anyone without the required permissions should be denied access to remove group from an account", async () => {
   await testApp.setLoggedInUser(mockOtherAccount);
 
   const groupName = "test-group-1";

--- a/tests/integration/api/mutations/removeUserPermissions/removeUserPermissionsMutation.graphql
+++ b/tests/integration/api/mutations/removeUserPermissions/removeUserPermissionsMutation.graphql
@@ -1,0 +1,19 @@
+mutation removeUserPermissions($groups: [String!]!, $shopId: String! ) {
+
+  removeUserPermissions (input: {
+    groups: $groups
+    shopId: $shopId
+  }) {
+    account {
+      groups {
+        nodes {
+          _id
+          description
+          name
+          permissions
+        }
+      }
+    }
+  }
+
+}

--- a/tests/integration/api/mutations/removeUserPermissions/removeUserPermissionsMutation.graphql
+++ b/tests/integration/api/mutations/removeUserPermissions/removeUserPermissionsMutation.graphql
@@ -1,8 +1,9 @@
-mutation removeUserPermissions($groups: [String!]!, $shopId: String! ) {
+mutation removeUserPermissions($accountId: String!, $shopId: String!, $groups: [String!]! ) {
 
   removeUserPermissions (input: {
-    groups: $groups
     shopId: $shopId
+    accountId: $accountId
+    groups: $groups
   }) {
     account {
       groups {


### PR DESCRIPTION
Resolves #5830, #5957
Impact: **major**  
Type: **feature**

## Issue
 
This PR  started off as 

>We need to add a GraphQL equivalent of the `removeUserPermissions` found in `reaction-admin` at https://github.com/reactioncommerce/reaction-admin/blob/trunk/imports/plugins/core/accounts/server/methods/removeUserPermissions.js into reaction. This will allow for removing an account from a group( called `role` in `reaction-authorization`) and therefore denying that account a set of permissions (called `policies` in `reaction-authorization` service). This will also help our demeteorization efforts and also help transition to reaction-authorization service

After much discussion (see discussion here https://github.com/reactioncommerce/reaction/pull/5842#issuecomment-567471818), we have decided that we dont need `removeUserPermissions` found in `reaction-admin`. We instead need to add `removeAccountFromGroups` that allows for the removal of an account from a group

We also need to add integration tests and unit tests for the newly created `removeAccountFromGroups`

## Solution

- Add GraphQL equivalent of `removeAccountFromGroups` found in `reaction-admin` to `reaction` (resolver function and mutation functions)
- Add integration and unit tests for the newly created GQL `removeAccountFromGroups`

## Breaking changes

none

## Testing

1. Tests should pass on CI
2. integration tests are found at 
 - **tests/integration/api/mutations/removeAccountFromGroups/removeAccountFromGroups.test.js**
3. unit tests are found at 
 - `src/core-services/account/resolvers/Mutation/removeAccountFromGroups.test.js`
4. run the tests with `npm run test`
