### PR TITLE
Proper sitemap last modify date

### DIFF
--- a/src/plugins/sitemap-generator/util/generate-sitemaps.js
+++ b/src/plugins/sitemap-generator/util/generate-sitemaps.js
@@ -302,10 +302,10 @@ function generateIndexXML(items) {
  * @private
  * @summary Given a date, returns a formatted date string
  * @param {Date} date - Date to format
- * @returns {String} - in the format of YYYY-MM-DD
+ * @returns {String} - in the format of YYYY-MM-DDTHH:MM:SSZ
  */
 function getLastModStr(date) {
-  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+  return date.toISOString();
 }
 
 /**


### PR DESCRIPTION
Resolves N.A.
Impact: **minor**  
Type: **bugfix**

## Issue
Currently sitemap is not generated properly: lastmod date can take value YYYY-M-D or YYYY-M-DD what will break validation against sitemaps.org xsd and Google Search Console

## Solution
Change lastmod date to ISO Date format

## Breaking changes
None.

## Testing
1. Generate sitemaps
2. Validate it against sitemaps.org xsd schemas / upload sitemap to google search console
