### PR TITLE
test: add navigation query integration tests

### DIFF
--- a/src/plugins/navigation/schemas/schema.graphql
+++ b/src/plugins/navigation/schemas/schema.graphql
@@ -31,6 +31,9 @@ extend type Query {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = desc,
 

--- a/tests/integration/api/queries/navigation/__snapshots__/navigationItemsByShopId.test.js.snap
+++ b/tests/integration/api/queries/navigation/__snapshots__/navigationItemsByShopId.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throws access-denied when getting NavigationItems if user is not an admin with core permissions 1`] = `
+Object {
+  "extensions": Object {
+    "code": "FORBIDDEN",
+    "exception": Object {
+      "details": Object {},
+      "error": "access-denied",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Access Denied",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Access Denied",
+  "path": Array [
+    "navigationItemsByShopId",
+  ],
+}
+`;

--- a/tests/integration/api/queries/navigation/navigationItemsByShopId.test.js
+++ b/tests/integration/api/queries/navigation/navigationItemsByShopId.test.js
@@ -1,0 +1,134 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const navigationItemsQuery = importAsString("./navigationItemsByShopIdQuery.graphql");
+
+jest.setTimeout(300000);
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const shopName = "Test Shop";
+const navigationItemDocuments = [];
+
+for (let index = 100; index < 123; index += 1) {
+  const doc = {
+    _id: `navigationItem-${index}`,
+    shopId: internalShopId,
+    data: {
+      content: [
+        {
+          language: "en",
+          value: "Camperos"
+        }
+      ],
+      url: `/tag/item-${index}`,
+      isUrlRelative: true,
+      shouldOpenInNewWindow: false
+    },
+    draftData: {
+      content: [
+        {
+          language: "en",
+          value: "Camperos"
+        }
+      ],
+      url: `/tag/item-${index}`,
+      isUrlRelative: true,
+      shouldOpenInNewWindow: false
+    },
+    metadata: {
+      tagId: "68umfiY5xWMR86a26"
+    },
+    treeIds: [
+      "R2rQ2DroFwjsAT2oW"
+    ],
+    createdAt: new Date(),
+    hasUnpublishedChanges: false
+  };
+
+  navigationItemDocuments.push(doc);
+}
+
+const mockCustomerAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: []
+  },
+  shopId: internalShopId
+});
+
+const mockAdminAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: ["admin", "core"]
+  },
+  shopId: internalShopId
+});
+
+let testApp;
+let navigationItems;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+
+  await Promise.all(navigationItemDocuments.map((doc) => (
+    testApp.collections.NavigationItems.insertOne(doc)
+  )));
+
+  await testApp.createUserAndAccount(mockCustomerAccount);
+  await testApp.createUserAndAccount(mockAdminAccount);
+
+  navigationItems = testApp.query(navigationItemsQuery);
+});
+
+afterAll(async () => {
+  await testApp.collections.NavigationItems.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.stop();
+});
+
+test("throws access-denied when getting NavigationItems if not an admin with core permissions", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  try {
+    await navigationItems({
+      shopId: opaqueShopId
+    });
+  } catch (errors) {
+    expect(errors[0]).toMatchSnapshot();
+  }
+});
+
+test("returns NavigationItems records if user is an admin with core permissions", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  const result = await navigationItems({
+    shopId: opaqueShopId,
+    first: 5,
+    sortBy: "_id",
+    sortOrder: "asc"
+  });
+
+  expect(result.navigationItemsByShopId.nodes.length).toEqual(5);
+  expect(result.navigationItemsByShopId.nodes[0]._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-100"));
+  expect(result.navigationItemsByShopId.nodes[4]._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-104"));
+});
+
+
+test("returns NavigationItems records on second page if user is an admin with core permissions", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  const result = await navigationItems({
+    shopId: opaqueShopId,
+    first: 5,
+    offset: 5,
+    sortBy: "_id",
+    sortOrder: "asc"
+  });
+  expect(result.navigationItemsByShopId.nodes.length).toEqual(5);
+  expect(result.navigationItemsByShopId.nodes[0]._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-105"));
+  expect(result.navigationItemsByShopId.nodes[4]._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-109"));
+});

--- a/tests/integration/api/queries/navigation/navigationItemsByShopId.test.js
+++ b/tests/integration/api/queries/navigation/navigationItemsByShopId.test.js
@@ -90,7 +90,7 @@ afterAll(async () => {
   await testApp.stop();
 });
 
-test("throws access-denied when getting NavigationItems if not an admin with core permissions", async () => {
+test("throws access-denied when getting NavigationItems if user is not an admin with core permissions", async () => {
   await testApp.setLoggedInUser(mockCustomerAccount);
 
   try {

--- a/tests/integration/api/queries/navigation/navigationItemsByShopIdQuery.graphql
+++ b/tests/integration/api/queries/navigation/navigationItemsByShopIdQuery.graphql
@@ -1,0 +1,43 @@
+query NavigationItemsByShopId(
+  $shopId: ID!
+  $first: ConnectionLimitInt
+  $last:  ConnectionLimitInt
+  $before: ConnectionCursor
+  $after: ConnectionCursor
+  $offset: Int
+  $sortBy: NavigationItemSortByField
+  $sortOrder: SortOrder
+) {
+  navigationItemsByShopId(
+    shopId: $shopId
+    first: $first
+    last: $last
+    before: $before
+    after: $after
+    offset: $offset
+    sortBy: $sortBy,
+    sortOrder: $sortOrder
+  ) {
+    nodes {
+      _id
+      data {
+        content {
+          language
+          value
+        }
+        url
+        isUrlRelative
+        shouldOpenInNewWindow
+      }
+      draftData {
+        content {
+          language
+          value
+        }
+      }
+      metadata
+      createdAt
+      hasUnpublishedChanges
+    }
+  }
+}

--- a/tests/integration/api/queries/navigation/navigationTreeById.test.js
+++ b/tests/integration/api/queries/navigation/navigationTreeById.test.js
@@ -1,0 +1,328 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const navigationTreeQuery = importAsString("./navigationTreeByIdQuery.graphql");
+
+jest.setTimeout(300000);
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const shopName = "Test Shop";
+const navigationItemDocuments = [];
+
+for (let index = 100; index < 123; index += 1) {
+  const doc = {
+    _id: `navigationItem-${index}`,
+    shopId: internalShopId,
+    data: {
+      content: [
+        {
+          language: "en",
+          value: "Shoes"
+        },
+        {
+          language: "fr",
+          value: "Chaussures"
+        }
+      ],
+      url: `/tag/item-${index}`,
+      isUrlRelative: true,
+      shouldOpenInNewWindow: false
+    },
+    draftData: {
+      content: [
+        {
+          language: "en",
+          value: "Shirt"
+        },
+        {
+          language: "fr",
+          value: "Chemise"
+        }
+      ],
+      url: `/tag/item-${index}`,
+      isUrlRelative: true,
+      shouldOpenInNewWindow: false
+    },
+    metadata: {
+      tagId: "68umfiY5xWMR86a26"
+    },
+    treeIds: [
+      "R2rQ2DroFwjsAT2oW"
+    ],
+    createdAt: new Date(),
+    hasUnpublishedChanges: false
+  };
+
+  navigationItemDocuments.push(doc);
+}
+
+const mockNavigationTreeDoc = {
+  _id: "navigationTree-1",
+  name: "Default Navigation",
+  shopId: internalShopId,
+  items: [
+    {
+      isPrivate: true,
+      isSecondary: false,
+      isVisible: true,
+      navigationItemId: "navigationItem-100"
+    },
+    {
+      isPrivate: false,
+      isSecondary: false,
+      isVisible: false,
+      navigationItemId: "navigationItem-101",
+      items: [
+        {
+          isPrivate: false,
+          isSecondary: false,
+          isVisible: true,
+          navigationItemId: "navigationItem-102",
+          items: [
+            {
+              isPrivate: false,
+              isSecondary: false,
+              isVisible: true,
+              navigationItemId: "navigationItem-103"
+            }
+          ]
+        },
+        {
+          isPrivate: false,
+          isSecondary: false,
+          isVisible: false,
+          navigationItemId: "navigationItem-104"
+        }
+      ]
+    }
+  ],
+  draftItems: [
+    {
+      isPrivate: false,
+      isSecondary: false,
+      isVisible: false,
+      navigationItemId: "navigationItem-100"
+    },
+    {
+      isPrivate: false,
+      isSecondary: false,
+      isVisible: false,
+      navigationItemId: "navigationItem-101",
+      items: [
+        {
+          isPrivate: false,
+          isSecondary: false,
+          isVisible: false,
+          navigationItemId: "navigationItem-102",
+          items: [
+            {
+              isPrivate: false,
+              isSecondary: false,
+              isVisible: false,
+              navigationItemId: "navigationItem-103"
+            }
+          ]
+        },
+        {
+          isPrivate: false,
+          isSecondary: false,
+          isVisible: false,
+          navigationItemId: "navigationItem-104"
+        }
+      ]
+    }
+  ]
+};
+
+const mockNavigationTreeDoc2 = {
+  _id: "navigationTree-2",
+  name: "Alternate Navigation",
+  shopId: internalShopId,
+  hasUnpublishedChanges: false,
+  items: [
+    {
+      isPrivate: false,
+      isSecondary: false,
+      isVisible: true,
+      navigationItemId: "navigationItem-110"
+    },
+    {
+      isPrivate: false,
+      isSecondary: false,
+      isVisible: true,
+      navigationItemId: "navigationItem-100",
+      items: [
+        {
+          isPrivate: false,
+          isSecondary: true,
+          isVisible: true,
+          navigationItemId: "navigationItem-105",
+          items: [
+            {
+              isPrivate: false,
+              isSecondary: true,
+              isVisible: true,
+              navigationItemId: "navigationItem-110"
+            },
+            {
+              isPrivate: true,
+              isSecondary: true,
+              isVisible: true,
+              navigationItemId: "navigationItem-111"
+            },
+            {
+              isPrivate: false,
+              isSecondary: false,
+              isVisible: false,
+              navigationItemId: "navigationItem-112"
+            }
+          ]
+        },
+        {
+          isPrivate: false,
+          isSecondary: false,
+          isVisible: true,
+          navigationItemId: "navigationItem-104"
+        }
+      ]
+    }
+  ],
+  draftItems: [
+    {
+      isPrivate: false,
+      isSecondary: false,
+      isVisible: false,
+      navigationItemId: "navigationItem-110"
+    },
+    {
+      isPrivate: false,
+      isSecondary: false,
+      isVisible: false,
+      navigationItemId: "navigationItem-100",
+      items: [
+        {
+          isPrivate: false,
+          isSecondary: false,
+          isVisible: false,
+          navigationItemId: "navigationItem-105"
+        },
+        {
+          isPrivate: false,
+          isSecondary: false,
+          isVisible: false,
+          navigationItemId: "navigationItem-104"
+        }
+      ]
+    }
+  ]
+};
+
+const mockCustomerAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: []
+  },
+  shopId: internalShopId
+});
+
+const mockAdminAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: ["admin", "core"]
+  },
+  shopId: internalShopId
+});
+
+let testApp;
+let queryNavigationTree;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+
+  await Promise.all(navigationItemDocuments.map((doc) => (
+    testApp.collections.NavigationItems.insertOne(doc)
+  )));
+
+  await testApp.collections.NavigationTrees.insertOne(mockNavigationTreeDoc);
+  await testApp.collections.NavigationTrees.insertOne(mockNavigationTreeDoc2);
+
+  await testApp.createUserAndAccount(mockCustomerAccount);
+  await testApp.createUserAndAccount(mockAdminAccount);
+
+  queryNavigationTree = testApp.query(navigationTreeQuery);
+});
+
+afterAll(async () => {
+  await testApp.collections.NavigationItems.deleteMany({});
+  await testApp.collections.NavigationTrees.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.stop();
+});
+
+test("returns a NavigationItem tree named `Default Navigation` for an admin account", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  const result = await queryNavigationTree({
+    id: encodeOpaqueId("reaction/navigationTree", "navigationTree-1"),
+    language: "en",
+    shopId: opaqueShopId
+  });
+
+  expect(result.navigationTreeById.name).toEqual("Default Navigation");
+  expect(result.navigationTreeById.items[0].navigationItem.data.contentForLanguage).toEqual("Shoes");
+  expect(result.navigationTreeById.draftItems[1].items[0].items[0].navigationItem._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-103"));
+});
+
+test("returns a NavigationItem tree named `Default Navigation` with no items for a customer account", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  const result = await queryNavigationTree({
+    id: encodeOpaqueId("reaction/navigationTree", "navigationTree-1"),
+    language: "en",
+    shopId: opaqueShopId
+  });
+
+  expect(result.navigationTreeById.name).toEqual("Default Navigation");
+  expect(result.navigationTreeById.items.length).toEqual(0);
+});
+
+test("returns a NavigationItem tree named `Alternate Navigation` for a customer account", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  const result = await queryNavigationTree({
+    id: encodeOpaqueId("reaction/navigationTree", "navigationTree-2"),
+    language: "fr",
+    shopId: opaqueShopId
+  });
+
+  expect(result.navigationTreeById.name).toEqual("Alternate Navigation");
+  expect(result.navigationTreeById.items[0].navigationItem.data.contentForLanguage).toEqual("Chaussures");
+  expect(result.navigationTreeById.items[1].navigationItem._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-100"));
+  expect(result.navigationTreeById.items[1].items.length).toEqual(1);
+  expect(result.navigationTreeById.items[1].items[0].navigationItem._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-104"));
+  expect(result.navigationTreeById.draftItems).toEqual([]);
+});
+
+
+test("returns a NavigationItem tree named `Alternate Navigation` with secondary items for a customer account", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  const result = await queryNavigationTree({
+    id: encodeOpaqueId("reaction/navigationTree", "navigationTree-2"),
+    language: "fr",
+    shopId: opaqueShopId,
+    shouldIncludeSecondary: true
+  });
+
+  expect(result.navigationTreeById.name).toEqual("Alternate Navigation");
+  expect(result.navigationTreeById.items[0].navigationItem.data.contentForLanguage).toEqual("Chaussures");
+  expect(result.navigationTreeById.items[1].navigationItem._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-100"));
+  expect(result.navigationTreeById.items[1].items[0].navigationItem._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-105"));
+  expect(result.navigationTreeById.items[1].items[1].navigationItem._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-104"));
+  expect(result.navigationTreeById.items[1].items[0].items.length).toEqual(1);
+  expect(result.navigationTreeById.items[1].items[0].items[0].navigationItem._id).toEqual(encodeOpaqueId("reaction/navigationItem", "navigationItem-110"));
+});

--- a/tests/integration/api/queries/navigation/navigationTreeByIdQuery.graphql
+++ b/tests/integration/api/queries/navigation/navigationTreeByIdQuery.graphql
@@ -1,0 +1,68 @@
+fragment NavigationTreeItem on NavigationItem {
+  _id
+  data {
+    content {
+      language
+      value
+    }
+    contentForLanguage
+    url
+    isUrlRelative
+    shouldOpenInNewWindow
+  }
+  draftData {
+    content {
+      language
+      value
+    }
+  }
+  metadata
+  createdAt
+  hasUnpublishedChanges
+}
+
+query NavigationTreeById(
+  $id: ID!
+  $language: String!
+  $shopId:  ID!
+  $shouldIncludeSecondary: Boolean
+) {
+  navigationTreeById(
+    id: $id
+    language: $language
+    shopId: $shopId
+    shouldIncludeSecondary: $shouldIncludeSecondary
+  ) {
+    name
+    items {
+      navigationItem {
+				...NavigationTreeItem
+      }
+      items {
+        navigationItem {
+          ...NavigationTreeItem
+        }
+        items {
+          navigationItem {
+            ...NavigationTreeItem
+          }
+        }
+      }
+    }
+    draftItems {
+      navigationItem {
+				...NavigationTreeItem
+      }
+      items {
+        navigationItem {
+          ...NavigationTreeItem
+        }
+        items {
+          navigationItem {
+            ...NavigationTreeItem
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves #5706  
Impact: **minor**  
Type: **feature|test**

## Issue

Missing tests for these queries:
-  navigationItemsByShopId
-  navigationTreeById

## Solution

- Add missing integration tests
- Add `offset` param to `navigationItemsByShopId` schema to unlock the ability to query via an offset

## Breaking changes

none

## Testing
1. See that the tests pass for `navigationTreeById` and `navigationItemsByShopId`
