### PR TITLE
add integration test for payment methods

### DIFF
--- a/tests/integration/api/queries/paymentMethods/PaymentMethodsQuery.graphql
+++ b/tests/integration/api/queries/paymentMethods/PaymentMethodsQuery.graphql
@@ -1,0 +1,6 @@
+query ($shopId: ID!){
+  paymentMethods(shopId: $shopId){
+    isEnabled
+    name
+  }
+}

--- a/tests/integration/api/queries/paymentMethods/__snapshots__/paymentMethods.test.js.snap
+++ b/tests/integration/api/queries/paymentMethods/__snapshots__/paymentMethods.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`an anonymous user cannot view all payment methods 1`] = `
+Array [
+  Object {
+    "extensions": Object {
+      "code": "FORBIDDEN",
+      "exception": Object {
+        "details": Object {},
+        "error": "access-denied",
+        "eventData": Object {},
+        "isClientSafe": true,
+        "reason": "Access Denied",
+      },
+    },
+    "locations": Array [
+      Object {
+        "column": 3,
+        "line": 2,
+      },
+    ],
+    "message": "Access Denied",
+    "path": Array [
+      "paymentMethods",
+    ],
+  },
+]
+`;

--- a/tests/integration/api/queries/paymentMethods/paymentMethods.test.js
+++ b/tests/integration/api/queries/paymentMethods/paymentMethods.test.js
@@ -1,0 +1,67 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const PaymentMethodsQuery = importAsString("./PaymentMethodsQuery.graphql");
+
+jest.setTimeout(300000);
+
+const internalShopId = "123";
+const opaqueShopId = encodeOpaqueId("reaction/shop", internalShopId); // reaction/shop:123
+const shopName = "Test Shop";
+let paymentMethods;
+let testApp;
+
+const mockShopOwnerAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: ["owner"]
+  },
+  shopId: internalShopId
+});
+
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName, PaymentMethods: ["iou_example"] });
+  await testApp.createUserAndAccount(mockShopOwnerAccount);
+  paymentMethods = testApp.query(PaymentMethodsQuery);
+});
+
+afterAll(async () => {
+  await testApp.collections.Accounts.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.collections.Packages.deleteMany({});
+  await testApp.stop();
+});
+
+test("an anonymous user cannot view all payment methods", async () => {
+  try {
+    await paymentMethods({
+      shopId: opaqueShopId
+    });
+  } catch (error) {
+    expect(error).toMatchSnapshot();
+    return;
+  }
+});
+
+test("a shop owner can view a full list of all payment methods", async () => {
+  await testApp.setLoggedInUser(mockShopOwnerAccount);
+  let result;
+  try {
+    result = await paymentMethods({
+      shopId: opaqueShopId
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.paymentMethods[0].name).toEqual("iou_example");
+  expect(result.paymentMethods[0].isEnabled).toEqual(false);
+  expect(result.paymentMethods[1].name).toEqual("stripe_card");
+  expect(result.paymentMethods[1].isEnabled).toEqual(false);
+});


### PR DESCRIPTION
Resolves #5880  
Impact: minor  
Type: test | chore

## Summary
Adds integration test for `paymentMethods` query, CI will perform testing 🤖 