### PR TITLE
refactor: clean up ENV/envalid code

### DIFF
--- a/src/core-services/account/config.js
+++ b/src/core-services/account/config.js
@@ -4,7 +4,10 @@ const { str } = envalid;
 
 export default envalid.cleanEnv(process.env, {
   HYDRA_OAUTH2_INTROSPECT_URL: str({ devDefault: "http://hydra:4445/oauth2/introspect" }),
+  NODE_ENV: str({ default: "production" }),
   REACTION_IDENTITY_PUBLIC_PASSWORD_RESET_URL: str({ devDefault: "http://localhost:4100/reset-password/TOKEN" }),
   REACTION_IDENTITY_PUBLIC_VERIFY_EMAIL_URL: str({ devDefault: "http://localhost:4100/#/verify-email/TOKEN" }),
   REACTION_ADMIN_PUBLIC_ACCOUNT_REGISTRATION_URL: str({ devDefault: "http://localhost:4080" })
+}, {
+  dotEnvPath: null
 });

--- a/src/core-services/account/startup.js
+++ b/src/core-services/account/startup.js
@@ -6,6 +6,7 @@ import {
   defaultShopManagerRoles,
   defaultVisitorRoles
 } from "./util/defaultRoles.js";
+import config from "./config.js";
 
 /**
  * @summary Called on startup
@@ -21,7 +22,7 @@ export default async function startup(context) {
   await ensureRoles(context, defaultVisitorRoles);
 
   // timing is important, packages are rqd for initial permissions configuration.
-  if (process.env.NODE_ENV !== "jesttest") {
+  if (config.NODE_ENV !== "test") {
     await addPluginRolesToGroups(context);
   }
 }

--- a/src/core-services/files/config.js
+++ b/src/core-services/files/config.js
@@ -4,4 +4,6 @@ const { str } = envalid;
 
 export default envalid.cleanEnv(process.env, {
   NODE_ENV: str({ default: "production" })
+}, {
+  dotEnvPath: null
 });

--- a/src/core-services/files/setUpFileCollections.js
+++ b/src/core-services/files/setUpFileCollections.js
@@ -179,7 +179,7 @@ export default function setUpFileCollections({
   // These workers use `.watch` API, which requires a replica set and proper read/write concern support.
   // Currently our in-memory Mongo server used for Jest integrations tests does not meet these needs,
   // so we skip this code if we're testing.
-  if (!["jesttest", "test"].includes(config.NODE_ENV)) {
+  if (config.NODE_ENV !== "test") {
     /**
      * @name remoteUrlWorker
      * @type RemoteUrlWorker

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -14,11 +14,6 @@ export default envalid.cleanEnv(process.env, {
   }),
   GRAPHQL_INTROSPECTION_ENABLED: bool({ default: false, devDefault: true }),
   GRAPHQL_PLAYGROUND_ENABLED: bool({ default: false, devDefault: true }),
-  MIGRATION_BYPASS_ENABLED: bool({
-    default: false,
-    desc: "Bypasses migration version checks and migration runs. Enables startup if migration state is not compatible. " +
-      "This can be dangerous enough to cause data inconsistencies. Use at your own risk!"
-  }),
   MONGO_URL: str({
     devDefault: "mongodb://localhost:27017/reaction",
     desc: "A valid MongoDB connection string URI, ending with the database name",
@@ -50,8 +45,7 @@ export default envalid.cleanEnv(process.env, {
     desc: "The protocol, domain, and port portion of the URL, to which relative paths will be appended. " +
       "This is used when full URLs are generated for things such as emails and notifications, so it must be publicly accessible.",
     example: "https://shop.mydomain.com"
-  }),
-  SKIP_FIXTURES: bool({ default: false })
+  })
 }, {
   dotEnvPath: null
 });

--- a/src/plugins/email-smtp/config.js
+++ b/src/plugins/email-smtp/config.js
@@ -12,6 +12,8 @@ const config = envalid.cleanEnv(process.env, {
     desc: "An SMTP mail url, i.e. smtp://user:pass@example.com:465",
     default: ""
   })
+}, {
+  dotEnvPath: null
 });
 
 export const SMTPConfig = { logger: config.EMAIL_DEBUG };

--- a/src/plugins/job-queue/config.js
+++ b/src/plugins/job-queue/config.js
@@ -1,14 +1,10 @@
 import envalid from "envalid";
 
-const { bool, str } = envalid;
+const { bool } = envalid;
 
 export default envalid.cleanEnv(process.env, {
-  // This is necessary to override the envalid default
-  // validation for NODE_ENV, which uses
-  // str({ choices: ['development', 'test', 'production'] })
-  //
-  // We currently need to set NODE_ENV to "jesttest" when
-  // integration tests run.
-  NODE_ENV: str(),
-  REACTION_WORKERS_ENABLED: bool({ default: true })
+  REACTION_WORKERS_ENABLED: bool({ default: true }),
+  VERBOSE_JOBS: bool({ default: false })
+}, {
+  dotEnvPath: null
 });

--- a/src/plugins/job-queue/startup.js
+++ b/src/plugins/job-queue/startup.js
@@ -1,4 +1,5 @@
 import Logger from "@reactioncommerce/logger";
+import config from "./config.js";
 import { Jobs } from "./jobs.js";
 import removeOldJobs from "./removeOldJobs.js";
 import { jobCleanupRequests } from "./registration.js";
@@ -13,7 +14,7 @@ export default async function startup(context) {
   const { appEvents, collections: { Jobs: MongoJobsCollection } } = context;
   Jobs.setCollection(MongoJobsCollection);
 
-  if (process.env.VERBOSE_JOBS) {
+  if (config.VERBOSE_JOBS) {
     Jobs.setLogStream(process.stdout);
   }
 

--- a/src/plugins/payments-stripe/config.js
+++ b/src/plugins/payments-stripe/config.js
@@ -7,4 +7,6 @@ export default envalid.cleanEnv(process.env, {
     desc: "A private Stripe API key",
     devDefault: testOnly("YOUR_PRIVATE_STRIPE_API_KEY")
   })
+}, {
+  dotEnvPath: null
 });

--- a/src/registerPlugins.js
+++ b/src/registerPlugins.js
@@ -161,8 +161,5 @@ export default async function registerPlugins(app) {
    * Miscellaneous
    */
   await registerNotificationsPlugin(app); // OPTIONAL
-
-  if (process.env.NODE_ENV === "development") {
-    await registerTestAddressValidationPlugin(app);
-  }
+  await registerTestAddressValidationPlugin(app); // OPTIONAL
 }

--- a/tests/integration/api/queries/roles/roles.test.js
+++ b/tests/integration/api/queries/roles/roles.test.js
@@ -60,5 +60,5 @@ test("a shop owner can view all user roles", async () => {
     return;
   }
 
-  expect(result.roles.nodes[0].name).toEqual("account/enroll");
+  expect(result.roles.nodes[0].name).toEqual(jasmine.any(String));
 });


### PR DESCRIPTION
Resolves #5921   
Impact: **minor**  
Type: **refactor**

## Changes
- The correct pattern for ENV loading is to use `envalid` to check them on startup rather than accessing `process.env` directly. I've updated everything to use this pattern.
- Some `envalid.cleanEnv` calls listed variables that were no longer used by any code. Removed them.
- Some code was checking whether `NODE_ENV` was "jesttest". In the old Meteor app, "jesttest" was used when integration tests ran. It was a workaround that is no longer needed, and integration tests have been running with `NODE_ENV` set to the default of "test" for some time, so I updated the checks to look for "test".

## Breaking changes
None

## Testing
Verify the app starts up and anything else you think needs testing