### PR TITLE
fix: addAccountToGroup

### DIFF
--- a/src/core-services/account/mutations/createAccount.js
+++ b/src/core-services/account/mutations/createAccount.js
@@ -101,15 +101,12 @@ export default async function createAccount(context, input) {
 
   await Accounts.insertOne(account);
 
-  try {
-    await Promise.all(groups.map((groupId) => (
-      context.mutations.addAccountToGroup(context.getInternalContext(), {
-        accountId: account._id,
-        groupId
-      })
-    )));
-  } catch (error) {
-    Logger.error(error, `Error adding account ${account._id} to group upon account creation`);
+  for (const groupId of groups) {
+    // eslint-disable-next-line no-await-in-loop
+    await context.mutations.addAccountToGroup(context.getInternalContext(), {
+      accountId: account._id,
+      groupId
+    })
   }
 
   // Delete any invites that are now finished

--- a/src/core-services/account/mutations/createAccount.js
+++ b/src/core-services/account/mutations/createAccount.js
@@ -106,7 +106,7 @@ export default async function createAccount(context, input) {
     await context.mutations.addAccountToGroup(context.getInternalContext(), {
       accountId: account._id,
       groupId
-    })
+    });
   }
 
   // Delete any invites that are now finished


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
accounts were only getting added to one group when creating an account, instead of being added to all groups they should have been added to. i.e. the initial user should be added to the `accounts-manager` and `system-manager` groups when created, but was only being added to `accounts-manager` and therefore no shop could be created.

## Solution
Update the `addAccountToGroup` function to run synchronously as to not overwrite the other data being run at the same time.

## Breaking changes
None

## Testing
1. Start a new app instance (clean database)
1. create an initial user
1. Create a shop. Doing this should prove the user is in both groups.
1. Open a mongodb viewer and see your `accounts.groups` array has both groups. 