### PR TITLE
Fix cart total calculation when shipping includes handling fee

### DIFF
--- a/imports/node-app/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
+++ b/imports/node-app/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
@@ -87,6 +87,7 @@ export default async function getFulfillmentMethodsWithQuotes(context, commonOrd
         if (!method.carrier) {
           method.carrier = carrier;
         }
+        
         rates.push({
           carrier,
           handlingPrice: method.handling,

--- a/imports/node-app/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
+++ b/imports/node-app/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
@@ -87,13 +87,12 @@ export default async function getFulfillmentMethodsWithQuotes(context, commonOrd
         if (!method.carrier) {
           method.carrier = carrier;
         }
-        const rate = method.rate + method.handling;
         rates.push({
           carrier,
           handlingPrice: method.handling,
           method,
-          rate,
-          shippingPrice: method.rate,
+          rate: method.rate,
+          shippingPrice: method.rate + method.handling,
           shopId: doc.shopId
         });
       }

--- a/imports/node-app/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
+++ b/imports/node-app/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
@@ -87,7 +87,7 @@ export default async function getFulfillmentMethodsWithQuotes(context, commonOrd
         if (!method.carrier) {
           method.carrier = carrier;
         }
-        
+
         rates.push({
           carrier,
           handlingPrice: method.handling,

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
@@ -141,7 +141,7 @@ function xformCartFulfillmentGroup(fulfillmentGroup, cart) {
       currencyCode: cart.currencyCode
     },
     price: {
-      amount: option.rate || 0,
+      amount: (option.rate + option.handlingPrice) || 0,
       currencyCode: cart.currencyCode
     }
   }));
@@ -162,7 +162,7 @@ function xformCartFulfillmentGroup(fulfillmentGroup, cart) {
         currencyCode: cart.currencyCode
       },
       price: {
-        amount: fulfillmentGroup.shipmentMethod.rate || 0,
+        amount: (fulfillmentGroup.shipmentMethod.rate + fulfillmentGroup.shipmentMethod.handling) || 0,
         currencyCode: cart.currencyCode
       }
     };


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issue
Total price mismatch between submitted payment and expected total when shipping includes a handling fee

## Solution
Include handling in price calculations in cart.js and getFulfillmentMethodWithQuotes.js

## Breaking changes
No breaking changes

## Testing
1. Set a shipping method that includes a handling fee.
2. Complete a checkout using this fulfillment method.
3. Payment must match the total for the order.


