### PR TITLE
tests: add integration test for enablePaymentMethodForShop

### DIFF
--- a/tests/integration/api/mutations/payments/EnablePaymentMethodsForShopMutation.graphql
+++ b/tests/integration/api/mutations/payments/EnablePaymentMethodsForShopMutation.graphql
@@ -1,0 +1,8 @@
+mutation( $enablePaymentMethodForShopInput: EnablePaymentMethodForShopInput!) {
+  enablePaymentMethodForShop(input: $enablePaymentMethodForShopInput) {
+    paymentMethods {
+      isEnabled
+      name
+    }
+  }
+}

--- a/tests/integration/api/mutations/payments/__snapshots__/enablePaymentMethodsForShop.test.js.snap
+++ b/tests/integration/api/mutations/payments/__snapshots__/enablePaymentMethodsForShop.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`an unauthorized user should not be able to update the payment methods 1`] = `
+Array [
+  Object {
+    "extensions": Object {
+      "code": "FORBIDDEN",
+      "exception": Object {
+        "details": Object {},
+        "error": "access-denied",
+        "eventData": Object {},
+        "isClientSafe": true,
+        "reason": "Access Denied",
+      },
+    },
+    "locations": Array [
+      Object {
+        "column": 3,
+        "line": 2,
+      },
+    ],
+    "message": "Access Denied",
+    "path": Array [
+      "enablePaymentMethodForShop",
+    ],
+  },
+]
+`;

--- a/tests/integration/api/mutations/payments/enablePaymentMethodsForShop.test.js
+++ b/tests/integration/api/mutations/payments/enablePaymentMethodsForShop.test.js
@@ -1,0 +1,75 @@
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const EnablePaymentMethodsForShopMutation = importAsString("./EnablePaymentMethodsForShopMutation.graphql");
+
+const internalShopId = "123";
+const opaqueShopId = "cmVhY3Rpb24vc2hvcDoxMjM="; // reaction/shop:123
+const shopName = "Test Shop";
+
+const mockAdminAccount = Factory.Account.makeOne({
+  roles: {
+    [internalShopId]: ["admin", "core"]
+  }
+});
+
+jest.setTimeout(300000);
+
+let testApp;
+let enablePaymentMethodsForShop;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  await testApp.insertPrimaryShop({ _id: internalShopId, name: shopName, PaymentMethods: ["iou_example"] });
+  await testApp.createUserAndAccount(mockAdminAccount);
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  enablePaymentMethodsForShop = await testApp.mutate(EnablePaymentMethodsForShopMutation);
+});
+
+beforeEach(async () => {
+  await testApp.clearLoggedInUser();
+});
+
+afterAll(async () => {
+  await testApp.collections.users.deleteMany({});
+  await testApp.collections.Accounts.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.stop();
+});
+
+test("an authorized user should be able to update the payment methods", async () => {
+  let result;
+  try {
+    await testApp.setLoggedInUser(mockAdminAccount);
+    result = await enablePaymentMethodsForShop({
+      enablePaymentMethodForShopInput: {
+        isEnabled: true,
+        paymentMethodName: "iou_example",
+        shopId: opaqueShopId
+      }
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+  }
+
+  const updatedPaymentMethod = result.enablePaymentMethodForShop.paymentMethods.find((paymentMethod) => paymentMethod.name === "iou_example");
+  expect(typeof updatedPaymentMethod).toEqual("object");
+  expect(updatedPaymentMethod).toEqual({ isEnabled: true, name: "iou_example" });
+});
+
+test("an unauthorized user should not be able to update the payment methods", async () => {
+  try {
+    await enablePaymentMethodsForShop({
+      enablePaymentMethodForShopInput: {
+        isEnabled: true,
+        paymentMethodName: "iou_example",
+        shopId: opaqueShopId
+      }
+    });
+  } catch (error) {
+    expect(error).toMatchSnapshot();
+  }
+});


### PR DESCRIPTION
Signed-off-by: trojanh <rajan.tiwari@kiprosh.com>

Resolves https://github.com/reactioncommerce/reaction/issues/5943
Impact: **minor**  
Type: **test|chore**

## Issue
Integration test for enablePaymentMethodForShop