### PR TITLE
test: add Tag query integration test

### DIFF
--- a/src/core-services/catalog/queries/tag.js
+++ b/src/core-services/catalog/queries/tag.js
@@ -17,17 +17,11 @@ export default async function tag(context, input) {
   const { Tags } = collections;
   const { slugOrId, shopId, shouldIncludeInvisible = false } = input;
 
-  // Check to make sure user has `read` permissions for this tag
-  await context.validatePermissions(`reaction:tags:${slugOrId}`, "read", {
-    shopId,
-    legacyRoles: ["admin", "owner", "tags"]
-  });
-
   // Check to see if user has `read` permissions for hidden / deleted tags
   // TODO(pod-auth): revisit using `inactive` in resource, and revisit the word `inactive`
   const hasInactivePermissions = await context.userHasPermission(`reaction:tags:${slugOrId}:inactive`, "read", {
     shopId,
-    legacyRoles: ["admin", "owner", "tags"]
+    legacyRoles: ["admin", "owner"]
   });
 
   let query = {

--- a/tests/integration/api/queries/tags/TagQuery.graphql
+++ b/tests/integration/api/queries/tags/TagQuery.graphql
@@ -1,0 +1,7 @@
+query Tag($slugOrId: String!, $shopId: ID!, $shouldIncludeInvisible: Boolean) {
+  tag(slugOrId: $slugOrId, shopId: $shopId, shouldIncludeInvisible: $shouldIncludeInvisible) {
+    _id
+    slug
+    isVisible
+  }
+}

--- a/tests/integration/api/queries/tags/__snapshots__/tag.test.js.snap
+++ b/tests/integration/api/queries/tags/__snapshots__/tag.test.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not show a hidden tag to a customer 1`] = `
+Object {
+  "extensions": Object {
+    "code": "NOT_FOUND",
+    "exception": Object {
+      "details": Object {},
+      "error": "not-found",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Tag not found",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Tag not found",
+  "path": Array [
+    "tag",
+  ],
+}
+`;
+
+exports[`should not show a hidden tag to an admin 1`] = `
+Object {
+  "extensions": Object {
+    "code": "NOT_FOUND",
+    "exception": Object {
+      "details": Object {},
+      "error": "not-found",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Tag not found",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Tag not found",
+  "path": Array [
+    "tag",
+  ],
+}
+`;

--- a/tests/integration/api/queries/tags/tag.test.js
+++ b/tests/integration/api/queries/tags/tag.test.js
@@ -1,0 +1,141 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const TagQuery = importAsString("./TagQuery.graphql");
+
+jest.setTimeout(300000);
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const shopName = "Test Shop";
+const mockTags = Factory.Tag.makeMany(25, {
+  _id: (index) => (index + 100).toString(),
+  position: (index) => index + 100,
+  shopId: internalShopId,
+  slug: (index) => `slug${index + 100}`,
+  isVisible: (index) => index < 20
+});
+
+const mockCustomerAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: []
+  },
+  shopId: internalShopId
+});
+
+const mockAdminAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: ["admin"]
+  },
+  shopId: internalShopId
+});
+
+
+let testApp;
+let query;
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  query = testApp.query(TagQuery);
+
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+  await Promise.all(mockTags.map((tag) => testApp.collections.Tags.insertOne(tag)));
+
+  await testApp.createUserAndAccount(mockAdminAccount);
+  await testApp.createUserAndAccount(mockCustomerAccount);
+});
+
+
+afterAll(async () => {
+  await testApp.collections.Accounts.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.collections.Tags.deleteMany({});
+  await testApp.clearLoggedInUser();
+  await testApp.stop();
+});
+
+test("should get a tag by ID", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  const tagId = encodeOpaqueId("reaction/tag", "101");
+  let result;
+  try {
+    result = await query({
+      slugOrId: tagId,
+      shopId: opaqueShopId
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tag._id).toEqual(tagId);
+  expect(result.tag.slug).toEqual("slug101");
+});
+
+test("should get a tag by slug", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  let result;
+  try {
+    result = await query({
+      slugOrId: "slug106",
+      shopId: opaqueShopId
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tag._id).toEqual(encodeOpaqueId("reaction/tag", "106"));
+  expect(result.tag.slug).toEqual("slug106");
+});
+
+test("should not show a hidden tag to a customer", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  try {
+    await query({
+      slugOrId: "slug122",
+      shopId: opaqueShopId
+    });
+  } catch (errors) {
+    expect(errors[0]).toMatchSnapshot();
+    return;
+  }
+});
+
+test("should show a hidden tag to an admin", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  let result;
+  try {
+    result = await query({
+      slugOrId: "slug122",
+      shopId: opaqueShopId,
+      shouldIncludeInvisible: true
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.tag.slug).toEqual("slug122");
+});
+
+test("should not show a hidden tag to an admin", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  try {
+    await query({
+      slugOrId: "slug122",
+      shopId: opaqueShopId,
+      shouldIncludeInvisible: false
+    });
+  } catch (errors) {
+    expect(errors[0]).toMatchSnapshot();
+    return;
+  }
+});


### PR DESCRIPTION
Resolves #5867  
Impact: **minor**  
Type: **bugfix|test**

## Issue

Add test for `tag` query

## Solution

- add test for tag query
- fix permissions for customers as it doesn't allow access for anonymous users
- fix permissions for admins as it allows too much access for logged in customers that have the tag permissions
    - Removed the `tags` permission as it's actually `tag` and all users have it by default 

## Breaking changes

none

## Testing
1. See the test pass on CI
