### PR TITLE
chore: fix up eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,5 @@
 jest.config.js
 .reaction/**/*
+client/plugins.js
+server/plugins.js
+imports/plugins/*/*/node_modules


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Issue
Running `npm lint` locally was showing 100K+ errors. It was fine in CI though. My theory is maybe plugin dependencies were not yet installed in CI so there were no node_modules sand traps for eslint to fall into. Locally there there are lots of node_modules directories under plugins so we ignore those now.

## Solution
Ignore generated files and 3rd party deps.

