### PR TITLE
feat: Add Accounts GraphQL query to find non-admin accounts

### DIFF
--- a/src/core-services/account/queries/accounts.js
+++ b/src/core-services/account/queries/accounts.js
@@ -1,0 +1,31 @@
+/**
+ * @name accounts
+ * @method
+ * @memberof Accounts/NoMeteorQueries
+ * @summary query the Accounts collection and a list of non-admin accounts
+ * @param {Object} context - an object containing the per-request state
+ * @param {String} input - input for query
+ * @param {String} input.shopId - Shop ID to get accounts for
+ * @returns {Promise} Mongo cursor
+ */
+export default async function accounts(context, input) {
+  const { checkPermissions, collections } = context;
+  const { Accounts, Groups } = collections;
+  const { shopId } = input;
+
+  await checkPermissions(["reaction-accounts"], shopId);
+
+  const groups = await Groups.find({
+    name: { $in: ["guest", "customer"] },
+    shopId
+  }, {
+    fields: { _id: 1 }
+  }).toArray();
+
+  const groupIds = groups.map((group) => group._id);
+
+  return Accounts.find({
+    groups: { $in: groupIds },
+    shopId
+  });
+}

--- a/src/core-services/account/queries/index.js
+++ b/src/core-services/account/queries/index.js
@@ -1,3 +1,4 @@
+import accounts from "./accounts.js";
 import group from "./group.js";
 import groups from "./groups.js";
 import roles from "./roles.js";
@@ -5,6 +6,7 @@ import shopAdministrators from "./shopAdministrators.js";
 import userAccount from "./userAccount.js";
 
 export default {
+  accounts,
   group,
   groups,
   roles,

--- a/src/core-services/account/resolvers/Account/index.js
+++ b/src/core-services/account/resolvers/Account/index.js
@@ -16,7 +16,7 @@ export default {
   preferences: (account) => _.get(account, "profile.preferences"),
   primaryEmailAddress: (account) => {
     const primaryRecord = (account.emails || []).find((record) => record.provides === "default");
-    return (primaryRecord && primaryRecord.address) || null;
+    return (primaryRecord && primaryRecord.address) || "";
   },
   shop: resolveShopFromShopId
 };

--- a/src/core-services/account/resolvers/Query/accounts.js
+++ b/src/core-services/account/resolvers/Query/accounts.js
@@ -1,0 +1,29 @@
+import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
+import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
+import { decodeShopOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Query/accounts
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary query the Accounts collection and return a list of accounts
+ * @param {Object} _ - unused
+ * @param {Object} args - an object of all arguments that were sent by the client
+ * @param {String} args.shopId - Shop Id
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} info Info about the GraphQL request
+ * @returns {Promise<Object>} Promise containing queried accounts
+ */
+export default async function account(_, args, context, info) {
+  const { shopId: opaqueShopId, ...connectionArgs } = args;
+
+  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  const query = await context.queries.accounts(context, { shopId });
+
+  return getPaginatedResponse(query, connectionArgs, {
+    includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
+    includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
+    includeTotalCount: wasFieldRequested("totalCount", info)
+  });
+}

--- a/src/core-services/account/resolvers/Query/index.js
+++ b/src/core-services/account/resolvers/Query/index.js
@@ -1,4 +1,5 @@
 import account from "./account.js";
+import accounts from "./accounts.js";
 import administrators from "./administrators.js";
 import group from "./group.js";
 import groups from "./groups.js";
@@ -7,6 +8,7 @@ import viewer from "./viewer.js";
 
 export default {
   account,
+  accounts,
   administrators,
   group,
   groups,

--- a/src/core-services/account/schemas/account.graphql
+++ b/src/core-services/account/schemas/account.graphql
@@ -438,6 +438,30 @@ extend type Query {
     id: ID!
   ): Account
 
+  "Returns accounts for the provided shop ID"
+  accounts(
+    "The shop ID"
+    shopId: ID!
+
+    "Return accounts that are administrators in this shop"
+    shopId: ID!
+
+    "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
+    after: ConnectionCursor
+
+    "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
+    before: ConnectionCursor
+
+    "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
+    first: ConnectionLimitInt
+
+    "Return at most this many results. This parameter may be used with the `before` parameter."
+    last: ConnectionLimitInt
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int
+  ): AccountConnection
+
   """
   Returns a list of administrators for the shop with ID `shopId`, as a Relay-compatible connection.
   "Administrators" means all linked accounts that have the "admin" role for this shop.

--- a/tests/integration/api/queries/account/__snapshots__/accounts.test.js.snap
+++ b/tests/integration/api/queries/account/__snapshots__/accounts.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throws access-denied when getting accounts if not an admin 1`] = `
+Object {
+  "extensions": Object {
+    "code": "FORBIDDEN",
+    "exception": Object {
+      "details": Object {},
+      "error": "access-denied",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Access Denied",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Access Denied",
+  "path": Array [
+    "accounts",
+  ],
+}
+`;

--- a/tests/integration/api/queries/account/accounts.test.js
+++ b/tests/integration/api/queries/account/accounts.test.js
@@ -82,7 +82,13 @@ beforeAll(async () => {
   queryAccounts = testApp.query(accountsQuery);
 });
 
-afterAll(() => testApp.stop());
+afterAll(async () => {
+  await testApp.collections.Accounts.deleteMany({});
+  await testApp.collections.Groups.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.stop();
+});
+
 
 test("get all non-admin accounts", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);

--- a/tests/integration/api/queries/account/accounts.test.js
+++ b/tests/integration/api/queries/account/accounts.test.js
@@ -1,0 +1,119 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const accountsQuery = importAsString("./accountsQuery.graphql");
+
+jest.setTimeout(300000);
+
+const internalNonAdminAccountId = "123";
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const internalAdminAccountId = "456";
+const mockAccounts = [];
+
+for (let index = 100; index < 136; index += 1) {
+  const mockAccount = Factory.Account.makeOne({
+    _id: `account-${index}`,
+    shopId: internalShopId,
+    username: `username-${index}`,
+    groups: [
+      "group-customer"
+    ]
+  });
+
+  mockAccounts.push(mockAccount);
+}
+
+const mockCustomerGroup = {
+  _id: "group-customer",
+  name: "customer",
+  slug: "customer",
+  permissions: [
+    "guest",
+    "account/profile",
+    "product",
+    "tag",
+    "index",
+    "cart/checkout",
+    "cart/completed",
+    "notifications",
+    "reaction-paypal/paypalDone",
+    "reaction-paypal/paypalCancel",
+    "stripe/connect/authorize",
+    "account/verify",
+    "account/login",
+    "reset-password",
+    "not-found",
+    "account/enroll"
+  ],
+  shopId: internalShopId,
+  createdAt: "2018-06-22T20:35:33.369Z",
+  updatedAt: "2019-04-30T19:02:34.276Z"
+};
+
+let testApp;
+let queryAccounts;
+let mockAdminAccount;
+let mockNonAdminAccount;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+
+  mockAdminAccount = Factory.Account.makeOne({
+    _id: internalAdminAccountId,
+    shopId: internalShopId
+  });
+  await testApp.createUserAndAccount(mockAdminAccount, ["reaction-accounts"]);
+
+  mockNonAdminAccount = Factory.Account.makeOne({
+    _id: internalNonAdminAccountId
+  });
+  await testApp.createUserAndAccount(mockNonAdminAccount);
+
+  await testApp.collections.Groups.insertOne(mockCustomerGroup);
+
+  await Promise.all(mockAccounts.map((account) => (
+    testApp.createUserAndAccount(account, ["guest", "customer"])
+  )));
+
+  queryAccounts = testApp.query(accountsQuery);
+});
+
+afterAll(() => testApp.stop());
+
+test("get all non-admin accounts", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  let result;
+
+  try {
+    result = await queryAccounts({
+      shopId: opaqueShopId,
+      first: 10
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.accounts.nodes.length).toEqual(10);
+  expect(result.accounts.nodes[0]._id).toEqual(encodeOpaqueId("reaction/account", "account-100"));
+  expect(result.accounts.nodes[1]._id).toEqual(encodeOpaqueId("reaction/account", "account-101"));
+});
+
+test("throws access-denied when getting accounts if not an admin", async () => {
+  await testApp.setLoggedInUser(mockNonAdminAccount);
+
+  try {
+    await queryAccounts({
+      shopId: opaqueShopId,
+      first: 10
+    });
+  } catch (errors) {
+    expect(errors[0]).toMatchSnapshot();
+    return;
+  }
+});

--- a/tests/integration/api/queries/account/accountsQuery.graphql
+++ b/tests/integration/api/queries/account/accountsQuery.graphql
@@ -1,0 +1,61 @@
+query accounts(
+  $shopId: ID!,
+  $first: ConnectionLimitInt,
+  $last:  ConnectionLimitInt,
+  $before: ConnectionCursor,
+  $after: ConnectionCursor,
+  $offset: Int
+) {
+  accounts(
+    shopId: $shopId,
+    first: $first,
+    last: $last,
+    before: $before,
+    after: $after,
+    offset: $offset
+  ) {
+    nodes {
+      _id
+      addressBook {
+        nodes {
+          address1
+        }
+      }
+      createdAt
+      currency {
+        code
+      }
+      emailRecords {
+        address
+        verified
+      }
+      groups {
+        nodes {
+          _id
+          description
+          name
+          permissions
+        }
+      }
+      metafields {
+        key
+        scope
+        namespace
+        description
+        value
+        valueType
+      }
+      name
+      note
+      preferences
+      shop {
+        _id
+      }
+      taxSettings {
+        exemptionNo
+        customerUsageType
+      }
+      updatedAt
+    }
+  }
+}


### PR DESCRIPTION
Resolves #5847  
Impact: **minor**  
Type: **feature**

## Issue

No query for non-admin user accounts

## Solution

Add a query for non-admin user accounts

## Breaking changes

none

## Testing
1. Query user accounts

```graphql
query {
  accounts(shopId: "SHOP_ID") {
    nodes {
      _id
      firstName
      lastName
      name
      primaryEmailAddress
      groups {
        nodes {
          name
        }
      }
    }
  }
}
```