### PR TITLE
[WIP] Add graphql equivalent of updateGroup found in reaction-admin

### DIFF
--- a/src/core-services/account/mutations/updateAccountGroup.js
+++ b/src/core-services/account/mutations/updateAccountGroup.js
@@ -1,0 +1,63 @@
+import Logger from "@reactioncommerce/logger";
+import { check } from "meteor/check";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import ReactionError from "@reactioncommerce/reaction-error";
+import { Accounts, Groups } from "/lib/collections";
+import setUserPermissions from "../../util/setUserPermissions";
+
+/**
+ * @name group/updateGroup
+ * @method
+ * @memberof Group/Methods
+ * @summary Updates a permission group for a shop.
+ * Change the details of a group (name, desc, permissions etc) to the values passed in.
+ * It also goes into affected user data to modify both the groupName (using Accounts schema)
+ * and group permissions (using "accounts/removeUserPermissions")
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - an object of all mutation arguments that were sent by the client
+ * @param {Object} input.groupId - groupId of group to be updated
+ * @param {Object} input.newGroupData - updated group info (similar to current group data)
+ * slug remains untouched; used as key in querying
+ * @param {String} input.shopId - id of the shop the group belongs to
+ * @returns {Object} - the updated group
+ */
+export default function updateGroup(context, input) {
+  check(groupId, String);
+  check(newGroupData, Object);
+  check(shopId, String);
+
+  const { groupId, newGroupData, shopId } = input
+  // we are limiting group method actions to only users with admin roles
+  // this also include shop owners, since they have the `admin` role in their Roles.GLOBAL_GROUP
+  if (!Reaction.hasPermission("admin", Reaction.getUserId(), shopId)) {
+    throw new ReactionError("access-denied", "Access Denied");
+  }
+
+  // 1. Update the group data
+  const update = newGroupData;
+  delete update.slug; // slug remains constant because it's used as key in querying. So we remove it if it was passed
+
+  const group = Groups.findOne({ _id: groupId }) || {};
+
+  // prevent edits on owner. Owner groups is the default containing all roles, and as such should be untouched
+  if (group.slug === "owner") {
+    throw new ReactionError("invalid-parameter", "Bad request");
+  }
+
+  Groups.update({ _id: groupId, shopId }, { $set: update });
+
+  // 2. Check & Modify users in the group that changed
+  const users = Accounts.find({ groups: { $in: [groupId] } }).fetch();
+  let error;
+
+  if (newGroupData.permissions && newGroupData.permissions.length) {
+    error = setUserPermissions(users, newGroupData.permissions, shopId);
+  }
+
+  // 3. Return response
+  if (!error) {
+    return { status: 200, group: Groups.findOne({ _id: groupId }) };
+  }
+  Logger.error(error);
+  throw new ReactionError("server-error", "Update not successful");
+}


### PR DESCRIPTION
Resolves #5832  
Impact: **major**  
Type: **feature**

## Issue
We need to add a GraphQL equivalent of the `updateGroup` found in reaction-admin at https://github.com/reactioncommerce/reaction-admin/blob/trunk/imports/plugins/core/accounts/server/methods/group/updateGroup.js into reaction. This will allow for updating groups that users belong to in `reaction`. This will also help our demeteorization efforts and also help transition to reaction-authorization service.

We also need to add integration tests and unit tests for the newly created equivalent

## Solution
- Add GraphQL equivalent of `updateGroup`  found in reaction-admin to reaction (resolver function and mutation functions)
- Add integration tests for the newly created GQL `updateGroup` 
- We've changed the name of the equivalent `updateGroup`  to `updateAccountGroup`  as that best describes the functionality what is being performed 

## Breaking changes
-  the `updateGroup`  GQL mutation has been renamed to `updateAccountGroup` 


## Testing
1. Tests should pass on CI
2. integration tests are found at
 - **YET TO BE ADDED**
 3. unit tests are found at
 - **YET TO BE ADDED**
4. run the tests with `npm run test`
