### PR TITLE
fix: missing logout button

### DIFF
--- a/imports/plugins/core/accounts/server/init.js
+++ b/imports/plugins/core/accounts/server/init.js
@@ -126,6 +126,11 @@ Meteor.startup(() => {
       emailIsVerified = true;
     }
 
+    // Set the first email to be the default
+    if (user.emails[0]) {
+      user.emails[0].provides = "default";
+    }
+
     // create a tokenObj and send a welcome email to new users,
     // but skip the first default admin user and anonymous users
     // (default admins already get a verification email)


### PR DESCRIPTION
Resolves #5740  
Impact: **critical**  
Type: **bugfix**

## Issue

no logout button

## Solution

Set the first email to default when creating a user. This seems to be an issue when creating new users.

## Breaking changes

none

## Testing
1. Start the app with a fresh DB
1. Sign in to the admin
1. Look in the top right and see the `(A)` button, click it
1. Sign out
