### PR TITLE
fix: routing when logging in from storefront

### DIFF
--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -6,6 +6,7 @@ import Logger from "/client/modules/logger";
 import { Meteor } from "meteor/meteor";
 import Button from "@material-ui/core/Button";
 import withStyles from "@material-ui/core/styles/withStyles";
+import InlineAlert from "@reactioncommerce/components/InlineAlert/v1";
 import ShopLogo from "/imports/client/ui/components/ShopLogoWithData/ShopLogoWithData";
 
 const styles = (theme) => ({
@@ -80,6 +81,24 @@ function CoreLayout({ classes, isAdmin, isLoading, isLoggedIn, location, storefr
         </div>
       );
     }
+  }
+
+  // If user is logged in, and they come from storefront (/account in url)
+  // redirect to storefront
+  if (location.pathname.startsWith("/account") && isLoggedIn) {
+    if (storefrontHomeUrl && storefrontHomeUrl.length) {
+      window.location.href = storefrontHomeUrl;
+      return null;
+    }
+
+    Logger.warn("Missing storefront home URL. Please set this from the shop settings panel so that customer users can be redirected to your storefront.");
+
+    content = (
+      <InlineAlert
+        alertType="error"
+        message="Missing storefront home URL. Please set this from the shop settings panel so that customer users can be redirected to your storefront."
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
Resolves #5878 
Impact: **critical**  
Type: **bugfix**

## Issue
Logging in from the storefront left the user on the login page, no redirect back to storefront

## Solution
Fix this so you go back to storefront when logging in from storefront

## Breaking changes
None


## Testing
1. Go to storefront
1. Click login
1. Login with credentials
1. See you are redirected back to storefront after logging in