### PR TITLE
fix: add shop based roles to first user account

### DIFF
--- a/imports/node-app/core-services/account/util/createDefaultAdminUser.js
+++ b/imports/node-app/core-services/account/util/createDefaultAdminUser.js
@@ -76,7 +76,8 @@ export default async function createDefaultAdminUser(context) {
     $set: {
       name: userInput.name,
       roles: {
-        __global_roles__: defaultOwnerRoles // eslint-disable-line camelcase
+        __global_roles__: defaultOwnerRoles, // eslint-disable-line camelcase
+        [shop._id]: defaultOwnerRoles // eslint-disable-line camelcase
       }
     }
   });


### PR DESCRIPTION
Resolves #5794 & #5805 
Impact: **critical**  
Type: **bugfix**

## Issue
The initial user created was not getting roles on a per-shop basis, which causes a lot of issues throughout the app.

## Solution
Add roles based on `shopId` for the first user.

If you're solving a UIX related issue, please attach screen-caps or gifs showing how your solution differs from the issue.

## Breaking changes
None

## Testing
1. Start the app
1. See you can invite a user when logged in as the first user (#5794)
1. See that you see products in the operator (#5805)