### PR TITLE
fix: remove extra `handling` charge from fulfillment total

### DIFF
--- a/imports/node-app/core-services/orders/util/addInvoiceToGroup.js
+++ b/imports/node-app/core-services/orders/util/addInvoiceToGroup.js
@@ -27,7 +27,6 @@ export default function addInvoiceToGroup({
 
   // Fulfillment
   const shippingTotal = group.shipmentMethod.rate || 0;
-  const handlingTotal = group.shipmentMethod.handling || 0;
   const fulfillmentTotal = shippingTotal;
 
   // Totals

--- a/imports/node-app/core-services/orders/util/addInvoiceToGroup.js
+++ b/imports/node-app/core-services/orders/util/addInvoiceToGroup.js
@@ -26,8 +26,7 @@ export default function addInvoiceToGroup({
   const effectiveTaxRate = taxableAmount > 0 ? taxTotal / taxableAmount : 0;
 
   // Fulfillment
-  const shippingTotal = group.shipmentMethod.rate || 0;
-  const fulfillmentTotal = shippingTotal;
+  const fulfillmentTotal = group.shipmentMethod.rate || 0;
 
   // Totals
   // To avoid rounding errors, be sure to keep this calculation the same between here and

--- a/imports/node-app/core-services/orders/util/addInvoiceToGroup.js
+++ b/imports/node-app/core-services/orders/util/addInvoiceToGroup.js
@@ -28,7 +28,7 @@ export default function addInvoiceToGroup({
   // Fulfillment
   const shippingTotal = group.shipmentMethod.rate || 0;
   const handlingTotal = group.shipmentMethod.handling || 0;
-  const fulfillmentTotal = shippingTotal + handlingTotal;
+  const fulfillmentTotal = shippingTotal;
 
   // Totals
   // To avoid rounding errors, be sure to keep this calculation the same between here and

--- a/imports/node-app/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
+++ b/imports/node-app/plugins/shipping-rates/getFulfillmentMethodsWithQuotes.js
@@ -87,13 +87,13 @@ export default async function getFulfillmentMethodsWithQuotes(context, commonOrd
         if (!method.carrier) {
           method.carrier = carrier;
         }
-
+        const rate = method.rate + method.handling;
         rates.push({
           carrier,
           handlingPrice: method.handling,
           method,
-          rate: method.rate,
-          shippingPrice: method.rate + method.handling,
+          rate,
+          shippingPrice: method.rate,
           shopId: doc.shopId
         });
       }

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
@@ -1,3 +1,4 @@
+import { toFixed } from "accounting-js";
 import getRateObjectForRate from "@reactioncommerce/api-utils/getRateObjectForRate.js";
 import namespaces from "@reactioncommerce/api-utils/graphql/namespaces.js";
 import ReactionError from "@reactioncommerce/reaction-error";
@@ -147,22 +148,27 @@ function xformCartFulfillmentGroup(fulfillmentGroup, cart) {
   }));
 
   let selectedFulfillmentOption = null;
-  if (fulfillmentGroup.shipmentMethod) {
+  const { shipmentMethod: selectedShipmentMethod } = fulfillmentGroup;
+  if (selectedShipmentMethod) {
     selectedFulfillmentOption = {
       fulfillmentMethod: {
-        _id: fulfillmentGroup.shipmentMethod._id,
-        carrier: fulfillmentGroup.shipmentMethod.carrier || null,
-        displayName: fulfillmentGroup.shipmentMethod.label || fulfillmentGroup.shipmentMethod.name,
-        group: fulfillmentGroup.shipmentMethod.group || null,
-        name: fulfillmentGroup.shipmentMethod.name,
-        fulfillmentTypes: fulfillmentGroup.shipmentMethod.fulfillmentTypes
+        _id: selectedShipmentMethod._id,
+        carrier: selectedShipmentMethod.carrier || null,
+        displayName: selectedShipmentMethod.label || selectedShipmentMethod.name,
+        group: selectedShipmentMethod.group || null,
+        name: selectedShipmentMethod.name,
+        fulfillmentTypes: selectedShipmentMethod.fulfillmentTypes
       },
       handlingPrice: {
-        amount: fulfillmentGroup.shipmentMethod.handling || 0,
+        amount: selectedShipmentMethod.handling || 0,
         currencyCode: cart.currencyCode
       },
       price: {
-        amount: fulfillmentGroup.shipmentMethod.rate || 0,
+        amount: +toFixed((selectedShipmentMethod.handling || 0) + (selectedShipmentMethod.rate || 0), 3),
+        currencyCode: cart.currencyCode
+      },
+      shippingPrice: {
+        amount: selectedShipmentMethod.rate || 0,
         currencyCode: cart.currencyCode
       }
     };

--- a/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
+++ b/imports/plugins/core/graphql/server/no-meteor/xforms/cart.js
@@ -141,7 +141,7 @@ function xformCartFulfillmentGroup(fulfillmentGroup, cart) {
       currencyCode: cart.currencyCode
     },
     price: {
-      amount: (option.rate + option.handlingPrice) || 0,
+      amount: option.rate || 0,
       currencyCode: cart.currencyCode
     }
   }));
@@ -162,7 +162,7 @@ function xformCartFulfillmentGroup(fulfillmentGroup, cart) {
         currencyCode: cart.currencyCode
       },
       price: {
-        amount: (fulfillmentGroup.shipmentMethod.rate + fulfillmentGroup.shipmentMethod.handling) || 0,
+        amount: fulfillmentGroup.shipmentMethod.rate || 0,
         currencyCode: cart.currencyCode
       }
     };


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issue
Total price mismatch between submitted payment and expected total when shipping includes a handling fee.

## Solution
Remove extra `handling` charge addition in `addInvoiceToGroup`

## Breaking changes
No breaking changes

## Testing
1. Set a shipping method that includes a handling fee.
2. Complete a checkout using this fulfillment method.
3. Payment must match the total for the order.