### PR TITLE
temp: lock `api-utils` version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,9 +1224,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@reactioncommerce/api-utils": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.5.0.tgz",
-      "integrity": "sha512-nCLdVRMpAd63GsXau0/x948JU0VY6vscwF7lCcve/AKbZuEn19A0KoOIK3Pfq7oXXPV/UZooTTg/WT6VUlzqJA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.6.0.tgz",
+      "integrity": "sha512-UQUinst6MO8/dP7dPwUmaFxudJEQZ5N1/X/Kj7qXK/41W8JgEc0XVQJJGyofIUsDqKrYFoxtro2VMeoJGJ8qkg==",
       "requires": {
         "@reactioncommerce/logger": "^1.1.2",
         "@reactioncommerce/random": "^1.0.1",
@@ -1380,7 +1380,7 @@
     },
     "@types/accepts": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "http://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "requires": {
         "@types/node": "*"
@@ -9709,9 +9709,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
     "pretty-format": {
       "version": "24.9.0",
@@ -11646,9 +11646,9 @@
           }
         },
         "yargs": {
-          "version": "14.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
-          "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
+          "version": "14.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
+          "integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
           "requires": {
             "cliui": "^5.0.0",
             "decamelize": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,9 +1224,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@reactioncommerce/api-utils": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.6.0.tgz",
-      "integrity": "sha512-UQUinst6MO8/dP7dPwUmaFxudJEQZ5N1/X/Kj7qXK/41W8JgEc0XVQJJGyofIUsDqKrYFoxtro2VMeoJGJ8qkg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.5.0.tgz",
+      "integrity": "sha512-nCLdVRMpAd63GsXau0/x948JU0VY6vscwF7lCcve/AKbZuEn19A0KoOIK3Pfq7oXXPV/UZooTTg/WT6VUlzqJA==",
       "requires": {
         "@reactioncommerce/logger": "^1.1.2",
         "@reactioncommerce/random": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/reactioncommerce/reaction/issues"
   },
   "dependencies": {
-    "@reactioncommerce/api-utils": "~1.5.0",
+    "@reactioncommerce/api-utils": "1.6.0",
     "@reactioncommerce/file-collections": "~0.7.0",
     "@reactioncommerce/file-collections-sa-gridfs": "~0.1.0",
     "@reactioncommerce/logger": "~1.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/reactioncommerce/reaction/issues"
   },
   "dependencies": {
-    "@reactioncommerce/api-utils": "1.6.0",
+    "@reactioncommerce/api-utils": "1.5.0",
     "@reactioncommerce/file-collections": "~0.7.0",
     "@reactioncommerce/file-collections-sa-gridfs": "~0.1.0",
     "@reactioncommerce/logger": "~1.1.2",


### PR DESCRIPTION
Lock the `release-3.0.0` branch into using `api-utils v1.6.0` for the time being, as I need to make some changes to `mockContext` to allow for our auth work to pass tests.

I will unlock the version number in #5772 which is where the auth changes will be merged.