### PR TITLE
fix: fix order email data

### DIFF
--- a/src/core-services/orders/util/getDataForOrderEmail.test.js
+++ b/src/core-services/orders/util/getDataForOrderEmail.test.js
@@ -63,6 +63,18 @@ test("returns expected data structure (base case)", async () => {
   });
 
   const mockShop = Factory.Shop.makeOne({
+    addressBook: [
+      {
+        address1: "mockAddress1",
+        address2: "mockAddress2",
+        city: "mockCity",
+        company: "mockCompany",
+        country: "mockCountry",
+        fullName: "mockFullName",
+        postal: "mockPostal",
+        region: "mockRegion"
+      }
+    ],
     storefrontUrls: {
       storefrontHomeUrl: "http://example.com/storefrontHomeUrl",
       storefrontOrderUrl: "http://example.com/storefrontOrderUrl/:orderId?token=:token"
@@ -78,6 +90,7 @@ test("returns expected data structure (base case)", async () => {
       address: {
         address: "mockAddress1 mockAddress2",
         city: "mockCity",
+        fullName: "mockFullName",
         postal: "mockPostal",
         region: "mockRegion"
       },
@@ -169,7 +182,12 @@ test("returns expected data structure (base case)", async () => {
     orderUrl: "http://example.com/storefrontOrderUrl/mockReferenceId?token=",
     physicalAddress: {
       address: "mockAddress1 mockAddress2",
+      address1: "mockAddress1",
+      address2: "mockAddress2",
       city: "mockCity",
+      company: "mockCompany",
+      country: "mockCountry",
+      fullName: "mockFullName",
       postal: "mockPostal",
       region: "mockRegion"
     },
@@ -177,6 +195,7 @@ test("returns expected data structure (base case)", async () => {
       address: {
         address: "mockAddress1 mockAddress2",
         city: "mockCity",
+        fullName: "mockFullName",
         postal: "mockPostal",
         region: "mockRegion"
       },

--- a/src/core-services/orders/util/sendOrderEmail.js
+++ b/src/core-services/orders/util/sendOrderEmail.js
@@ -15,18 +15,13 @@ export default async function sendOrderEmail(context, order, action) {
     return false;
   }
 
-  const registeredFuncs = context.getFunctionsOfType("getDataForOrderEmail");
-  const getDataForOrderEmail = registeredFuncs[0];
-  if (!getDataForOrderEmail) {
-    Logger.warn("Cannot send email because no function of type `getDataForOrderEmail` is registered.");
-    return false;
+  const dataForEmail = {};
+  const getDataForOrderEmailFns = context.getFunctionsOfType("getDataForOrderEmail");
+  for (const getDataForOrderEmailFn of getDataForOrderEmailFns) {
+    const someData = await getDataForOrderEmailFn(context, { order }); // eslint-disable-line no-await-in-loop
+    Object.assign(dataForEmail, someData);
   }
 
-  if (registeredFuncs.length > 1) {
-    Logger.warn("Plugins registered more than one function of type `getDataForOrderEmail`. Using the first one.");
-  }
-
-  const dataForEmail = await getDataForOrderEmail(context, { order });
   const language = await getLanguageForOrder(context, order);
 
   await context.mutations.sendOrderEmail(context, {

--- a/src/core-services/shop/mutations/updateShop.js
+++ b/src/core-services/shop/mutations/updateShop.js
@@ -146,11 +146,7 @@ export default async function updateShop(context, input) {
     }
 
     if (setting === "emails") {
-      // Currently only supporting one email record entry per shop
-      const emailInfo = shopSettings[setting][0];
-      Object.keys(emailInfo).forEach((key) => {
-        sets[`emails.0.${key}`] = emailInfo[key];
-      });
+      sets[setting] = shopSettings[setting];
       return;
     }
 

--- a/src/plugins/email-templates/templates/accounts/inviteNewShopMember.js
+++ b/src/plugins/email-templates/templates/accounts/inviteNewShopMember.js
@@ -146,7 +146,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                     <td height="18" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                   </tr>
                   <tr>
                     <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>

--- a/src/plugins/email-templates/templates/accounts/resetPassword.js
+++ b/src/plugins/email-templates/templates/accounts/resetPassword.js
@@ -146,7 +146,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                     <td height="18" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                   </tr>
                   <tr>
                     <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>

--- a/src/plugins/email-templates/templates/accounts/sendWelcomeEmail.js
+++ b/src/plugins/email-templates/templates/accounts/sendWelcomeEmail.js
@@ -146,7 +146,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                     <td height="18" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                   </tr>
                   <tr>
                     <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>

--- a/src/plugins/email-templates/templates/accounts/verifyEmail.js
+++ b/src/plugins/email-templates/templates/accounts/verifyEmail.js
@@ -165,7 +165,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                   </tr>
 
                   <tr>
-                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                   </tr>
                   <tr>
                     <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>

--- a/src/plugins/email-templates/templates/accounts/verifyUpdatedEmail.js
+++ b/src/plugins/email-templates/templates/accounts/verifyUpdatedEmail.js
@@ -166,7 +166,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                   </tr>
 
                   <tr>
-                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                   </tr>
                   <tr>
                     <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>

--- a/src/plugins/email-templates/templates/orders/itemRefund.js
+++ b/src/plugins/email-templates/templates/orders/itemRefund.js
@@ -238,12 +238,12 @@ export default `
                                             <tr>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
                                                 {{#with shipping.address}}
-                                                  {{this.address}},<br> {{this.city}}, {{this.region}} {{this.postal}}
+                                                  {{this.fullName}}<br>{{this.address}}<br>{{this.city}} {{this.region}} {{this.postal}}
                                                 {{/with}}
                                               </td>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
                                                 {{#with billing.address}}
-                                                  {{this.address}},<br> {{this.city}}, {{this.region}} {{this.postal}}
+                                                  {{this.fullName}}<br>{{this.address}}<br>{{this.city}} {{this.region}} {{this.postal}}
                                                 {{/with}}
                                               </td>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
@@ -299,7 +299,7 @@ export default `
                                                 <table width="360" border="0" cellspacing="0" cellpadding="0" class="emailwrapto100pc">
                                                   <tbody>
                                                     <tr>
-                                                      <td align="left" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{title}} - {{variants.title}}</td>
+                                                      <td align="left" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{variantTitle}}</td>
                                                       <td align="right" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{price.displayAmount}}</td>
                                                     </tr>
                                                   </tbody>
@@ -441,13 +441,13 @@ export default `
                               <td height="18" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                             </tr>
                             <tr>
-                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                             </tr>
                             <tr>
                               <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                             </tr>
                             <tr>
-                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}</td>
+                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{#if physicalAddress}}{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}{{/if}}</td>
                             </tr>
                             <!-- End footer -->
 

--- a/src/plugins/email-templates/templates/orders/new.js
+++ b/src/plugins/email-templates/templates/orders/new.js
@@ -229,12 +229,12 @@ export default `
                                             <tr>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
                                                 {{#with shipping.address}}
-                                                  {{this.address}},<br> {{this.city}}, {{this.region}} {{this.postal}}
+                                                  {{this.fullName}}<br>{{this.address}}<br>{{this.city}} {{this.region}} {{this.postal}}
                                                 {{/with}}
                                               </td>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
                                                 {{#with billing.address}}
-                                                  {{this.address}},<br> {{this.city}}, {{this.region}} {{this.postal}}
+                                                  {{this.fullName}}<br>{{this.address}}<br>{{this.city}} {{this.region}} {{this.postal}}
                                                 {{/with}}
                                               </td>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
@@ -290,7 +290,7 @@ export default `
                                                 <table width="360" border="0" cellspacing="0" cellpadding="0" class="emailwrapto100pc">
                                                   <tbody>
                                                     <tr>
-                                                      <td align="left" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{title}} - {{variants.title}}</td>
+                                                      <td align="left" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{variantTitle}}</td>
                                                       <td align="right" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{price.displayAmount}}</td>
                                                     </tr>
                                                   </tbody>
@@ -420,13 +420,13 @@ export default `
                               <td height="18" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                             </tr>
                             <tr>
-                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                             </tr>
                             <tr>
                               <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                             </tr>
                             <tr>
-                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}</td>
+                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{#if physicalAddress}}{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}{{/if}}</td>
                             </tr>
                             <!-- End footer -->
 

--- a/src/plugins/email-templates/templates/orders/refunded.js
+++ b/src/plugins/email-templates/templates/orders/refunded.js
@@ -229,12 +229,12 @@ export default `
                                             <tr>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
                                                 {{#with shipping.address}}
-                                                  {{this.address}},<br> {{this.city}}, {{this.region}} {{this.postal}}
+                                                  {{this.fullName}}<br>{{this.address}}<br>{{this.city}} {{this.region}} {{this.postal}}
                                                 {{/with}}
                                               </td>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
                                                 {{#with billing.address}}
-                                                  {{this.address}},<br> {{this.city}}, {{this.region}} {{this.postal}}
+                                                  {{this.fullName}}<br>{{this.address}}<br>{{this.city}} {{this.region}} {{this.postal}}
                                                 {{/with}}
                                               </td>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
@@ -290,7 +290,7 @@ export default `
                                                 <table width="360" border="0" cellspacing="0" cellpadding="0" class="emailwrapto100pc">
                                                   <tbody>
                                                     <tr>
-                                                      <td align="left" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{title}} - {{variants.title}}</td>
+                                                      <td align="left" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{variantTitle}}</td>
                                                       <td align="right" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{price.displayAmount}}</td>
                                                     </tr>
                                                   </tbody>
@@ -435,13 +435,13 @@ export default `
                               <td height="18" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                             </tr>
                             <tr>
-                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                             </tr>
                             <tr>
                               <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                             </tr>
                             <tr>
-                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}</td>
+                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{#if physicalAddress}}{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}{{/if}}</td>
                             </tr>
                             <!-- End footer -->
 

--- a/src/plugins/email-templates/templates/orders/shipped.js
+++ b/src/plugins/email-templates/templates/orders/shipped.js
@@ -233,12 +233,12 @@ export default `
                                             <tr>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
                                                 {{#with shipping.address}}
-                                                  {{this.address}},<br> {{this.city}}, {{this.region}} {{this.postal}}
+                                                  {{this.fullName}}<br>{{this.address}}<br>{{this.city}} {{this.region}} {{this.postal}}
                                                 {{/with}}
                                               </td>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
                                                 {{#with billing.address}}
-                                                  {{this.address}},<br> {{this.city}}, {{this.region}} {{this.postal}}
+                                                  {{this.fullName}}<br>{{this.address}}<br>{{this.city}} {{this.region}} {{this.postal}}
                                                 {{/with}}
                                               </td>
                                               <td width="33%" align="left" valign="top" style="font-size:10px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">
@@ -294,7 +294,7 @@ export default `
                                                 <table width="360" border="0" cellspacing="0" cellpadding="0" class="emailwrapto100pc">
                                                   <tbody>
                                                     <tr>
-                                                      <td align="left" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{title}} - {{variants.title}}</td>
+                                                      <td align="left" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{variantTitle}}</td>
                                                       <td align="right" valign="middle" style="font-size:12px; line-height:normal; color:#4c4c4d; font-family:Arial, helvetica;">{{price.displayAmount}}</td>
                                                     </tr>
                                                   </tbody>
@@ -424,13 +424,13 @@ export default `
                               <td height="18" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                             </tr>
                             <tr>
-                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{legalName}}. All rights reserved</td>
+                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:12px; color:#4d4c4d;">&copy; {{copyrightDate}} {{#if legalName}}{{legalName}}{{else}}{{shopName}}{{/if}}. All rights reserved</td>
                             </tr>
                             <tr>
                               <td height="8" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                             </tr>
                             <tr>
-                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}</td>
+                              <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:10px; font-weight:normal; line-height:10px; color:#787878;">{{#if physicalAddress}}{{physicalAddress.address}}, {{physicalAddress.city}}, {{physicalAddress.region}} {{physicalAddress.postal}}{{/if}}</td>
                             </tr>
                             <!-- End footer -->
 


### PR DESCRIPTION
Resolves #5849   
Impact: **minor**  
Type: **bugfix**

Order email template data fixes

## Issue
- If a plugin registered an additional function of type `getDataForOrderEmail`, it was ignored because the one in the `orders` plugin always took precedence.
- The default `getDataForOrderEmail` function in the `orders` plugin does not include `account` data when the order is linked with an account.
- The default `getDataForOrderEmail` function in the `orders` plugin does not include `fullName` field with any of the address objects.
- The default order email templates do not show the name line for billing or shipping address
- The default order email templates show some text that says "undefined" if you haven't added a shop address yet.
- The default order email templates do not properly show the variant title for each item. They show only the product title.

## Solution
- If a plugin registers an additional function of type `getDataForOrderEmail`, the object that it returns is combined with the default object. There can still be some uncertainty about which plugin's function will run first, but as long as you return an object with unique keys, you can rely on them in your email templates.
- The default `getDataForOrderEmail` function in the `orders` plugin now includes `account` data when the order is linked with an account. For example, something like this will work for an email subject line:
    ```
    Your order is confirmed, {{#if account.profile.firstName}}{{account.profile.firstName}}{{else if account.profile.name}}{{account.profile.name}}{{else}}{{order.email}}{{/if}} - {{order.referenceId}}
    ```
- The default `getDataForOrderEmail` function in the `orders` plugin now includes `fullName` field with all of the address objects.
- The default order email templates now show the name line for billing and shipping address
- The default order email templates no longer contain "undefined" text if you haven't added a shop address yet.
- The default order email templates now properly show the variant title for each item.

## Breaking changes
None

## Testing
1. Use a fresh database and create a new shop so that the default email templates get used.
2. Set up emailing, ensure your shop does not have any addresses listed, and then place an order while logged in to the storefront.
3. Verify everything looks good in the new order email you receive.