### PR TITLE
fix: login from storefront

### DIFF
--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -75,7 +75,9 @@ class AuthContainer extends Component {
             }
           });
         } else {
-          Router.go(this.props.currentRoute.route.path);
+          Meteor.call("oauth/login", { challenge }, (err, redirect_to) => {
+            window.location.href = redirect_to;
+          });
         }
       });
     } else if (this.props.currentView === "loginFormSignUpView") {

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -45,6 +45,7 @@ class AuthContainer extends Component {
 
     const validatedEmail = LoginFormValidation.email(username);
     const validatedPassword = LoginFormValidation.password(pword, { validationLevel: "exists" });
+    const challenge = Router.current().query.login_challenge;
 
     if (validatedEmail !== true) {
       errors.email = validatedEmail;

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -75,8 +75,8 @@ class AuthContainer extends Component {
             }
           });
         } else {
-          Meteor.call("oauth/login", { challenge }, (err, redirect_to) => {
-            window.location.href = redirect_to;
+          Meteor.call("oauth/login", { challenge }, (err, redirectUrl) => {
+            window.location.href = redirectUrl;
           });
         }
       });
@@ -96,8 +96,8 @@ class AuthContainer extends Component {
             }
           });
         } else {
-          Meteor.call("oauth/login", { challenge }, (err, redirect_to) => {
-            window.location.href = redirect_to;
+          Meteor.call("oauth/login", { challenge }, (err, redirectUrl) => {
+            window.location.href = redirectUrl;
           });
         }
       });

--- a/imports/plugins/core/accounts/client/containers/auth.js
+++ b/imports/plugins/core/accounts/client/containers/auth.js
@@ -96,7 +96,9 @@ class AuthContainer extends Component {
             }
           });
         } else {
-          Router.go(this.props.currentRoute.route.path);
+          Meteor.call("oauth/login", { challenge }, (err, redirect_to) => {
+            window.location.href = redirect_to;
+          });
         }
       });
     }

--- a/imports/plugins/core/hydra-oauth/server/oauthMethods.js
+++ b/imports/plugins/core/hydra-oauth/server/oauthMethods.js
@@ -30,7 +30,9 @@ export function oauthLogin(options) {
       // eslint-disable-next-line camelcase
       remember_for: HYDRA_SESSION_LIFESPAN ? Number(HYDRA_SESSION_LIFESPAN) : 86400
     })
-    .then((response) => response.redirect_to)
+    .then((response) => {
+      return response.redirect_to;
+    })
     .catch((error) => {
       Logger.error(error);
       throw error;

--- a/imports/plugins/core/layout/client/components/coreLayout.js
+++ b/imports/plugins/core/layout/client/components/coreLayout.js
@@ -142,6 +142,7 @@ CoreLayout.propTypes = {
   isLoading: PropTypes.bool,
   isLoggedIn: PropTypes.bool,
   location: PropTypes.object,
+  referer: PropTypes.string,
   storefrontHomeUrl: PropTypes.string
 };
 
@@ -158,7 +159,7 @@ function composer(props, onData) {
   const shop = Reaction.getCurrentShop();
   const isLoading = (isAdmin !== true && isAdmin !== false) || !shop;
   const isLoggedIn = !!Reaction.getUserId();
-  const referer = Router.current().query.referer;
+  const { referer } = Router.current().query;
 
   onData(null, {
     isAdmin,


### PR DESCRIPTION
Impact: **critical**  
Type: **bugfix**

You need to be [this branch of Example Storefront](https://github.com/reactioncommerce/example-storefront/pull/633) when testing. That PR and this one should be merged at the same time.


## Issue
Account login was not working when trying to login via example storefront.

## Solution
Add `oauth` login method to new `AuthContainer`. This is how we used to do oauth login in the past, when we used `OauthContainer`, but this was removed / with the new `AuthContainer`.

## Breaking changes
None

## Testing
1. Start the full app (reaction / storefront (PR https://github.com/reactioncommerce/example-storefront/pull/633)
1. Navigate to storefront
1. Login
1. See you are redirected back to storefront, and you are logged in
1. Logout
1. See you are redirected back to storefront, and are logged out
