### PR TITLE
refactor: remove restriction that limits account to one group per shop

### DIFF
--- a/src/core-services/account/mutations/addAccountToGroup.js
+++ b/src/core-services/account/mutations/addAccountToGroup.js
@@ -48,6 +48,9 @@ export default async function addAccountToGroup(context, input) {
   const accountUser = await users.findOne({ _id: account.userId });
   if (!accountUser) throw new ReactionError("not-found", "No user found with that ID");
 
+  const groupToAdd = account.groups.includes(groupId);
+  if (groupToAdd) throw new ReactionError("group-found", "Account is already in this group");
+
   // Get existing roles from a user
   const newAccountUserRoles = new Set((accountUser.roles || {})[shopId] || []);
 

--- a/src/core-services/account/mutations/addAccountToGroup.js
+++ b/src/core-services/account/mutations/addAccountToGroup.js
@@ -60,8 +60,7 @@ export default async function addAccountToGroup(context, input) {
   const uniqueRoles = _.uniq(newRoles);
 
   // Add all group roles to the user. Make sure this stays in this order.
-  const newAccountUserRolesArray = [...newAccountUserRoles];
-  await ensureRoles(context, newAccountUserRolesArray);
+  await ensureRoles(context, newRoles);
   await users.updateOne({
     _id: account.userId
   }, {
@@ -72,7 +71,7 @@ export default async function addAccountToGroup(context, input) {
   // TODO(pod-auth): this will likely be removed in #6031, where we no longer get roles from user.roles
 
   // Add new group to Account
-  const accountGroups = (Array.isArray(account.groups) && account.groups) || [];
+  const accountGroups = Array.isArray(account.groups) ? account.groups : [];
   accountGroups.push(groupId);
 
   await Accounts.updateOne({ _id: accountId }, { $set: { groups: accountGroups } });

--- a/src/core-services/account/mutations/index.js
+++ b/src/core-services/account/mutations/index.js
@@ -8,6 +8,7 @@ import createAuthGroupsForShop from "./createAuthGroupsForShop.js";
 import inviteShopMember from "./inviteShopMember.js";
 import removeAccountAddressBookEntry from "./removeAccountAddressBookEntry.js";
 import removeAccountEmailRecord from "./removeAccountEmailRecord.js";
+import removeAccountFromGroup from "./removeAccountFromGroup.js";
 import removeAccountGroup from "./removeAccountGroup.js";
 import sendResetAccountPasswordEmail from "./sendResetAccountPasswordEmail.js";
 import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
@@ -26,6 +27,7 @@ export default {
   inviteShopMember,
   removeAccountAddressBookEntry,
   removeAccountEmailRecord,
+  removeAccountFromGroup,
   removeAccountGroup,
   sendResetAccountPasswordEmail,
   setAccountProfileCurrency,

--- a/src/core-services/account/mutations/removeAccountFromGroup.js
+++ b/src/core-services/account/mutations/removeAccountFromGroup.js
@@ -59,12 +59,12 @@ export default async function removeAccountFromGroup(context, input) {
 
   // update user to only have roles from other groups they belong
   // TODO(pod-auth): this will likely be removed in #6031, where we no longer get roles from user.roles
-  await ensureRoles(context, remainingRolesToGiveUser || []);
+  await ensureRoles(context, remainingRolesToGiveUser);
   await users.updateOne({
     _id: account.userId
   }, {
     $set: {
-      [`roles.${shopId}`]: remainingRolesToGiveUser || []
+      [`roles.${shopId}`]: remainingRolesToGiveUser
     }
   });
   // TODO(pod-auth): this will likely be removed in #6031, where we no longer get roles from user.roles
@@ -84,5 +84,5 @@ export default async function removeAccountFromGroup(context, input) {
   });
 
   // Return the group the account was added to
-  return Groups.findOne({ _id: groupId });
+  return allGroupsUserBelongsTo.find((group) => group._id === groupId);
 }

--- a/src/core-services/account/mutations/removeAccountFromGroup.js
+++ b/src/core-services/account/mutations/removeAccountFromGroup.js
@@ -48,32 +48,33 @@ export default async function removeAccountFromGroup(context, input) {
   const accountUser = await users.findOne({ _id: account.userId });
   if (!accountUser) throw new ReactionError("not-found", "No user found with that ID");
 
-  // Get all other groups user belongs to, and all permissions from these groups
-  const otherGroupsUserBelongsTo = account.groups.filter((group) => group.shopId === shopId && group._id !== groupId);
+  const groupToRemove = account.groups.includes(groupId);
+  if (!groupToRemove) throw new ReactionError("not-found", "Account not found in this group");
 
-  let otherGroupPermissions;
-  if (Array.isArray(otherGroupsUserBelongsTo) && otherGroupsUserBelongsTo.length) {
-    const otherGroups = await Groups.find({ _id: { $in: otherGroupsUserBelongsTo } }).toArray();
-    otherGroupPermissions = _.uniq(otherGroups.map((group) => group.permissions).flat());
-  }
+  const allGroupsUserBelongsTo = await Groups.find({ _id: { $in: account.groups } }).toArray();
+
+  // Get all other groups user belongs to, and all permissions from these groups, and flatten into single array
+  const remainingGroupsUserBelongsTo = allGroupsUserBelongsTo.filter((group) => group.shopId === shopId && group._id !== groupId);
+  const remainingRolesToGiveUser = _.uniq(remainingGroupsUserBelongsTo.map((group) => group.permissions).flat());
 
   // update user to only have roles from other groups they belong
   // TODO(pod-auth): this will likely be removed in #6031, where we no longer get roles from user.roles
-  await ensureRoles(context, otherGroupPermissions || []);
+  await ensureRoles(context, remainingRolesToGiveUser || []);
   await users.updateOne({
     _id: account.userId
   }, {
     $set: {
-      [`roles.${shopId}`]: otherGroupPermissions || []
+      [`roles.${shopId}`]: remainingRolesToGiveUser || []
     }
   });
   // TODO(pod-auth): this will likely be removed in #6031, where we no longer get roles from user.roles
 
-  await Accounts.updateOne({ _id: accountId }, { $set: { groups: otherGroupsUserBelongsTo } });
+  const remainingGroupIds = remainingGroupsUserBelongsTo.map((group) => group._id);
+  await Accounts.updateOne({ _id: accountId }, { $set: { groups: remainingGroupIds } });
 
   const updatedAccount = {
     ...account,
-    groups: otherGroupsUserBelongsTo
+    groups: remainingGroupsUserBelongsTo
   };
 
   await appEvents.emit("afterAccountUpdate", {

--- a/src/core-services/account/mutations/removeAccountFromGroup.js
+++ b/src/core-services/account/mutations/removeAccountFromGroup.js
@@ -1,0 +1,87 @@
+import _ from "lodash";
+import ReactionError from "@reactioncommerce/reaction-error";
+import SimpleSchema from "simpl-schema";
+import canAddAccountToGroup from "../util/canAddAccountToGroup.js";
+import ensureRoles from "../util/ensureRoles.js";
+
+const inputSchema = new SimpleSchema({
+  accountId: String,
+  groupId: String
+});
+
+/**
+ * @name accounts/removeAccountFromGroup
+ * @memberof Mutations/Accounts
+ * @method
+ * @summary Add an account to a group
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Input arguments
+ * @param {String} input.accountId - The account ID
+ * @param {String} input.groupId - The group ID
+ * @return {Promise<Object>} with updated address
+ */
+export default async function removeAccountFromGroup(context, input) {
+  inputSchema.validate(input);
+
+  const { accountId, groupId } = input;
+  const {
+    appEvents,
+    collections: {
+      Accounts,
+      Groups,
+      users
+    },
+    userId
+  } = context;
+
+  const groupToRemoveUserFrom = await Groups.findOne({ _id: groupId });
+  if (!groupToRemoveUserFrom) throw new ReactionError("not-found", "No group found with that ID");
+
+  const { shopId } = groupToRemoveUserFrom;
+
+  const isAllowed = await canAddAccountToGroup(context, groupToRemoveUserFrom);
+  if (!isAllowed) throw new ReactionError("access-denied", "Access Denied");
+
+  const account = await Accounts.findOne({ _id: accountId });
+  if (!account) throw new ReactionError("not-found", "No account found with that ID");
+
+  const accountUser = await users.findOne({ _id: account.userId });
+  if (!accountUser) throw new ReactionError("not-found", "No user found with that ID");
+
+  // Get all other groups user belongs to, and all permissions from these groups
+  const otherGroupsUserBelongsTo = account.groups.filter((group) => group.shopId === shopId && group._id !== groupId);
+
+  let otherGroupPermissions;
+  if (Array.isArray(otherGroupsUserBelongsTo) && otherGroupsUserBelongsTo.length) {
+    const otherGroups = await Groups.find({ _id: { $in: otherGroupsUserBelongsTo } }).toArray();
+    otherGroupPermissions = _.uniq(otherGroups.map((group) => group.permissions).flat());
+  }
+
+  // update user to only have roles from other groups they belong
+  // TODO(pod-auth): this will likely be removed in #6031, where we no longer get roles from user.roles
+  await ensureRoles(context, otherGroupPermissions || []);
+  await users.updateOne({
+    _id: account.userId
+  }, {
+    $set: {
+      [`roles.${shopId}`]: otherGroupPermissions || []
+    }
+  });
+  // TODO(pod-auth): this will likely be removed in #6031, where we no longer get roles from user.roles
+
+  await Accounts.updateOne({ _id: accountId }, { $set: { groups: otherGroupsUserBelongsTo } });
+
+  const updatedAccount = {
+    ...account,
+    groups: otherGroupsUserBelongsTo
+  };
+
+  await appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: userId,
+    updatedFields: ["groups"]
+  });
+
+  // Return the group the account was added to
+  return Groups.findOne({ _id: groupId });
+}

--- a/src/core-services/account/policies.json
+++ b/src/core-services/account/policies.json
@@ -76,7 +76,8 @@
     "actions": [
       "read",
       "update",
-      "delete"
+      "delete",
+      "manage:accounts"
     ],
     "effect": "allow"
   }

--- a/src/core-services/account/resolvers/Mutation/index.js
+++ b/src/core-services/account/resolvers/Mutation/index.js
@@ -6,6 +6,7 @@ import inviteShopMember from "./inviteShopMember.js";
 import removeAccountAddressBookEntry from "./removeAccountAddressBookEntry.js";
 import removeAccountEmailRecord from "./removeAccountEmailRecord.js";
 import removeAccountGroup from "./removeAccountGroup.js";
+import removeAccountFromGroup from "./removeAccountFromGroup.js";
 import sendResetAccountPasswordEmail from "./sendResetAccountPasswordEmail.js";
 import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
@@ -20,6 +21,7 @@ export default {
   inviteShopMember,
   removeAccountAddressBookEntry,
   removeAccountEmailRecord,
+  removeAccountFromGroup,
   removeAccountGroup,
   sendResetAccountPasswordEmail,
   setAccountProfileCurrency,

--- a/src/core-services/account/resolvers/Mutation/removeAccountFromGroup.js
+++ b/src/core-services/account/resolvers/Mutation/removeAccountFromGroup.js
@@ -1,0 +1,31 @@
+import { decodeAccountOpaqueId, decodeGroupOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Mutation/removeAccountFromGroup
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver for the removeAccountFromGroup GraphQL mutation
+ * @param {Object} parentResult - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} args.input.accountId - The account ID
+ * @param {String} args.input.groupId - The group ID
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @returns {Object} removeAccountFromGroupPayload
+ */
+export default async function removeAccountFromGroup(parentResult, { input }, context) {
+  const { accountId: opaqueAccountId, groupId: opaqueGroupId, clientMutationId = null } = input;
+
+  const accountId = decodeAccountOpaqueId(opaqueAccountId);
+  const groupId = decodeGroupOpaqueId(opaqueGroupId);
+
+  const group = await context.mutations.removeAccountFromGroup(context, {
+    accountId,
+    groupId
+  });
+
+  return {
+    group,
+    clientMutationId
+  };
+}

--- a/src/core-services/account/resolvers/Mutation/removeAccountFromGroup.test.js
+++ b/src/core-services/account/resolvers/Mutation/removeAccountFromGroup.test.js
@@ -1,0 +1,30 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import { encodeAccountOpaqueId, encodeGroupOpaqueId } from "../../xforms/id.js";
+import removeAccountFromGroup from "./removeAccountFromGroup.js";
+
+mockContext.mutations.removeAccountFromGroup = jest.fn().mockName("mutations.removeAccountFromGroup");
+
+test("correctly passes through to internal mutation function", async () => {
+  const accountId = encodeAccountOpaqueId("1");
+  const groupId = encodeGroupOpaqueId("g1");
+  const group = { name: "customer" };
+
+  const fakeResult = { _id: "g1", ...group };
+
+  mockContext.mutations.removeAccountFromGroup.mockReturnValueOnce(Promise.resolve(fakeResult));
+
+  const result = await removeAccountFromGroup(null, {
+    input: {
+      accountId,
+      groupId,
+      clientMutationId: "clientMutationId"
+    }
+  }, mockContext);
+
+  expect(mockContext.mutations.removeAccountFromGroup).toHaveBeenCalledWith(mockContext, { accountId: "1", groupId: "g1" });
+
+  expect(result).toEqual({
+    group: fakeResult,
+    clientMutationId: "clientMutationId"
+  });
+});

--- a/src/core-services/account/schemas/group.graphql
+++ b/src/core-services/account/schemas/group.graphql
@@ -203,7 +203,7 @@ type RemoveAccountFromGroupPayload {
   clientMutationId: String
 
   "The removed group"
-  group: Group
+  group: Group!
 }
 
 

--- a/src/core-services/account/schemas/group.graphql
+++ b/src/core-services/account/schemas/group.graphql
@@ -94,6 +94,18 @@ input AddAccountToGroupInput {
   groupId: ID!
 }
 
+"Defines a group and account that should be unlinked"
+input RemoveAccountFromGroupInput {
+  "The account ID"
+  accountId: ID!
+
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "The group ID"
+  groupId: ID!
+}
+
 "Represents an account group"
 type Group implements Node {
   "The group ID"
@@ -185,6 +197,16 @@ type UpdateAccountGroupPayload {
   group: Group
 }
 
+"The response from the `removeAccountFromGroup` mutation"
+type RemoveAccountFromGroupPayload {
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+
+  "The removed group"
+  group: Group
+}
+
+
 "The response from the `removeGroup` mutation"
 type RemoveAccountGroupPayload {
   "The same string you sent with the mutation params, for matching mutation calls with their responses"
@@ -229,6 +251,12 @@ extend type Mutation {
     "Mutation input"
     input: CreateAccountGroupInput!
   ): CreateAccountGroupPayload
+
+  "Remove an account from a group"
+  removeAccountFromGroup(
+    "Mutation input"
+    input: RemoveAccountFromGroupInput!
+  ): RemoveAccountFromGroupPayload
 
   "Remove an existing permission group"
   removeAccountGroup(

--- a/src/core-services/account/util/canAddAccountToGroup.js
+++ b/src/core-services/account/util/canAddAccountToGroup.js
@@ -12,13 +12,12 @@ export default async function canAddAccountToGroup(context, group) {
     account: contextUserAccount,
     collections: { Groups },
     isInternalCall,
-    user,
     userHasPermission
   } = context;
 
   if (isInternalCall) return true;
 
-  const { permissions: groupPermissions = [], shopId } = group;
+  const { shopId } = group;
 
   // An account can add another account to a group as long as the person adding
   // has all permissions granted by that group.
@@ -31,5 +30,5 @@ export default async function canAddAccountToGroup(context, group) {
     !!ownerGroup && contextUserAccount && contextUserAccount.groups.includes(ownerGroup._id)) ||
     userHasPermission("reaction:legacy:shops", "owner", { shopId }); // TODO(pod-auth): update this to figure out what to do with "owner"
 
-  return isOwnerAccount || _.difference(groupPermissions, user.roles[shopId] || []).length === 0;
+  return isOwnerAccount || userHasPermission("reaction:legacy:groups", "manage:accounts", { shopId });
 }

--- a/src/core-services/account/util/canAddAccountToGroup.js
+++ b/src/core-services/account/util/canAddAccountToGroup.js
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 /**
  * @summary Determine whether one user is allowed to add another user
  *   to an auth group.
@@ -30,5 +28,7 @@ export default async function canAddAccountToGroup(context, group) {
     !!ownerGroup && contextUserAccount && contextUserAccount.groups.includes(ownerGroup._id)) ||
     userHasPermission("reaction:legacy:shops", "owner", { shopId }); // TODO(pod-auth): update this to figure out what to do with "owner"
 
-  return isOwnerAccount || userHasPermission("reaction:legacy:groups", "manage:accounts", { shopId });
+  const hasPermissionToAddAccountToGroup = await isOwnerAccount || await userHasPermission("reaction:legacy:groups", "manage:accounts", { shopId });
+
+  return hasPermissionToAddAccountToGroup;
 }

--- a/src/core-services/account/util/defaultRoles.js
+++ b/src/core-services/account/util/defaultRoles.js
@@ -56,6 +56,7 @@ export const defaultShopManagerRoles = [
   "reaction:legacy:fulfillment/read",
   "reaction:legacy:groups/create",
   "reaction:legacy:groups/delete",
+  "reaction:legacy:groups/manage:accounts",
   "reaction:legacy:groups/read",
   "reaction:legacy:groups/update",
   "reaction:legacy:inventory/read",

--- a/tests/integration/api/mutations/addAccountToGroup/addAccountToGroup.test.js
+++ b/tests/integration/api/mutations/addAccountToGroup/addAccountToGroup.test.js
@@ -10,7 +10,6 @@ jest.setTimeout(300000);
 let accountOpaqueId;
 let addAccountToGroup;
 let customerGroup;
-let customerGroupOpaqueId;
 let mockAdminAccount;
 let mockAdminAccountWithMissingPermission;
 let mockOtherAccount;
@@ -70,7 +69,6 @@ beforeAll(async () => {
   await testApp.collections.Groups.insertOne(customerGroup);
 
   accountOpaqueId = encodeOpaqueId("reaction/account", mockOtherAccount._id);
-  customerGroupOpaqueId = encodeOpaqueId("reaction/group", customerGroup._id);
   shopOpaqueId = encodeOpaqueId("reaction/shop", shopId);
   shopManagerGroupOpaqueId = encodeOpaqueId("reaction/group", shopManagerGroup._id);
 
@@ -142,24 +140,4 @@ test("anyone cannot add account to group if they do not have ALL the group permi
 
   const user = await testApp.collections.users.findOne({ _id: mockOtherAccount._id });
   expect(user.roles[shopId]).toBe(undefined);
-});
-
-test("permissions from the account's previous group are removed", async () => {
-  await testApp.setLoggedInUser(mockAdminAccount);
-
-  await addAccountToGroup({ accountId: accountOpaqueId, groupId: shopManagerGroupOpaqueId });
-
-  let account = await testApp.collections.Accounts.findOne({ _id: mockOtherAccount._id });
-  expect(account.groups).toEqual([shopManagerGroup._id]);
-
-  let user = await testApp.collections.users.findOne({ _id: mockOtherAccount._id });
-  expect(user.roles[shopId]).toEqual(shopManagerGroup.permissions);
-
-  await addAccountToGroup({ accountId: accountOpaqueId, groupId: customerGroupOpaqueId });
-
-  account = await testApp.collections.Accounts.findOne({ _id: mockOtherAccount._id });
-  expect(account.groups).toEqual([customerGroup._id]);
-
-  user = await testApp.collections.users.findOne({ _id: mockOtherAccount._id });
-  expect(user.roles[shopId]).toEqual(customerGroup.permissions);
 });

--- a/tests/integration/api/mutations/removeAccountFromGroup/RemoveAccountFromGroupMutation.graphql
+++ b/tests/integration/api/mutations/removeAccountFromGroup/RemoveAccountFromGroupMutation.graphql
@@ -1,0 +1,19 @@
+mutation ($accountId: ID!, $groupId: ID!) {
+  removeAccountFromGroup(input: { accountId: $accountId, groupId: $groupId }) {
+    group {
+      _id
+      createdAt
+      createdBy {
+        _id
+      }
+      description
+      name
+      permissions
+      shop {
+        _id
+      }
+      slug
+      updatedAt
+    }
+  }
+}

--- a/tests/integration/api/mutations/removeAccountFromGroup/__snapshots__/removeAccountFromGroup.test.js.snap
+++ b/tests/integration/api/mutations/removeAccountFromGroup/__snapshots__/removeAccountFromGroup.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cannot remove account from group if they do not have \`reaction:legacy:groups/manage:accounts\` permission 1`] = `
+Object {
+  "extensions": Object {
+    "code": "FORBIDDEN",
+    "exception": Object {
+      "details": Object {},
+      "error": "access-denied",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Access Denied",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Access Denied",
+  "path": Array [
+    "removeAccountFromGroup",
+  ],
+}
+`;

--- a/tests/integration/api/mutations/removeAccountFromGroup/removeAccountFromGroup.test.js
+++ b/tests/integration/api/mutations/removeAccountFromGroup/removeAccountFromGroup.test.js
@@ -3,19 +3,21 @@ import importAsString from "@reactioncommerce/api-utils/importAsString.js";
 import Factory from "/tests/util/factory.js";
 import TestApp from "/tests/util/TestApp.js";
 
-const AddAccountToGroupMutation = importAsString("./AddAccountToGroupMutation.graphql");
+const RemoveAccountFromGroupMutation = importAsString("./RemoveAccountFromGroupMutation.graphql");
 
 jest.setTimeout(300000);
 
 let accountOpaqueId;
-let addAccountToGroup;
 let customerGroup;
 let mockAdminAccount;
 let mockAdminAccountWithMissingPermission;
 let mockOtherAccount;
+let removeAccountFromGroup;
 let shopId;
 let shopManagerGroup;
+let shopManagerGroupWithoutGroupPermissions;
 let shopManagerGroupOpaqueId;
+let shopManagerGroupWithoutGroupPermissionsOpaqueId;
 let shopOpaqueId;
 let testApp;
 
@@ -26,8 +28,9 @@ beforeAll(async () => {
 
   mockAdminAccount = Factory.Account.makeOne({
     _id: "mockAdminAccount",
+    groups: ["shop-manager-group"],
     roles: {
-      [shopId]: ["owner", "admin", "shopManagerGroupPermission", "someOtherPermission", "customerGroupPermission", "reaction:legacy:groups/manage:accounts"]
+      [shopId]: ["reaction:legacy:groups/manage:accounts"]
     },
     shopId
   });
@@ -35,8 +38,9 @@ beforeAll(async () => {
 
   mockAdminAccountWithMissingPermission = Factory.Account.makeOne({
     _id: "mockAdminAccountWithMissingPermission",
+    groups: ["shop-manager-group-without-group-permissions"],
     roles: {
-      [shopId]: ["admin", "someOtherPermission"]
+      [shopId]: ["someOtherPermission"]
     },
     shopId
   });
@@ -44,22 +48,34 @@ beforeAll(async () => {
 
   mockOtherAccount = Factory.Account.makeOne({
     _id: "mockOtherAccount",
-    groups: [],
+    groups: ["customer-group", "shop-manager-group"],
     roles: {},
     shopId
   });
   await testApp.createUserAndAccount(mockOtherAccount);
 
   shopManagerGroup = Factory.Group.makeOne({
+    _id: "shop-manager-group",
     createdBy: null,
     name: "shop manager",
-    permissions: ["admin", "shopManagerGroupPermission"],
+    permissions: ["reaction:legacy:groups/manage:accounts", "reaction:legacy:accounts/update"],
     slug: "shop manager",
     shopId
   });
   await testApp.collections.Groups.insertOne(shopManagerGroup);
 
+  shopManagerGroupWithoutGroupPermissions = Factory.Group.makeOne({
+    _id: "shop-manager-group-without-group-permissions",
+    createdBy: null,
+    name: "shop manager without group permissions",
+    permissions: ["someOtherPermissions"],
+    slug: "shop manager without group permissions",
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(shopManagerGroupWithoutGroupPermissions);
+
   customerGroup = Factory.Group.makeOne({
+    _id: "customer-group",
     createdBy: null,
     name: "customer",
     permissions: ["customerGroupPermission"],
@@ -71,8 +87,9 @@ beforeAll(async () => {
   accountOpaqueId = encodeOpaqueId("reaction/account", mockOtherAccount._id);
   shopOpaqueId = encodeOpaqueId("reaction/shop", shopId);
   shopManagerGroupOpaqueId = encodeOpaqueId("reaction/group", shopManagerGroup._id);
+  shopManagerGroupWithoutGroupPermissionsOpaqueId = encodeOpaqueId("reaction/group", shopManagerGroupWithoutGroupPermissions._id);
 
-  addAccountToGroup = testApp.mutate(AddAccountToGroupMutation);
+  removeAccountFromGroup = testApp.mutate(RemoveAccountFromGroupMutation);
 });
 
 afterAll(async () => {
@@ -86,23 +103,25 @@ afterAll(async () => {
 beforeEach(async () => {
   await testApp.collections.Accounts.updateOne({ _id: mockOtherAccount._id }, {
     $set: {
-      groups: []
+      groups: ["customer-group", "shop-manager-group"]
     }
   });
 
   await testApp.collections.users.updateOne({ _id: mockOtherAccount._id }, {
     $set: {
-      roles: {}
+      roles: {
+        [shopId]: ["customerGroupPermission", "reaction:legacy:groups/manage:accounts", "reaction:legacy:shops/owner"]
+      }
     }
   });
 });
 
-test("anyone can add account to group if they have ALL the group permissions", async () => {
+test("can remove account from group if they have `reaction:legacy:groups/manage:accounts` permission", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);
 
-  const result = await addAccountToGroup({ accountId: accountOpaqueId, groupId: shopManagerGroupOpaqueId });
+  const result = await removeAccountFromGroup({ accountId: accountOpaqueId, groupId: shopManagerGroupOpaqueId });
 
-  expect(result.addAccountToGroup.group).toEqual({
+  expect(result.removeAccountFromGroup.group).toEqual({
     _id: shopManagerGroupOpaqueId,
     createdAt: shopManagerGroup.createdAt.toISOString(),
     createdBy: null,
@@ -117,27 +136,32 @@ test("anyone can add account to group if they have ALL the group permissions", a
   });
 
   const account = await testApp.collections.Accounts.findOne({ _id: mockOtherAccount._id });
-  expect(account.groups).toEqual([shopManagerGroup._id]);
+  expect(account.groups).toEqual([customerGroup._id]);
 
   const user = await testApp.collections.users.findOne({ _id: mockOtherAccount._id });
-  expect(user.roles[shopId]).toEqual(shopManagerGroup.permissions);
+  expect(user.roles[shopId]).toEqual(customerGroup.permissions);
 });
 
-test("anyone cannot add account to group if they do not have ALL the group permissions", async () => {
+test("cannot remove account from group if they do not have `reaction:legacy:groups/manage:accounts` permission", async () => {
   await testApp.setLoggedInUser(mockAdminAccountWithMissingPermission);
 
+  const beforeAccount = await testApp.collections.Accounts.findOne({ userId: mockOtherAccount._id });
+  expect(beforeAccount.groups).toEqual(["customer-group", "shop-manager-group"]);
+
+
   const beforeUser = await testApp.collections.users.findOne({ _id: mockOtherAccount._id });
-  expect(beforeUser.roles[shopId]).toBe(undefined);
+  expect(beforeUser.roles[shopId]).toEqual(["customerGroupPermission", "reaction:legacy:groups/manage:accounts", "reaction:legacy:shops/owner"]);
 
   try {
-    await addAccountToGroup({ accountId: accountOpaqueId, groupId: shopManagerGroupOpaqueId });
+    await removeAccountFromGroup({ accountId: accountOpaqueId, groupId: shopManagerGroupOpaqueId });
   } catch (errors) {
     expect(errors[0]).toMatchSnapshot();
   }
 
   const account = await testApp.collections.Accounts.findOne({ _id: mockOtherAccount._id });
-  expect(account.groups.length).toBe(0);
+  expect(account.groups.length).toBe(2);
+  expect(account.groups).toEqual(["customer-group", "shop-manager-group"]);
 
   const user = await testApp.collections.users.findOne({ _id: mockOtherAccount._id });
-  expect(user.roles[shopId]).toBe(undefined);
+  expect(user.roles[shopId]).toEqual(["customerGroupPermission", "reaction:legacy:groups/manage:accounts", "reaction:legacy:shops/owner"]);
 });

--- a/tests/integration/api/mutations/removeAccountFromGroup/removeAccountFromGroup.test.js
+++ b/tests/integration/api/mutations/removeAccountFromGroup/removeAccountFromGroup.test.js
@@ -17,7 +17,6 @@ let shopId;
 let shopManagerGroup;
 let shopManagerGroupWithoutGroupPermissions;
 let shopManagerGroupOpaqueId;
-let shopManagerGroupWithoutGroupPermissionsOpaqueId;
 let shopOpaqueId;
 let testApp;
 

--- a/tests/integration/api/mutations/removeAccountFromGroup/removeAccountFromGroup.test.js
+++ b/tests/integration/api/mutations/removeAccountFromGroup/removeAccountFromGroup.test.js
@@ -86,7 +86,6 @@ beforeAll(async () => {
   accountOpaqueId = encodeOpaqueId("reaction/account", mockOtherAccount._id);
   shopOpaqueId = encodeOpaqueId("reaction/shop", shopId);
   shopManagerGroupOpaqueId = encodeOpaqueId("reaction/group", shopManagerGroup._id);
-  shopManagerGroupWithoutGroupPermissionsOpaqueId = encodeOpaqueId("reaction/group", shopManagerGroupWithoutGroupPermissions._id);
 
   removeAccountFromGroup = testApp.mutate(RemoveAccountFromGroupMutation);
 });


### PR DESCRIPTION
Resolves #5959 
Impact: **minor**  
Type: **feature**

## Issue
Accounts are only allowed to belong to one Group per shop. This will impede how we envision groups working in the future.

## Solution
- Update the existing `addAccountToGroup` mutation to no longer remove the account from the previous group when the account is added to a new group.
- Create a new `removeAccountFromGroup` mutation that will remove users from a group.
- Update `canAddAccountToGroup` helper to use `reaction:legacy:groups/manage:accounts` permission as the main check. Previously, it was comparing the `roles` of the account doing the removing, with the `roles` of the account being removed, and they had to be equal. This didn't make sense in the past because that means anyone in your group could remove you from the group. A "customer" could remove a "customer" from the group since they shared permissions. Additionally, with these changes, it didn't make sense because a user can be in multiple groups, meaning User A could have 1000 permissions, User B could only have 1 permission, which User A and B shared, and yet User A would be denied access because the `roles` didn't match exactly.

## Breaking changes
None

## Testing
1. Create two users: an admin and a customer
2. As an admin, add the customer account to the two non-admin groups (guest, customer) from the same shop (this will allow for permission testing later on)
1. See that the `Groups` array on the `account` has multiple IDs in it
1. See that the `user.roles` is updated to include all the permissions these two groups offer, with no duplicates (This will be refactored in #6031 but is needed now).
1. Log in as the customer, and attempt to add your own account to an admin account. See that you are restricted.
