### PR TITLE
Return fulfillment quotes without a shipping address

### DIFF
--- a/src/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
+++ b/src/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
@@ -2,6 +2,8 @@ import Logger from "@reactioncommerce/logger";
 import isShippingRestricted from "./util/isShippingRestricted.js";
 import filterShippingMethods from "./util/filterShippingMethods.js";
 
+const packageName = "flat-rate-shipping";
+
 /**
  * @summary Returns a list of fulfillment method quotes based on the items in a fulfillment group.
  * @param {Object} context - Context
@@ -19,29 +21,13 @@ export default async function getFulfillmentMethodsWithQuotes(context, commonOrd
   const { collections } = context;
   const { Shipping } = collections;
   const [rates = [], retrialTargets = []] = previousQueryResults;
-  const currentMethodInfo = {
-    packageName: "flat-rate-shipping",
-    fileName: "hooks.js"
-  };
+  const currentMethodInfo = { packageName };
 
   if (retrialTargets.length > 0) {
-    const isNotAmongFailedRequests = retrialTargets.every((target) =>
-      target.packageName !== currentMethodInfo.packageName &&
-      target.fileName !== currentMethodInfo.fileName);
+    const isNotAmongFailedRequests = retrialTargets.every((target) => target.packageName !== packageName);
     if (isNotAmongFailedRequests) {
       return previousQueryResults;
     }
-  }
-
-  // Verify that we have a valid address to work with
-  if (!commonOrder.shippingAddress) {
-    const errorDetails = {
-      requestStatus: "error",
-      shippingProvider: "flat-rate-shipping",
-      message: "Fulfillment group is missing a shipping address"
-    };
-    rates.push(errorDetails);
-    return [rates, retrialTargets];
   }
 
   const { isShippingRatesFulfillmentEnabled } = await context.queries.appSettings(context, commonOrder.shopId);
@@ -63,7 +49,7 @@ export default async function getFulfillmentMethodsWithQuotes(context, commonOrd
   if (isOrderShippingRestricted) {
     const errorDetails = {
       requestStatus: "error",
-      shippingProvider: "flat-rate-shipping",
+      shippingProvider: packageName,
       message: "Flat rate shipping did not return any shipping methods."
     };
     rates.push(errorDetails);
@@ -101,7 +87,7 @@ export default async function getFulfillmentMethodsWithQuotes(context, commonOrd
   if (rates.length === initialNumOfRates) {
     const errorDetails = {
       requestStatus: "error",
-      shippingProvider: "flat-rate-shipping",
+      shippingProvider: packageName,
       message: "Flat rate shipping did not return any shipping methods."
     };
     rates.push(errorDetails);

--- a/src/plugins/shipping-rates/util/attributeDenyCheck.js
+++ b/src/plugins/shipping-rates/util/attributeDenyCheck.js
@@ -1,10 +1,11 @@
 import operators from "@reactioncommerce/api-utils/operators.js";
 import propertyTypes from "@reactioncommerce/api-utils/propertyTypes.js";
+import isDestinationRestricted from "./isDestinationRestricted.js";
 
 /**
  * @summary Filter shipping methods based on per method deny attribute restrictions
  * @param {Object} methodRestrictions - method restrictions from FlatRateFulfillmentRestrcitionsCollection
- * @param {Object} method - current method to check restrcictions against
+ * @param {Object} method - current method to check restrictions against
  * @param {Object} hydratedOrder - hydrated order for current order
  * @returns {Bool} true / false as to whether method is still valid after this check
  */
@@ -34,24 +35,7 @@ export async function attributeDenyCheck(methodRestrictions, method, hydratedOrd
 
         if (attributeFound) {
           // If there is no destination restriction, destination restriction is global
-          // Return true to restrict this method
-          if (!destination) return attributeFound;
-
-          const { country: restrictionCountry, postal: restrictionPostal, region: restrictionRegion } = destination;
-
-          if (restrictionPostal && restrictionPostal.includes(shippingAddress.postal)) {
-            return true;
-          }
-
-          // Check for an allow list of regions
-          if (restrictionRegion && restrictionRegion.includes(shippingAddress.region)) {
-            return true;
-          }
-
-          // Check for an allow list of countries
-          if (restrictionCountry && restrictionCountry.includes(shippingAddress.country)) {
-            return true;
-          }
+          return !destination || isDestinationRestricted(destination, shippingAddress);
         }
 
         // If shipping location does not match restricted location && attribute, method is not restricted

--- a/src/plugins/shipping-rates/util/isDestinationRestricted.js
+++ b/src/plugins/shipping-rates/util/isDestinationRestricted.js
@@ -1,0 +1,29 @@
+/**
+ * @summary Returns true if the given shipping address is restricted by destination rules
+ * @param {Object} destination Destination restrictions
+ * @param {Object} [shippingAddress] Shipping address, if known
+ * @return {Boolean} True if restricted
+ */
+export default function isDestinationRestricted(destination, shippingAddress) {
+  // If there is no shipping address, we can't restrict by destination
+  if (!shippingAddress) return false;
+
+  const { country: restrictionCountry, postal: restrictionPostal, region: restrictionRegion } = destination;
+
+  // Start checking at the micro-level, and move more macro as we go on
+  if (restrictionPostal && restrictionPostal.includes(shippingAddress.postal)) {
+    return true;
+  }
+
+  // Check for an allow list of regions
+  if (restrictionRegion && restrictionRegion.includes(shippingAddress.region)) {
+    return true;
+  }
+
+  // Check for an allow list of countries
+  if (restrictionCountry && restrictionCountry.includes(shippingAddress.country)) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/plugins/shipping-rates/util/isShippingRestricted.js
+++ b/src/plugins/shipping-rates/util/isShippingRestricted.js
@@ -1,5 +1,6 @@
 import operators from "@reactioncommerce/api-utils/operators.js";
 import propertyTypes from "@reactioncommerce/api-utils/propertyTypes.js";
+import isDestinationRestricted from "./isDestinationRestricted.js";
 
 /**
  * @summary Filter shipping methods based on global restrictions
@@ -29,24 +30,7 @@ export default async function isShippingRestricted(context, hydratedOrder) {
 
           if (attributeFound) {
             // If there is no destination restriction, destination restriction is global
-            // Return true to restrict this method
-            if (!destination) return attributeFound;
-
-            const { country: restrictionCountry, postal: restrictionPostal, region: restrictionRegion } = destination;
-
-            if (restrictionPostal && restrictionPostal.includes(shippingAddress.postal)) {
-              return true;
-            }
-
-            // Check for an allow list of regions
-            if (restrictionRegion && restrictionRegion.includes(shippingAddress.region)) {
-              return true;
-            }
-
-            // Check for an allow list of countries
-            if (restrictionCountry && restrictionCountry.includes(shippingAddress.country)) {
-              return true;
-            }
+            return !destination || isDestinationRestricted(destination, shippingAddress);
           }
 
           // If shipping location does not match restricted location && attribute, method is not restricted
@@ -56,21 +40,7 @@ export default async function isShippingRestricted(context, hydratedOrder) {
 
       if (destination) {
         // There are no attribute restrictions, only check destination restrictions
-        const { country: restrictionCountry, postal: restrictionPostal, region: restrictionRegion } = destination;
-
-        if (restrictionPostal && restrictionPostal.includes(shippingAddress.postal)) {
-          return true;
-        }
-
-        // Check for an allow list of regions
-        if (restrictionRegion && restrictionRegion.includes(shippingAddress.region)) {
-          return true;
-        }
-
-        // Check for an allow list of countries
-        if (restrictionCountry && restrictionCountry.includes(shippingAddress.country)) {
-          return true;
-        }
+        return isDestinationRestricted(destination, shippingAddress);
       }
 
       return false;

--- a/src/plugins/shipping-rates/util/locationAllowCheck.js
+++ b/src/plugins/shipping-rates/util/locationAllowCheck.js
@@ -1,7 +1,9 @@
+import isDestinationRestricted from "./isDestinationRestricted.js";
+
 /**
  * @summary Filter shipping methods based on per method allow location restrictions
  * @param {Object} methodRestrictions - method restrictions from FlatRateFulfillmentRestrcitionsCollection
- * @param {Object} method - current method to check restrcictions against
+ * @param {Object} method - current method to check restrictions against
  * @param {Object} hydratedOrder - hydrated order for current order
  * @returns {Bool} true / false as to whether method is still valid after this check
  */
@@ -18,28 +20,7 @@ export async function locationAllowCheck(methodRestrictions, method, hydratedOrd
   const isAllowed = allowRestrictions.some((methodRestriction) => {
     const { destination } = methodRestriction;
 
-    // If there is no destination restriction on this method, it is valid at this point
-    if (!destination) {
-      return true;
-    }
-
-    // Start checking at the micro-level, and move more macro as we go on
-    // Check for an allow list of postal codes
-    if (destination.postal && destination.postal.includes(shippingAddress.postal)) {
-      return true;
-    }
-
-    // Check for an allow list of regions
-    if (destination.region && destination.region.includes(shippingAddress.region)) {
-      return true;
-    }
-
-    // Check for an allow list of countries
-    if (destination.country && destination.country.includes(shippingAddress.country)) {
-      return true;
-    }
-
-    return false;
+    return !destination || isDestinationRestricted(destination, shippingAddress);
   });
 
   return isAllowed;

--- a/src/plugins/shipping-rates/util/locationDenyCheck.js
+++ b/src/plugins/shipping-rates/util/locationDenyCheck.js
@@ -1,7 +1,9 @@
+import isDestinationRestricted from "./isDestinationRestricted.js";
+
 /**
  * @summary Filter shipping methods based on per method deny location restrictions
  * @param {Object} methodRestrictions - method restrictions from FlatRateFulfillmentRestrcitionsCollection
- * @param {Object} method - current method to check restrcictions against
+ * @param {Object} method - current method to check restrictions against
  * @param {Object} hydratedOrder - hydrated order for current order
  * @returns {Bool} true / false as to whether method is still valid after this check
  */
@@ -18,28 +20,7 @@ export async function locationDenyCheck(methodRestrictions, method, hydratedOrde
   const isAllowed = denyRestrictions.every((methodRestriction) => {
     const { destination } = methodRestriction;
 
-    // If there is no destination restriction on this method, it is valid at this point
-    if (!destination) {
-      return true;
-    }
-
-    // Start checking at the macro-level, and move more macro as we go on
-    // Check for an allow list of countries
-    if (destination.country && destination.country.includes(shippingAddress.country)) {
-      return false;
-    }
-
-    // Check for an allow list of regions
-    if (destination.region && destination.region.includes(shippingAddress.region)) {
-      return false;
-    }
-
-    // Check for an allow list of postal codes
-    if (destination.postal && destination.postal.includes(shippingAddress.postal)) {
-      return false;
-    }
-
-    return true;
+    return !destination || !isDestinationRestricted(destination, shippingAddress);
   });
 
   return isAllowed;


### PR DESCRIPTION
Resolves #5472   
Impact: **minor**  
Type: **feature**

## Changes
The `getFulfillmentMethodsWithQuotes` function in the `shipping-rates` plugin now looks up shipping rates and applies shipping restrictions as much as it can when there is no `shippingAddress` on the order/cart yet. Previously it would throw an error.

## Breaking changes
The behavior has changed, but not in a way that is likely to confuse anyone.

## Testing
- Call the `updateFulfillmentOptionsForGroup` mutation before setting a shipping address on the cart and verify that shipping rates are added to the cart.
- Define a restriction that is not based on destination and verify that it is correctly applied.