### PR TITLE
chore: use published image for docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ typings/
 client/plugins.js
 client/plugins.less
 server/plugins.js
+
+docker-compose.override.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+# This docker-compose file is used to run the project in Docker for development.
+# The local files are mounted into the created container.
+#
+# Usage:
+#  ln -s docker-compose.dev.yml docker-compose.override.yml
+#  docker-compose up [-d]
+#
+# To go back to running the published image:
+#  rm docker-compose.override.yml
+
+version: '3.4'
+
+services:
+  api:
+    image: reactioncommerce/node-dev:12.10.0-v1
+    volumes:
+      - .:/usr/local/src/app:cached
+      - api_node_modules:/usr/local/src/app/node_modules # do not link node_modules in, and persist it between dc up runs
+
+volumes:
+  mongo-db4:
+  api_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-# This docker-compose file is used to run the Reaction API in Docker for development.
-# The local files are mounted into the created container.
+# This docker-compose file is used to run the project's published image
+#
 # Usage: docker-compose up [-d]
+#
+# See comment in docker-compose.dev.yml if you want to run for development.
 
 version: '3.4'
 
@@ -16,9 +18,8 @@ networks:
       name: streams.reaction.localhost
 
 services:
-
   api:
-    image: reactioncommerce/node-dev:12.10.0-v1
+    image: reactioncommerce/reaction:release-3.0.0
     depends_on:
       - mongo
     env_file:
@@ -29,9 +30,6 @@ services:
       auth:
     ports:
       - "3000:3000"
-    volumes:
-      - .:/usr/local/src/app:cached
-      - api_node_modules:/usr/local/src/app/node_modules # do not link node_modules in, and persist it between dc up runs
 
   mongo:
     image: mongo:4.2.0
@@ -46,4 +44,3 @@ services:
 
 volumes:
   mongo-db4:
-  api_node_modules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.0.0-alpha",
+  "version": "3.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Impact: **minor**
Type: **chore**

## Changes
When you clone this branch and run `docker-compose up`, it will now pull and use the latest published `reactioncommerce/reaction:release-3.0.0` image from DockerHub instead of `node-dev`. Host files are not linked in and NPM deps are not reinstalled.

## Breaking changes
Breaking only for devs who will now need to run `ln -s docker-compose.dev.yml docker-compose.override.yml` to get the previous behavior.

## Testing
- Verify `dc up` starts from the published image.
- After `dc down`, run `ln -s docker-compose.dev.yml docker-compose.override.yml` and then `dc up` again. Verify it now uses local files and reloads when you change files.
- After `dc down`, run `rm docker-compose.override.yml` to remove the override file. It should be back to running in prod mode when you do `dc up`.