### PR TITLE
chore: update config files to prep for renaming default branch…

### DIFF
--- a/.circleci/bin/docker-tags
+++ b/.circleci/bin/docker-tags
@@ -26,7 +26,7 @@ git show-ref --tags -d | grep "^${SHA1}" | sed -e 's,.* refs/tags/,,' -e 's/\^{}
   echo "%"
 
 # Tag with latest if certain conditions are met
-if [[ "$BRANCH" == "master" ]]; then
+if [[ "$BRANCH" == "trunk" ]]; then
   # Check to see if we have a valid `vX.X.X` tag and assign to CURRENT_TAG
   CURRENT_TAG=$( \
     git show-ref --tags -d \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
     - TOOL_NODE_FLAGS: "--max-old-space-size=4000"
   working_directory: ~/reaction-app
   docker:
-    - image: circleci/node:8-stretch
+    - image: circleci/node@sha256:deb885eea09fdd008066738298de1c14815e5b200a302c5c25e8d3280060ee6e
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
     - TOOL_NODE_FLAGS: "--max-old-space-size=4000"
   working_directory: ~/reaction-app
   docker:
-    - image: circleci/node@sha256:deb885eea09fdd008066738298de1c14815e5b200a302c5c25e8d3280060ee6e
+    - image: circleci/node:8-stretch
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,4 +299,4 @@ workflows:
             - docker-build
           filters:
             branches:
-              only: /^master$/
+              only: /^trunk$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
           paths:
             - ~/.meteor
       - run:
-          name: Meteor NPM Install
-          command: meteor npm install
+          name: NPM Install
+          command: npm install
       - run:
           name: Build dist bundle
           command: meteor build --directory ../build/

--- a/.reaction/jsdoc/templates/tmpl/details.tmpl
+++ b/.reaction/jsdoc/templates/tmpl/details.tmpl
@@ -14,11 +14,11 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
 }
 
 function getGitHubLink(meta) {
-  return "https://github.com/reactioncommerce/reaction/blob/master/" + meta.shortpath
+  return "https://github.com/reactioncommerce/reaction/blob/trunk/" + meta.shortpath
 }
 
 function getGitHubLinkWithLine(meta) {
-  return "https://github.com/reactioncommerce/reaction/blame/master/" + meta.shortpath + "#L" + meta.lineno
+  return "https://github.com/reactioncommerce/reaction/blame/trunk/" + meta.shortpath + "#L" + meta.lineno
 }
 ?>
 

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "reacto-form": "0.0.2",
     "recompose": "^0.26.0",
     "shallowequal": "^1.0.2",
-    "sharp": "^0.20.5",
+    "sharp": "0.20.5",
     "simpl-schema": "1.5.0",
     "slugify": "1.3.1",
     "store": "^2.0.12",


### PR DESCRIPTION
To keep all of Reaction's main repositories in sync, we are renaming the default branches from `master` to `trunk`. This PR updates the config files that used `master` as the default.

Once this PR is merged, we should immediately make `trunk` the default branch of this repository.