### PR TITLE
refactor: use globalRoles if shopId is not provided

### DIFF
--- a/src/plugins/legacy-authorization/util/hasPermission.js
+++ b/src/plugins/legacy-authorization/util/hasPermission.js
@@ -35,7 +35,12 @@ export default async function hasPermission(context, resource, action, authConte
 
   if (!authContext) throw new ReactionError("invalid-param", "authContext must be provided");
 
-  const { legacyRoles: permissions, shopId: roleGroup } = authContext; // TODO(pod-auth): temporarily provide legacy roles
+  let roleGroup = "__global_roles__";
+  const { legacyRoles: permissions, shopId } = authContext; // TODO(pod-auth): temporarily provide legacy roles
+
+  if (shopId) {
+    roleGroup = shopId;
+  }
 
   if (!Array.isArray(permissions)) throw new ReactionError("invalid-param", "permissions must be an array of strings");
   if (roleGroup !== undefined && roleGroup !== null && (typeof roleGroup !== "string" || roleGroup.length === 0)) {


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
If shopId is not provided in a permission check, the check fails no matter what.

## Solution
Add a check to check against `__global_roles__` if `shopId` isn't provided.

## Testing
1. Perform an action using a mutation where `shopId` is not provided, such as `updateAppSettings.js`
1. See that permissions pass if the user has global roles
