### PR TITLE
feat: implement origin tax sourcing

### DIFF
--- a/src/core-services/shop/mutations/updateShop.js
+++ b/src/core-services/shop/mutations/updateShop.js
@@ -56,7 +56,6 @@ const inputSchema = new SimpleSchema({
 });
 
 const complexSettings = [
-  "addressBook",
   "emails",
   "shopLogoUrls",
   "storefrontUrls"
@@ -124,23 +123,8 @@ export default async function updateShop(context, input) {
       return;
     }
 
-    // Simple string settings
+    // Simple settings
     if (shopSettings[setting] && !complexSettings.includes(setting)) {
-      sets[setting] = shopSettings[setting];
-      return;
-    }
-
-    // Compound settings
-    if (setting === "addressBook") {
-      // Currently only supporting one addressBook entry entry per shop
-      const addressBookEntry = shopSettings[setting][0];
-      Object.keys(addressBookEntry).forEach((key) => {
-        sets[`addressBook.0.${key}`] = addressBookEntry[key];
-      });
-      return;
-    }
-
-    if (setting === "defaultParcelSize") {
       sets[setting] = shopSettings[setting];
       return;
     }

--- a/src/core-services/shop/simpleSchemas.js
+++ b/src/core-services/shop/simpleSchemas.js
@@ -245,6 +245,10 @@ export const ShopAddress = new SimpleSchema({
     type: String,
     optional: true
   },
+  "addressName": {
+    optional: true,
+    type: String
+  },
   "city": {
     type: String,
     label: "City"

--- a/src/plugins/taxes-rates/mutations/createTaxRate.js
+++ b/src/plugins/taxes-rates/mutations/createTaxRate.js
@@ -10,7 +10,15 @@ import Random from "@reactioncommerce/random";
  * @returns {Promise<Object>} AddTaxRatePayload
  */
 export default async function createTaxRate(context, input) {
-  const { shopId, country, region, postal, taxCode, rate } = input;
+  const {
+    country,
+    postal,
+    rate,
+    region,
+    shopId,
+    sourcing: taxLocale,
+    taxCode
+  } = input;
   const { appEvents, collections } = context;
   const { Taxes } = collections;
 
@@ -18,13 +26,13 @@ export default async function createTaxRate(context, input) {
 
   const taxRate = {
     _id: Random.id(),
-    shopId,
     country,
-    region,
     postal,
+    rate,
+    region,
+    shopId,
     taxCode,
-    taxLocale: "destination",
-    rate
+    taxLocale
   };
 
   await Taxes.insertOne(taxRate);

--- a/src/plugins/taxes-rates/mutations/updateTaxRate.js
+++ b/src/plugins/taxes-rates/mutations/updateTaxRate.js
@@ -8,23 +8,37 @@
  * @returns {Promise<Object>} UpdateTaxRatePayload
  */
 export default async function updateTaxRate(context, input) {
-  const { shopId, _id, country, region, postal, taxCode, rate } = input;
+  const {
+    _id,
+    country,
+    postal,
+    rate,
+    region,
+    shopId,
+    sourcing: taxLocale,
+    taxCode
+  } = input;
   const { appEvents, collections } = context;
   const { Taxes } = collections;
 
   await context.validatePermissions("reaction:legacy:taxRates", "update", { shopId });
 
+  const updates = {
+    country,
+    region,
+    postal,
+    taxCode,
+    rate
+  };
+  if (taxLocale) {
+    updates.taxLocale = taxLocale;
+  }
+
   await Taxes.updateOne({
     _id,
     shopId
   }, {
-    $set: {
-      country,
-      region,
-      postal,
-      taxCode,
-      rate
-    }
+    $set: updates
   });
 
   const taxRate = await Taxes.findOne({ _id });

--- a/src/plugins/taxes-rates/schemas/schema.graphql
+++ b/src/plugins/taxes-rates/schemas/schema.graphql
@@ -45,6 +45,9 @@ input CreateTaxRateInput {
   "Shop ID"
   shopId: ID!
 
+  "Whether the `country`, `postal`, and `region` filters apply to the origin address or the destination address"
+  sourcing: TaxSource = destination
+
   "An optional tax code, to apply this tax rate to only products that have this tax code"
   taxCode: String
 }
@@ -80,6 +83,9 @@ input UpdateTaxRateInput {
 
   "Shop ID"
   shopId: ID!
+
+  "Whether the `country`, `postal`, and `region` filters apply to the origin address or the destination address"
+  sourcing: TaxSource
 
   "An optional tax code, to apply this tax rate to only products that have this tax code"
   taxCode: String

--- a/src/plugins/taxes-rates/util/calculateOrderTaxes.js
+++ b/src/plugins/taxes-rates/util/calculateOrderTaxes.js
@@ -3,30 +3,56 @@ import Random from "@reactioncommerce/random";
 const TAX_SERVICE_NAME = "custom-rates";
 
 /**
- * @summary Gets all applicable tax definitions based on shop ID and shipping address of a fulfillment group
+ * @summary Gets all applicable tax definitions based on shop ID and shipping
+ *   or origin address of a fulfillment group
  * @param {Object} collections Map of MongoDB collections
  * @param {Object} order The order
  * @returns {Object[]} Array of tax definition docs
  */
 async function getTaxesForShop(collections, order) {
   const { Taxes } = collections;
-  const { shippingAddress, shopId } = order;
+  const { originAddress, shippingAddress, shopId } = order;
+
+  const orArray = [];
+
+  if (shippingAddress) {
+    orArray.push({
+      taxLocale: "destination",
+      $or: [{
+        postal: shippingAddress.postal
+      }, {
+        postal: null,
+        region: shippingAddress.region,
+        country: shippingAddress.country
+      }, {
+        postal: null,
+        region: null,
+        country: shippingAddress.country
+      }]
+    });
+  }
+
+  if (originAddress) {
+    orArray.push({
+      taxLocale: "origin",
+      $or: [{
+        postal: originAddress.postal
+      }, {
+        postal: null,
+        region: originAddress.region,
+        country: originAddress.country
+      }, {
+        postal: null,
+        region: null,
+        country: originAddress.country
+      }]
+    });
+  }
 
   // Find all defined taxes where the shipping address is a match
   const taxDocs = await Taxes.find({
     shopId,
-    taxLocale: "destination",
-    $or: [{
-      postal: shippingAddress.postal
-    }, {
-      postal: null,
-      region: shippingAddress.region,
-      country: shippingAddress.country
-    }, {
-      postal: null,
-      region: null,
-      country: shippingAddress.country
-    }]
+    $or: orArray
   }).toArray();
 
   // Rate is entered and stored in the database as a percent. Convert to ratio.
@@ -46,9 +72,9 @@ async function getTaxesForShop(collections, order) {
  * @returns {Object|null} Calculated tax information, in `TaxServiceResult` schema, or `null` if can't calculate
  */
 export default async function calculateOrderTaxes({ context, order }) {
-  const { items, shippingAddress } = order;
+  const { items, originAddress, shippingAddress } = order;
 
-  if (!shippingAddress) return null;
+  if (!shippingAddress && !originAddress) return null;
 
   const allTaxes = await getTaxesForShop(context.collections, order);
 

--- a/tests/integration/api/mutations/taxRates/createTaxRateMutation.graphql
+++ b/tests/integration/api/mutations/taxRates/createTaxRateMutation.graphql
@@ -1,17 +1,19 @@
 mutation (
-  $region: String,
-  $rate: Float!,
-  $shopId: ID!,
   $country: String,
   $postal: String,
+  $rate: Float!,
+  $region: String,
+  $shopId: ID!,
+  $sourcing: TaxSource,
   $taxCode: String
 ) {
   createTaxRate(input: {
-    region: $region,
-    rate: $rate,
-    shopId: $shopId,
     country: $country,
     postal: $postal,
+    rate: $rate,
+    region: $region,
+    shopId: $shopId,
+    sourcing: $sourcing,
     taxCode: $taxCode
   }) {
     taxRate {

--- a/tests/integration/api/mutations/taxRates/taxRates.test.js
+++ b/tests/integration/api/mutations/taxRates/taxRates.test.js
@@ -56,11 +56,11 @@ test("user can add a tax rate", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);
 
   const taxRateInput = {
-    shopId: shopOpaqueId,
-    region: "CA",
-    rate: 0.10,
     country: "USA",
     postal: "90066",
+    rate: 0.10,
+    region: "CA",
+    shopId: shopOpaqueId,
     taxCode: "CODE"
   };
 
@@ -80,13 +80,13 @@ test("user can add a tax rate", async () => {
   // Validate the response
   // _id is omitted since the ID is tested for proper opaque ID conversion in the DB test below.
   const expectedTaxRateResponse = {
+    country: "USA",
+    postal: "90066",
+    rate: 0.10,
+    region: "CA",
     shop: {
       _id: shopOpaqueId
     },
-    region: "CA",
-    rate: 0.10,
-    country: "USA",
-    postal: "90066",
     sourcing: "destination",
     taxCode: "CODE"
   };
@@ -120,13 +120,14 @@ test("user can update an existing tax rate", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);
 
   const taxRateInput = {
-    taxRateId: taxRateOpaqueId,
-    shopId: shopOpaqueId,
-    region: "CA",
-    rate: 0.40,
     country: "USA",
     postal: "90210",
-    taxCode: "CODE"
+    rate: 0.40,
+    region: "CA",
+    shopId: shopOpaqueId,
+    sourcing: "origin",
+    taxCode: "CODE",
+    taxRateId: taxRateOpaqueId
   };
 
   let result;
@@ -142,14 +143,14 @@ test("user can update an existing tax rate", async () => {
   // Validate the response
   // _id is omitted since the ID is tested for proper opaque ID conversion in the DB test below.
   const expectedTaxRateResponse = {
+    country: "USA",
+    postal: "90210",
+    rate: 0.40,
+    region: "CA",
     shop: {
       _id: shopOpaqueId
     },
-    region: "CA",
-    rate: 0.40,
-    country: "USA",
-    postal: "90210",
-    sourcing: "destination",
+    sourcing: "origin",
     taxCode: "CODE"
   };
 
@@ -166,27 +167,28 @@ test("user can update an existing tax rate", async () => {
   // The document we expect to see in the database
   const expectedTaxRateDocument = {
     _id: updatedTaxRateDatabaseId,
-    shopId,
-    region: "CA",
-    rate: 0.40,
     country: "USA",
     postal: "90210",
+    rate: 0.40,
+    region: "CA",
+    shopId,
     taxCode: "CODE",
-    taxLocale: "destination"
+    taxLocale: "origin"
   };
 
   expect(savedTaxRate).toEqual(expectedTaxRateDocument);
 });
 
-test("user can update an existing tax rate to clear all fields except rate", async () => {
+test("user can update an existing tax rate to clear all fields except rate and sourcing", async () => {
   await testApp.setLoggedInUser(mockAdminAccount);
 
   const taxRateInput = {
-    shopId: shopOpaqueId,
-    region: "CA",
-    rate: 0.10,
     country: "USA",
     postal: "90066",
+    rate: 0.10,
+    region: "CA",
+    shopId: shopOpaqueId,
+    sourcing: "destination",
     taxCode: "CODE"
   };
 
@@ -201,9 +203,9 @@ test("user can update an existing tax rate to clear all fields except rate", asy
   const { _id: createdTaxRateOpaqueId } = result.createTaxRate.taxRate;
 
   const taxRateUpdateInput = {
-    taxRateId: createdTaxRateOpaqueId,
+    rate: 0.40,
     shopId: shopOpaqueId,
-    rate: 0.40
+    taxRateId: createdTaxRateOpaqueId
   };
 
   try {
@@ -218,13 +220,13 @@ test("user can update an existing tax rate to clear all fields except rate", asy
   // Validate the response
   // _id is omitted since the ID is tested for proper opaque ID conversion in the DB test below.
   const expectedTaxRateResponse = {
+    country: null,
+    postal: null,
+    rate: 0.40,
+    region: null,
     shop: {
       _id: shopOpaqueId
     },
-    region: null,
-    rate: 0.40,
-    country: null,
-    postal: null,
     sourcing: "destination",
     taxCode: null
   };
@@ -242,11 +244,11 @@ test("user can update an existing tax rate to clear all fields except rate", asy
   // The document we expect to see in the database
   const expectedTaxRateDocument = {
     _id: updatedTaxRateDatabaseId,
-    shopId,
-    region: null,
-    rate: 0.40,
     country: null,
     postal: null,
+    rate: 0.40,
+    region: null,
+    shopId,
     taxCode: null,
     taxLocale: "destination"
   };
@@ -275,14 +277,14 @@ test("user can delete an existing tax rate", async () => {
   // Validate the response
   // _id is omitted since the ID is tested for proper opaque ID conversion in the DB test below.
   const expectedTaxRateResponse = {
+    country: "USA",
+    postal: "90210",
+    rate: 0.40,
+    region: "CA",
     shop: {
       _id: shopOpaqueId
     },
-    region: "CA",
-    rate: 0.40,
-    country: "USA",
-    postal: "90210",
-    sourcing: "destination",
+    sourcing: "origin",
     taxCode: "CODE"
   };
 

--- a/tests/integration/api/mutations/taxRates/updateTaxRateMutation.graphql
+++ b/tests/integration/api/mutations/taxRates/updateTaxRateMutation.graphql
@@ -1,20 +1,22 @@
 mutation (
-  $taxRateId: ID!,
-  $region: String,
-  $rate: Float!,
-  $shopId: ID!,
   $country: String,
   $postal: String,
-  $taxCode: String
+  $rate: Float!,
+  $region: String,
+  $shopId: ID!,
+  $sourcing: TaxSource,
+  $taxCode: String,
+  $taxRateId: ID!
 ) {
   updateTaxRate(input: {
-    taxRateId: $taxRateId,
-    region: $region,
-    rate: $rate,
-    shopId: $shopId,
     country: $country,
     postal: $postal,
-    taxCode: $taxCode
+    rate: $rate,
+    region: $region,
+    shopId: $shopId,
+    sourcing: $sourcing,
+    taxCode: $taxCode,
+    taxRateId: $taxRateId
   }) {
     taxRate {
       _id


### PR DESCRIPTION
Resolves #5166  
Impact: **minor**  
Type: **feature**

## Changes
- It's now possible to set `sourcing` to "origin" with the `createTaxRate` and `updateTaxRate` mutations. Previously they always used "destination" as the sourcing.
- The tax-rates plugin respects origin sourcing when determining which tax jurisdictions apply to an order. This uses `order.originAddress`, which currently is always set to the first address in the shop address book. If the shop has no addresses, no origin-type tax rates will be applied.
- Allow `udateShop` to set/update the `addressName` field

## Breaking changes
None, except that if you have origin-type tax rates defined, they will now begin getting applied to orders. The only way you could have these defined is by creating them directly in the database or through your own custom process.

The `createTaxRate` and `updateTaxRate` mutations are backwards compatible because the `sourcing` field is optional and defaults to "destination" as before.

## Testing
1. Use `updateShop` mutation to set `addressBook` to an array with a single address in it.
2. Use `createTaxRate` and/or `updateTaxRate` mutations to create at least one tax rate rule where the address filter is based on "origin" sourcing. Make sure this will match the shop address you added in the previous step.
3. Place an order and ensure that your tax rate gets applied to it.