### PR TITLE
Allow remoteURL in MediaRecordInfo schema

### DIFF
--- a/src/core-services/files/simpleSchemas.js
+++ b/src/core-services/files/simpleSchemas.js
@@ -2,8 +2,15 @@ import SimpleSchema from "simpl-schema";
 
 const MediaRecordInfo = new SimpleSchema({
   name: String,
+  remoteURL: {
+    type: String,
+    optional: true
+  },
   size: SimpleSchema.Integer,
-  tempStoreId: String,
+  tempStoreId: {
+    type: String,
+    optional: true
+  },
   type: String,
   updatedAt: Date,
   uploadedAt: Date


### PR DESCRIPTION
Resolves #6073  
Impact: **major**  
Type: **feature**

## Issue
Allow plugins to make use of `@reactioncommerce/file-collections`'s `remoteURL` field alongside `tempStoreId` when adding media to the database.

## Solution
Add `remoteURL` in the `MediaRecordInfo` schema as an optional string, and modify `tempStoreId` to be an optional string as well.

## Breaking changes
`tempStoreId` will no longer be mandatory (listed as `optional: true`). Any plugin that depends on this schema-level validation needs to be updated.

## Testing
1. Try to upload a product image with `reaction-admin` and confirm that it still works.
2. Use a plugin that uses `remoteURL` like [`@outgrowio/reaction-dummy-data`](https://github.com/outgrow/reaction-dummy-data) and validate that media insertion works too.