### PR TITLE
fix: fix default public password reset URL

### DIFF
--- a/src/core-services/account/config.js
+++ b/src/core-services/account/config.js
@@ -5,7 +5,7 @@ const { str } = envalid;
 export default envalid.cleanEnv(process.env, {
   HYDRA_OAUTH2_INTROSPECT_URL: str({ devDefault: "http://hydra:4445/oauth2/introspect" }),
   NODE_ENV: str({ default: "production" }),
-  REACTION_IDENTITY_PUBLIC_PASSWORD_RESET_URL: str({ devDefault: "http://localhost:4100/reset-password/TOKEN" }),
+  REACTION_IDENTITY_PUBLIC_PASSWORD_RESET_URL: str({ devDefault: "http://localhost:4100/account/reset-password/TOKEN" }),
   REACTION_IDENTITY_PUBLIC_VERIFY_EMAIL_URL: str({ devDefault: "http://localhost:4100/#/verify-email/TOKEN" }),
   REACTION_ADMIN_PUBLIC_ACCOUNT_REGISTRATION_URL: str({ devDefault: "http://localhost:4080" })
 }, {


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
Default `REACTION_IDENTITY_PUBLIC_PASSWORD_RESET_URL` env variable value used when `NODE_ENV` is `development` doesn't match the actual Reaction Identity URL.

## Solution
Updated URL to match Reaction Identity.

NOTE: In production environments, you will need to update the URL manually. The path part should be `/account/reset-password/TOKEN`

## Breaking changes
None

## Testing
Test this with https://github.com/reactioncommerce/example-storefront/pull/637. All instructions are in that pull request.