### PR TITLE
Don't use Packages for tax settings, and tax rates GQL fixes

### DIFF
--- a/src/core-services/taxes/i18n/en.json
+++ b/src/core-services/taxes/i18n/en.json
@@ -13,18 +13,28 @@
           "taxesTitle": "Taxes",
           "taxesDescription": "Tax configuration"
         },
-        "taxGrid": {
-          "taxCode": "Item Code",
-          "rate": "Rate",
+        "taxFormFields": {
           "country": "Country",
+          "postal": "Postal code",
+          "rate": "Rate",
+          "ratePlaceholder": "Example: 0.05 means a 5% tax rate",
           "region": "Region",
-          "postal": "Postal"
+          "taxCode": "Tax code"
+        },
+        "taxFormHelpText": "For which destination addresses and for which products is this tax rate applicable? Leave these blank to apply this rate to every product and every destination address.",
+        "taxGrid": {
+          "any": "Any",
+          "country": "Country",
+          "newTaxRateButton": "New Tax Rate",
+          "postal": "Postal Code",
+          "rate": "Rate",
+          "region": "Region",
+          "taxCode": "Tax Code"
         },
         "settings": {
           "taxSettingsLabel": "Tax"
         },
         "taxSettings": {
-          "noCustomTaxRatesFound": "No custom tax rates found.",
           "shopCustomTaxRatesSaved": "Custom tax rate saved.",
           "shopCustomTaxRatesFailed": "Error saving tax rate.",
           "shopTaxMethodsSaved": "Saved tax method.",

--- a/src/core-services/taxes/index.js
+++ b/src/core-services/taxes/index.js
@@ -45,24 +45,28 @@ export default async function register(app) {
     },
     mutations,
     queries,
-    registry: [
-      {
-        provides: ["dashboard"],
-        name: "taxes",
-        label: "Taxes",
-        description: "Provide tax rates",
-        icon: "fa fa-university",
-        priority: 1,
-        container: "core",
-        workflow: "coreDashboardWorkflow"
+    shopSettingsConfig: {
+      defaultTaxCode: {
+        rolesThatCanEdit: ["admin", "tax-settings/write"],
+        simpleSchema: {
+          type: String,
+          min: 1
+        }
       },
-      {
-        label: "Tax Settings",
-        icon: "fa fa-university",
-        name: "taxes/settings",
-        provides: ["settings"],
-        template: "taxSettings"
+      fallbackTaxServiceName: {
+        rolesThatCanEdit: ["admin", "tax-settings/write"],
+        simpleSchema: {
+          type: String,
+          min: 1
+        }
+      },
+      primaryTaxServiceName: {
+        rolesThatCanEdit: ["admin", "tax-settings/write"],
+        simpleSchema: {
+          type: String,
+          min: 1
+        }
       }
-    ]
+    }
   });
 }

--- a/src/core-services/taxes/mutateNewVariantBeforeCreate.js
+++ b/src/core-services/taxes/mutateNewVariantBeforeCreate.js
@@ -11,10 +11,7 @@ export default async function mutateNewVariantBeforeCreate(newVariant, { context
     newVariant.isTaxable = true;
 
     // Give new variants the default tax code, if one is set
-    const plugin = await context.collections.Packages.findOne({ name: "reaction-taxes", shopId: newVariant.shopId });
-    if (!plugin) return;
-
-    const { defaultTaxCode } = plugin.settings || {};
+    const { defaultTaxCode } = await context.queries.appSettings(context, newVariant.shopId);
     if (!defaultTaxCode) return;
 
     newVariant.taxCode = defaultTaxCode;

--- a/src/core-services/taxes/registration.js
+++ b/src/core-services/taxes/registration.js
@@ -20,10 +20,7 @@ export function registerPluginHandler({ name: pluginName, taxServices: pluginTax
  *   primary and fallback tax services currently enabled for the shop with ID `shopId`.
  */
 export async function getTaxServicesForShop(context, shopId) {
-  const plugin = await context.collections.Packages.findOne({ name: "reaction-taxes", shopId });
-  if (!plugin) return {};
-
-  const { primaryTaxServiceName, fallbackTaxServiceName } = plugin.settings || {};
+  const { fallbackTaxServiceName, primaryTaxServiceName } = await context.queries.appSettings(context, shopId);
   if (!primaryTaxServiceName) return {}; // at least a primary service must be set
 
   const primaryTaxService = taxServices[primaryTaxServiceName];

--- a/src/core-services/taxes/registration.test.js
+++ b/src/core-services/taxes/registration.test.js
@@ -1,72 +1,78 @@
-import { cloneDeep } from "lodash";
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import { registerPluginHandler, getTaxServicesForShop } from "./registration.js";
 
 const fakeShopId = "FAKE_SHOP_ID";
-const fakePackage = {
-  _id: "FAKE_PKG_ID",
-  name: "fake",
-  shopId: fakeShopId,
-  settings: {
-    primaryTaxServiceName: "custom-rates",
-    fallbackTaxServiceName: "rapid-tax-service"
+
+const customRatesTaxService = {
+  displayName: "Custom Rates",
+  name: "custom-rates",
+  functions: {
+    calculateOrderTaxes() { },
+    getTaxCodes() { }
+  }
+};
+
+const rapidTaxService = {
+  displayName: "RapidTaxService",
+  name: "rapid-tax-service",
+  functions: {
+    calculateOrderTaxes() { },
+    getTaxCodes() { }
   }
 };
 
 // test pluginTaxServices
 const pluginTaxServices = [{
   name: "rapid-tax-service",
-  taxServices: [{
-    displayName: "RapidTaxService",
-    name: "rapid-tax-service",
-    functions: {
-      calculateOrderTaxes() { },
-      getTaxCodes() { }
-    }
-  }]
+  taxServices: [rapidTaxService]
 }, {
   name: "custom-rates",
-  taxServices: [{
-    displayName: "Custom Rates",
-    name: "custom-rates",
-    functions: {
-      calculateOrderTaxes() { },
-      getTaxCodes() { }
-    }
-  }]
+  taxServices: [customRatesTaxService]
 }];
 
 pluginTaxServices.forEach(({ name, taxServices }) => {
   registerPluginHandler({ name, taxServices });
 });
 
+mockContext.queries.appSettings = jest.fn().mockName("context.queries.appSettings");
+
 test("returns object containing primary tax service when available", async () => {
-  const testPackage = cloneDeep(fakePackage);
-  testPackage.settings.fallbackTaxServiceName = null;
-  mockContext.collections.Packages.findOne.mockReturnValueOnce(testPackage);
+  mockContext.queries.appSettings.mockReturnValueOnce({
+    fallbackTaxServiceName: null,
+    primaryTaxServiceName: "custom-rates"
+  });
   const result = await getTaxServicesForShop(mockContext, fakeShopId);
 
-  expect(mockContext.collections.Packages.findOne).toHaveBeenCalledWith({ name: "reaction-taxes", shopId: fakeShopId });
-  expect(typeof result.primaryTaxService).toEqual("object");
+  expect(mockContext.queries.appSettings).toHaveBeenCalledWith(mockContext, fakeShopId);
+  expect(result.fallbackTaxService).toBe(undefined);
+  expect(result.primaryTaxService).toEqual({
+    ...customRatesTaxService,
+    pluginName: "custom-rates"
+  });
 });
 
 test("returns an empty object when no primary tax service is found", async () => {
-  const testPackage = cloneDeep(fakePackage);
-  testPackage.settings = null;
-  mockContext.collections.Packages.findOne.mockReturnValueOnce(testPackage);
+  mockContext.queries.appSettings.mockReturnValueOnce({});
   const result = await getTaxServicesForShop(mockContext, fakeShopId);
 
-  expect(mockContext.collections.Packages.findOne).toHaveBeenCalledWith({ name: "reaction-taxes", shopId: fakeShopId });
-  expect(result.primaryTaxService).toEqual(undefined);
-  expect(result.fallbackTaxService).toEqual(undefined);
+  expect(mockContext.queries.appSettings).toHaveBeenCalledWith(mockContext, fakeShopId);
+  expect(result).toEqual({});
 });
 
 test("returns object containing both primary and fallback tax service when both are available", async () => {
-  const testPackage = cloneDeep(fakePackage);
-  mockContext.collections.Packages.findOne.mockReturnValueOnce(testPackage);
+  mockContext.queries.appSettings.mockReturnValueOnce({
+    fallbackTaxServiceName: "rapid-tax-service",
+    primaryTaxServiceName: "custom-rates"
+  });
   const result = await getTaxServicesForShop(mockContext, fakeShopId);
 
-  expect(mockContext.collections.Packages.findOne).toHaveBeenCalledWith({ name: "reaction-taxes", shopId: fakeShopId });
-  expect(typeof result.primaryTaxService).toEqual("object");
-  expect(typeof result.fallbackTaxService).toEqual("object");
+  expect(mockContext.queries.appSettings).toHaveBeenCalledWith(mockContext, fakeShopId);
+  expect(result.fallbackTaxService).toEqual({
+    ...rapidTaxService,
+    pluginName: "rapid-tax-service"
+  });
+  expect(result.primaryTaxService).toEqual({
+    ...customRatesTaxService,
+    pluginName: "custom-rates"
+  });
 });

--- a/src/core-services/taxes/resolvers/ShopSettings/index.js
+++ b/src/core-services/taxes/resolvers/ShopSettings/index.js
@@ -1,20 +1,15 @@
-import { decodeShopOpaqueId } from "../../xforms/id.js";
-
 // ShopSettings are public by default. Here we add a permission check.
 export default {
   async defaultTaxCode(settings, args, context) {
-    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], decodeShopOpaqueId(args.shopId));
-
+    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], settings.shopId);
     return settings.defaultTaxCode;
   },
   async fallbackTaxServiceName(settings, args, context) {
-    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], decodeShopOpaqueId(args.shopId));
-
+    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], settings.shopId);
     return settings.fallbackTaxServiceName;
   },
   async primaryTaxServiceName(settings, args, context) {
-    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], decodeShopOpaqueId(args.shopId));
-
+    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], settings.shopId);
     return settings.primaryTaxServiceName;
   }
 };

--- a/src/core-services/taxes/resolvers/ShopSettings/index.js
+++ b/src/core-services/taxes/resolvers/ShopSettings/index.js
@@ -1,0 +1,20 @@
+import { decodeShopOpaqueId } from "../../xforms/id.js";
+
+// ShopSettings are public by default. Here we add a permission check.
+export default {
+  async defaultTaxCode(settings, args, context) {
+    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], decodeShopOpaqueId(args.shopId));
+
+    return settings.defaultTaxCode;
+  },
+  async fallbackTaxServiceName(settings, args, context) {
+    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], decodeShopOpaqueId(args.shopId));
+
+    return settings.fallbackTaxServiceName;
+  },
+  async primaryTaxServiceName(settings, args, context) {
+    await context.checkPermissions(["admin", "tax-settings/write", "tax-settings/read"], decodeShopOpaqueId(args.shopId));
+
+    return settings.primaryTaxServiceName;
+  }
+};

--- a/src/core-services/taxes/resolvers/index.js
+++ b/src/core-services/taxes/resolvers/index.js
@@ -1,11 +1,13 @@
 import graphqlGroupXform from "../util/graphqlGroupXform.js";
 import graphqlItemXform from "../util/graphqlItemXform.js";
 import Query from "./Query/index.js";
+import ShopSettings from "./ShopSettings/index.js";
 
 export default {
   Cart: graphqlGroupXform,
   CartItem: graphqlItemXform,
   OrderFulfillmentGroup: graphqlGroupXform,
   OrderItem: graphqlItemXform,
-  Query
+  Query,
+  ShopSettings
 };

--- a/src/core-services/taxes/schemas/schema.graphql
+++ b/src/core-services/taxes/schemas/schema.graphql
@@ -146,3 +146,40 @@ type TaxSummary {
   "Full list of all taxes that were calculated by the active tax service for the cart or order group"
   taxes: [CalculatedTax]!
 }
+
+extend type ShopSettings {
+  "The default value to use for `taxCode` property of a product"
+  defaultTaxCode: String
+
+  """
+  The name of the tax service to fall back to if the primary tax service is down.
+  This will match the `name` field of one of the services returned by the `taxServices`
+  query.
+  """
+  fallbackTaxServiceName: String
+
+  """
+  The name of the tax service to use for calculating taxes on carts and orders.
+  This will match the `name` field of one of the services returned by the `taxServices`
+  query.
+  """
+  primaryTaxServiceName: String
+}
+
+extend input ShopSettingsUpdates {
+  "The default value to use for `taxCode` property of a product"
+  defaultTaxCode: String
+
+  """
+  Optionally, set the name of the tax service to fall back to if the primary tax service is down.
+  This must match the `name` field of one of the services returned by the `taxServices` query.
+  """
+  fallbackTaxServiceName: String
+
+  """
+  Set the name of the tax service to use for calculating taxes on carts and orders.
+  This will match the `name` field of one of the services returned by the `taxServices`
+  query. There will be no taxes charged for any carts or orders if this is not set.
+  """
+  primaryTaxServiceName: String
+}

--- a/src/plugins/navigation/resolvers/ShopSettings/index.js
+++ b/src/plugins/navigation/resolvers/ShopSettings/index.js
@@ -1,14 +1,14 @@
 export default {
   async shouldNavigationTreeItemsBeAdminOnly(settings, args, context) {
-    await context.checkPermissions(["admin"], args.shopId);
+    await context.checkPermissions(["admin"], settings.shopId);
     return settings.shouldNavigationTreeItemsBeAdminOnly;
   },
   async shouldNavigationTreeItemsBePubliclyVisible(settings, args, context) {
-    await context.checkPermissions(["admin"], args.shopId);
+    await context.checkPermissions(["admin"], settings.shopId);
     return settings.shouldNavigationTreeItemsBePubliclyVisible;
   },
   async shouldNavigationTreeItemsBeSecondaryNavOnly(settings, args, context) {
-    await context.checkPermissions(["admin"], args.shopId);
+    await context.checkPermissions(["admin"], settings.shopId);
     return settings.shouldNavigationTreeItemsBeSecondaryNavOnly;
   }
 };

--- a/src/plugins/taxes-rates/index.js
+++ b/src/plugins/taxes-rates/index.js
@@ -16,8 +16,8 @@ export default async function register(app) {
     label: "Custom Rates",
     name: "reaction-taxes-rates",
     collections: {
-      TaxRates: {
-        name: "TaxRates",
+      Taxes: {
+        name: "Taxes",
         indexes: [
           // Create indexes. We set specific names for backwards compatibility
           // with indexes created by the aldeed:schema-index Meteor package.
@@ -49,14 +49,6 @@ export default async function register(app) {
           calculateOrderTaxes,
           getTaxCodes
         }
-      }
-    ],
-    registry: [
-      {
-        label: "Custom Rates",
-        name: "taxes/settings/rates",
-        provides: ["taxSettings"],
-        template: "customTaxRates"
       }
     ]
   });

--- a/src/plugins/taxes-rates/mutations/createTaxRate.js
+++ b/src/plugins/taxes-rates/mutations/createTaxRate.js
@@ -13,7 +13,7 @@ export default async function createTaxRate(context, input) {
   // Check for owner or admin permissions from the user before allowing the mutation
   const { shopId, country, region, postal, taxCode, rate } = input;
   const { appEvents, checkPermissions, collections } = context;
-  const { TaxRates } = collections;
+  const { Taxes } = collections;
 
   await checkPermissions(["admin", "owner"], shopId);
 
@@ -24,10 +24,11 @@ export default async function createTaxRate(context, input) {
     region,
     postal,
     taxCode,
+    taxLocale: "destination",
     rate
   };
 
-  await TaxRates.insertOne(taxRate);
+  await Taxes.insertOne(taxRate);
 
   await appEvents.emit("afterTaxRateCreate", taxRate);
 

--- a/src/plugins/taxes-rates/mutations/deleteTaxRate.js
+++ b/src/plugins/taxes-rates/mutations/deleteTaxRate.js
@@ -11,16 +11,16 @@ export default async function deleteTaxRate(context, input) {
   // Check for owner or admin permissions from the user before allowing the mutation
   const { shopId, _id } = input;
   const { appEvents, checkPermissions, collections } = context;
-  const { TaxRates } = collections;
+  const { Taxes } = collections;
 
   await checkPermissions(["admin", "owner"], shopId);
 
-  const taxRateToDelete = await TaxRates.findOne({
+  const taxRateToDelete = await Taxes.findOne({
     _id,
     shopId
   });
 
-  await TaxRates.removeOne({
+  await Taxes.removeOne({
     _id,
     shopId
   });

--- a/src/plugins/taxes-rates/mutations/updateTaxRate.js
+++ b/src/plugins/taxes-rates/mutations/updateTaxRate.js
@@ -11,11 +11,11 @@ export default async function updateTaxRate(context, input) {
   // Check for owner or admin permissions from the user before allowing the mutation
   const { shopId, _id, country, region, postal, taxCode, rate } = input;
   const { appEvents, checkPermissions, collections } = context;
-  const { TaxRates } = collections;
+  const { Taxes } = collections;
 
   await checkPermissions(["admin", "owner"], shopId);
 
-  await TaxRates.updateOne({
+  await Taxes.updateOne({
     _id,
     shopId
   }, {
@@ -28,7 +28,7 @@ export default async function updateTaxRate(context, input) {
     }
   });
 
-  const taxRate = await TaxRates.findOne({ _id });
+  const taxRate = await Taxes.findOne({ _id });
 
   await appEvents.emit("afterTaxRateCreate", taxRate);
 

--- a/src/plugins/taxes-rates/queries/taxRates.js
+++ b/src/plugins/taxes-rates/queries/taxRates.js
@@ -2,18 +2,18 @@
  * @name taxRates
  * @method
  * @memberof GraphQL/TaxRates
- * @summary Query the TaxRates collection
+ * @summary Query the Taxes collection
  * @param {Object} context - an object containing the per-request state
  * @param {String} shopId - ID of Shop to query against
- * @returns {Promise<Object>} TaxRates object Promise
+ * @returns {Promise<Object>} Taxes object Promise
  */
 export default async function taxRates(context, shopId) {
   const { checkPermissions, collections } = context;
-  const { TaxRates } = collections;
+  const { Taxes } = collections;
 
   await checkPermissions(["owner", "admin"], shopId);
 
-  return TaxRates.find({
+  return Taxes.find({
     shopId
   });
 }

--- a/src/plugins/taxes-rates/resolvers/TaxRate/index.js
+++ b/src/plugins/taxes-rates/resolvers/TaxRate/index.js
@@ -3,5 +3,6 @@ import { encodeTaxRateOpaqueId } from "../../xforms/id.js";
 
 export default {
   _id: (node) => encodeTaxRateOpaqueId(node._id),
-  shop: resolveShopFromShopId
+  shop: resolveShopFromShopId,
+  sourcing: (node) => node.taxLocale
 };

--- a/src/plugins/taxes-rates/schemas/schema.graphql
+++ b/src/plugins/taxes-rates/schemas/schema.graphql
@@ -3,47 +3,50 @@ type TaxRate {
   "Tax rate ID"
   _id: ID!
 
-  "Did this tax match due to the order origin or the order destination?"
-  country: String!
+  "An optional country code to limit where this tax is applied, in conjunction with `sourcing` field"
+  country: String
 
-  "A human-readable display name for showing this tax to operators and customers in the UI"
-  postal: String!
+  "An optional postal code to limit where this tax is applied, in conjunction with `sourcing` field"
+  postal: String
 
-  "The tax rate used for this calculation"
+  "The tax rate. For example, 0.05 for a 5% sales tax."
   rate: Float!
 
-  "Amount of tax due"
-  region: String!
+  "An optional region (e.g., state) to limit where this tax is applied, in conjunction with `sourcing` field"
+  region: String
 
   "The shop to which this TaxRate belongs"
   shop: Shop!
 
-  "Amount that was used for calculating the tax due"
-  taxCode: String!
+  "Whether the `country`, `postal`, and `region` filters apply to the origin address or the destination address"
+  sourcing: TaxSource!
+
+  "An optional tax code, to apply this tax rate to only products that have this tax code"
+  taxCode: String
 }
 
-"Describes the input for creating a tax rate"
+"The input for creating a tax rate"
 input CreateTaxRateInput {
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
 
-  "Did this tax match due to the order origin or the order destination?"
-  country: String!
+  "An optional country code to limit where this tax is applied based on destination address"
+  country: String
 
-  "Postal code"
-  postal: String!
+  "An optional postal code to limit where this tax is applied based on destination address"
+  postal: String
 
-  "The tax rate used for this calculation"
+  "The tax rate. For example, 0.05 for a 5% sales tax."
   rate: Float!
 
-  "Amount of tax due"
-  region: String!
+  "An optional region (e.g., state) to limit where this tax is applied based on destination address"
+  region: String
 
   "Shop ID"
   shopId: ID!
 
-  "Amount that was used for calculating the tax due"
-  taxCode: String!
+  "An optional tax code, to apply this tax rate to only products that have this tax code"
+  taxCode: String
 }
 
 "The response from the `createTaxRate` mutation"
@@ -52,33 +55,36 @@ type CreateTaxRatePayload {
   clientMutationId: String
 
   "The created tax rate"
-  taxRate: TaxRate
+  taxRate: TaxRate!
 }
 
-"Describes the input for updating a tax rate"
+"""
+The input for updating a tax rate. Note that missing values will cause the field to be cleared, so
+send all optional fields with every request unless they aren't currently set or you intend to clear them.
+"""
 input UpdateTaxRateInput {
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
 
-  "Did this tax match due to the order origin or the order destination?"
-  country: String!
+  "An optional country code to limit where this tax is applied based on destination address"
+  country: String
 
-  "A human-readable display name for showing this tax to operators and customers in the UI"
-  postal: String!
+  "An optional postal code to limit where this tax is applied based on destination address"
+  postal: String
 
-  "The tax rate used for this calculation"
+  "The tax rate. For example, 0.05 for a 5% sales tax."
   rate: Float!
 
-  "Amount of tax due"
-  region: String!
+  "An optional region (e.g., state) to limit where this tax is applied based on destination address"
+  region: String
 
   "Shop ID"
   shopId: ID!
 
-  "Amount that was used for calculating the tax due"
-  taxCode: String!
+  "An optional tax code, to apply this tax rate to only products that have this tax code"
+  taxCode: String
 
-  "The tax rate ID"
+  "ID of the tax rate you want to update"
   taxRateId: ID!
 }
 
@@ -88,7 +94,7 @@ type UpdateTaxRatePayload {
   clientMutationId: String
 
   "The updated tax rate"
-  taxRate: TaxRate
+  taxRate: TaxRate!
 }
 
 "Describes the input for removing a tax rate"
@@ -109,7 +115,7 @@ type DeleteTaxRatePayload {
   clientMutationId: String
 
   "The deleted tax rate"
-  taxRate: TaxRate
+  taxRate: TaxRate!
 }
 
 extend type Mutation {
@@ -185,6 +191,6 @@ extend type Query {
     last: ConnectionLimitInt,
 
     "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
-    offset: Int,
+    offset: Int
   ): TaxRateConnection
 }

--- a/src/plugins/taxes-rates/simpleSchemas.js
+++ b/src/plugins/taxes-rates/simpleSchemas.js
@@ -16,8 +16,7 @@ export const TaxRates = new SimpleSchema({
   taxLocale: {
     label: "Taxation Location",
     type: String,
-    allowedValues: ["origin", "destination"],
-    defaultValue: "destination"
+    allowedValues: ["origin", "destination"]
   },
   region: {
     label: "State/Province/Region",

--- a/tests/integration/api/mutations/taxRates/createTaxRateMutation.graphql
+++ b/tests/integration/api/mutations/taxRates/createTaxRateMutation.graphql
@@ -1,10 +1,10 @@
 mutation (
-  $region: String!,
+  $region: String,
   $rate: Float!,
   $shopId: ID!,
-  $country: String!,
-  $postal: String!,
-  $taxCode: String!
+  $country: String,
+  $postal: String,
+  $taxCode: String
 ) {
   createTaxRate(input: {
     region: $region,
@@ -16,15 +16,16 @@ mutation (
   }) {
     taxRate {
       _id
+      country
+      postal
+      postal
       rate
+      region
       shop {
         _id
       }
-      region
-      postal
-      country
+      sourcing
       taxCode
-      postal
     }
   }
 }

--- a/tests/integration/api/mutations/taxRates/deleteTaxRateMutation.graphql
+++ b/tests/integration/api/mutations/taxRates/deleteTaxRateMutation.graphql
@@ -8,15 +8,16 @@ mutation (
   }) {
     taxRate {
       _id
+      country
+      postal
+      postal
       rate
+      region
       shop {
         _id
       }
-      region
-      postal
-      country
+      sourcing
       taxCode
-      postal
     }
   }
 }

--- a/tests/integration/api/mutations/taxRates/taxRates.test.js
+++ b/tests/integration/api/mutations/taxRates/taxRates.test.js
@@ -40,7 +40,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await testApp.collections.TaxRates.deleteMany({});
+  await testApp.collections.Taxes.deleteMany({});
   await testApp.collections.Shops.deleteMany({});
   await testApp.stop();
 });
@@ -88,7 +88,7 @@ test("user can add a tax rate", async () => {
   // Check the database for the new TaxRate document
   const createdTaxRateDatabaseId = decodeOpaqueIdForNamespace("reaction/taxRate")(createdTaxRateOpaqueId);
 
-  const savedTaxRate = await testApp.collections.TaxRates.findOne({
+  const savedTaxRate = await testApp.collections.Taxes.findOne({
     _id: createdTaxRateDatabaseId,
     shopId
   });
@@ -148,7 +148,7 @@ test("user can update an existing tax rate", async () => {
   // Check the database for the new TaxRate document
   const updatedTaxRateDatabaseId = decodeOpaqueIdForNamespace("reaction/taxRate")(updatedTaxRateOpaqueId);
 
-  const savedTaxRate = await testApp.collections.TaxRates.findOne({
+  const savedTaxRate = await testApp.collections.Taxes.findOne({
     _id: updatedTaxRateDatabaseId,
     shopId
   });
@@ -203,7 +203,7 @@ test("user can delete an existing tax rate", async () => {
   // Check the database for the new TaxRate document
   const deletedTaxRateDatabaseId = decodeOpaqueIdForNamespace("reaction/taxRate")(deletedTaxRateOpaqueId);
 
-  const savedTaxRate = await testApp.collections.TaxRates.findOne({
+  const savedTaxRate = await testApp.collections.Taxes.findOne({
     _id: deletedTaxRateDatabaseId,
     shopId
   });

--- a/tests/integration/api/mutations/taxRates/updateTaxRateMutation.graphql
+++ b/tests/integration/api/mutations/taxRates/updateTaxRateMutation.graphql
@@ -1,11 +1,11 @@
 mutation (
   $taxRateId: ID!,
-  $region: String!,
+  $region: String,
   $rate: Float!,
   $shopId: ID!,
-  $country: String!,
-  $postal: String!,
-  $taxCode: String!
+  $country: String,
+  $postal: String,
+  $taxCode: String
 ) {
   updateTaxRate(input: {
     taxRateId: $taxRateId,
@@ -18,15 +18,16 @@ mutation (
   }) {
     taxRate {
       _id
+      country
+      postal
+      postal
       rate
+      region
       shop {
         _id
       }
-      region
-      postal
-      country
+      sourcing
       taxCode
-      postal
     }
   }
 }

--- a/tests/integration/api/queries/taxRates/taxRates.test.js
+++ b/tests/integration/api/queries/taxRates/taxRates.test.js
@@ -49,7 +49,7 @@ beforeAll(async () => {
   await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
 
   await Promise.all(taxRateDocuments.map((doc) => (
-    testApp.collections.TaxRates.insertOne(doc)
+    testApp.collections.Taxes.insertOne(doc)
   )));
 
   await testApp.createUserAndAccount(mockCustomerAccount);
@@ -59,7 +59,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await testApp.collections.TaxRates.deleteMany({});
+  await testApp.collections.Taxes.deleteMany({});
   await testApp.collections.Shops.deleteMany({});
   await testApp.stop();
 });


### PR DESCRIPTION
 Impact: **minor**  
Type: **feature|bugfix**

## Issue
- Tax settings were stored in the `Packages` collection, which we're aiming to remove in 3.0
- New tax rates mutations were using `TaxRates` collection name while tax calculation code was still using `Taxes`.
- Some tax rates fields were listed as required in GQL schema but should not be. Also many of the descriptions were incorrect.

## Solution
- Move all tax settings to newer shop settings API
- Updated all `TaxRates` collection names to `Taxes`
- Fixed TaxRates GQL schema issues

## Breaking changes
At the moment there is not an automatic migration for tax settings, so you will need to re-set your primary and fallback tax service selections, as well as the default tax code for new variants. We may add a migration for all Packages collection things in the future.

## Testing
- Verify you can set and read all three tax settings using the shop settings GraphQL mutation and query. Setting requires admin permission but reading is open to anyone since they do not seem like sensitive data.
- Verify you can create, update, and delete tax rates. (3.0 may not be stable enough to test the storefront / order placement part of this yet, but it should be closer to working than it was before.)