### PR TITLE
refactor: pass cart down to calculateOrderTaxes fn

### DIFF
--- a/src/core-services/taxes/mutations/setTaxesOnOrderFulfillmentGroup.js
+++ b/src/core-services/taxes/mutations/setTaxesOnOrderFulfillmentGroup.js
@@ -6,7 +6,7 @@
  * @returns {Object} An object with `taxableAmount` and `taxTotal` properties. Also mutates `group`.
  */
 export default async function setTaxesOnOrderFulfillmentGroup(context, { group, commonOrder }) {
-  const { itemTaxes, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, { order: commonOrder, forceZeroes: true });
+  const { itemTaxes, taxSummary } = await context.mutations.getFulfillmentGroupTaxes(context, { cart: null, order: commonOrder, forceZeroes: true });
   group.items = group.items.map((item) => {
     const itemTax = itemTaxes.find((entry) => entry.itemId === item._id) || {};
 

--- a/src/core-services/taxes/util/getUpdatedCartItems.js
+++ b/src/core-services/taxes/util/getUpdatedCartItems.js
@@ -7,7 +7,7 @@
  */
 export default async function getUpdatedCartItems(context, cart, commonOrders) {
   const taxResultsByGroup = await Promise.all(commonOrders.map(async (order) =>
-    context.mutations.getFulfillmentGroupTaxes(context, { order, forceZeroes: false })));
+    context.mutations.getFulfillmentGroupTaxes(context, { cart, order, forceZeroes: false })));
 
   // Add tax properties to all items in the cart, if taxes were able to be calculated
   const cartItems = (cart.items || []).map((item) => {

--- a/src/plugins/taxes-rates/util/calculateOrderTaxes.js
+++ b/src/plugins/taxes-rates/util/calculateOrderTaxes.js
@@ -41,7 +41,8 @@ async function getTaxesForShop(collections, order) {
 /**
  * @summary Calculate and return taxes for an order
  * @param {Object} context App context
- * @param {Object} order The order
+ * @param {Object} [cart] The original cart object, if CommonOrder was built from a cart
+ * @param {Object} order The CommonOrder
  * @returns {Object|null} Calculated tax information, in `TaxServiceResult` schema, or `null` if can't calculate
  */
 export default async function calculateOrderTaxes({ context, order }) {


### PR DESCRIPTION
Resolves #5583   
Impact: **minor**  
Type: **refactor**

## Changes
When calling `calculateOrderTaxes` function for a fulfillment group that's in a cart, the parent `cart` object is passed in now. When called for an order, it's `null`. This is helpful for some tax plugins that may be storing additional information on the cart itself.

## Breaking changes
None

## Testing
Using logging or Node debugger, verify that `cart` is set on the `calculateOrderTaxes` function input object. It is called whenever you add or remove items from your cart or otherwise modify it.
