### PR TITLE
chore: add integration test for globalSettings query

### DIFF
--- a/tests/integration/api/queries/globalSettings/GlobalSettingsQuery.graphql
+++ b/tests/integration/api/queries/globalSettings/GlobalSettingsQuery.graphql
@@ -1,0 +1,6 @@
+
+query{
+  globalSettings {
+    canSellVariantWithoutInventory
+  }
+}

--- a/tests/integration/api/queries/globalSettings/TestGlobalSettingSchema.graphql
+++ b/tests/integration/api/queries/globalSettings/TestGlobalSettingSchema.graphql
@@ -1,0 +1,3 @@
+extend type GlobalSettings {
+  canSellVariantWithoutInventory: Boolean
+}

--- a/tests/integration/api/queries/globalSettings/globalSettings.test.js
+++ b/tests/integration/api/queries/globalSettings/globalSettings.test.js
@@ -1,0 +1,49 @@
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const GlobalSettingsQuery = importAsString("./GlobalSettingsQuery.graphql");
+const TestGlobalSettingSchema = importAsString("./TestGlobalSettingSchema.graphql");
+
+jest.setTimeout(300000);
+
+const internalShopId = "123";
+const shopName = "Test Shop";
+let testApp;
+let globalSettings;
+
+const mockGlobalSetting = {
+  canSellVariantWithoutInventory: true
+};
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  testApp.registerPlugin({
+    name: "testGlobalSetting",
+    graphQL: {
+      schemas: [TestGlobalSettingSchema]
+    }
+  });
+  await testApp.start();
+
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName });
+  await testApp.collections.AppSettings.insertOne(mockGlobalSetting);
+  globalSettings = testApp.query(GlobalSettingsQuery);
+});
+
+afterAll(async () => {
+  await testApp.collections.AppSettings.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.stop();
+});
+
+test("view global app settings", async () => {
+  let result;
+  try {
+    result = await globalSettings();
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.globalSettings.canSellVariantWithoutInventory).toEqual(true);
+});


### PR DESCRIPTION
Resolves #5870 
Impact: minor
Type: test | chore 

## Summary
Adds integration test for `globalSettings` query
