### PR TITLE
Port displayPrice resolver from 3.0.0 branch

### DIFF
--- a/imports/node-app/plugins/simple-pricing/resolvers/ProductPricingInfo.js
+++ b/imports/node-app/plugins/simple-pricing/resolvers/ProductPricingInfo.js
@@ -1,8 +1,26 @@
 import getCurrencyDefinitionByCode from "@reactioncommerce/api-utils/getCurrencyDefinitionByCode.js";
 import xformCurrencyExchangePricing from "../util/xformCurrencyExchangePricing.js";
+import getDisplayPrice from "../util/getDisplayPrice.js";
 
 export default {
   currency: (node) => getCurrencyDefinitionByCode(node.currencyCode),
   currencyExchangePricing: (node, { currencyCode }, context) => xformCurrencyExchangePricing(node, currencyCode, context),
-  compareAtPrice: ({ compareAtPrice: amount, currencyCode }) => (typeof amount === "number" && amount > 0 ? { amount, currencyCode } : null)
+  compareAtPrice: ({ compareAtPrice: amount, currencyCode }) => {
+    if (typeof amount === "number" && amount > 0) {
+      return { amount, currencyCode };
+    }
+    return null;
+  },
+  displayPrice: (node) => {
+    if (node.displayPrice) {
+      // Operating in core catalog plugin mode.
+      // Use displayPrice directly from mongo.
+      // It was computed at publish time.
+      return node.displayPrice;
+    }
+    // Operating in catalog publisher mode.
+    // displayPrice was not computed ahead of time.
+    // Compute it on the fly now.
+    return getDisplayPrice(node.minPrice, node.maxPrice, getCurrencyDefinitionByCode(node.currencyCode));
+  }
 };

--- a/imports/node-app/plugins/simple-pricing/resolvers/ProductPricingIngo.test.js
+++ b/imports/node-app/plugins/simple-pricing/resolvers/ProductPricingIngo.test.js
@@ -1,0 +1,10 @@
+import ProductPricingInfo from "./ProductPricingInfo.js";
+
+test("displayPrice: catalog plugin mongo mode", () => {
+  expect(ProductPricingInfo.displayPrice({ displayPrice: "$Unit test 1" })).toEqual("$Unit test 1");
+});
+
+test("displayPrice: catalog publisher resolver mode", () => {
+  const displayPrice = ProductPricingInfo.displayPrice({ minPrice: 1.01, maxPrice: 2.02, currencyCode: "USD" });
+  expect(displayPrice).toEqual("$1.01 - $2.02");
+});


### PR DESCRIPTION
Signed-off-by: Chris Potter <chris@reactioncommerce.com>

Impact: **minor**  
Type: **feature**

## Issue
display price resolver was added to 3.0 branch but not to 2.99 release. Adding here to include everywhere.