### PR TITLE
fix: remove check for shopId where not needed

### DIFF
--- a/src/plugins/legacy-authorization/util/__snapshots__/hasPermission.test.js.snap
+++ b/src/plugins/legacy-authorization/util/__snapshots__/hasPermission.test.js.snap
@@ -4,10 +4,8 @@ exports[`throws if no action 1`] = `"Action must be provided"`;
 
 exports[`throws if no authContext 1`] = `"authContext must be provided"`;
 
-exports[`throws if no authContext.shopId (referred to as \`roleGroup\`) 1`] = `"shopId (roleGroup) must be provided"`;
-
 exports[`throws if no resource 1`] = `"Resource must be provided"`;
 
-exports[`throws if roleGroup is present but an empty string 1`] = `"shopId (roleGroup) must be provided"`;
+exports[`throws if roleGroup is present but an empty string 1`] = `"roleGroup must be a non-empty string"`;
 
 exports[`throws if roleGroup is present but not a string 1`] = `"roleGroup must be a non-empty string"`;

--- a/src/plugins/legacy-authorization/util/hasPermission.js
+++ b/src/plugins/legacy-authorization/util/hasPermission.js
@@ -35,8 +35,6 @@ export default async function hasPermission(context, resource, action, authConte
 
   if (!authContext) throw new ReactionError("invalid-param", "authContext must be provided");
 
-  if (!authContext.shopId) throw new ReactionError("invalid-param", "shopId (roleGroup) must be provided");
-
   const { legacyRoles: permissions, shopId: roleGroup } = authContext; // TODO(pod-auth): temporarily provide legacy roles
 
   if (!Array.isArray(permissions)) throw new ReactionError("invalid-param", "permissions must be an array of strings");

--- a/src/plugins/legacy-authorization/util/hasPermission.test.js
+++ b/src/plugins/legacy-authorization/util/hasPermission.test.js
@@ -61,26 +61,6 @@ test("throws if no authContext", async () => {
   expect(result).rejects.toThrowErrorMatchingSnapshot();
 });
 
-test("throws if no authContext.shopId (referred to as `roleGroup`)", async () => {
-  const result = hasPermission(
-    {
-      user: {
-        roles: {
-          __global_roles__: ["can_fry_bacon"], // eslint-disable-line camelcase
-          scope: ["can_eat"]
-        }
-      }
-    },
-    "resource",
-    "action",
-    {
-      shopId: null,
-      legacyRoles: ["role1", "role2"]
-    }
-  );
-  expect(result).rejects.toThrowErrorMatchingSnapshot();
-});
-
 test("throws if roleGroup is present but not a string", async () => {
   const result = hasPermission(
     {


### PR DESCRIPTION
Resolves #5894   
Impact: **major**  
Type: **bugfix

## Issue
When creating the first shop, we don't have a shopID yet, so the check against the shopID was failing.

## Solution
Don't require shopId, and let the rest of the checks take care of this.

## Breaking changes
None

## Testing
1. Start the app and create your first shop