### PR TITLE
fix: find catalog product regardless of visibility

### DIFF
--- a/src/core-services/catalog/queries/findCatalogProductsAndVariants.js
+++ b/src/core-services/catalog/queries/findCatalogProductsAndVariants.js
@@ -11,12 +11,7 @@ export default async function findCatalogProductsAndVariants(context, variants) 
   const { collections: { Catalog } } = context;
   const productIds = variants.map((variant) => variant.productId);
 
-  const catalogProductItems = await Catalog.find({
-    "product.productId": { $in: productIds },
-    "product.isVisible": true,
-    "product.isDeleted": { $ne: true },
-    "isDeleted": { $ne: true }
-  }).toArray();
+  const catalogProductItems = await Catalog.find({ "product.productId": { $in: productIds } }).toArray();
 
   const catalogProductsAndVariants = catalogProductItems.map((catalogProductItem) => {
     const { product } = catalogProductItem;


### PR DESCRIPTION
Resolves #6077 
Impact: **minor**  
Type: **bugfix**

## Issue
Cart and order transformations fail when the catalog item related to a cart or order item has since been deleted or hidden.

## Solution
Remove deleted/hidden checks from the queries. Look up by product ID only. That way it will only fail if the document has been hard deleted, which can only be done outside of the official GraphQL API and should never be done outside of a development environment as a rule.

## Breaking changes
None

## Testing
See #6077 for reproduction steps and verify fixed.