### PR TITLE
refactor: allow all users with token to view order

### DIFF
--- a/src/core-services/orders/queries/orderById.js
+++ b/src/core-services/orders/queries/orderById.js
@@ -18,6 +18,5 @@ export default async function orderById(context, { orderId, shopId, token } = {}
     throw new ReactionError("invalid-param", "You must provide orderId and shopId arguments");
   }
 
-  const selector = getOrderQuery(context, { _id: orderId }, shopId, token);
-  return context.collections.Orders.findOne(selector);
+  return getOrderQuery(context, { _id: orderId }, shopId, token);
 }

--- a/src/core-services/orders/queries/orderByReferenceId.js
+++ b/src/core-services/orders/queries/orderByReferenceId.js
@@ -17,6 +17,6 @@ export default async function orderByReferenceId(context, { orderReferenceId, sh
   if (!orderReferenceId || !shopId) {
     throw new ReactionError("invalid-param", "You must provide orderReferenceId and shopId arguments");
   }
-  const selector = await getOrderQuery(context, { referenceId: orderReferenceId }, shopId, token);
-  return context.collections.Orders.findOne(selector);
+
+  return getOrderQuery(context, { referenceId: orderReferenceId }, shopId, token);
 }

--- a/src/core-services/orders/queries/refunds.js
+++ b/src/core-services/orders/queries/refunds.js
@@ -18,8 +18,7 @@ export default async function refunds(context, { orderId, shopId, token } = {}) 
     throw new ReactionError("invalid-param", "You must provide orderId and shopId arguments");
   }
 
-  const selector = getOrderQuery(context, { _id: orderId }, shopId, token);
-  const order = await context.collections.Orders.findOne(selector);
+  const order = await getOrderQuery(context, { _id: orderId }, shopId, token);
 
   if (!order) {
     throw new ReactionError("not-found", "Order not found");

--- a/src/core-services/orders/queries/refundsByPaymentId.js
+++ b/src/core-services/orders/queries/refundsByPaymentId.js
@@ -22,8 +22,7 @@ export default async function refundsByPaymentId(context, { orderId, paymentId, 
 
   let order = providedOrder;
   if (!providedOrder) {
-    const selector = getOrderQuery(context, { _id: orderId }, shopId, token);
-    order = await context.collections.Orders.findOne(selector);
+    order = await getOrderQuery(context, { _id: orderId }, shopId, token);
   }
 
   if (!order) {

--- a/src/core-services/orders/util/getOrderQuery.js
+++ b/src/core-services/orders/util/getOrderQuery.js
@@ -1,46 +1,37 @@
 import hashToken from "@reactioncommerce/api-utils/hashToken.js";
-import ReactionError from "@reactioncommerce/reaction-error";
 
 /**
  * @name getOrderQuery
  * @method
  * @memberof Order/helpers
- * @summary Creates Order mongo selector based on user permissions
+ * @summary Queries for an order and returns it if user has correct permissions
  * @param {Object} context An object containing the per-request state
- * @param {Object} selector A mongo selector
+ * @param {Object} selector Order ID or Reference ID to query
  * @param {String} shopId Shop ID of the order
  * @param {String} token An anonymous order token, required if the order was placed without being logged in
- * @returns {Object} A mongo selector
+ * @returns {Object} An order object
  */
 export async function getOrderQuery(context, selector, shopId, token) {
-  const { accountId: contextAccountId } = context;
-  const newSelector = { ...selector, shopId };
+  const { collections } = context;
+
+  const order = await collections.Orders.findOne(selector);
 
   // If you have the hashed token, you don't need to pass a permission check
-  if (token) {
-    newSelector["anonymousAccessTokens.hashedToken"] = hashToken(token);
-    return newSelector;
+  if (token && order.anonymousAccessTokens.some((accessToken) => accessToken.hashedToken === hashToken(token))) {
+    return order;
   }
 
   // if you don't have the hashed token,
   // you must either have `reaction:legacy:orders/read` permissions,
   // or this must be your own order
-  const userHasPermission = await context.userHasPermission(
+  await context.validatePermissions(
     "reaction:legacy:orders",
     "read",
-    { shopId }
+    {
+      shopId,
+      owner: order.accountId
+    }
   );
 
-  if (userHasPermission) {
-    // admins with orders permissions can see any order in the shop
-    // admins with order/fulfillment and order/view permissions can also view order
-    // with further permission checks in each component to limit functionality where needed
-    // No need to adjust the selector to get the order
-  } else if (contextAccountId) {
-    // Customer accounts can only see their own orders
-    newSelector.accountId = contextAccountId;
-  } else {
-    throw new ReactionError("access-denied", "Access Denied");
-  }
-  return newSelector;
+  return order;
 }

--- a/src/core-services/orders/util/getOrderQuery.js
+++ b/src/core-services/orders/util/getOrderQuery.js
@@ -1,4 +1,5 @@
 import hashToken from "@reactioncommerce/api-utils/hashToken.js";
+import ReactionError from "@reactioncommerce/reaction-error";
 
 /**
  * @name getOrderQuery
@@ -15,6 +16,10 @@ export async function getOrderQuery(context, selector, shopId, token) {
   const { collections } = context;
 
   const order = await collections.Orders.findOne(selector);
+
+  if (!order) {
+    throw new ReactionError("not-found", "Order not found");
+  }
 
   // If you have the hashed token, you don't need to pass a permission check
   if (token && order.anonymousAccessTokens.some((accessToken) => accessToken.hashedToken === hashToken(token))) {

--- a/tests/integration/api/queries/orderByReferenceId/__snapshots__/orderByReferenceId.test.js.snap
+++ b/tests/integration/api/queries/orderByReferenceId/__snapshots__/orderByReferenceId.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`get not found error for order that does not exist 1`] = `
+Object {
+  "extensions": Object {
+    "code": "NOT_FOUND",
+    "exception": Object {
+      "details": Object {},
+      "error": "not-found",
+      "eventData": Object {},
+      "isClientSafe": true,
+      "reason": "Order not found",
+    },
+  },
+  "locations": Array [
+    Object {
+      "column": 3,
+      "line": 2,
+    },
+  ],
+  "message": "Order not found",
+  "path": Array [
+    "orderByReferenceId",
+  ],
+}
+`;

--- a/tests/integration/api/queries/orderByReferenceId/orderByReferenceId.test.js
+++ b/tests/integration/api/queries/orderByReferenceId/orderByReferenceId.test.js
@@ -63,17 +63,17 @@ beforeEach(async () => {
 // test file gets its own test database.
 afterAll(() => testApp.stop());
 
-// test("get account order success", async () => {
-//   // Set up initial data state
-//   await testApp.collections.Orders.insertOne(order);
-//   await testApp.setLoggedInUser(mockOrdersAccount);
+test("get account order success", async () => {
+  // Set up initial data state
+  await testApp.collections.Orders.insertOne(order);
+  await testApp.setLoggedInUser(mockOrdersAccount);
 
-//   // Query for order and check results
-//   const result = await query({ orderReferenceId, shopId: opaqueShopId, token: null });
-//   expect(result.orderByReferenceId.account._id).toBe(opaqueAccountId);
-//   expect(result.orderByReferenceId.shop._id).toBe(opaqueShopId);
-//   expect(result.orderByReferenceId.shop.name).toBe(shopName);
-// });
+  // Query for order and check results
+  const result = await query({ orderReferenceId, shopId: opaqueShopId, token: null });
+  expect(result.orderByReferenceId.account._id).toBe(opaqueAccountId);
+  expect(result.orderByReferenceId.shop._id).toBe(opaqueShopId);
+  expect(result.orderByReferenceId.shop.name).toBe(shopName);
+});
 
 test("get not found error for order that does not exist", async () => {
   await testApp.collections.Orders.insertOne(order);
@@ -85,18 +85,18 @@ test("get not found error for order that does not exist", async () => {
   }
 });
 
-// test("get invalid params error", async () => {
-//   await testApp.collections.Orders.insertOne(orderAnon);
-//   try {
-//     await query({ orderReferenceId: orderReferenceIdAnon });
-//   } catch (error) {
-//     expect(error[0].message).toBe('Variable "$shopId" of required type "ID!" was not provided.');
-//   }
-// });
+test("get invalid params error", async () => {
+  await testApp.collections.Orders.insertOne(orderAnon);
+  try {
+    await query({ orderReferenceId: orderReferenceIdAnon });
+  } catch (error) {
+    expect(error[0].message).toBe('Variable "$shopId" of required type "ID!" was not provided.');
+  }
+});
 
-// test("get anonymous order success", async () => {
-//   await testApp.collections.Orders.insertOne(orderAnon);
-//   const result = await query({ orderReferenceId: orderReferenceIdAnon, shopId: opaqueShopId, token: tokenInfo.token });
-//   expect(result.orderByReferenceId.shop._id).toBe(opaqueShopId);
-//   expect(result.orderByReferenceId.shop.name).toBe(shopName);
-// });
+test("get anonymous order success", async () => {
+  await testApp.collections.Orders.insertOne(orderAnon);
+  const result = await query({ orderReferenceId: orderReferenceIdAnon, shopId: opaqueShopId, token: tokenInfo.token });
+  expect(result.orderByReferenceId.shop._id).toBe(opaqueShopId);
+  expect(result.orderByReferenceId.shop.name).toBe(shopName);
+});

--- a/tests/integration/api/queries/orderByReferenceId/orderByReferenceId.test.js
+++ b/tests/integration/api/queries/orderByReferenceId/orderByReferenceId.test.js
@@ -63,37 +63,40 @@ beforeEach(async () => {
 // test file gets its own test database.
 afterAll(() => testApp.stop());
 
-test("get account order success", async () => {
-  // Set up initial data state
+// test("get account order success", async () => {
+//   // Set up initial data state
+//   await testApp.collections.Orders.insertOne(order);
+//   await testApp.setLoggedInUser(mockOrdersAccount);
+
+//   // Query for order and check results
+//   const result = await query({ orderReferenceId, shopId: opaqueShopId, token: null });
+//   expect(result.orderByReferenceId.account._id).toBe(opaqueAccountId);
+//   expect(result.orderByReferenceId.shop._id).toBe(opaqueShopId);
+//   expect(result.orderByReferenceId.shop.name).toBe(shopName);
+// });
+
+test("get not found error for order that does not exist", async () => {
   await testApp.collections.Orders.insertOne(order);
   await testApp.setLoggedInUser(mockOrdersAccount);
-
-  // Query for order and check results
-  const result = await query({ orderReferenceId, shopId: opaqueShopId, token: null });
-  expect(result.orderByReferenceId.account._id).toBe(opaqueAccountId);
-  expect(result.orderByReferenceId.shop._id).toBe(opaqueShopId);
-  expect(result.orderByReferenceId.shop.name).toBe(shopName);
-});
-
-test("get account order failure", async () => {
-  await testApp.collections.Orders.insertOne(order);
-  await testApp.setLoggedInUser(mockOrdersAccount);
-  const result = await query({ orderReferenceId: "does-not-exist", shopId: opaqueShopId, token: null });
-  expect(result.orderByReferenceId).toBeNull();
-});
-
-test("get invalid params error", async () => {
-  await testApp.collections.Orders.insertOne(orderAnon);
   try {
-    await query({ orderReferenceId: orderReferenceIdAnon });
-  } catch (error) {
-    expect(error[0].message).toBe('Variable "$shopId" of required type "ID!" was not provided.');
+    await query({ orderReferenceId: "does-not-exist", shopId: opaqueShopId, token: null });
+  } catch (errors) {
+    expect(errors[0]).toMatchSnapshot();
   }
 });
 
-test("get anonymous order success", async () => {
-  await testApp.collections.Orders.insertOne(orderAnon);
-  const result = await query({ orderReferenceId: orderReferenceIdAnon, shopId: opaqueShopId, token: tokenInfo.token });
-  expect(result.orderByReferenceId.shop._id).toBe(opaqueShopId);
-  expect(result.orderByReferenceId.shop.name).toBe(shopName);
-});
+// test("get invalid params error", async () => {
+//   await testApp.collections.Orders.insertOne(orderAnon);
+//   try {
+//     await query({ orderReferenceId: orderReferenceIdAnon });
+//   } catch (error) {
+//     expect(error[0].message).toBe('Variable "$shopId" of required type "ID!" was not provided.');
+//   }
+// });
+
+// test("get anonymous order success", async () => {
+//   await testApp.collections.Orders.insertOne(orderAnon);
+//   const result = await query({ orderReferenceId: orderReferenceIdAnon, shopId: opaqueShopId, token: tokenInfo.token });
+//   expect(result.orderByReferenceId.shop._id).toBe(opaqueShopId);
+//   expect(result.orderByReferenceId.shop.name).toBe(shopName);
+// });


### PR DESCRIPTION
Resolves #5882   
Impact: **minor**  
Type: **refactor**

## Issue

> Checkout as an anonymous customer, you get an order with an ID and token so you can visit the order complete page /order/:id/:token in your storefront.
> 
> When you visit this page not logged in, you see the order details, as the token is in the URL.
> 
> Now if you login, the order is not found.
> 
> It appears that once logged in, the token value is ignored and it will attempt to find the order from your account. The order resolver, when given a order ID and token, should use these to locate the order, and ignore who they are logged in with. If it's presented with only an Order ID and no token, then it should try to find the order from the current account.

## Solution
Refactor check order to allow all users who have the order `token` to view the order.

## Breaking changes
None

## Testing
1. Create an order as a logged out user using `example-storefront`
1. See the order confirmation page, and copy the link to that page
1. Login as any user
1. Paste the link, see you can still see the order with the token URL