### PR TITLE
fix: comment out auth checks that aren't valid until new permissions are finished

### DIFF
--- a/src/core-services/catalog/queries/tag.js
+++ b/src/core-services/catalog/queries/tag.js
@@ -18,10 +18,11 @@ export default async function tag(context, input) {
   const { slugOrId, shopId, shouldIncludeInvisible = false } = input;
 
   // Check to make sure user has `read` permissions for this tag
-  await context.validatePermissions(`reaction:tags:${slugOrId}`, "read", {
-    shopId,
-    legacyRoles: ["admin", "owner", "tags"]
-  });
+  // TODO(auth-pod): revisit this check once legacyRoles are removed
+  // await context.validatePermissions("reaction:tags:${slugOrId}", "read", {
+  //   shopId,
+  //   legacyRoles: ["admin", "owner", "tags", "any"]
+  // });
 
   // Check to see if user has `read` permissions for hidden / deleted tags
   // TODO(pod-auth): revisit using `inactive` in resource, and revisit the word `inactive`

--- a/src/core-services/catalog/queries/tags.js
+++ b/src/core-services/catalog/queries/tags.js
@@ -35,7 +35,7 @@ export default async function tags(
   // Check to make sure user has `read` permissions for this tag
   await context.validatePermissions("reaction:tags", "read", {
     shopId,
-    legacyRoles: ["admin", "owner", "tags"]
+    legacyRoles: ["admin", "owner", "tags", "any"]
   });
 
   // Check to see if user has `read` permissions for hidden / deleted tags

--- a/src/core-services/catalog/queries/tags.js
+++ b/src/core-services/catalog/queries/tags.js
@@ -33,10 +33,11 @@ export default async function tags(
   let regexMatch;
 
   // Check to make sure user has `read` permissions for this tag
-  await context.validatePermissions("reaction:tags", "read", {
-    shopId,
-    legacyRoles: ["admin", "owner", "tags", "any"]
-  });
+  // TODO(auth-pod): revisit this check once legacyRoles are removed
+  // await context.validatePermissions("reaction:tags", "read", {
+  //   shopId,
+  //   legacyRoles: ["admin", "owner", "tags", "any"]
+  // });
 
   // Check to see if user has `read` permissions for hidden / deleted tags
   // TODO(pod-auth): revisit using `inactive` in resource, and revisit the word `inactive`

--- a/src/core-services/shop/mutations/createShop.js
+++ b/src/core-services/shop/mutations/createShop.js
@@ -163,6 +163,12 @@ export default async function createShop(context, input) {
 
     // Give the shop creator "owner" permissions
     await context.mutations.addAccountToGroupBySlug(context, { accountId, groupSlug: "owner", shopId: newShopId });
+    
+    // Add AppSettings object into database for the new shop
+    await collections.AppSettings.insertOne({
+      _id: Random.id(),
+      shopId: newShopId
+    });
   } catch (error) {
     Logger.error(error, "Error after creating shop");
   }

--- a/src/core-services/shop/mutations/createShop.js
+++ b/src/core-services/shop/mutations/createShop.js
@@ -163,7 +163,7 @@ export default async function createShop(context, input) {
 
     // Give the shop creator "owner" permissions
     await context.mutations.addAccountToGroupBySlug(context, { accountId, groupSlug: "owner", shopId: newShopId });
-    
+
     // Add AppSettings object into database for the new shop
     await collections.AppSettings.insertOne({
       _id: Random.id(),

--- a/src/plugins/legacy-authorization/util/hasPermission.js
+++ b/src/plugins/legacy-authorization/util/hasPermission.js
@@ -62,9 +62,6 @@ export default async function hasPermission(context, resource, action, authConte
     const groupRoles = roles[group];
 
     if (Array.isArray(groupRoles) && checkRoles.some((role) => groupRoles.includes(role))) return true;
-
-    // return true if "any" is provided
-    if (Array.isArray(permissions) && permissions.includes("any")) return true;
   }
 
   Logger.debug(`User ${user._id} has none of [${checkRoles.join(", ")}] permissions`);

--- a/src/plugins/legacy-authorization/util/hasPermission.js
+++ b/src/plugins/legacy-authorization/util/hasPermission.js
@@ -62,6 +62,9 @@ export default async function hasPermission(context, resource, action, authConte
     const groupRoles = roles[group];
 
     if (Array.isArray(groupRoles) && checkRoles.some((role) => groupRoles.includes(role))) return true;
+
+    // return true if "any" is provided
+    if (Array.isArray(permissions) && permissions.includes("any")) return true;
   }
 
   Logger.debug(`User ${user._id} has none of [${checkRoles.join(", ")}] permissions`);

--- a/src/plugins/navigation/queries/navigationTreeById.js
+++ b/src/plugins/navigation/queries/navigationTreeById.js
@@ -23,10 +23,11 @@ export default async function navigationTreeById(context, { language, navigation
     navigationTree.language = language;
 
     // Check to make sure user has `read` permissions for this navigationTree
-    await context.validatePermissions(`reaction:navigationTrees:${navigationTreeId}`, "read", {
-      shopId,
-      legacyRoles: ["owner", "admin", "create-product", "read-navigation", "any"]
-    });
+    // TODO(auth-pod): revisit this check once legacyRoles are removed
+    // await context.validatePermissions(`reaction:navigationTrees:${navigationTreeId}`, "read", {
+    //   shopId,
+    //   legacyRoles: ["owner", "admin", "create-product", "read-navigation", "any"]
+    // });
 
     // Check to see if user has `read` permissions for this navigationTree's drafts
     // TODO(pod-auth): revisit using `drafts` in resource

--- a/src/plugins/navigation/queries/navigationTreeById.js
+++ b/src/plugins/navigation/queries/navigationTreeById.js
@@ -25,7 +25,7 @@ export default async function navigationTreeById(context, { language, navigation
     // Check to make sure user has `read` permissions for this navigationTree
     await context.validatePermissions(`reaction:navigationTrees:${navigationTreeId}`, "read", {
       shopId,
-      legacyRoles: ["owner", "admin", "create-product", "read-navigation"]
+      legacyRoles: ["owner", "admin", "create-product", "read-navigation", "any"]
     });
 
     // Check to see if user has `read` permissions for this navigationTree's drafts


### PR DESCRIPTION
 Impact: **minor**  
Type: **bugfix**

## Issue
Because of the removal of "customer" and "anonymous" roles for accounts, there are a few places where read-only permissions were not functioning as expected.

## Solution
Add an "all" group to mock the old `customer` role and allow for navigation and tags to be read by anyone.

## Breaking changes
None


## Testing
1. See that tags and navigation queries work as expected
