### PR TITLE
fix: fix adding shop creator to owner group

### DIFF
--- a/src/core-services/shop/mutations/createShop.js
+++ b/src/core-services/shop/mutations/createShop.js
@@ -125,10 +125,14 @@ export default async function createShop(context, input) {
 
   try {
     // Create account groups for the new shop
-    await context.mutations.createAuthGroupsForShop(context, newShopId);
+    await context.mutations.createAuthGroupsForShop(context.getInternalContext(), newShopId);
 
     // Give the shop creator "owner" permissions
-    await context.mutations.addAccountToGroupBySlug(context, { accountId, groupSlug: "owner", shopId: newShopId });
+    await context.mutations.addAccountToGroupBySlug(context.getInternalContext(), {
+      accountId,
+      groupSlug: "owner",
+      shopId: newShopId
+    });
 
     // Add AppSettings object into database for the new shop
     await collections.AppSettings.insertOne({


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
After a shop is created, shop account groups are created and the account that created it is added as a shop owner, so that they can then access things about that shop. This was being done with incorrect permissions and failing, thus resulting in not being able to do anything with a shop (query, mutate, whatever) after creating it.

## Solution
Updated to call the account group mutations with internal context so they don't fail.

## Breaking changes
None

## Testing
1. Start platform on a clean database
2. Go to http://localhost:4080 (admin), and register a new user.
3. Enter a shop name and create a shop.
4. Go to other pages and verify that tables load, updating settings works, etc.