### PR TITLE
Fix partialProductPublish for products without Catalog

### DIFF
--- a/src/core-services/catalog/mutations/partialProductPublish.js
+++ b/src/core-services/catalog/mutations/partialProductPublish.js
@@ -10,6 +10,8 @@ export default async function partialProductPublish(context, { productId, startF
   const { collections: { Catalog, Products, Shops } } = context;
 
   const catalogItem = await Catalog.findOne({ "product.productId": productId });
+  if (!catalogItem) return;
+
   const { product: catalogProduct } = catalogItem;
 
   // Get some data that we pass to all publish transformation functions


### PR DESCRIPTION
Resolves https://github.com/reactioncommerce/reaction/issues/6051  
Impact: **critical**  
Type: **bugfix**

## Issue
- When any product is updated `afterBulkInventoryUpdate` event is emitted.
- This, in turn, causes `partialProductPublish` to be called from `inventoryStartup` startup method. - `partialProductPublish` tries to update the catalog of products that are not published yet. 
- `partialProductPublish` fails with an error as `catalogProduct` could not be destructured from `catalogItem` at [this line](https://github.com//reactioncommerce/reaction/blob/4a3f5dabfa54b2b2b934b11b478530ab3b404c23/src/core-services/catalog/mutations/partialProductPublish.js#L15) 


## Solution
If the `Catalog` is not found for `productId` in `partialProductPublish` then avoid processing further and return from the method.


## Testing
1. Update the inventory of the product which is not yet published.
2. Make sure no errors are thrown when `partialProductPublish` method gets called.
