### PR TITLE
refactor: use better cache policy to show newly created tags

### DIFF
--- a/imports/plugins/core/tags/client/components/TagDataTable.js
+++ b/imports/plugins/core/tags/client/components/TagDataTable.js
@@ -465,7 +465,7 @@ class TagDataTable extends Component {
 
     // All available props: https://github.com/tannerlinsley/react-table#props
     return (
-      <Query query={query} variables={variables}>
+      <Query query={query} variables={variables} fetchPolicy="cache-and-network">
         {({ data, fetchMore, refetch }) => {
           const result = (data[otherProps.dataKey] && data[otherProps.dataKey].nodes) || [];
           const resultCount = (Array.isArray(result) && result.length) || 0;


### PR DESCRIPTION
Resolves #5949   
Impact: **minor**  
Type: **bugfix|refactor**

## Issue
New tags are not showing up in the tags table in the admin, until the page is refreshed

## Solution
Update the query that retrieves the tags to get data from the network, in addition to the cache.

[cache-and-network](https://www.apollographql.com/docs/react/api/react-apollo/#optionsfetchpolicy) will use the cache first, so the page will load with the previous data, and then immediately update with new data. This query will not be hit consistently on the customer side, only sparingly on the admin side, so the performance hit that will occur from loading via the network shouldn't be noticeable.

## Breaking changes
None

## Testing
1. Add new tags via the admin UI
1. See the tags show up in the tag table immediately, without page refresh.
