### PR TITLE
Warn about non-unique names of functionsByType functions

### DIFF
--- a/src/core-services/account/index.js
+++ b/src/core-services/account/index.js
@@ -2,7 +2,7 @@ import i18n from "./i18n/index.js";
 import mutations from "./mutations/index.js";
 import policies from "./policies.json";
 import queries from "./queries/index.js";
-import { registerPluginHandler } from "./registration.js";
+import { registerPluginHandlerForAccounts } from "./registration.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
 import startup from "./startup.js";
@@ -65,7 +65,7 @@ export default async function register(app) {
       accountByUserId
     },
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler],
+      registerPluginHandler: [registerPluginHandlerForAccounts],
       startup: [startup]
     },
     graphQL: {

--- a/src/core-services/account/registration.js
+++ b/src/core-services/account/registration.js
@@ -5,7 +5,7 @@ export const packageRolesAndGroups = [];
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({ addRolesToGroups }) {
+export function registerPluginHandlerForAccounts({ addRolesToGroups }) {
   if (Array.isArray(addRolesToGroups)) {
     // We build the packageRolesAndGroups array here, and then we process it
     // in the startup function.

--- a/src/core-services/account/startup.js
+++ b/src/core-services/account/startup.js
@@ -14,7 +14,7 @@ import config from "./config.js";
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default async function startup(context) {
+export default async function accountStartup(context) {
   // Add missing roles to `roles` collection if needed
   await ensureRoles(context, defaultCustomerRoles);
   await ensureRoles(context, defaultOwnerRoles);

--- a/src/core-services/address/index.js
+++ b/src/core-services/address/index.js
@@ -1,7 +1,7 @@
 import i18n from "./i18n/index.js";
 import mutations from "./mutations/index.js";
 import queries from "./queries/index.js";
-import { registerPluginHandler } from "./registration.js";
+import { registerPluginHandlerForAddress } from "./registration.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
 
@@ -17,7 +17,7 @@ export default async function register(app) {
     version: app.context.appVersion,
     i18n,
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler]
+      registerPluginHandler: [registerPluginHandlerForAddress]
     },
     graphQL: {
       resolvers,

--- a/src/core-services/address/registration.js
+++ b/src/core-services/address/registration.js
@@ -5,7 +5,7 @@ export const addressValidationServices = {};
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({
+export function registerPluginHandlerForAddress({
   name: pluginName,
   addressValidationServices: pluginAddressValidationServices
 }) {

--- a/src/core-services/cart/index.js
+++ b/src/core-services/cart/index.js
@@ -3,7 +3,7 @@ import policies from "./policies.json";
 import queries from "./queries/index.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
-import { registerPluginHandler } from "./registration.js";
+import { registerPluginHandlerForCart } from "./registration.js";
 import { Cart, CartItem } from "./simpleSchemas.js";
 import startup from "./startup.js";
 
@@ -46,7 +46,7 @@ export default async function register(app) {
       }
     },
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler],
+      registerPluginHandler: [registerPluginHandlerForCart],
       startup: [startup]
     },
     graphQL: {

--- a/src/core-services/cart/registration.js
+++ b/src/core-services/cart/registration.js
@@ -14,7 +14,7 @@ export const cartTransforms = [];
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({ name, cart }) {
+export function registerPluginHandlerForCart({ name, cart }) {
   if (cart) {
     const { transforms } = cart;
 

--- a/src/core-services/cart/startup.js
+++ b/src/core-services/cart/startup.js
@@ -94,7 +94,7 @@ async function updateAllCartsForVariant({ Cart, context, variant }) {
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default async function startup(context) {
+export default async function cartStartup(context) {
   const { appEvents, collections } = context;
   const { Cart } = collections;
 

--- a/src/core-services/catalog/index.js
+++ b/src/core-services/catalog/index.js
@@ -1,7 +1,7 @@
 import i18n from "./i18n/index.js";
 import mutations from "./mutations/index.js";
 import queries from "./queries/index.js";
-import { registerPluginHandler } from "./registration.js";
+import { registerPluginHandlerForCatalog } from "./registration.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
 import startup from "./startup.js";
@@ -44,7 +44,7 @@ export default async function register(app) {
       }
     },
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler],
+      registerPluginHandler: [registerPluginHandlerForCatalog],
       startup: [startup]
     },
     graphQL: {

--- a/src/core-services/catalog/registration.js
+++ b/src/core-services/catalog/registration.js
@@ -6,7 +6,7 @@ export const customPublishedProductVariantFields = [];
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({ catalog }) {
+export function registerPluginHandlerForCatalog({ catalog }) {
   if (catalog) {
     const { publishedProductFields, publishedProductVariantFields } = catalog;
     if (Array.isArray(publishedProductFields)) {

--- a/src/core-services/catalog/startup.js
+++ b/src/core-services/catalog/startup.js
@@ -24,7 +24,7 @@ async function hashRelatedProduct(productId, collections) {
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default async function startup(context) {
+export default async function catalogStartup(context) {
   const { appEvents, collections } = context;
 
   appEvents.on("afterMediaInsert", ({ mediaRecord }) => {

--- a/src/core-services/email/startup.js
+++ b/src/core-services/email/startup.js
@@ -6,7 +6,7 @@ import processEmailJobs from "./util/processEmailJobs.js";
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default function startup(context) {
+export default function emailStartup(context) {
   processEmailJobs(context);
 }
 

--- a/src/core-services/files/startup.js
+++ b/src/core-services/files/startup.js
@@ -10,7 +10,7 @@ import saveTempImages from "./jobs/saveTempImages.js";
  * @param {Object} context.collections A map of MongoDB collections
  * @returns {undefined}
  */
-export default function startup(context) {
+export default function filesStartup(context) {
   const { app, collections, rootUrl } = context;
   const { MediaRecords } = collections;
 

--- a/src/core-services/i18n/index.js
+++ b/src/core-services/i18n/index.js
@@ -1,5 +1,5 @@
 import i18n from "./i18n/index.js";
-import { registerPluginHandler } from "./registration.js";
+import { registerPluginHandlerForI18n } from "./registration.js";
 import startup from "./startup.js";
 
 /**
@@ -14,7 +14,7 @@ export default async function register(app) {
     version: app.context.appVersion,
     i18n,
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler],
+      registerPluginHandler: [registerPluginHandlerForI18n],
       startup: [startup]
     }
   });

--- a/src/core-services/i18n/registration.js
+++ b/src/core-services/i18n/registration.js
@@ -5,7 +5,7 @@ import { mergeResource } from "./translations.js";
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({ i18n, name }) {
+export function registerPluginHandlerForI18n({ i18n, name }) {
   if (i18n) {
     const { translations } = i18n;
     if (!Array.isArray(translations)) throw new Error(`Plugin ${name} registered i18n.translations that is not an array`);

--- a/src/core-services/i18n/startup.js
+++ b/src/core-services/i18n/startup.js
@@ -6,7 +6,7 @@ import { addTranslationRoutes } from "./translations.js";
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default async function startup(context) {
+export default async function i18nStartup(context) {
   const { app } = context;
 
   if (app.expressApp) addTranslationRoutes(app.expressApp);

--- a/src/core-services/inventory/utils/preStartup.js
+++ b/src/core-services/inventory/utils/preStartup.js
@@ -6,6 +6,6 @@ import { extendInventorySchemas } from "../simpleSchemas.js";
  * @param {Object} context.simpleSchemas Simple schemas
  * @returns {undefined}
  */
-export default async function preStartup(context) {
+export default async function inventoryPreStartup(context) {
   extendInventorySchemas(context.simpleSchemas);
 }

--- a/src/core-services/inventory/utils/startup.js
+++ b/src/core-services/inventory/utils/startup.js
@@ -4,7 +4,7 @@
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default function startup(context) {
+export default function inventoryStartup(context) {
   const { appEvents } = context;
 
   // Whenever inventory is updated for any sellable variant, the plugin that did the update is

--- a/src/core-services/orders/preStartup.js
+++ b/src/core-services/orders/preStartup.js
@@ -6,6 +6,6 @@ import { extendOrdersSchemas } from "./simpleSchemas.js";
  * @param {Object} context.simpleSchemas Map of SimpleSchemas
  * @returns {undefined}
  */
-export default function preStartup(context) {
+export default function ordersPreStartup(context) {
   extendOrdersSchemas(context.simpleSchemas);
 }

--- a/src/core-services/orders/startup.js
+++ b/src/core-services/orders/startup.js
@@ -6,7 +6,7 @@ import sendOrderEmail from "./util/sendOrderEmail.js";
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default function startup(context) {
+export default function ordersStartup(context) {
   const { appEvents } = context;
 
   appEvents.on("afterOrderCreate", ({ order }) => sendOrderEmail(context, order));

--- a/src/core-services/orders/util/getDataForOrderEmail.js
+++ b/src/core-services/orders/util/getDataForOrderEmail.js
@@ -30,7 +30,7 @@ function formatDateForEmail(date) {
  * @param {Object} input.order - The order document
  * @returns {Object} Data object to use when rendering email templates
  */
-export default async function getDataForOrderEmail(context, { order }) {
+export default async function getDataForOrderEmailDefault(context, { order }) {
   const { collections, getAbsoluteUrl } = context;
   const { Shops } = collections;
 

--- a/src/core-services/payments/index.js
+++ b/src/core-services/payments/index.js
@@ -1,7 +1,7 @@
 import i18n from "./i18n/index.js";
 import mutations from "./mutations/index.js";
 import queries from "./queries/index.js";
-import { registerPluginHandler } from "./registration.js";
+import { registerPluginHandlerForPayments } from "./registration.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
 
@@ -17,7 +17,7 @@ export default async function register(app) {
     version: app.context.appVersion,
     i18n,
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler]
+      registerPluginHandler: [registerPluginHandlerForPayments]
     },
     graphQL: {
       resolvers,

--- a/src/core-services/payments/registration.js
+++ b/src/core-services/payments/registration.js
@@ -5,7 +5,7 @@ export const paymentMethods = {};
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({ name: pluginName, paymentMethods: pluginPaymentMethods }) {
+export function registerPluginHandlerForPayments({ name: pluginName, paymentMethods: pluginPaymentMethods }) {
   if (Array.isArray(pluginPaymentMethods)) {
     for (const pluginPaymentMethod of pluginPaymentMethods) {
       paymentMethods[pluginPaymentMethod.name] = { ...pluginPaymentMethod, pluginName };

--- a/src/core-services/settings/index.js
+++ b/src/core-services/settings/index.js
@@ -2,7 +2,7 @@ import mutations from "./mutations/index.js";
 import queries from "./queries/index.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
-import { registerPluginHandler } from "./util/settingsConfig.js";
+import { registerPluginHandlerForAppSettings } from "./util/settingsConfig.js";
 
 /**
  * @summary Import and call this function to add this plugin to your API.
@@ -23,7 +23,7 @@ export default async function register(app) {
       }
     },
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler]
+      registerPluginHandler: [registerPluginHandlerForAppSettings]
     },
     mutations,
     queries,

--- a/src/core-services/settings/util/settingsConfig.js
+++ b/src/core-services/settings/util/settingsConfig.js
@@ -102,7 +102,7 @@ const configSchema = new SimpleSchema({
  * @summary Reads and merges `appSettingsConfig` from all plugin registration.
  * @returns {undefined}
  */
-export function registerPluginHandler({
+export function registerPluginHandlerForAppSettings({
   globalSettingsConfig: globalSettingsConfigFromPlugin,
   name,
   shopSettingsConfig: shopSettingsConfigFromPlugin

--- a/src/core-services/taxes/index.js
+++ b/src/core-services/taxes/index.js
@@ -2,7 +2,7 @@ import i18n from "./i18n/index.js";
 import mutateNewOrderItemBeforeCreate from "./mutateNewOrderItemBeforeCreate.js";
 import mutateNewVariantBeforeCreate from "./mutateNewVariantBeforeCreate.js";
 import publishProductToCatalog from "./publishProductToCatalog.js";
-import { registerPluginHandler } from "./registration.js";
+import { registerPluginHandlerForTaxes } from "./registration.js";
 import mutations from "./mutations/index.js";
 import policies from "./policies.json";
 import preStartup from "./preStartup.js";
@@ -39,7 +39,7 @@ export default async function register(app) {
       mutateNewVariantBeforeCreate: [mutateNewVariantBeforeCreate],
       preStartup: [preStartup],
       publishProductToCatalog: [publishProductToCatalog],
-      registerPluginHandler: [registerPluginHandler]
+      registerPluginHandler: [registerPluginHandlerForTaxes]
     },
     graphQL: {
       schemas,

--- a/src/core-services/taxes/mutateNewOrderItemBeforeCreate.js
+++ b/src/core-services/taxes/mutateNewOrderItemBeforeCreate.js
@@ -6,7 +6,7 @@
  * @param {Object} item The OrderItem so far. Potentially mutates this to add additional properties.
  * @returns {undefined}
  */
-export default function mutateNewOrderItemBeforeCreate(context, { chosenVariant, item }) {
+export default function mutateNewOrderItemBeforeCreateForTaxes(context, { chosenVariant, item }) {
   item.isTaxable = !!(chosenVariant && chosenVariant.isTaxable);
   item.taxCode = chosenVariant.taxCode || null;
 }

--- a/src/core-services/taxes/mutateNewVariantBeforeCreate.js
+++ b/src/core-services/taxes/mutateNewVariantBeforeCreate.js
@@ -4,7 +4,7 @@
  * @param {Object} input Input data
  * @returns {undefined}
  */
-export default async function mutateNewVariantBeforeCreate(newVariant, { context, isOption }) {
+export default async function mutateNewVariantBeforeCreateForTaxes(newVariant, { context, isOption }) {
   // Tax fields are managed by and inherited from top-level variant
   if (!isOption) {
     // All new variants are taxable by default

--- a/src/core-services/taxes/preStartup.js
+++ b/src/core-services/taxes/preStartup.js
@@ -6,6 +6,6 @@ import { extendTaxesSchemas } from "./simpleSchemas.js";
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default async function preStartup(context) {
+export default async function taxesPreStartup(context) {
   extendTaxesSchemas(context.simpleSchemas);
 }

--- a/src/core-services/taxes/publishProductToCatalog.js
+++ b/src/core-services/taxes/publishProductToCatalog.js
@@ -4,7 +4,7 @@
  * @param {Object} input Input data
  * @returns {undefined}
  */
-export default function publishProductToCatalog(catalogProduct, { variants }) {
+export default function publishProductToCatalogForTaxes(catalogProduct, { variants }) {
   catalogProduct.variants.forEach((catalogProductVariant) => {
     const unpublishedVariant = variants.find((variant) => variant._id === catalogProductVariant.variantId);
     if (!unpublishedVariant) return;

--- a/src/core-services/taxes/registration.js
+++ b/src/core-services/taxes/registration.js
@@ -5,7 +5,7 @@ export const taxServices = {};
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({ name: pluginName, taxServices: pluginTaxServices }) {
+export function registerPluginHandlerForTaxes({ name: pluginName, taxServices: pluginTaxServices }) {
   if (Array.isArray(pluginTaxServices)) {
     for (const pluginTaxService of pluginTaxServices) {
       taxServices[pluginTaxService.name] = { ...pluginTaxService, pluginName };

--- a/src/core-services/taxes/registration.test.js
+++ b/src/core-services/taxes/registration.test.js
@@ -1,5 +1,5 @@
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
-import { registerPluginHandler, getTaxServicesForShop } from "./registration.js";
+import { registerPluginHandlerForTaxes, getTaxServicesForShop } from "./registration.js";
 
 const fakeShopId = "FAKE_SHOP_ID";
 
@@ -31,7 +31,7 @@ const pluginTaxServices = [{
 }];
 
 pluginTaxServices.forEach(({ name, taxServices }) => {
-  registerPluginHandler({ name, taxServices });
+  registerPluginHandlerForTaxes({ name, taxServices });
 });
 
 mockContext.queries.appSettings = jest.fn().mockName("context.queries.appSettings");

--- a/src/core/ReactionAPI.js
+++ b/src/core/ReactionAPI.js
@@ -142,6 +142,13 @@ export default class ReactionAPI {
           this.functionsByType[type] = [];
         }
         functionsByType[type].forEach((func) => {
+          const entryWithSameName = this.functionsByType[type].find((existingEntry) => existingEntry.func.name === func.name);
+          if (entryWithSameName) {
+            Logger.warn(`Plugin "${pluginName}" registers a function of type "${type}" named "${func.name}", `
+              + `but plugin "${entryWithSameName.pluginName}" has already registered a function of type "${type}" named "${entryWithSameName.func.name}".`
+              + " We recommend you choose a unique and descriptive name for all functions passed to `functionsByType` to help with debugging.");
+          }
+
           this.functionsByType[type].push({ func, pluginName });
         });
       });

--- a/src/plugins/email-smtp/startup.js
+++ b/src/plugins/email-smtp/startup.js
@@ -6,6 +6,6 @@ import sendSMTPEmail from "./util/sendSMTPEmail.js";
  * @param {Object} context App context
  * @returns {undefined}
  */
-export default function startup(context) {
+export default function emailSMTPStartup(context) {
   context.appEvents.on("sendEmail", (...args) => sendSMTPEmail(context, ...args));
 }

--- a/src/plugins/email-templates/startup.js
+++ b/src/plugins/email-templates/startup.js
@@ -6,7 +6,7 @@ import seedEmailTemplatesForShop from "./util/seedEmailTemplatesForShop.js";
  * @param {Object} context App context
  * @returns {undefined}
  */
-export default async function startup(context) {
+export default async function emailTemplatesStartup(context) {
   context.appEvents.on("afterShopCreate", async (payload) => {
     const { shop } = payload;
 

--- a/src/plugins/job-queue/index.js
+++ b/src/plugins/job-queue/index.js
@@ -1,5 +1,5 @@
 import { addWorker, cancelJobs, getJob, scheduleJob } from "./api.js";
-import { registerPluginHandler } from "./registration.js";
+import { registerPluginHandlerForJobQueue } from "./registration.js";
 import shutdown from "./shutdown.js";
 import startup from "./startup.js";
 
@@ -14,7 +14,7 @@ export default async function register(app) {
     name: "reaction-job-queue",
     version: app.context.appVersion,
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler],
+      registerPluginHandler: [registerPluginHandlerForJobQueue],
       shutdown: [shutdown],
       startup: [startup]
     },

--- a/src/plugins/job-queue/registration.js
+++ b/src/plugins/job-queue/registration.js
@@ -20,7 +20,7 @@ export const jobCleanupRequests = [];
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({ backgroundJobs }) {
+export function registerPluginHandlerForJobQueue({ backgroundJobs }) {
   if (backgroundJobs) {
     schema.validate(backgroundJobs);
 

--- a/src/plugins/job-queue/shutdown.js
+++ b/src/plugins/job-queue/shutdown.js
@@ -7,7 +7,7 @@ import { Jobs } from "./jobs.js";
  * @param {Object} context App context
  * @returns {undefined}
  */
-export default function shutdown() {
+export default function jobQueueShutdown() {
   return new Promise((resolve, reject) => {
     try {
       Jobs.shutdownJobServer(() => {

--- a/src/plugins/job-queue/startup.js
+++ b/src/plugins/job-queue/startup.js
@@ -10,7 +10,7 @@ import { jobCleanupRequests } from "./registration.js";
  * @param {Object} context App context
  * @returns {undefined}
  */
-export default async function startup(context) {
+export default async function jobQueueStartup(context) {
   const { appEvents, collections: { Jobs: MongoJobsCollection } } = context;
   Jobs.setCollection(MongoJobsCollection);
 

--- a/src/plugins/navigation/startup/shopCreateListener.js
+++ b/src/plugins/navigation/startup/shopCreateListener.js
@@ -5,7 +5,7 @@ import createDefaultNavigationTreeForShop from "../util/createDefaultNavigationT
  * @param {Object} context Startup context
  * @returns {undefined}
  */
-export default async function shopCreateListener(context) {
+export default async function shopCreateListenerForNavigation(context) {
   context.appEvents.on("afterShopCreate", async ({ shop }) => {
     if (shop.defaultNavigationTreeId) return;
     await createDefaultNavigationTreeForShop(context, shop);

--- a/src/plugins/notifications/startup.js
+++ b/src/plugins/notifications/startup.js
@@ -7,7 +7,7 @@ import sendNewOrderNotifications from "./util/sendNewOrderNotifications.js";
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default function startup(context) {
+export default function notificationsStartup(context) {
   const { appEvents } = context;
 
   appEvents.on("afterOrderCreate", ({ order }) => sendNewOrderNotifications(context, order));

--- a/src/plugins/payments-example/startup.js
+++ b/src/plugins/payments-example/startup.js
@@ -4,6 +4,6 @@
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default function startup(context) {
+export default function exampleIOUPaymentsStartup(context) {
   context.collections.ExampleIOUPaymentRefunds = context.app.db.collection("ExampleIOUPaymentRefunds");
 }

--- a/src/plugins/simple-inventory/startup.js
+++ b/src/plugins/simple-inventory/startup.js
@@ -16,7 +16,7 @@ function getAllOrderItems(order) {
  * @param {Object} context.collections Map of MongoDB collections
  * @returns {undefined}
  */
-export default function startup(context) {
+export default function simpleInventoryStartup(context) {
   const { appEvents, collections } = context;
   const { SimpleInventory } = collections;
 

--- a/src/plugins/simple-inventory/utils/createDataLoaders.js
+++ b/src/plugins/simple-inventory/utils/createDataLoaders.js
@@ -5,7 +5,7 @@ import _ from "lodash";
   * @param {Function} dataloaderFactory dataloader factory
   * @returns {Array} converted result
   */
-export default function createDataLoaders(context, dataloaderFactory) {
+export default function createDataLoadersForSimpleInventory(context, dataloaderFactory) {
   return {
     SimpleInventoryByProductVariantId: dataloaderFactory(async (productVariantIds) => {
       const results = await context.collections.SimpleInventory.find({

--- a/src/plugins/simple-inventory/utils/inventoryForProductConfigurations.js
+++ b/src/plugins/simple-inventory/utils/inventoryForProductConfigurations.js
@@ -14,7 +14,7 @@ import _ from "lodash";
  *   you have already looked them up. This will save a database query.
  * @returns {Promise<Object[]>} Array of responses, in same order as `input.productConfigurations` array.
  */
-export default async function inventoryForProductConfigurations(context, input) {
+export default async function simpleInventoryForProductConfigurations(context, input) {
   const { productConfigurations } = input;
   const { collections, dataLoaders } = context;
 

--- a/src/plugins/simple-pricing/preStartup.js
+++ b/src/plugins/simple-pricing/preStartup.js
@@ -6,6 +6,6 @@ import { extendSimplePricingSchemas } from "./simpleSchemas.js";
  * @param {Object} context - App context.
  * @returns {undefined} - void, no return.
  */
-export default function preStartup(context) {
+export default function simplePricingPreStartup(context) {
   extendSimplePricingSchemas(context.simpleSchemas);
 }

--- a/src/plugins/simple-pricing/startup.js
+++ b/src/plugins/simple-pricing/startup.js
@@ -10,7 +10,7 @@ const fieldsThatChangeAncestorPricing = ["isDeleted", "isVisible", "price"];
  * @param {Object} context - App context.
  * @returns {undefined} - void, no return.
  */
-export default async function startup(context) {
+export default async function simplePricingStartup(context) {
   const { appEvents, collections } = context;
   const { Catalog, Products, Shops } = collections;
 

--- a/src/plugins/simple-pricing/util/getMinPriceSortByFieldPath.js
+++ b/src/plugins/simple-pricing/util/getMinPriceSortByFieldPath.js
@@ -4,7 +4,7 @@
  * @param {String} connectionArgs.sortPriceByCurrencyCode - currency code
  * @returns {Number} minimum price
  */
-export default function getMinPriceSortByFieldPath(context, { connectionArgs }) {
+export default function getMinPriceSortByFieldPathForSimplePricing(context, { connectionArgs }) {
   const { sortByPriceCurrencyCode } = connectionArgs || {};
 
   if (typeof sortByPriceCurrencyCode !== "string") {

--- a/src/plugins/simple-pricing/util/mutateNewProductBeforeCreate.js
+++ b/src/plugins/simple-pricing/util/mutateNewProductBeforeCreate.js
@@ -3,7 +3,7 @@
  * @param {Object} product Product object to mutate
  * @returns {undefined}
  */
-export default function mutateNewProductBeforeCreate(product) {
+export default function mutateNewProductBeforeCreateForSimplePricing(product) {
   if (!product.price) {
     product.price = {
       range: "0.00 - 0.00",

--- a/src/plugins/simple-pricing/util/mutateNewVariantBeforeCreate.js
+++ b/src/plugins/simple-pricing/util/mutateNewVariantBeforeCreate.js
@@ -3,6 +3,6 @@
  * @param {Object} variant Variant product object to mutate
  * @returns {undefined}
  */
-export default function mutateNewVariantBeforeCreate(variant) {
+export default function mutateNewVariantBeforeCreateForSimplePricing(variant) {
   if (!variant.price) variant.price = 0;
 }

--- a/src/plugins/simple-pricing/util/publishProductToCatalog.js
+++ b/src/plugins/simple-pricing/util/publishProductToCatalog.js
@@ -27,7 +27,7 @@ function getPricingObject(doc, priceInfo) {
  * @param {Object[]} input.variants All variants and options of the product being published, in Products collection schema
  * @returns {undefined} No return. Mutates `catalogProduct` object.
  */
-export default function publishProductToCatalog(catalogProduct, { product, shop, variants }) {
+export default function publishProductToCatalogForSimplePricing(catalogProduct, { product, shop, variants }) {
   const shopCurrencyCode = shop.currency;
   const shopCurrencyInfo = CurrencyDefinitions[shopCurrencyCode];
 

--- a/src/plugins/simple-schema/index.js
+++ b/src/plugins/simple-schema/index.js
@@ -1,4 +1,4 @@
-import { registerPluginHandler, simpleSchemas } from "./registration.js";
+import { registerPluginHandlerForSimpleSchema, simpleSchemas } from "./registration.js";
 
 /**
  * @summary Import and call this function to add this plugin to your API.
@@ -11,7 +11,7 @@ export default async function register(app) {
     name: "reaction-simple-schema",
     version: app.context.appVersion,
     functionsByType: {
-      registerPluginHandler: [registerPluginHandler]
+      registerPluginHandler: [registerPluginHandlerForSimpleSchema]
     },
     contextAdditions: {
       simpleSchemas

--- a/src/plugins/simple-schema/registration.js
+++ b/src/plugins/simple-schema/registration.js
@@ -5,7 +5,7 @@ export const simpleSchemas = {};
  * @param {Object} options The options object that the plugin passed to registerPackage
  * @returns {undefined}
  */
-export function registerPluginHandler({ name, simpleSchemas: pluginSimpleSchemas }) {
+export function registerPluginHandlerForSimpleSchema({ name, simpleSchemas: pluginSimpleSchemas }) {
   if (pluginSimpleSchemas) {
     Object.keys(pluginSimpleSchemas).forEach((key) => {
       if (simpleSchemas[key]) {

--- a/src/plugins/sitemap-generator/startup.js
+++ b/src/plugins/sitemap-generator/startup.js
@@ -8,7 +8,7 @@ import getSitemapRouteHandler from "./middleware/handle-sitemap-routes.js";
  * @param {Object} context.collections A map of MongoDB collections
  * @returns {undefined}
  */
-export default async function startup(context) {
+export default async function siteMapGeneratorStartup(context) {
   const { app } = context;
 
   // Setup sitemap generation recurring job


### PR DESCRIPTION
Resolves #5464   
Impact: **minor**  
Type: **refactor**

## Issue
Logging and stack traces are confusing when all functions of a particular type have the same name, as has been the pattern. For example, all plugins that register a "startup" function also name that function "startup".

## Solution
#5464 suggested making unique names mandatory but I'm only logging a warning on startup. I've updated all built-in services and plugins so that all function names are unique and the warning does not print on startup.

## Breaking changes
None

## Testing
Verify no warnings about `functionsByType` name are shown in the API startup logs. Temporarily change one fn name to be the same as another of that type, and verify that the warning now shows in the logs.