### PR TITLE
feat(simple-pricing): Compute displayPrice as resolver as needed

### DIFF
--- a/src/plugins/simple-pricing/resolvers/ProductPricingInfo.js
+++ b/src/plugins/simple-pricing/resolvers/ProductPricingInfo.js
@@ -3,8 +3,12 @@ import getDisplayPrice from "../util/getDisplayPrice.js";
 
 export default {
   currency: (node) => getCurrencyDefinitionByCode(node.currencyCode),
-  compareAtPrice: ({ compareAtPrice: amount, currencyCode }) =>
-    typeof amount === "number" && amount > 0 ? { amount, currencyCode } : null,
+  compareAtPrice: ({ compareAtPrice: amount, currencyCode }) => {
+    if (typeof amount === "number" && amount > 0) {
+      return { amount, currencyCode };
+    }
+    return null;
+  },
   displayPrice: (node) => {
     if (node.displayPrice) {
       // Operating in core catalog plugin mode.

--- a/src/plugins/simple-pricing/resolvers/ProductPricingInfo.js
+++ b/src/plugins/simple-pricing/resolvers/ProductPricingInfo.js
@@ -1,6 +1,20 @@
 import getCurrencyDefinitionByCode from "@reactioncommerce/api-utils/getCurrencyDefinitionByCode.js";
+import getDisplayPrice from "../util/getDisplayPrice.js";
 
 export default {
   currency: (node) => getCurrencyDefinitionByCode(node.currencyCode),
-  compareAtPrice: ({ compareAtPrice: amount, currencyCode }) => (typeof amount === "number" && amount > 0 ? { amount, currencyCode } : null)
+  compareAtPrice: ({ compareAtPrice: amount, currencyCode }) =>
+    typeof amount === "number" && amount > 0 ? { amount, currencyCode } : null,
+  displayPrice: (node) => {
+    if (node.displayPrice) {
+      // Operating in core catalog plugin mode.
+      // Use displayPrice directly from mongo.
+      // It was computed at publish time.
+      return node.displayPrice;
+    }
+    // Operating in catalog publisher mode.
+    // displayPrice was not computed ahead of time.
+    // Compute it on the fly now.
+    return getDisplayPrice(node.minPrice, node.maxPrice, getCurrencyDefinitionByCode(node.currencyCode));
+  }
 };

--- a/src/plugins/simple-pricing/resolvers/ProductPricingInfo.test.js
+++ b/src/plugins/simple-pricing/resolvers/ProductPricingInfo.test.js
@@ -1,0 +1,10 @@
+import ProductPricingInfo from "./ProductPricingInfo.js";
+
+test("displayPrice: catalog plugin mongo mode", () => {
+  expect(ProductPricingInfo.displayPrice({ displayPrice: "$Unit test 1" })).toEqual("$Unit test 1");
+});
+
+test("displayPrice: catalog publisher resolver mode", () => {
+  const displayPrice = ProductPricingInfo.displayPrice({ minPrice: 1.01, maxPrice: 2.02, currencyCode: "USD" });
+  expect(displayPrice).toEqual("$1.01 - $2.02");
+});


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
With the existing simple-pricing core plugin flow, `catalogProduct.product.pricing.displayPrice` is computed at publication time (ahead of time) and stored in mongodb. For the in-development Catalog Publisher component, doing the computation of `displayPrice` at publish time would require the full set of currency formatting I18N data and logic to be available in kafka and kafka streams. 

## Solution

Allow `displayPrice` to be computed at query time via a graphql resolver if necessary. This implementation works seamlessly with both the core simple-pricing plugin as before, but computes `displayPrice` as needed if the catalog plugin is disabled in favor of the catalog publisher service in a particular deployment. No configuration is necessary and data could in theory even be mixed between catalog plugin and catalog publisher.

## Breaking changes

This should be fully compatible with existing clients and installations.

## Testing

A unit test has been added. Manual testing is still planned/underway so I'll convert to ready for review when that is completed.

At the moment catalog publisher output data is arriving in the `Catalog2` collection in mongodb which is not used at all by reaction core or plugins. To test this we'd need to retarget or rename that so it's the real `Catalog` collection. Undoubtedly the first time we do that some bugs will surface which we'll have to fix. Once those are fixed though, we should now be able to test this PR. If you query graphql with a query similar to below, and the `displayPrice` attribute looks correct, this change is working properly.


```graphql
query {
  catalogItemProduct(shopId: "cmVhY3Rpb24vc2hvcDpKOEJocTN1VHRkZ3daeDNyeg==", slugOrId: "timberlands") {
    product {
      pricing {
        currency {
          rate
        }
        compareAtPrice {
          amount
        }
        displayPrice
        
      }
    }
  }
}# Write your query or mutation here
```