### PR TITLE
fix: Add variant tax fields to schemas

### DIFF
--- a/src/core-services/product/index.js
+++ b/src/core-services/product/index.js
@@ -6,6 +6,7 @@ import schemas from "./schemas/index.js";
 import {
   Product,
   ProductVariant,
+  ProductVariantInputSchema,
   VariantMedia
 } from "./simpleSchemas.js";
 
@@ -46,6 +47,7 @@ export default async function register(app) {
     simpleSchemas: {
       Product,
       ProductVariant,
+      ProductVariantInputSchema,
       VariantMedia
     }
   });

--- a/src/core-services/product/mutations/updateProductVariant.js
+++ b/src/core-services/product/mutations/updateProductVariant.js
@@ -1,106 +1,5 @@
-import SimpleSchema from "simpl-schema";
 import ReactionError from "@reactioncommerce/reaction-error";
-
-const metafieldInputSchema = new SimpleSchema({
-  key: {
-    type: String,
-    max: 30,
-    optional: true
-  },
-  namespace: {
-    type: String,
-    max: 20,
-    optional: true
-  },
-  scope: {
-    type: String,
-    optional: true
-  },
-  value: {
-    type: String,
-    optional: true
-  },
-  valueType: {
-    type: String,
-    optional: true
-  },
-  description: {
-    type: String,
-    optional: true
-  }
-});
-
-const inputSchema = new SimpleSchema({
-  "attributeLabel": {
-    type: String,
-    optional: true
-  },
-  "barcode": {
-    type: String,
-    optional: true
-  },
-  "height": {
-    type: Number,
-    min: 0,
-    optional: true
-  },
-  "index": {
-    type: SimpleSchema.Integer,
-    optional: true
-  },
-  "isDeleted": {
-    type: Boolean,
-    optional: true
-  },
-  "isVisible": {
-    type: Boolean,
-    optional: true
-  },
-  "length": {
-    type: Number,
-    min: 0,
-    optional: true
-  },
-  "metafields": {
-    type: Array,
-    optional: true
-  },
-  "metafields.$": {
-    type: metafieldInputSchema
-  },
-  "minOrderQuantity": {
-    type: SimpleSchema.Integer,
-    optional: true
-  },
-  "optionTitle": {
-    type: String,
-    optional: true
-  },
-  "originCountry": {
-    type: String,
-    optional: true
-  },
-  "sku": {
-    type: String,
-    optional: true
-  },
-  "title": {
-    type: String,
-    optional: true
-  },
-  "weight": {
-    type: Number,
-    min: 0,
-    optional: true,
-    defaultValue: 0
-  },
-  "width": {
-    type: Number,
-    min: 0,
-    optional: true
-  }
-});
-
+import { ProductVariantInputSchema } from "../simpleSchemas.js";
 
 /**
  * @method updateProductVariant
@@ -125,7 +24,7 @@ export default async function updateProductVariant(context, input) {
     { shopId }
   );
 
-  inputSchema.validate(variantInput);
+  ProductVariantInputSchema.validate(variantInput);
   const fields = Object.keys(variantInput);
   if (fields.length === 0) throw new ReactionError("invalid-param", "At least one field to update must be provided");
 

--- a/src/core-services/product/simpleSchemas.js
+++ b/src/core-services/product/simpleSchemas.js
@@ -414,3 +414,99 @@ export const Product = new SimpleSchema({
     optional: true
   }
 });
+
+export const ProductVariantInputSchema = new SimpleSchema({
+  "attributeLabel": {
+    type: String,
+    optional: true
+  },
+  "barcode": {
+    type: String,
+    optional: true
+  },
+  "height": {
+    type: Number,
+    min: 0,
+    optional: true
+  },
+  "index": {
+    type: SimpleSchema.Integer,
+    optional: true
+  },
+  "isDeleted": {
+    type: Boolean,
+    optional: true
+  },
+  "isVisible": {
+    type: Boolean,
+    optional: true
+  },
+  "length": {
+    type: Number,
+    min: 0,
+    optional: true
+  },
+  "metafields": {
+    type: Array,
+    optional: true
+  },
+  "metafields.$": new SimpleSchema({
+    key: {
+      type: String,
+      max: 30,
+      optional: true
+    },
+    namespace: {
+      type: String,
+      max: 20,
+      optional: true
+    },
+    scope: {
+      type: String,
+      optional: true
+    },
+    value: {
+      type: String,
+      optional: true
+    },
+    valueType: {
+      type: String,
+      optional: true
+    },
+    description: {
+      type: String,
+      optional: true
+    }
+  }),
+  "minOrderQuantity": {
+    type: SimpleSchema.Integer,
+    optional: true
+  },
+  "optionTitle": {
+    type: String,
+    optional: true
+  },
+  "originCountry": {
+    type: String,
+    optional: true
+  },
+  "sku": {
+    type: String,
+    optional: true
+  },
+  "title": {
+    type: String,
+    optional: true
+  },
+  "weight": {
+    type: Number,
+    min: 0,
+    optional: true,
+    defaultValue: 0
+  },
+  "width": {
+    type: Number,
+    min: 0,
+    optional: true
+  }
+});

--- a/src/core-services/taxes/schemas/schema.graphql
+++ b/src/core-services/taxes/schemas/schema.graphql
@@ -166,6 +166,17 @@ extend type ShopSettings {
   primaryTaxServiceName: String
 }
 
+extend type ProductVariant {
+  "Whether this variant is taxable"
+  isTaxable: Boolean
+
+  "Tax code"
+  taxCode: String
+
+  "Tax description"
+  taxDescription: String
+}
+
 extend input ShopSettingsUpdates {
   "The default value to use for `taxCode` property of a product"
   defaultTaxCode: String
@@ -182,4 +193,15 @@ extend input ShopSettingsUpdates {
   query. There will be no taxes charged for any carts or orders if this is not set.
   """
   primaryTaxServiceName: String
+}
+
+extend input ProductVariantInput {
+  "Whether this variant is taxable"
+  isTaxable: Boolean
+
+  "Tax code"
+  taxCode: String
+
+  "Tax description"
+  taxDescription: String
 }

--- a/src/core-services/taxes/simpleSchemas.js
+++ b/src/core-services/taxes/simpleSchemas.js
@@ -119,7 +119,8 @@ export function extendTaxesSchemas(schemas) {
     CatalogProductVariant,
     OrderFulfillmentGroup,
     OrderItem,
-    ProductVariant
+    ProductVariant,
+    ProductVariantInputSchema
   } = schemas;
 
   Cart.extend({
@@ -193,7 +194,7 @@ export function extendTaxesSchemas(schemas) {
     "taxes.$": Taxes
   });
 
-  ProductVariant.extend({
+  const productVariantSchemaExtension = {
     isTaxable: {
       type: Boolean,
       optional: true
@@ -206,9 +207,11 @@ export function extendTaxesSchemas(schemas) {
       type: String,
       optional: true
     }
-  });
+  };
 
   // Extend the catalog variant database schemas
   CatalogProductVariant.extend(variantSchemaExtension);
   CatalogProductOption.extend(variantSchemaExtension);
+  ProductVariant.extend(productVariantSchemaExtension);
+  ProductVariantInputSchema.extend(productVariantSchemaExtension);
 }

--- a/tests/integration/api/mutations/updateProduct/updateProduct.test.js
+++ b/tests/integration/api/mutations/updateProduct/updateProduct.test.js
@@ -165,6 +165,9 @@ test("expect product variant fields to be updated", async () => {
     variant: {
       title: "Updated variant title",
       attributeLabel: "color",
+      isTaxable: true,
+      taxCode: "1234",
+      taxDescription: "tax description",
       metafields: [
         { key: "size", value: "small" },
         { key: "pattern", value: "striped" }
@@ -181,6 +184,9 @@ test("expect product variant fields to be updated", async () => {
 
   expect(result.updateProductVariant.variant.title).toEqual("Updated variant title");
   expect(result.updateProductVariant.variant.attributeLabel).toEqual("color");
+  expect(result.updateProductVariant.variant.isTaxable).toEqual(true);
+  expect(result.updateProductVariant.variant.taxCode).toEqual("1234");
+  expect(result.updateProductVariant.variant.taxDescription).toEqual("tax description");
   expect(result.updateProductVariant.variant.metafields).toEqual([
     { key: "size", value: "small" },
     { key: "pattern", value: "striped" }

--- a/tests/integration/api/mutations/updateProduct/updateProductVariantMutation.graphql
+++ b/tests/integration/api/mutations/updateProduct/updateProductVariantMutation.graphql
@@ -29,6 +29,9 @@ mutation($variantId: ID!, $shopId: ID!, $variant: ProductVariantInput!) {
       updatedAt
       weight
       width
+      isTaxable
+      taxCode
+      taxDescription
     }
   }
 }

--- a/tests/util/factory.js
+++ b/tests/util/factory.js
@@ -47,7 +47,8 @@ import {
 
 import {
   Product,
-  ProductVariant
+  ProductVariant,
+  ProductVariantInputSchema,
 } from "../../src/core-services/product/simpleSchemas.js";
 
 import {
@@ -131,6 +132,7 @@ const schemasToAddToFactory = {
   Payment,
   Product,
   ProductVariant,
+  ProductVariantInputSchema,
   Restriction,
   ShipmentQuote,
   Shop,

--- a/tests/util/factory.js
+++ b/tests/util/factory.js
@@ -48,7 +48,7 @@ import {
 import {
   Product,
   ProductVariant,
-  ProductVariantInputSchema,
+  ProductVariantInputSchema
 } from "../../src/core-services/product/simpleSchemas.js";
 
 import {


### PR DESCRIPTION
Resolves #6088 
Impact: **critical**
Type: **bugfix**

## Issue

Fields `isTaxable`, `taxCode` and `taxDescription` where not available for product variants. They are present for `CatalogProductVariant` and `CatalogProductOption`

## Solution

- Extend GQL ProductVariant schemas
- Extend product variant input schema to add missing fields

## Breaking changes

none

## Testing
1. Updated integration test should pass
1. Run the query below and ensure they values update in the DB / results

```
mutation updateProductVariant {
  updateProductVariant(input: {
    variant: {
      isTaxable: true
      taxCode: "1234"
      taxDescription: "desc"
    }
    variantId: "VARIANT_ID"
    shopId: "SHOP_ID"
  }) {
    variant {
      _id
      isTaxable
      taxCode
      taxDescription
    }
  }
}
```
