### PR TITLE
Add updateAccountGroup mutation

### DIFF
--- a/src/core-services/account/mutations/index.js
+++ b/src/core-services/account/mutations/index.js
@@ -12,6 +12,7 @@ import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 import createAccountGroup from "./createAccountGroup.js";
+import updateAccountGroup from "./updateAccountGroup.js";
 
 export default {
   addressBookAdd,
@@ -27,5 +28,6 @@ export default {
   setAccountProfileCurrency,
   setAccountProfileLanguage,
   updateAccountAddressBookEntry,
-  createAccountGroup
+  createAccountGroup,
+  updateAccountGroup
 };

--- a/src/core-services/account/mutations/updateAccountGroup.js
+++ b/src/core-services/account/mutations/updateAccountGroup.js
@@ -42,7 +42,7 @@ export default async function updateAccountGroup(context, input) {
   // TODO: Remove when we move away from legacy permission verification
   const defaultCustomerPermissions = defaultCustomerGroupForShop.permissions;
 
-  // ensure one group type per shop
+  // Ensure group exists before proceeding
   const existingGroup = await Groups.findOne({ _id: groupId });
 
   if (!existingGroup) {

--- a/src/core-services/account/mutations/updateAccountGroup.js
+++ b/src/core-services/account/mutations/updateAccountGroup.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 import ReactionError from "@reactioncommerce/reaction-error";
 import SimpleSchema from "simpl-schema";
 import getSlug from "@reactioncommerce/api-utils/getSlug.js";
-import setRolesOnGroupAndUsers from "../util/setRolesOnGroupAndUsers";
+import setRolesOnGroupAndUsers from "../util/setRolesOnGroupAndUsers.js";
 
 const inputSchema = new SimpleSchema({
   slug: { type: String, optional: true },

--- a/src/core-services/account/mutations/updateAccountGroup.js
+++ b/src/core-services/account/mutations/updateAccountGroup.js
@@ -1,0 +1,107 @@
+import _ from "lodash";
+import ReactionError from "@reactioncommerce/reaction-error";
+import SimpleSchema from "simpl-schema";
+import getSlug from "@reactioncommerce/api-utils/getSlug.js";
+import setRolesOnGroupAndUsers from "../util/setRolesOnGroupAndUsers";
+
+const inputSchema = new SimpleSchema({
+  slug: { type: String, optional: true },
+  name: { type: String, optional: true },
+  description: { type: String, optional: true },
+  updatedAt: Date
+});
+
+/**
+ * @name group/updateAccountGroup
+ * @method
+ * @memberof Group/Methods
+ * @summary Updates an existing permission group for a shop
+ * It updates permission group for a given shop with passed in roles
+ * This method also effectively updates a role in reaction authorization service with the same
+ * name as the supplied group if kafka connect mongo has been configured on the mongo db
+ * @param {object} context - The GraphQL context
+ * @param {String} context.shopId - id of the shop the group belongs to
+ * @param {object} input - The input supplied from GraphQL
+ * @param {Object} input.groupData - info about group to updated
+ * @param {String} input.groupData.name - name of the group to be updated
+ * @param {String} input.groupData.description - Optional description of the group to be updated
+ * @param {Array} input.groupData.permissions - permissions to assign to the group being updated
+ * @param {Array} input.groupData.members - members of the
+ * @returns {Object} - `object.status` of 200 on success or Error object on failure
+ */
+export default async function updateAccountGroup(context, input) {
+  const { group, groupId, shopId } = input;
+  const { appEvents, user } = context;
+  const { Groups } = context.collections;
+
+  // we are limiting group method actions to only users within the account managers role
+  await context.validatePermissions("reaction:accounts", "update:group", { shopId, legacyRoles: ["admin"] });
+
+  const defaultCustomerGroupForShop = await Groups.findOne({ slug: "customer", shopId }) || {};
+
+  // TODO: Remove when we move away from legacy permission verification
+  const defaultCustomerPermissions = defaultCustomerGroupForShop.permissions;
+
+  // ensure one group type per shop
+  const existingGroup = await Groups.findOne({ _id: groupId });
+
+  if (!existingGroup) {
+    throw new ReactionError("not-found", `Group with ID (${groupId}) doesn't exist`);
+  }
+
+  const updateGroupData = {
+    updatedAt: new Date()
+  };
+
+  // Update the name if provided
+  if (group.name) {
+    updateGroupData.name = group.name;
+  }
+
+  // Update the slug if available, or sligufy the name
+  if (group.slug) {
+    updateGroupData.slug = getSlug(group.slug);
+  } else if (group.name && !group.slug) {
+    updateGroupData.slug = getSlug(group.name);
+  }
+
+  // Update description
+  if (updateGroupData.description) {
+    updateGroupData.description = group.description;
+  }
+
+  // TODO: Remove when we move away from legacy permission verification
+  // Update the roles on the group and any user in those groups
+  if (Array.isArray(group.permissions)) {
+    const roles = _.uniq([...group.permissions, ...defaultCustomerPermissions]);
+    await setRolesOnGroupAndUsers(context, existingGroup, roles);
+  }
+
+  // Validate final group object
+  inputSchema.validate(updateGroupData);
+
+  /** Kafka connect mongo should be listening for update events
+  and should place the updated group on the kakfa groups topic.
+  reaction authorization listens on the topic and updates role (group) in
+  reaction authorization
+  */
+  const { value: updatedGroup } = await Groups.findOneAndUpdate(
+    { _id: groupId },
+    {
+      $set: updateGroupData
+    },
+    {
+      returnOriginal: false
+    }
+  );
+
+  if (!updatedGroup) throw new ReactionError("server-error", `Unable to update Group ${group._id}`);
+
+  await appEvents.emit("afterAccountGroupUpdate", {
+    account: updatedGroup,
+    updatedBy: user._id,
+    updatedFields: Object.keys(updateGroupData)
+  });
+
+  return updatedGroup;
+}

--- a/src/core-services/account/mutations/updateAccountGroup.js
+++ b/src/core-services/account/mutations/updateAccountGroup.js
@@ -66,7 +66,7 @@ export default async function updateAccountGroup(context, input) {
   }
 
   // Update description
-  if (updateGroupData.description) {
+  if (group.description) {
     updateGroupData.description = group.description;
   }
 

--- a/src/core-services/account/resolvers/Mutation/index.js
+++ b/src/core-services/account/resolvers/Mutation/index.js
@@ -9,6 +9,7 @@ import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
 import createAccountGroup from "./createAccountGroup.js";
+import updateAccountGroup from "./updateAccountGroup.js";
 
 export default {
   addAccountAddressBookEntry,
@@ -21,5 +22,6 @@ export default {
   setAccountProfileCurrency,
   setAccountProfileLanguage,
   updateAccountAddressBookEntry,
-  createAccountGroup
+  createAccountGroup,
+  updateAccountGroup
 };

--- a/src/core-services/account/resolvers/Mutation/updateAccountGroup.js
+++ b/src/core-services/account/resolvers/Mutation/updateAccountGroup.js
@@ -1,0 +1,35 @@
+import { decodeGroupOpaqueId, decodeShopOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name group/updateAccountGroup
+ * @method
+ * @memberof Group/GraphQL
+ * @summary A resolver that updates an existing permission group for a shop
+ * @param {object} _ - Not used
+ * @param {object} input - The input supplied from GraphQL
+ * @param {Object} input.group - info about group to update
+ * @param {String} input.group.name - name of the group to be updated
+ * @param {String} [input.group.description] - Optional description of the group to be updated
+ * @param {Array} input.group.permissions - permissions to assign to the group being updated
+ * @param {Array} [input.group.members] - members of the group
+ * @param {object} context - The GraphQL context
+ * @param {String} context.shopId - id of the shop the group belongs to
+ * @returns {Object} - `object.status` of 200 on success or Error object on failure
+ */
+export default async function updateAccountGroup(_, { input }, context) {
+  const { groupId, shopId, clientMutationId } = input;
+
+  const decodedGroupId = decodeGroupOpaqueId(groupId);
+  const decodedShopId = decodeShopOpaqueId(shopId);
+
+  const group = context.mutations.updateAccountGroup(context, {
+    ...input,
+    groupId: decodedGroupId,
+    shopId: decodedShopId
+  });
+
+  return {
+    clientMutationId,
+    group
+  };
+}

--- a/src/core-services/account/schemas/group.graphql
+++ b/src/core-services/account/schemas/group.graphql
@@ -60,14 +60,14 @@ input UpdateAccountGroupInput {
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
 
+  "The changes to apply to the group"
+  group: UpdateGroupInput!
+
   "The group ID"
   groupId: ID!
 
   "The ID of the shop this group belongs to"
   shopId: ID!
-
-  "The changes to apply to the group"
-  group: UpdateGroupInput!
 }
 
 "The details for removing a group"

--- a/src/core-services/account/schemas/group.graphql
+++ b/src/core-services/account/schemas/group.graphql
@@ -28,6 +28,21 @@ input GroupInput {
   slug: String!
 }
 
+"A type definition for updating account groups"
+input UpdateGroupInput {
+  "A free text description of this group"
+  description: String
+
+  "A unique name for the group"
+  name: String
+
+  "A list of the account permissions implied by membership in this group"
+  permissions: [String]
+
+  "A unique URL-safe string representing this group"
+  slug: String
+}
+
 "The details for creating a group"
 input CreateAccountGroupInput {
   "An optional string identifying the mutation call, which will be returned in the response payload"
@@ -41,18 +56,18 @@ input CreateAccountGroupInput {
 }
 
 "The details for updating a group"
-input UpdateGroupInput {
+input UpdateAccountGroupInput {
   "An optional string identifying the mutation call, which will be returned in the response payload"
   clientMutationId: String
 
   "The group ID"
-  id: ID!
+  groupId: ID!
 
   "The ID of the shop this group belongs to"
   shopId: ID!
 
   "The changes to apply to the group"
-  updates: GroupInput!
+  group: UpdateGroupInput!
 }
 
 "The details for removing a group"
@@ -158,8 +173,8 @@ type CreateAccountGroupPayload {
   group: Group
 }
 
-"The response from the `updateGroup` mutation"
-type UpdateGroupPayload {
+"The response from the `updateAccountGroup` mutation"
+type UpdateAccountGroupPayload {
   "The same string you sent with the mutation params, for matching mutation calls with their responses"
   clientMutationId: String
 
@@ -219,10 +234,10 @@ extend type Mutation {
   ): RemoveGroupPayload
 
   "Update an existing permission group"
-  updateGroup(
+  updateAccountGroup(
     "Mutation input"
-    input: UpdateGroupInput!
-  ): UpdateGroupPayload
+    input: UpdateAccountGroupInput!
+  ): UpdateAccountGroupPayload
 }
 
 extend type Query {

--- a/src/core-services/account/util/setRolesOnGroupAndUsers.js
+++ b/src/core-services/account/util/setRolesOnGroupAndUsers.js
@@ -1,0 +1,72 @@
+import Logger from "@reactioncommerce/logger";
+
+/**
+ * @name setRolesOnGroupAndUsers
+ * @private
+ * @summary Sets the given roles to the given group and updates users, if necessary
+ * @param {Object} context App context
+ * @param {Object} group - Group to update the roles of, and update users for
+ * @param {String} group._id - Group's _id
+ * @param {String} group.shopId - _id of shop group belongs to
+ * @param {String} group.name - Name of group
+ * @param {Array} roles - Array of roles/permissions (strings)
+ * @returns {undefined} Nothing
+ */
+export default async function setRolesOnGroupAndUsers(context, { _id, shopId, name }, roles) {
+  const { collections } = context;
+  const { Accounts, Groups, users } = collections;
+
+  await Groups.updateOne({
+    _id
+  }, {
+    $set: {
+      permissions: roles
+    }
+  });
+
+  const maxAccountsPerUpdate = 100000;
+  const accountSelector = { groups: _id };
+  const numAccounts = await Accounts.find(accountSelector).count();
+  if (numAccounts === 0) {
+    Logger.debug("No users need roles updated");
+    return;
+  }
+
+  Logger.debug(`Number of users to add roles to: ${numAccounts}`);
+  const numQueriesNeeded = Math.ceil(numAccounts / maxAccountsPerUpdate);
+  Logger.debug(`Number of updates needed: ${numQueriesNeeded}`);
+
+  const accountOptions = {
+    projection: { _id: 1 },
+    sort: { _id: 1 },
+    limit: maxAccountsPerUpdate
+  };
+  let lastUserIdUpdated = "";
+
+  for (let inc = 0; inc < numQueriesNeeded; inc += 1) {
+    Logger.debug(`Processing user role update #${inc + 1} of ${numQueriesNeeded} for ${name} group, ${roles} roles`);
+
+    if (lastUserIdUpdated) {
+      accountSelector._id = {
+        $gt: lastUserIdUpdated
+      };
+    }
+
+    const accounts = await Accounts.find(accountSelector, accountOptions).toArray(); // eslint-disable-line no-await-in-loop
+    const userIds = accounts.map((account) => account._id);
+    const firstUserIdInBatch = userIds[0];
+    const lastUserIdInBatch = userIds[userIds.length - 1];
+    const userSelector = { _id: { $gte: firstUserIdInBatch, $lte: lastUserIdInBatch } };
+    const userModifier = {
+      $set: {
+        [`roles.${shopId}`]: roles
+      }
+    };
+
+    await users.updateMany(userSelector, userModifier); // eslint-disable-line no-await-in-loop
+
+    lastUserIdUpdated = lastUserIdInBatch;
+  }
+
+  Logger.debug(`setRolesOnGroupAndUsers completed for ${name} group, ${roles} roles`);
+}

--- a/tests/integration/api/mutations/updateAccountGroup/AddAccountToGroupMutation.graphql
+++ b/tests/integration/api/mutations/updateAccountGroup/AddAccountToGroupMutation.graphql
@@ -1,0 +1,19 @@
+mutation ($accountId: ID!, $groupId: ID!) {
+  addAccountToGroup(input: { accountId: $accountId, groupId: $groupId }) {
+    group {
+      _id
+      createdAt
+      createdBy {
+        _id
+      }
+      description
+      name
+      permissions
+      shop {
+        _id
+      }
+      slug
+      updatedAt
+    }
+  }
+}

--- a/tests/integration/api/mutations/updateAccountGroup/UpdateAccountGroupMutation.graphql
+++ b/tests/integration/api/mutations/updateAccountGroup/UpdateAccountGroupMutation.graphql
@@ -1,0 +1,11 @@
+mutation UpdateAccountGroup($input: UpdateAccountGroupInput!) {
+  updateAccountGroup(input: $input) {
+    group {
+      _id
+      slug
+      name
+      description
+      permissions
+    }
+  }
+}

--- a/tests/integration/api/mutations/updateAccountGroup/__snapshots__/updateAccountGroup.test.js.snap
+++ b/tests/integration/api/mutations/updateAccountGroup/__snapshots__/updateAccountGroup.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`a customer account should not be able to update groups 1`] = `
+Array [
+  Object {
+    "extensions": Object {
+      "code": "FORBIDDEN",
+      "exception": Object {
+        "details": Object {},
+        "error": "access-denied",
+        "eventData": Object {},
+        "isClientSafe": true,
+        "reason": "Access Denied",
+      },
+    },
+    "locations": Array [
+      Object {
+        "column": 5,
+        "line": 3,
+      },
+    ],
+    "message": "Access Denied",
+    "path": Array [
+      "updateAccountGroup",
+      "group",
+    ],
+  },
+]
+`;

--- a/tests/integration/api/mutations/updateAccountGroup/updateAccountGroup.test.js
+++ b/tests/integration/api/mutations/updateAccountGroup/updateAccountGroup.test.js
@@ -1,0 +1,161 @@
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const AddAccountToGroupMutation = importAsString("./AddAccountToGroupMutation.graphql");
+const UpdateAccountGroupMutation = importAsString("./UpdateAccountGroupMutation.graphql");
+
+jest.setTimeout(300000);
+
+let addAccountToGroup;
+let updateAccountGroup;
+let customerGroup;
+let mockAdminAccount;
+let mockAdminAccountWithBadPermissions;
+let mockCustomerAccount;
+let shopId;
+let shopOpaqueId;
+let testApp;
+let testGroup;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+
+  shopId = await testApp.insertPrimaryShop();
+  shopOpaqueId = encodeOpaqueId("reaction/shop", shopId);
+
+  addAccountToGroup = testApp.mutate(AddAccountToGroupMutation);
+  updateAccountGroup = testApp.mutate(UpdateAccountGroupMutation);
+
+  // Create users
+  mockAdminAccount = Factory.Account.makeOne({
+    _id: "mockAdminAccount",
+    roles: {
+      [shopId]: ["owner", "admin", "ownerGroupPermission", "testGroupGroupPermission", "customerGroupPermission"]
+    },
+    shopId
+  });
+
+  mockAdminAccountWithBadPermissions = Factory.Account.makeOne({
+    _id: "mockAdminAccountWithBadPermissions",
+    roles: {
+      [shopId]: ["admin"]
+    },
+    shopId
+  });
+
+  mockCustomerAccount = Factory.Account.makeOne({
+    _id: "mockCustomerAccount",
+    shopId
+  });
+
+  await testApp.context.collections.Accounts.updateOne(
+    { _id: "mockAdminAccount" },
+    {
+      $set: {
+        groups: ["testGroup"]
+      }
+    }
+  );
+
+
+  await testApp.createUserAndAccount(mockAdminAccount);
+  await testApp.createUserAndAccount(mockAdminAccountWithBadPermissions);
+  await testApp.createUserAndAccount(mockCustomerAccount);
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  // Create groups
+  customerGroup = Factory.Group.makeOne({
+    createdBy: null,
+    name: "customer",
+    permissions: [],
+    slug: "customer",
+    shopId
+  });
+
+  testGroup = Factory.Group.makeOne({
+    _id: "testGroup",
+    createdBy: null,
+    description: "a group for testing purposes",
+    name: "test-int-group",
+    permissions: ["test-perm-1", "test-perm-2"],
+    slug: "test-int-group",
+    shopId
+  });
+
+  await testApp.collections.Groups.insertOne(customerGroup);
+  await testApp.collections.Groups.insertOne(testGroup);
+
+  // Add customer account to the test group
+  await addAccountToGroup({
+    accountId: encodeOpaqueId("reaction/account", "mockCustomerAccount"),
+    groupId: encodeOpaqueId("reaction/group", "testGroup")
+  });
+
+  await testApp.clearLoggedInUser();
+});
+
+
+afterAll(async () => {
+  await testApp.collections.Groups.deleteMany({});
+  await testApp.collections.Accounts.deleteMany({});
+  await testApp.collections.users.deleteMany({});
+  await testApp.collections.Shops.deleteMany({});
+  await testApp.stop();
+});
+
+test("a customer account should not be able to update groups", async () => {
+  await testApp.setLoggedInUser(mockCustomerAccount);
+
+  // Expect the before customer to have been added to the test group and have all the roles of that group
+  const beforeCustomer = await testApp.context.collections.users.findOne({ _id: "mockCustomerAccount" });
+  expect(beforeCustomer.roles[shopId]).toEqual(["test-perm-1", "test-perm-2"]);
+
+  try {
+    await updateAccountGroup({
+      input: {
+        groupId: encodeOpaqueId("reaction/group", "testGroup"),
+        shopId: shopOpaqueId,
+        group: {
+          permissions: ["test-perm-4"]
+        }
+      }
+    });
+  } catch (errors) {
+    expect(errors).toMatchSnapshot();
+    return;
+  }
+});
+
+test("anyone can add account to group if they have ALL the group permissions", async () => {
+  await testApp.setLoggedInUser(mockAdminAccount);
+
+  // Expect the before customer to have been added to the test group and have all the roles of that group
+  const beforeCustomer = await testApp.context.collections.users.findOne({ _id: "mockCustomerAccount" });
+  expect(beforeCustomer.roles[shopId]).toEqual(["test-perm-1", "test-perm-2"]);
+
+  let result;
+
+  try {
+    result = await updateAccountGroup({
+      input: {
+        groupId: encodeOpaqueId("reaction/group", "testGroup"),
+        shopId: shopOpaqueId,
+        group: {
+          permissions: ["test-perm-4"]
+        }
+      }
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  expect(result.updateAccountGroup.group.permissions).toEqual(["test-perm-4"]);
+
+  const afterCustomer = await testApp.context.collections.users.findOne({ _id: "mockCustomerAccount" });
+  expect(afterCustomer.roles[shopId]).toEqual(["test-perm-4"]);
+});
+

--- a/tests/integration/api/mutations/updateAccountGroup/updateAccountGroup.test.js
+++ b/tests/integration/api/mutations/updateAccountGroup/updateAccountGroup.test.js
@@ -60,7 +60,6 @@ beforeAll(async () => {
     }
   );
 
-
   await testApp.createUserAndAccount(mockAdminAccount);
   await testApp.createUserAndAccount(mockAdminAccountWithBadPermissions);
   await testApp.createUserAndAccount(mockCustomerAccount);
@@ -96,7 +95,6 @@ beforeAll(async () => {
 
   await testApp.clearLoggedInUser();
 });
-
 
 afterAll(async () => {
   await testApp.collections.Groups.deleteMany({});
@@ -158,4 +156,3 @@ test("an admin account should be able to update groups", async () => {
   const afterCustomer = await testApp.context.collections.users.findOne({ _id: "mockCustomerAccount" });
   expect(afterCustomer.roles[shopId]).toEqual(["test-perm-4"]);
 });
-

--- a/tests/integration/api/mutations/updateAccountGroup/updateAccountGroup.test.js
+++ b/tests/integration/api/mutations/updateAccountGroup/updateAccountGroup.test.js
@@ -129,7 +129,7 @@ test("a customer account should not be able to update groups", async () => {
   }
 });
 
-test("anyone can add account to group if they have ALL the group permissions", async () => {
+test("an admin account should be able to update groups", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);
 
   // Expect the before customer to have been added to the test group and have all the roles of that group

--- a/tests/integration/api/mutations/updateAccountGroup/updateAccountGroup.test.js
+++ b/tests/integration/api/mutations/updateAccountGroup/updateAccountGroup.test.js
@@ -87,7 +87,7 @@ beforeAll(async () => {
   await testApp.collections.Groups.insertOne(customerGroup);
   await testApp.collections.Groups.insertOne(testGroup);
 
-  // Add customer account to the test group
+  // Add customer account to the testGroup
   await addAccountToGroup({
     accountId: encodeOpaqueId("reaction/account", "mockCustomerAccount"),
     groupId: encodeOpaqueId("reaction/group", "testGroup")
@@ -107,7 +107,7 @@ afterAll(async () => {
 test("a customer account should not be able to update groups", async () => {
   await testApp.setLoggedInUser(mockCustomerAccount);
 
-  // Expect the before customer to have been added to the test group and have all the roles of that group
+  // Expect the customer to have all of the roles from the testGroup
   const beforeCustomer = await testApp.context.collections.users.findOne({ _id: "mockCustomerAccount" });
   expect(beforeCustomer.roles[shopId]).toEqual(["test-perm-1", "test-perm-2"]);
 
@@ -130,7 +130,7 @@ test("a customer account should not be able to update groups", async () => {
 test("an admin account should be able to update groups", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);
 
-  // Expect the before customer to have been added to the test group and have all the roles of that group
+  // Expect the customer to have all of the roles from the testGroup
   const beforeCustomer = await testApp.context.collections.users.findOne({ _id: "mockCustomerAccount" });
   expect(beforeCustomer.roles[shopId]).toEqual(["test-perm-1", "test-perm-2"]);
 


### PR DESCRIPTION
Resolves #5983
Resolves #5947
Impact: **minor**  
Type: **feature**

## Issue

Missing a mutation for updating account groups.

## Solution

- Add mutation `updateAccountGroup` to update account group metadata and permissions

## Breaking changes

none

## Testing
1. Ensure the test pass
---

**Manual testing**
1. Make a customer account using the admin
1. Ensure they're in the customer group in the `Accounts` collection
1. Check their roles in the `users` collection
1. Update the permissions for the customer group
1. See if the user's roles were updated in the `users` collection
1. Check other updated fields from mutation

---

```graphql
# Get Shop ID
query shopId {
  primaryShopId
}

# Query groups
query groups {
  groups(shopId: "SHOP_ID") {
    nodes {
      _id
      name
      slug
    }
  }
}

# Update queried group
mutation updateAccountGroup {
  updateAccountGroup(input: {
    groupId: "GROUP_ID",
    shopId: "SHOP_ID"
    group: {
      name: "Customer Edited"
      slug: "customer"
      description: "Customers"
      permissions: ["permissions"] # This set all the permisisons (not append)
    }
  }) {
    group {
      _id
      slug
      name
      permissions
    }
  }
}
```