### PR TITLE
feat: Update brand assets and parcel size on shop (GQL)

### DIFF
--- a/src/core-services/shop/mutations/updateShop.js
+++ b/src/core-services/shop/mutations/updateShop.js
@@ -13,6 +13,10 @@ const inputSchema = new SimpleSchema({
   "addressBook.$": {
     type: ShopAddress
   },
+  "brandAssets": {
+    type: String,
+    optional: true
+  },
   "description": {
     type: String,
     optional: true
@@ -64,6 +68,7 @@ const complexSettings = [
  * @param {String} input.description - The shop's description
  * @param {Array} input.addressBook - The shop's physical address
  * @param {Boolean} input.allowGuestCheckout - Allow user to checkout without creating an account
+ * @param {String} input.brandAssets - A media record id to use as the shop's brand asset
  * @param {Array} input.emails - The shop's primary email address
  * @param {String} input.keywords - The shop's keywords
  * @param {String} input.name - The shop's name
@@ -99,6 +104,19 @@ export default async function updateShop(context, input) {
       && !complexSettings.includes(setting)
     ) {
       sets[setting] = shopSettings[setting];
+      return;
+    }
+
+    // Accept a string media record ID for the brandAssets array, and convert it to an
+    // array of a single object. The `brandAssets` resolver for shop only returns
+    // a single brand asset. "navbarBrandImage" has been the only brand asset used.
+    // With the move to have a separate storefront and login apps, brand assets shouldn't
+    // be used and other methods, like the settings api or .env vars, should be preferred.
+    if (setting === "brandAssets") {
+      sets[setting] = [{
+        mediaId: shopSettings[setting],
+        type: "navbarBrandImage"
+      }];
       return;
     }
 

--- a/src/core-services/shop/mutations/updateShop.js
+++ b/src/core-services/shop/mutations/updateShop.js
@@ -1,5 +1,5 @@
 import SimpleSchema from "simpl-schema";
-import { Email, ShopAddress, ShopLogoUrls, StorefrontUrls } from "../simpleSchemas.js";
+import { Email, ParcelSize, ShopAddress, ShopLogoUrls, StorefrontUrls } from "../simpleSchemas.js";
 
 const inputSchema = new SimpleSchema({
   "addressBook": {
@@ -19,6 +19,10 @@ const inputSchema = new SimpleSchema({
   },
   "description": {
     type: String,
+    optional: true
+  },
+  "defaultParcelSize": {
+    type: ParcelSize,
     optional: true
   },
   "emails": {
@@ -133,6 +137,11 @@ export default async function updateShop(context, input) {
       Object.keys(addressBookEntry).forEach((key) => {
         sets[`addressBook.0.${key}`] = addressBookEntry[key];
       });
+      return;
+    }
+
+    if (setting === "defaultParcelSize") {
+      sets[setting] = shopSettings[setting];
       return;
     }
 

--- a/src/core-services/shop/resolvers/Mutation/updateShop.js
+++ b/src/core-services/shop/resolvers/Mutation/updateShop.js
@@ -10,6 +10,7 @@ import { decodeMediaRecordOpaqueId, decodeShopOpaqueId } from "../../xforms/id.j
  * @param {String} input.description - The shop's description
  * @param {Array} input.addressBook - The shop's physical address
  * @param {Boolean} input.allowGuestCheckout - Allow user to checkout without creating an account
+ * @param {String} input.brandAssets - A media record id to use as the shop's brand asset
  * @param {Array} input.emails - The shop's primary email address
  * @param {String} input.keywords - The shop's keywords
  * @param {Object} arts.input.name - The shop's name

--- a/src/core-services/shop/resolvers/Mutation/updateShop.js
+++ b/src/core-services/shop/resolvers/Mutation/updateShop.js
@@ -1,4 +1,4 @@
-import { decodeShopOpaqueId } from "../../xforms/id.js";
+import { decodeMediaRecordOpaqueId, decodeShopOpaqueId } from "../../xforms/id.js";
 
 /**
  * @name Mutation/updateShop
@@ -26,6 +26,11 @@ export default async function updateShop(_, { input }, context) {
     ...passThroughInput
   } = input;
   const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  // Decode brand asset media record id
+  if (passThroughInput.brandAssets) {
+    passThroughInput.brandAssets = decodeMediaRecordOpaqueId(passThroughInput.brandAssets);
+  }
 
   const updatedShop = await context.mutations.updateShop(context, {
     ...passThroughInput,

--- a/src/core-services/shop/schemas/schema.graphql
+++ b/src/core-services/shop/schemas/schema.graphql
@@ -31,6 +31,21 @@ type StorefrontUrls {
   storefrontOrdersUrl: String
 }
 
+"Parcel size"
+type ShopParcelSize {
+  "Parcel height"
+  height: Float!
+
+  "Parcel length"
+  length: Float!
+
+  "Parcel weight"
+  weight: Float!
+
+  "Parcel width"
+  width: Float!
+}
+
 "Represents a Reaction shop"
 type Shop implements Node {
   "The shop ID"
@@ -59,6 +74,9 @@ type Shop implements Node {
 
   "The ID of the shop's default navigation tree"
   defaultNavigationTreeId: String
+
+  "Default parcel size for this shop"
+  defaultParcelSize: ShopParcelSize
 
   "Shop description"
   description: String

--- a/src/core-services/shop/schemas/updateShop.graphql
+++ b/src/core-services/shop/schemas/updateShop.graphql
@@ -22,6 +22,21 @@ input ShopLogoUrlsInput {
   primaryShopLogoUrl: String
 }
 
+"Parcel size input"
+input ShopParcelSizeInput {
+  "Parcel height"
+  height: Float!
+
+  "Parcel length"
+  length: Float!
+
+  "Parcel weight"
+  weight: Float!
+
+  "Parcel width"
+  width: Float!
+}
+
 "Input parameters for the updateShop mutation"
 input UpdateShopInput {
   "An address book entry to set the primary shop's address"
@@ -35,6 +50,9 @@ input UpdateShopInput {
 
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
+
+  "Default parcel size used for this shop"
+  defaultParcelSize: ShopParcelSizeInput
 
   "The shop's description"
   description: String

--- a/src/core-services/shop/schemas/updateShop.graphql
+++ b/src/core-services/shop/schemas/updateShop.graphql
@@ -30,6 +30,9 @@ input UpdateShopInput {
   "Whether to allow user to checkout without creating an account"
   allowGuestCheckout: Boolean
 
+  "ID of media record to be used as the brand asset"
+  brandAssets: ID
+
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
 

--- a/src/core-services/shop/xforms/id.js
+++ b/src/core-services/shop/xforms/id.js
@@ -2,9 +2,12 @@ import decodeOpaqueIdForNamespace from "@reactioncommerce/api-utils/decodeOpaque
 import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
 
 const namespaces = {
-  Shop: "reaction/shop"
+  Shop: "reaction/shop",
+  MediaRecord: "reaction/mediaRecord"
 };
 
+export const encodeMediaRecordOpaqueId = encodeOpaqueId(namespaces.MediaRecord);
 export const encodeShopOpaqueId = encodeOpaqueId(namespaces.Shop);
 
+export const decodeMediaRecordOpaqueId = decodeOpaqueIdForNamespace(namespaces.MediaRecord);
 export const decodeShopOpaqueId = decodeOpaqueIdForNamespace(namespaces.Shop);

--- a/tests/integration/api/mutations/updateShop/UpdateShopMutation.graphql
+++ b/tests/integration/api/mutations/updateShop/UpdateShopMutation.graphql
@@ -16,6 +16,12 @@ mutation updateShop($input: UpdateShopInput!) {
         isShippingDefault
       }
       allowGuestCheckout
+      defaultParcelSize {
+        width
+        length
+        height
+        weight
+      }
       description
       emails {
         address

--- a/tests/integration/api/mutations/updateShop/UpdateShopMutation.graphql
+++ b/tests/integration/api/mutations/updateShop/UpdateShopMutation.graphql
@@ -16,6 +16,16 @@ mutation updateShop($input: UpdateShopInput!) {
         isShippingDefault
       }
       allowGuestCheckout
+      brandAssets {
+        navbarBrandImage {
+          large
+          medium
+          original
+          small
+          thumbnail
+        }
+        navbarBrandImageId
+      }
       defaultParcelSize {
         width
         length

--- a/tests/integration/api/mutations/updateShop/updateShop.test.js
+++ b/tests/integration/api/mutations/updateShop/updateShop.test.js
@@ -94,6 +94,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  await testApp.collections.MediaRecords.deleteMany();
   await testApp.collections.Accounts.deleteMany();
   await testApp.collections.Shops.deleteMany();
   await testApp.stop();

--- a/tests/integration/api/mutations/updateShop/updateShop.test.js
+++ b/tests/integration/api/mutations/updateShop/updateShop.test.js
@@ -53,6 +53,12 @@ test("user with admin/owner roles can update various shop settings", async () =>
       }
     ],
     allowGuestCheckout: true,
+    defaultParcelSize: {
+      width: 20,
+      length: 20,
+      height: 10,
+      weight: 15
+    },
     description: "My shop is super awesome!",
     emails: [
       {

--- a/tests/integration/api/mutations/updateShop/updateShop.test.js
+++ b/tests/integration/api/mutations/updateShop/updateShop.test.js
@@ -7,6 +7,71 @@ const UpdateShopMutation = importAsString("./UpdateShopMutation.graphql");
 
 jest.setTimeout(300000);
 
+const mockMediaRecord = {
+  _id: "mediaRecord-1",
+  original: {
+    name: "hats.jpg",
+    size: 120629,
+    type: "image/jpeg",
+    updatedAt: "2018-06-25T17:20:47.335Z",
+    uploadedAt: "2018-06-25T17:21:11.192Z"
+  },
+  metadata: {
+    ownerId: "NGn6GR8L7DfWnfGCh",
+    shopId: "shopId",
+    priority: 1,
+    toGrid: 1,
+    workflow: "published"
+  },
+  copies: {
+    image: {
+      name: "hats.jpg",
+      type: "image/jpeg",
+      key: "5b312541d2bc3f00fe7cab1c",
+      storageAdapter: "gridfs",
+      size: 103909,
+      updatedAt: "2018-06-25T17:24:17.717Z",
+      createdAt: "2018-06-25T17:24:17.717Z"
+    },
+    large: {
+      name: "hats.jpg",
+      type: "image/jpeg",
+      key: "5b312541d2bc3f00fe7cab1e",
+      storageAdapter: "gridfs",
+      size: 49330,
+      updatedAt: "2018-06-25T17:24:17.789Z",
+      createdAt: "2018-06-25T17:24:17.789Z"
+    },
+    medium: {
+      name: "hats.jpg",
+      type: "image/jpeg",
+      key: "5b312541d2bc3f00fe7cab20",
+      storageAdapter: "gridfs",
+      size: 20087,
+      updatedAt: "2018-06-25T17:24:17.838Z",
+      createdAt: "2018-06-25T17:24:17.838Z"
+    },
+    small: {
+      name: "hats.png",
+      type: "image/png",
+      key: "5b312541d2bc3f00fe7cab22",
+      storageAdapter: "gridfs",
+      size: 150789,
+      updatedAt: "2018-06-25T17:24:17.906Z",
+      createdAt: "2018-06-25T17:24:17.906Z"
+    },
+    thumbnail: {
+      name: "hats.png",
+      type: "image/png",
+      key: "5b312541d2bc3f00fe7cab24",
+      storageAdapter: "gridfs",
+      size: 27795,
+      updatedAt: "2018-06-25T17:24:17.946Z",
+      createdAt: "2018-06-25T17:24:17.946Z"
+    }
+  }
+};
+
 let testApp;
 let updateShop;
 let shopId;
@@ -15,6 +80,8 @@ beforeAll(async () => {
   testApp = new TestApp();
   await testApp.start();
   shopId = await testApp.insertPrimaryShop();
+
+  testApp.collections.MediaRecords.insertOne(mockMediaRecord);
 
   mockAdminAccount = Factory.Account.makeOne({
     roles: {
@@ -53,6 +120,7 @@ test("user with admin/owner roles can update various shop settings", async () =>
       }
     ],
     allowGuestCheckout: true,
+    brandAssets: encodeOpaqueId("reaction/mediaRecord", "mediaRecord-1"),
     defaultParcelSize: {
       width: 20,
       length: 20,
@@ -91,5 +159,19 @@ test("user with admin/owner roles can update various shop settings", async () =>
     return;
   }
 
-  expect(result.updateShop.shop).toEqual(mockShopSettings);
+  const expectedShopSettings = {
+    ...mockShopSettings,
+    brandAssets: {
+      navbarBrandImage: {
+        large: "https://shop.fake.site/assets/files/Media/mediaRecord-1/large/hats.jpg",
+        medium: "https://shop.fake.site/assets/files/Media/mediaRecord-1/medium/hats.jpg",
+        original: "https://shop.fake.site/assets/files/Media/mediaRecord-1/image/hats.jpg",
+        small: "https://shop.fake.site/assets/files/Media/mediaRecord-1/small/hats.png",
+        thumbnail: "https://shop.fake.site/assets/files/Media/mediaRecord-1/thumbnail/hats.png"
+      },
+      navbarBrandImageId: "mediaRecord-1"
+    }
+  };
+
+  expect(result.updateShop.shop).toEqual(expectedShopSettings);
 });


### PR DESCRIPTION
Resolves #5845  
Impact: **minor**  
Type: **feature**

## Issue

Add mutations for...
- `shop/updateDefaultParcelSize`
- `shop/updateBrandAssets`

## Solution

Update the current `updateShop` mutation to accepts parcel size and brand assets.

## Breaking changes

Brand assets, while still an array in the database, will now be treated an a single object when updating has it has been treated as a single object when querying.

## Testing
1. Update fields on shop (see mutations below)

### Update default parcel size
```graphql
mutation updateShop($input: UpdateShopInput!) {
  updateShop(input: $input) {
    shop {
      defaultParcelSize {
        width
        height
        length
        weight
      }
    }
  }
}
```

```json
{
  "input": {
    "defaultParcelSize": {
      "weight": 255.55,
      "height": 255.23,
      "length": 200.11,
      "width": 200.02
    }
  }
}
```

### Update brand assets
```graphql
mutation updateShop($input: UpdateShopInput!) {
  updateShop(input: $input) {
    shop {
      brandAssets {
        navbarBrandImage {
          large
          medium
          original
          small
          thumbnail
        }
        navbarBrandImageId
      }
    }
  }
}
```

If you're using the standard data dump, this ID should work, otherwise, its an encoded `reaction/mediaRecord:mongo_id` id

```json
{
  "input": {
    "brandAssets": "cmVhY3Rpb24vbWVkaWFSZWNvcmQ6NllCR2JKY3pYZURkRWVKeUU=",
  }
}
```