### PR TITLE
refactor: only allow provides: default for one email address

### DIFF
--- a/src/core-services/account/mutations/addAccountEmailRecord.js
+++ b/src/core-services/account/mutations/addAccountEmailRecord.js
@@ -41,16 +41,23 @@ export default async function addAccountEmailRecord(context, input) {
     throw new ReactionError("duplicate", "Account already has this email address");
   }
 
+  const emails = {
+    address: email,
+    verified: false
+  };
+
+  const isDefaultEmailSet = (account.emails || []).some(({ provides }) => provides === "default");
+
+  if (!isDefaultEmailSet) {
+    emails.provides = "default";
+  }
+
   // add email to Account
   const { value: updatedAccount } = await Accounts.findOneAndUpdate(
     { _id: accountId },
     {
       $addToSet: {
-        emails: {
-          address: email,
-          provides: "default",
-          verified: false
-        }
+        emails
       }
     },
     {

--- a/src/core-services/account/mutations/index.js
+++ b/src/core-services/account/mutations/index.js
@@ -11,6 +11,7 @@ import removeAccountEmailRecord from "./removeAccountEmailRecord.js";
 import removeAccountFromGroup from "./removeAccountFromGroup.js";
 import removeAccountGroup from "./removeAccountGroup.js";
 import sendResetAccountPasswordEmail from "./sendResetAccountPasswordEmail.js";
+import setAccountDefaultEmail from "./setAccountDefaultEmail.js";
 import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
@@ -30,6 +31,7 @@ export default {
   removeAccountFromGroup,
   removeAccountGroup,
   sendResetAccountPasswordEmail,
+  setAccountDefaultEmail,
   setAccountProfileCurrency,
   setAccountProfileLanguage,
   updateAccountAddressBookEntry,

--- a/src/core-services/account/mutations/removeAccountEmailRecord.js
+++ b/src/core-services/account/mutations/removeAccountEmailRecord.js
@@ -47,6 +47,10 @@ export default async function removeAccountEmailRecord(context, input) {
     throw new ReactionError("invalid-param", "Account does not have this email address");
   }
 
+  if (existingEmail.provides === "default") {
+    throw new ReactionError("server-error", "Cannot delete default email address.");
+  }
+
   // Remove email from Account
   const { value: updatedAccount } = await Accounts.findOneAndUpdate(
     { _id: accountId },

--- a/src/core-services/account/mutations/setAccountDefaultEmail.js
+++ b/src/core-services/account/mutations/setAccountDefaultEmail.js
@@ -1,0 +1,88 @@
+import SimpleSchema from "simpl-schema";
+import ReactionError from "@reactioncommerce/reaction-error";
+
+const inputSchema = new SimpleSchema({
+  accountId: {
+    type: String,
+    optional: true
+  },
+  email: String
+});
+
+/**
+ * @name accounts/setAccountDefaultEmail
+ * @memberof Mutations/Accounts
+ * @summary Update default email in account
+ * @param {Object} context - GraphQL execution context
+ * @param {Object} input - Necessary input for mutation. See SimpleSchema.
+ * @param {String} input.accountId - decoded ID of account on which entry should be updated
+ * @param {String} input.email - the email to set as the default from the account
+ * @returns {Promise<Object>} account with updated default email
+ */
+export default async function setAccountDefaultEmail(context, input) {
+  inputSchema.validate(input);
+  const {
+    accountId: accountIdFromContext,
+    appEvents,
+    collections: {
+      Accounts
+    },
+    userId
+  } = context;
+  const { email: newDefaultEmail } = input;
+
+  // If no account ID input, default to the account that's calling
+  const accountId = input.accountId || accountIdFromContext;
+
+  const account = await Accounts.findOne({ _id: accountId });
+  if (!account) throw new ReactionError("not-found", "Account not Found");
+
+  await context.validatePermissions(`reaction:legacy:accounts:${accountId}`, "delete:emails", {
+    shopId: account.shopId,
+    owner: account.userId
+  });
+
+  const existingEmail = (account.emails || []).find(({ address }) => address === newDefaultEmail);
+  if (!existingEmail) {
+    throw new ReactionError("invalid-param", "Email address is not associated with this account");
+  }
+
+  if (existingEmail && existingEmail.provides === "default") {
+    throw new ReactionError("invalid-param", "Email is already default address for this account");
+  }
+
+  // remove `provides: default` from any email address which had it
+  const emails = account.emails.map((eml) => {
+    delete eml.provides;
+    return eml;
+  });
+
+  // set `provides: default to new email
+  emails.map((eml) => {
+    if (eml.address === newDefaultEmail) {
+      eml.provides = "default";
+    }
+    return eml;
+  });
+
+  // update emails on Account
+  const { value: updatedAccount } = await Accounts.findOneAndUpdate(
+    { _id: accountId },
+    {
+      $set: { emails }
+    },
+    {
+      returnOriginal: false
+    }
+  );
+
+  if (!updatedAccount) throw new ReactionError("server-error", "Unable to update Account");
+
+  await appEvents.emit("afterAccountUpdate", {
+    account: updatedAccount,
+    updatedBy: userId,
+    updatedFields: ["emails"]
+  });
+
+  return updatedAccount;
+}

--- a/src/core-services/account/resolvers/Mutation/index.js
+++ b/src/core-services/account/resolvers/Mutation/index.js
@@ -8,6 +8,7 @@ import removeAccountEmailRecord from "./removeAccountEmailRecord.js";
 import removeAccountGroup from "./removeAccountGroup.js";
 import removeAccountFromGroup from "./removeAccountFromGroup.js";
 import sendResetAccountPasswordEmail from "./sendResetAccountPasswordEmail.js";
+import setAccountDefaultEmail from "./setAccountDefaultEmail.js";
 import setAccountProfileCurrency from "./setAccountProfileCurrency.js";
 import setAccountProfileLanguage from "./setAccountProfileLanguage.js";
 import updateAccountAddressBookEntry from "./updateAccountAddressBookEntry.js";
@@ -24,6 +25,7 @@ export default {
   removeAccountFromGroup,
   removeAccountGroup,
   sendResetAccountPasswordEmail,
+  setAccountDefaultEmail,
   setAccountProfileCurrency,
   setAccountProfileLanguage,
   updateAccountAddressBookEntry,

--- a/src/core-services/account/resolvers/Mutation/setAccountDefaultEmail.js
+++ b/src/core-services/account/resolvers/Mutation/setAccountDefaultEmail.js
@@ -1,0 +1,29 @@
+import { decodeAccountOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Mutation/setAccountDefaultEmail
+ * @method
+ * @memberof Accounts/GraphQL
+ * @summary resolver for the setAccountDefaultEmail GraphQL mutation
+ * @param {Object} _ - unused
+ * @param {Object} args.input - an object of all mutation arguments that were sent by the client
+ * @param {String} args.input.accountId - The account ID
+ * @param {String} args.input.email - The email to set as default
+ * @param {String} [args.input.clientMutationId] - An optional string identifying the mutation call
+ * @param {Object} context - an object containing the per-request state
+ * @returns {Object} setAccountDefaultEmailPayload
+ */
+export default async function setAccountDefaultEmail(_, { input }, context) {
+  const { accountId, email, clientMutationId = null } = input;
+  const decodedAccountId = decodeAccountOpaqueId(accountId);
+
+  const updatedAccount = await context.mutations.setAccountDefaultEmail(context, {
+    accountId: decodedAccountId,
+    email
+  });
+
+  return {
+    account: updatedAccount,
+    clientMutationId
+  };
+}

--- a/src/core-services/account/resolvers/Mutation/setAccountDefaultEmail.test.js
+++ b/src/core-services/account/resolvers/Mutation/setAccountDefaultEmail.test.js
@@ -1,0 +1,31 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import { encodeAccountOpaqueId } from "../../xforms/id.js";
+import setAccountDefaultEmail from "./setAccountDefaultEmail.js";
+
+mockContext.mutations.setAccountDefaultEmail = jest.fn().mockName("mutations.setAccountDefaultEmail");
+
+test("correctly passes through to internal mutation function", async () => {
+  const accountId = encodeAccountOpaqueId("2");
+  const email = "test-account@email.com";
+  const updatedAccount = { _id: "2", emails: [] };
+
+  mockContext.mutations.setAccountDefaultEmail.mockReturnValueOnce(Promise.resolve(updatedAccount));
+
+  const result = await setAccountDefaultEmail(null, {
+    input: {
+      accountId,
+      email,
+      clientMutationId: "clientMutationId"
+    }
+  }, mockContext);
+
+  expect(mockContext.mutations.setAccountDefaultEmail).toHaveBeenCalledWith(
+    mockContext,
+    { accountId: "2", email }
+  );
+
+  expect(result).toEqual({
+    account: updatedAccount,
+    clientMutationId: "clientMutationId"
+  });
+});

--- a/src/core-services/account/schemas/account.graphql
+++ b/src/core-services/account/schemas/account.graphql
@@ -121,6 +121,18 @@ input RemoveAccountEmailRecordInput {
   email: Email!
 }
 
+"Defines which email address should be set as the default for which account"
+input SetAccountDefaultEmailInput {
+  "The account ID, which defaults to the viewer account"
+  accountId: ID
+
+  "An optional string identifying the mutation call, which will be returned in the response payload"
+  clientMutationId: String
+
+  "The email address to set as default"
+  email: Email!
+}
+
 "Per-account tax exemption settings used by the Avalara plugin"
 type TaxSettings {
   "Customer usage type. A value matching the `code` field of one TaxEntityCode, or any custom string."
@@ -307,6 +319,15 @@ type RemoveAccountEmailRecordPayload {
   clientMutationId: String
 }
 
+"The response from the `setAccountDefaultEmail` mutation"
+type SetAccountDefaultEmailPayload {
+  "The account, with updated `emailRecords`"
+  account: Account
+
+  "The same string you sent with the mutation params, for matching mutation calls with their responses"
+  clientMutationId: String
+}
+
 "The response from the `updateAccountAddressBookEntry` mutation"
 type UpdateAccountAddressBookEntryPayload {
   "The updated address"
@@ -370,6 +391,12 @@ extend type Mutation {
     "Mutation input"
     input: SendResetAccountPasswordEmailInput!
   ): SendResetAccountPasswordEmailPayload
+
+  "Set default email address for an account"
+  setAccountDefaultEmail(
+    "Mutation input"
+    input: SetAccountDefaultEmailInput!
+  ): SetAccountDefaultEmailPayload
 
   "Set the preferred currency for an account"
   setAccountProfileCurrency(

--- a/tests/integration/api/mutations/addAccountEmailRecord/AddAccountEmailRecordMutation.graphql
+++ b/tests/integration/api/mutations/addAccountEmailRecord/AddAccountEmailRecordMutation.graphql
@@ -4,7 +4,6 @@ mutation ($accountId: ID, $email: Email!) {
       _id
       emailRecords {
         address
-        provides
         verified
       }
     }

--- a/tests/integration/api/mutations/addAccountEmailRecord/addAccountEmailRecord.test.js
+++ b/tests/integration/api/mutations/addAccountEmailRecord/addAccountEmailRecord.test.js
@@ -41,10 +41,10 @@ afterAll(() => testApp.stop());
 test("user can add an email to their own account", async () => {
   await testApp.setLoggedInUser(mockUserAccount);
 
-  const email = Factory.Email.makeOne();
-
-  // _id is set by the server, true
-  delete email._id;
+  const email = {
+    address: "new@mockemail.com",
+    verified: false
+  };
 
   let result;
   try {
@@ -54,16 +54,18 @@ test("user can add an email to their own account", async () => {
     return;
   }
 
-  expect(result.addAccountEmailRecord.account.emailRecords.pop()).toEqual(email);
+  const resultEmail = result.addAccountEmailRecord.account.emailRecords.pop();
+
+  expect(resultEmail).toEqual(email);
 });
 
 test("accountId is optional and defaults to calling account", async () => {
   await testApp.setLoggedInUser(mockUserAccount);
 
-  const email = Factory.Email.makeOne();
-
-  // _id is set by the server, true
-  delete email._id;
+  const email = {
+    address: "new-two@mockemail.com",
+    verified: false
+  };
 
   let result;
   try {

--- a/tests/integration/api/mutations/removeAccountEmailRecord/__snapshots__/removeAccountEmailRecord.test.js.snap
+++ b/tests/integration/api/mutations/removeAccountEmailRecord/__snapshots__/removeAccountEmailRecord.test.js.snap
@@ -26,3 +26,30 @@ Array [
   },
 ]
 `;
+
+exports[`user cannot remove default account email 1`] = `
+Array [
+  Object {
+    "extensions": Object {
+      "code": "INTERNAL_SERVER_ERROR",
+      "exception": Object {
+        "details": Object {},
+        "error": "server-error",
+        "eventData": Object {},
+        "isClientSafe": true,
+        "reason": "Cannot delete default email address.",
+      },
+    },
+    "locations": Array [
+      Object {
+        "column": 3,
+        "line": 2,
+      },
+    ],
+    "message": "Cannot delete default email address.",
+    "path": Array [
+      "removeAccountEmailRecord",
+    ],
+  },
+]
+`;

--- a/tests/integration/api/mutations/setAccountDefaultEmail/SetAccountDefaultEmailMutation.graphql
+++ b/tests/integration/api/mutations/setAccountDefaultEmail/SetAccountDefaultEmailMutation.graphql
@@ -1,0 +1,12 @@
+mutation ($accountId: ID, $email: Email!) {
+  setAccountDefaultEmail(input: { accountId: $accountId, email: $email }) {
+    account {
+      _id
+      emailRecords {
+        address
+        provides
+        verified
+      }
+    }
+  }
+}

--- a/tests/integration/api/mutations/setAccountDefaultEmail/__snapshots__/setAccountDefaultEmail.test.js.snap
+++ b/tests/integration/api/mutations/setAccountDefaultEmail/__snapshots__/setAccountDefaultEmail.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`user cannot set default email on their own account if address doesn't already exists 1`] = `
+Array [
+  Object {
+    "extensions": Object {
+      "code": "INTERNAL_SERVER_ERROR",
+      "exception": Object {
+        "details": Object {},
+        "error": "invalid-param",
+        "eventData": Object {},
+        "isClientSafe": true,
+        "reason": "Email address is not associated with this account",
+      },
+    },
+    "locations": Array [
+      Object {
+        "column": 3,
+        "line": 2,
+      },
+    ],
+    "message": "Email address is not associated with this account",
+    "path": Array [
+      "setAccountDefaultEmail",
+    ],
+  },
+]
+`;
+
+exports[`user cannot update default email if provided address is already default email 1`] = `
+Array [
+  Object {
+    "extensions": Object {
+      "code": "INTERNAL_SERVER_ERROR",
+      "exception": Object {
+        "details": Object {},
+        "error": "invalid-param",
+        "eventData": Object {},
+        "isClientSafe": true,
+        "reason": "Email is already default address for this account",
+      },
+    },
+    "locations": Array [
+      Object {
+        "column": 3,
+        "line": 2,
+      },
+    ],
+    "message": "Email is already default address for this account",
+    "path": Array [
+      "setAccountDefaultEmail",
+    ],
+  },
+]
+`;

--- a/tests/integration/api/mutations/setAccountDefaultEmail/setAccountDefaultEmail.test.js
+++ b/tests/integration/api/mutations/setAccountDefaultEmail/setAccountDefaultEmail.test.js
@@ -1,0 +1,123 @@
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import encodeOpaqueId from "@reactioncommerce/api-utils/encodeOpaqueId.js";
+import Factory from "/tests/util/factory.js";
+import TestApp from "/tests/util/TestApp.js";
+
+const SetAccountDefaultEmailMutation = importAsString("./SetAccountDefaultEmailMutation.graphql");
+
+jest.setTimeout(300000);
+
+let testApp;
+let setAccountDefaultEmail;
+let shopId;
+let mockUserAccount;
+let accountOpaqueId;
+
+beforeAll(async () => {
+  testApp = new TestApp();
+  await testApp.start();
+  shopId = await testApp.insertPrimaryShop();
+  setAccountDefaultEmail = testApp.mutate(SetAccountDefaultEmailMutation);
+
+  mockUserAccount = Factory.Account.makeOne({
+    _id: "mockUserId",
+    groups: [],
+    emails: [
+      {
+        address: "original-default@email.com",
+        provides: "default",
+        verified: false
+      }, {
+        address: "other@email.com",
+        verified: false
+      }
+    ],
+    profile: {
+      language: "en"
+    },
+    shopId
+  });
+
+  accountOpaqueId = encodeOpaqueId("reaction/account", mockUserAccount._id);
+
+  await testApp.createUserAndAccount(mockUserAccount);
+});
+
+beforeEach(async () => {
+  await testApp.collections.Accounts.updateOne({ _id: mockUserAccount._id }, {
+    $set: {
+      emails: [
+        {
+          address: "original-default@email.com",
+          provides: "default",
+          verified: false
+        }, {
+          address: "other@email.com",
+          verified: false
+        }
+      ]
+    }
+  });
+});
+
+// There is no need to delete any test data from collections because
+// testApp.stop() will drop the entire test database. Each integration
+// test file gets its own test database.
+afterAll(() => testApp.stop());
+
+test("user can set default email on their own account if address already exists", async () => {
+  await testApp.setLoggedInUser(mockUserAccount);
+
+  let result;
+  try {
+    result = await setAccountDefaultEmail({ accountId: accountOpaqueId, email: mockUserAccount.emails[1].address });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  const resultEmails = result.setAccountDefaultEmail.account.emailRecords;
+  const newDefaultEmail = resultEmails.find(({ provides }) => provides === "default");
+  const oldDefaultEmail = resultEmails.find(({ provides }) => provides !== "default");
+
+  expect(newDefaultEmail.address).toEqual(mockUserAccount.emails[1].address);
+  expect(oldDefaultEmail.address).toEqual(mockUserAccount.emails[0].address);
+});
+
+test("accountId is optional and defaults to calling account", async () => {
+  await testApp.setLoggedInUser(mockUserAccount);
+
+  let result;
+  try {
+    result = await setAccountDefaultEmail({ email: mockUserAccount.emails[1].address });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+
+  const resultEmails = result.setAccountDefaultEmail.account.emailRecords;
+  const newDefaultEmail = resultEmails.find(({ provides }) => provides === "default");
+  const oldDefaultEmail = resultEmails.find(({ provides }) => provides !== "default");
+
+  expect(newDefaultEmail.address).toEqual(mockUserAccount.emails[1].address);
+  expect(oldDefaultEmail.address).toEqual(mockUserAccount.emails[0].address);
+});
+
+test("user cannot set default email on their own account if address doesn't already exists", async () => {
+  await testApp.setLoggedInUser(mockUserAccount);
+  try {
+    await setAccountDefaultEmail({ accountId: accountOpaqueId, email: "invalid@email.com" });
+  } catch (error) {
+    expect(error).toMatchSnapshot();
+  }
+});
+
+test("user cannot update default email if provided address is already default email", async () => {
+  await testApp.setLoggedInUser(mockUserAccount);
+
+  try {
+    await setAccountDefaultEmail({ accountId: accountOpaqueId, email: "original-default@email.com" });
+  } catch (error) {
+    expect(error).toMatchSnapshot();
+  }
+});


### PR DESCRIPTION
1. update `addAccountEmailRecord` to allow only one email address to be set as `provides: default`.
1. update `removeAccountEmailRecord` to disallow removing of a default email address from an account
1. create a `setAccountDefaultEmail` mutation

@aldeed this PR goes into your other PR branch which addresses a lot of similar issues. Just wanted to keep the work separate in case it needed to be worked on more, didn't want to pull it into #6056 and hold that up.