### PR TITLE
feat: change graphql route

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ dc up -d mongo
 docker run -e NODE_ENV=production -e MONGO_URL=mongodb://mongo:27017/reaction -e ROOT_URL=http://localhost:3000 -p 3000:3000 --network streams.reaction.localhost -it test-api
 ```
 
-Use an external GraphQL client to test http://localhost:3000/graphql-beta. GraphQL Playground isn't served on GET requests because it's in production mode.
+Use an external GraphQL client to test http://localhost:3000/graphql. GraphQL Playground isn't served on GET requests because it's in production mode.
 
 # Get involved
 

--- a/src/core/createApolloServer.js
+++ b/src/core/createApolloServer.js
@@ -94,9 +94,10 @@ export default function createApolloServer(options = {}) {
     ...gqlMiddleware.filter((def) => def.stage === "before-response").map((def) => def.fn(contextFromOptions))
   ]);
 
-  // Redirect for legacy graphql routes
-  app.all(/\/graphql-\w+/, (req, res) => {
-    res.redirect(path);
+  // Rewrite url to support legacy graphql routes
+  app.all(/\/graphql-\w+/, (req, res, next) => {
+    req.url = path;
+    next();
   });
 
   apolloServer.applyMiddleware({ app, cors: true, path });

--- a/src/core/createApolloServer.js
+++ b/src/core/createApolloServer.js
@@ -11,7 +11,7 @@ const require = createRequire(import.meta.url);
 const { makeExecutableSchema, mergeSchemas } = require("apollo-server");
 const { ApolloServer } = require("apollo-server-express");
 
-const DEFAULT_GRAPHQL_PATH = "/graphql-beta";
+const DEFAULT_GRAPHQL_PATH = "/graphql";
 
 const resolverValidationOptions = {
   // After we fix all errors that this prints, we should probably go
@@ -94,9 +94,8 @@ export default function createApolloServer(options = {}) {
     ...gqlMiddleware.filter((def) => def.stage === "before-response").map((def) => def.fn(contextFromOptions))
   ]);
 
-  // Redirect for graphql-alpha route
-  app.all("/graphql-alpha", (req, res) => {
-    // Redirect to path once graphql-alpha is received
+  // Redirect for legacy graphql routes
+  app.all(/\/graphql-\w+/, (req, res) => {
     res.redirect(path);
   });
 


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
We had our default graphql route set to `/graphql-beta` as we were phasing it in. Now that it is officially our only recommended API entrypoint we should remove the `-beta` suffix.

## Solution
This changes the default graphql route to be `/graphql`, updates all docs within the project, and adds a redirect for `/graphql-*` to point to the new path.

## Breaking changes
Technically none, as this adds a redirect for legacy endpoints. All the same, this does change the default graphql endpoint so projects should ultimately update to the new path on their own time.

## Testing
1. Verify that `/graphql` works for graphql requests.
2. Verify that `GET /graphql` loads the Apollo playground.
3. Verify that `/graphql-beta`, `/graphql-alpha`, and `/graphql-anything` all redirect to `/graphql`.