### PR TITLE
fix: add default account as owner and add provides to accounts

### DIFF
--- a/imports/node-app/core-services/account/util/createDefaultAdminUser.js
+++ b/imports/node-app/core-services/account/util/createDefaultAdminUser.js
@@ -11,7 +11,7 @@ import createUser from "./createUser.js";
  */
 export default async function createDefaultAdminUser(context) {
   const { collections } = context;
-  const { Shops, users } = collections;
+  const { Shops, users, Accounts } = collections;
 
   // Check whether a non-shop-specific "owner" user already exists
   const ownerUser = await users.findOne({ "roles.__global_roles__": "owner" });
@@ -69,6 +69,16 @@ export default async function createDefaultAdminUser(context) {
   }
 
   const userId = await createUser(userInput);
+
+  // The default user have to be the owner.
+  const group = await collections.Groups.findOne({ slug: "owner", shopId: shop._id });
+
+  await Accounts.findOneAndUpdate({
+    _id: userId,
+    shopId: shop._id
+  }, {
+    $set: { groups: [group._id] }
+  });
 
   // Update the new user document with roles and other fields that Meteor's createUser
   // doesn't support.

--- a/imports/plugins/core/accounts/server/init.js
+++ b/imports/plugins/core/accounts/server/init.js
@@ -77,6 +77,8 @@ Meteor.startup(() => {
         const group = Collections.Groups.findOne({ slug: "customer", shopId });
         // if no group or customer permissions retrieved from DB, use the default Reaction customer set
         roles[shopId] = (group && group.permissions) || Reaction.defaultCustomerRoles;
+        // if we have not services we have to set the provides to "default" to get primaryEmailAddress
+        user.emails[0].provides = "default";
       }
     }
 
@@ -123,6 +125,7 @@ Meteor.startup(() => {
     let emailIsVerified = false;
     if (user.emails[0] && user.emails[0].address.indexOf("localhost") > -1) {
       user.emails[0].verified = true;
+      user.emails[0].provides = "default";
       emailIsVerified = true;
     }
 


### PR DESCRIPTION
Resolves #5805 
Impact: **minor**  
Type: **bugfix**

## Issue
When the project is started for first time, the default account have not correct role in Accounts collection. The Account is created as customer and it has not provides field in the collection. This missing information affect the profile component when it's called the account viewer and the primaryEmailAddress is null.

## Solution
First at all, I assigned the provide field in the Account collection for the user when is created if this has not services from authentication. After that I assigned the owner role to the default account because I want to have all permissions for modify the store.

## Breaking changes
The behavior is the same. No Braking changes.

## Testing
1. Clean the database
2. Start the project
3. Login with the default account and get into profile settings