### PR TITLE
chore: reconfigure docker-compose networks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-MONGO_URL=mongodb://mongo:27017/reaction
+MONGO_URL=mongodb://mongo.reaction.localhost:27017/reaction
 ROOT_URL=http://localhost:3000
 STRIPE_API_KEY=YOUR_PRIVATE_STRIPE_API_KEY

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Run:
 
 ```sh
 dc up -d mongo
-docker run --env-file ./.env -p 3000:3000 --network streams.reaction.localhost -it test-api:latest
+docker run --env-file ./.env -p 3000:3000 --network reaction.localhost -it test-api:latest
 ```
 
 Use an external GraphQL client to test http://localhost:3000/graphql. GraphQL Playground isn't served on GET requests because it's in production mode.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,15 +7,9 @@
 version: '3.4'
 
 networks:
-  api:
+  reaction:
     external:
-      name: api.reaction.localhost
-  auth:
-    external:
-      name: auth.reaction.localhost
-  streams:
-    external:
-      name: streams.reaction.localhost
+      name: reaction.localhost
 
 services:
   api:
@@ -26,8 +20,7 @@ services:
       - ./.env
     networks:
       default:
-      api:
-      auth:
+      reaction:
     ports:
       - "3000:3000"
 
@@ -36,7 +29,7 @@ services:
     command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
     networks:
       default:
-      streams:
+      reaction:
     ports:
       - "27017:27017"
     volumes:


### PR DESCRIPTION
There are 5 related PRs that should be tested together:
https://github.com/reactioncommerce/example-storefront/pull/653
https://github.com/reactioncommerce/reaction-hydra/pull/46
https://github.com/reactioncommerce/reaction-admin/pull/194
https://github.com/reactioncommerce/reaction-identity/pull/23
https://github.com/reactioncommerce/reaction/pull/6068

All of these ensure that docker-compose defines exactly one external network named `reaction.localhost` and update all services and ENV to use that one. This is being done to cut down on confusion caused by having various arbitrary networks. This affects only local development using docker-compose.

The only downside we're aware of is that project authors need to be more careful about giving Reaction services unique names (e.g., can't call them all `web`).

One upside in addition to being generally less confusing is that the primary internal hostname for the API is now just `api.reaction.localhost` rather than the more confusing `api.api.reaction.localhost`.

## Testing
1. Switch to the PR branches of all 5 projects linked above.
2. Copy `.env.example` to `.env` in each project, completely replacing `.env`.
3. Stop all Docker containers.
4. `docker system prune`
5. Delete the `docker-compose.override.yml` file from each of the project directories. It doesn't technically matter whether you leave the override in place, but everything will start faster if you don't.
6. In the platform directory, `make start`.
7. Once all services are running, check all service logs for errors, and do some basic smoke tests such as logging in to both admin and storefront.