### PR TITLE
fix: check if the url is already absolute

### DIFF
--- a/src/core/util/getAbsoluteUrl.js
+++ b/src/core/util/getAbsoluteUrl.js
@@ -6,15 +6,16 @@
  * @returns {String} Full URL
  */
 export default function getAbsoluteUrl(rootUrl, path = "") {
+  // If the path already contains the rootUrl
+  // don't add it again
+  const regExp = /^https?:\/\/|^\/\//i;
+  if (regExp.exec(path) !== null) {
+    return path;
+  }
+
   let pathNoSlash = path;
   if (path.startsWith("/")) {
     pathNoSlash = path.slice(1);
-  }
-
-  // If the path already contains the rootUrl
-  // don't add it again
-  if (rootUrl === path.slice(0, rootUrl.length)) {
-    return pathNoSlash;
   }
 
   return `${rootUrl}${pathNoSlash}`;

--- a/src/core/util/getAbsoluteUrl.js
+++ b/src/core/util/getAbsoluteUrl.js
@@ -11,5 +11,11 @@ export default function getAbsoluteUrl(rootUrl, path = "") {
     pathNoSlash = path.slice(1);
   }
 
+  // If the path already contains the rootUrl
+  // don't add it again
+  if (rootUrl === path.slice(0, rootUrl.length)) {
+    return pathNoSlash;
+  }
+
   return `${rootUrl}${pathNoSlash}`;
 }

--- a/src/core/util/getAbsoluteUrl.js
+++ b/src/core/util/getAbsoluteUrl.js
@@ -6,10 +6,9 @@
  * @returns {String} Full URL
  */
 export default function getAbsoluteUrl(rootUrl, path = "") {
-  // If the path already contains the rootUrl
-  // don't add it again
+  // Check if the path is already absolute
   const regExp = /^https?:\/\/|^\/\//i;
-  if (regExp.exec(path) !== null) {
+  if (regExp.test(path)) {
     return path;
   }
 

--- a/src/core/util/getAbsoluteUrl.js
+++ b/src/core/util/getAbsoluteUrl.js
@@ -7,8 +7,8 @@
  */
 export default function getAbsoluteUrl(rootUrl, path = "") {
   // Check if the path is already absolute
-  const pathStart = path.slice(0, 7).toLowerCase();
-  if (pathStart.startsWith("https://") || pathStart.startsWith("http") || pathStart.startsWith("//")) {
+  const pathStart = path.slice(0, 8).toLowerCase();
+  if (pathStart.startsWith("https://") || pathStart.startsWith("http://") || pathStart.startsWith("//")) {
     return path;
   }
 

--- a/src/core/util/getAbsoluteUrl.js
+++ b/src/core/util/getAbsoluteUrl.js
@@ -7,8 +7,8 @@
  */
 export default function getAbsoluteUrl(rootUrl, path = "") {
   // Check if the path is already absolute
-  const regExp = /^https?:\/\/|^\/\//i;
-  if (regExp.test(path)) {
+  const pathStart = path.slice(0, 7).toLowerCase();
+  if (pathStart.startsWith("https://") || pathStart.startsWith("http") || pathStart.startsWith("//")) {
     return path;
   }
 

--- a/src/core/util/getAbsoluteUrl.test.js
+++ b/src/core/util/getAbsoluteUrl.test.js
@@ -11,3 +11,9 @@ test("returns the correct URL when given a path", () => {
   const path = "/media/test.jpg";
   expect(getAbsoluteUrl(rootUrl, path)).toBe("http://localhost:3000/media/test.jpg");
 });
+
+test("returns the correct URL if the path already contains the rootUrl", () => {
+  const rootUrl = "http://localhost:3000/";
+  const path = "http://localhost:3000/media/test.jpg";
+  expect(getAbsoluteUrl(rootUrl, path)).toBe("http://localhost:3000/media/test.jpg");
+});

--- a/src/core/util/getAbsoluteUrl.test.js
+++ b/src/core/util/getAbsoluteUrl.test.js
@@ -17,3 +17,15 @@ test("returns the correct URL if the path already contains the rootUrl", () => {
   const path = "http://localhost:3000/media/test.jpg";
   expect(getAbsoluteUrl(rootUrl, path)).toBe("http://localhost:3000/media/test.jpg");
 });
+
+test("returns the correct URL for 3rd party services", () => {
+  const rootUrl = "http://localhost:3000/";
+  const path = "https://cloudinary.com/media/test.jpg";
+  expect(getAbsoluteUrl(rootUrl, path)).toBe("https://cloudinary.com/media/test.jpg");
+});
+
+test("returns the correct URL for protocol-relative URLs", () => {
+  const rootUrl = "http://localhost:3000/";
+  const path = "//example.com/img/logo.png";
+  expect(getAbsoluteUrl(rootUrl, path)).toBe("//example.com/img/logo.png");
+});

--- a/src/core/util/getAbsoluteUrl.test.js
+++ b/src/core/util/getAbsoluteUrl.test.js
@@ -26,6 +26,12 @@ test("returns the correct URL for 3rd party services", () => {
 
 test("returns the correct URL for protocol-relative URLs", () => {
   const rootUrl = "http://localhost:3000/";
-  const path = "//example.com/img/logo.png";
-  expect(getAbsoluteUrl(rootUrl, path)).toBe("//example.com/img/logo.png");
+  const path = "//example.com/img/logo.jpg";
+  expect(getAbsoluteUrl(rootUrl, path)).toBe("//example.com/img/logo.jpg");
+});
+
+test("returns the correct URL for path starting with http", () => {
+  const rootUrl = "http://localhost:3000/";
+  const path = "http.jpg";
+  expect(getAbsoluteUrl(rootUrl, path)).toBe("http://localhost:3000/http.jpg");
 });


### PR DESCRIPTION
Signed-off-by: Maria Paktiti <maria.paktiti@gmail.com>

Resolves https://github.com/reactioncommerce/catalog-publisher/issues/253
Impact: **minor**  
Type: **bugfix**

## Issue
The image URLs coming from the Catalog Publisher, are already absolute. When this function is called to "absolutify" it again, the result looks like this:
```
{
  "data": {
    "catalogItemProduct": {
      "product": {
        "title": "Timberlands",
        "primaryImage": {
          "URLs": {
            "large": "http://reaction.api.reaction.localhost:3000/http://reaction.api.reaction.localhost:3000/assets/files/Media/rx9fN8A7qJtnAQr4L/large/adult-beautiful-beautiful-girl-1054249.jpg"
          }
        },
```

## Solution
Add a check to see if the `path` already is absolute. If not add the rootUrl, otherwise return the path. 

## Breaking changes
None, it's an additional check.

## Testing
Run the tests (I added one for this case), or send a GraphQL request for a product that has an absolute url already. The request should look like that:
```
{
  catalogItemProduct(slugOrId: "product3") {
    _id
    createdAt
    product {
      title
      primaryImage {
        URLs {
          large
        }
      }
    }
  }
}
```
