### PR TITLE
docs: update links to use trunk branch of docs

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,6 +1,6 @@
 Issue tracker is **ONLY** used for reporting bugs. NO NEW FEATURE REQUESTS ACCEPTED. For new features, add an issue in our [Request Feature Request](https://github.com/reactioncommerce/reaction-feature-requests) repository.
 
-Are you looking for help with getting started on Reaction? Please visit our [Reaction documentation](https://docs.reactioncommerce.com/reaction-docs/master/getting-started-developing-with-reaction).
+Are you looking for help with getting started on Reaction? Please visit our [Reaction documentation](https://docs.reactioncommerce.com/reaction-docs/trunk/getting-started-developing-with-reaction).
 
 ## Prerequisites
 * [ ] Are you running the latest version?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
-Resolves #issueNumber  
-Impact: **breaking|critical|major|minor**  
+Resolves #issueNumber
+Impact: **breaking|critical|major|minor**
 Type: **feature|bugfix|performance|test|style|refactor|docs|chore**
 
 ## Issue
@@ -23,4 +23,4 @@ Note any work that you did to mitigate the effect of any breaking changes such a
 2. Assume that testers already know how to start the app, and do the basic setup tasks.
 3. Be detailed enough that someone can work through it without being too granular
 
-More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
+More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/trunk/contributing-to-reaction)

--- a/.reaction/jsdoc/templates/static/README.md
+++ b/.reaction/jsdoc/templates/static/README.md
@@ -23,7 +23,7 @@ Start here:
 
 ## Learn more
 - [Reaction Commerce engineering blog posts](https://blog.reactioncommerce.com/tag/engineering/)
-- [Customization themes & plugins tutorial](https://docs.reactioncommerce.com/reaction-docs/master/tutorial)
+- [Customization themes & plugins tutorial](https://docs.reactioncommerce.com/reaction-docs/trunk/tutorial)
 - [Reaction Commerce YouTube videos](https://www.youtube.com/user/reactioncommerce/videos)
 
 ## Join the community calls

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,7 +10,7 @@ This isn’t an exhaustive list of things that you can’t do. Rather, take it i
 
 This code of conduct applies to all spaces managed by Reaction Commerce. This includes our [development chat room](https://gitter.im/reactioncommerce/reaction), [forums](https://forums.reactioncommerce.com), [blog](https://blog.reactioncommerce.com), mailing lists, [issue tracker](https://github.com/reactioncommerce/reaction/issues), [project boards](https://github.com/reactioncommerce/reaction/projects), Reaction events and meetups, and any other forums or service created by the core project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing <mailto:conduct@reactioncommerce.com>. For more details, please see our [Reporting Guidelines](https://docs.reactioncommerce.com/reaction-docs/master/reporting-guide).
+If you believe someone is violating the code of conduct, we ask that you report it by emailing <mailto:conduct@reactioncommerce.com>. For more details, please see our [Reporting Guidelines](https://docs.reactioncommerce.com/reaction-docs/trunk/reporting-guide).
 
 -   **Be friendly and patient.**
 
@@ -35,4 +35,4 @@ If you believe someone is violating the code of conduct, we ask that you report 
 
 ## Questions?
 
-If you have questions, please see the [FAQs](https://docs.reactioncommerce.com/reaction-docs/master/guideline-faqs). If that doesn't answer your questions, feel free to [contact us](mailto:hello@reactioncommerce.com).
+If you have questions, please see the [FAQs](https://docs.reactioncommerce.com/reaction-docs/trunk/guideline-faqs). If that doesn't answer your questions, feel free to [contact us](mailto:hello@reactioncommerce.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-At Reaction Commerce, we're dedicated to the open source community. In fact, we've designed our entire platform and business to grow from the passion and creativity that an open source community ignites. We've already attracted a small, dedicated team of open source contributors, and there's always room for more. 
+At Reaction Commerce, we're dedicated to the open source community. In fact, we've designed our entire platform and business to grow from the passion and creativity that an open source community ignites. We've already attracted a small, dedicated team of open source contributors, and there's always room for more.
 
-If you'd like to join us, check out our detailed [Contributing Guide](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction).
+If you'd like to join us, check out our detailed [Contributing Guide](https://docs.reactioncommerce.com/reaction-docs/trunk/contributing-to-reaction).
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Use an external GraphQL client to test http://localhost:3000/graphql. GraphQL Pl
 ## Get help & contact the team
 
 - [Gitter chat](https://gitter.im/reactioncommerce/reaction)
-- Report security vulnerabilities to <mailto:security@reactioncommerce.com>: [Security reporting instructions](https://docs.reactioncommerce.com/reaction-docs/master/reporting-vulnerabilities)
+- Report security vulnerabilities to <mailto:security@reactioncommerce.com>: [Security reporting instructions](https://docs.reactioncommerce.com/reaction-docs/trunk/reporting-vulnerabilities)
 - Request features in this [repository](https://github.com/reactioncommerce/reaction-feature-requests/)
 
 ## Contribute
@@ -92,7 +92,7 @@ We love your pull requests! Check our our [`Good First Issue`](https://github.co
 ### Pull Request guidelines
 Pull requests should pass all automated tests, style, and security checks.
 
-Your code should pass all [acceptance tests and unit tests](https://docs.reactioncommerce.com/reaction-docs/master/testing-reaction). Run `docker-compose run --rm reaction npm run test` to run the test suites in containers. If you're adding functionality to Reaction, you should add tests for the added functionality.
+Your code should pass all [acceptance tests and unit tests](https://docs.reactioncommerce.com/reaction-docs/trunk/testing-reaction). Run `docker-compose run --rm reaction npm run test` to run the test suites in containers. If you're adding functionality to Reaction, you should add tests for the added functionality.
 
 
 We require that all code contributed to Reaction follows [Reaction's ESLint rules](https://github.com/reactioncommerce/reaction-eslint-config). You can run `docker-compose run --rm reaction npm run lint` to run ESLint against your code locally.

--- a/src/core-services/shop/simpleSchemas.js
+++ b/src/core-services/shop/simpleSchemas.js
@@ -14,7 +14,7 @@ const withoutCodeCountries = ["AO", "AG", "AW", "BS", "BZ", "BJ", "BW",
  * @type {SimpleSchema}
  * @summary Layouts are used to in two ways: 1) Define the template layout on the site
  * 2) Define workflow components used in each layout block
- * @description Read more about Layouts in {@link https://docs.reactioncommerce.com/reaction-docs/master/layout documentation}
+ * @description Read more about Layouts in {@link https://docs.reactioncommerce.com/reaction-docs/trunk/layout documentation}
  * @property {String} template optional
  * @property {String} layoutHeader optional
  * @property {String} layoutFooter optional
@@ -63,7 +63,7 @@ export const LayoutStructure = new SimpleSchema({
  * @name Layout
  * @memberof Schemas
  * @type {SimpleSchema}
- * @summary Read more about Layouts in {@link https://docs.reactioncommerce.com/reaction-docs/master/layout documentation}
+ * @summary Read more about Layouts in {@link https://docs.reactioncommerce.com/reaction-docs/trunk/layout documentation}
  * @property {String} layout optional
  * @property {String} workflow optional
  * @property {String} template optional

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,3 +1,3 @@
 # Integration Tests
 
-This folder contains test files that run GraphQL integration tests. Refer to [the documentation](https://docs.reactioncommerce.com/reaction-docs/master/running-jest-integration-tests).
+This folder contains test files that run GraphQL integration tests. Refer to [the documentation](https://docs.reactioncommerce.com/reaction-docs/trunk/running-jest-integration-tests).


### PR DESCRIPTION
We updated the default / next branch of our docs repo: https://github.com/reactioncommerce/reaction-docs/pull/896

This PR updates all links to our docs to use this new branch.