### PR TITLE
fix: canBackorder has lowercase o throughout codebase

### DIFF
--- a/src/core-services/orders/mutations/placeOrder.test.js
+++ b/src/core-services/orders/mutations/placeOrder.test.js
@@ -37,7 +37,7 @@ test("places an anonymous $0 order with no cartId and no payments", async () => 
 
   mockContext.queries.inventoryForProductConfiguration = jest.fn().mockName("inventoryForProductConfiguration");
   mockContext.queries.inventoryForProductConfiguration.mockReturnValueOnce({
-    canBackOrder: true,
+    canBackorder: true,
     inventoryAvailableToSell: 10
   });
 


### PR DESCRIPTION
Throughout the code we spell `canBackorder` with a lowercase o, except this one spot.