### PR TITLE
release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.0
 
-Reaction v3.2.0 enables Federated Gateway capability for the API, moves the `simple-authorization` and `system-information` plugins into their own `npm` packages, and adds an `updateProductsVisibility` GraphQL mutation to the API.
+Reaction v3.2.0 introduces Federated Gateway capability for the API, moves the `simple-authorization` and `system-information` plugins into their own `npm` packages, and adds an `updateProductsVisibility` GraphQL mutation to the API.
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# v3.2.0
+
+Reaction v3.2.0 enables Federated Gateway capability for the API, moves the `simple-authorization` and `system-information` plugins into their own `npm` packages, and adds an `updateProductsVisibility` GraphQL mutation to the API.
+
+## Features
+
+- feat: add gateway capabilities to API ([#6100](https://github.com/reactioncommerce/reaction/pull/6100))
+- feat: add updateProductsVisibility mutation ([#6104](https://github.com/reactioncommerce/reaction/pull/6104))
+
+## Refactor
+
+- refactor: move system information plugin to npm ([#6105](https://github.com/reactioncommerce/reaction/pull/6105))
+- refactor: replace internal authentication plugin with NPM installed plugin-authentication ([#6108](https://github.com/reactioncommerce/reaction/pull/6108))
+
+## Chores
+
+- chore: update `plugin-simple-authorization` package ([#6110](https://github.com/reactioncommerce/reaction/pull/6110))
+
 # v3.1.0
 
 Reaction v3.1.0 moves our `simple-authorization` plugin (formerly `legacy-permission`) into it's own `npm` package to set up the pattern of installing Reaction API plugins from `npm`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   api:
-    image: reactioncommerce/reaction:3.1.0
+    image: reactioncommerce/reaction:3.2.0
     depends_on:
       - mongo
     env_file:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5417,9 +5417,9 @@
       }
     },
     "@octokit/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-iEeW3XlkxeM/CObeoYvbUv24Oe+DldGofY+3QyeJ5XKKA6B+V94ePk14EDCarseWdMs6afKZPv3dFq8C+SY5lw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-rvJP1Y9A/+Cky2C3var1vsw3Lf5Rjn/0sojNl2AjCX+WbpIHYccaJ46abrZoIxMYnOToul6S9tPytUVkFI7CXQ==",
       "requires": {
         "@types/node": ">= 8"
       }
@@ -5677,9 +5677,9 @@
       }
     },
     "@reactioncommerce/plugin-simple-authorization": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/plugin-simple-authorization/-/plugin-simple-authorization-1.0.1.tgz",
-      "integrity": "sha512-L4e0fmgIpfoECnCgmUcPVZeI7XGB/oEAq6GDAGwJ8EoqGYvIl29JVT9BJX88KmeGaWbdTWt9Z5VfKb9+crjR5Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/plugin-simple-authorization/-/plugin-simple-authorization-1.0.2.tgz",
+      "integrity": "sha512-0+DyEKellBTMA11PsB0NR09fvJfXVW5VKvwcjBUPHeq3Oh1cvYeEhVlRAljT472niUbwtfwP7gsM3fr7uJSFFg==",
       "requires": {
         "@reactioncommerce/db-version-check": "^1.0.0",
         "@reactioncommerce/logger": "^1.1.3",
@@ -21156,9 +21156,9 @@
       "integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw=="
     },
     "npm": {
-      "version": "6.13.7",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.7.tgz",
-      "integrity": "sha512-X967EKTT407CvgrWFjXusnPh0VLERcmR9hZFSVgkEquOomZkvpwLJ5zrQ3qrG9SpPLKJE4bPLUu76exKQ4a3Cg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.0.tgz",
+      "integrity": "sha512-OgfdLadz7j6dikbpaimmLzMxwLKbXthQXHiJwtegorwtBVnhecfUeYkHopwd5ICaiClQnqlYQCHERXDiYK3Jcw==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -21171,7 +21171,7 @@
         "byte-size": "^5.0.1",
         "cacache": "^12.0.3",
         "call-limit": "^1.1.1",
-        "chownr": "^1.1.3",
+        "chownr": "^1.1.4",
         "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.5.1",
@@ -21191,7 +21191,7 @@
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.3",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.8.5",
+        "hosted-git-info": "^2.8.6",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
         "infer-owner": "^1.0.4",
@@ -21236,10 +21236,10 @@
         "npm-install-checks": "^3.0.2",
         "npm-lifecycle": "^3.1.4",
         "npm-package-arg": "^6.1.1",
-        "npm-packlist": "^1.4.7",
+        "npm-packlist": "^1.4.8",
         "npm-pick-manifest": "^3.0.2",
         "npm-profile": "^4.0.2",
-        "npm-registry-fetch": "^4.0.2",
+        "npm-registry-fetch": "^4.0.3",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
@@ -21256,7 +21256,7 @@
         "read-installed": "~4.0.3",
         "read-package-json": "^2.1.1",
         "read-package-tree": "^5.3.1",
-        "readable-stream": "^3.4.0",
+        "readable-stream": "^3.6.0",
         "readdir-scoped-modules": "^1.1.0",
         "request": "^2.88.0",
         "retry": "^0.12.0",
@@ -21287,8 +21287,7 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.5",
-          "resolved": false,
-          "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+          "bundled": true,
           "requires": {
             "jsonparse": "^1.2.0",
             "through": ">=2.2.7 <3"
@@ -21296,29 +21295,25 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+          "bundled": true
         },
         "agent-base": {
           "version": "4.3.0",
-          "resolved": false,
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "bundled": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
           "version": "3.5.2",
-          "resolved": false,
-          "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+          "bundled": true,
           "requires": {
             "humanize-ms": "^1.2.1"
           }
         },
         "ajv": {
           "version": "5.5.2",
-          "resolved": false,
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "bundled": true,
           "requires": {
             "co": "^4.6.0",
             "fast-deep-equal": "^1.0.0",
@@ -21328,49 +21323,41 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+          "bundled": true,
           "requires": {
             "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "bundled": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": false,
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "bundled": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": false,
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+          "bundled": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": false,
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
+          "bundled": true
         },
         "aproba": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+          "bundled": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -21378,8 +21365,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -21392,8 +21378,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -21402,46 +21387,38 @@
         },
         "asap": {
           "version": "2.0.6",
-          "resolved": false,
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+          "bundled": true
         },
         "asn1": {
           "version": "0.2.4",
-          "resolved": false,
-          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "bundled": true,
           "requires": {
             "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "bundled": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": false,
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+          "bundled": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "resolved": false,
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+          "bundled": true
         },
         "aws4": {
           "version": "1.8.0",
-          "resolved": false,
-          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+          "bundled": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "tweetnacl": "^0.14.3"
@@ -21449,8 +21426,7 @@
         },
         "bin-links": {
           "version": "1.1.7",
-          "resolved": false,
-          "integrity": "sha512-/eaLaTu7G7/o7PV04QPy1HRT65zf+1tFkPGv0sPTV0tRwufooYBQO3zrcyGgm+ja+ZtBf2GEuKjDRJ2pPG+yqA==",
+          "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",
             "cmd-shim": "^3.0.0",
@@ -21462,13 +21438,11 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "resolved": false,
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+          "bundled": true
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+          "bundled": true,
           "requires": {
             "ansi-align": "^2.0.0",
             "camelcase": "^4.0.0",
@@ -21481,8 +21455,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -21490,28 +21463,23 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+          "bundled": true
         },
         "builtins": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+          "bundled": true
         },
         "byline": {
           "version": "5.0.0",
-          "resolved": false,
-          "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+          "bundled": true
         },
         "byte-size": {
           "version": "5.0.1",
-          "resolved": false,
-          "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw=="
+          "bundled": true
         },
         "cacache": {
           "version": "12.0.3",
-          "resolved": false,
-          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+          "bundled": true,
           "requires": {
             "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
@@ -21532,28 +21500,23 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ=="
+          "bundled": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": false,
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "bundled": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+          "bundled": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": false,
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+          "bundled": true
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": false,
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "bundled": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -21561,32 +21524,27 @@
           }
         },
         "chownr": {
-          "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+          "version": "1.1.4",
+          "bundled": true
         },
         "ci-info": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+          "bundled": true
         },
         "cidr-regex": {
           "version": "2.0.10",
-          "resolved": false,
-          "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
+          "bundled": true,
           "requires": {
             "ip-regex": "^2.1.0"
           }
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+          "bundled": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "resolved": false,
-          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
+          "bundled": true,
           "requires": {
             "string-width": "^2.0.0",
             "strip-ansi": "^3.0.1"
@@ -21594,8 +21552,7 @@
         },
         "cli-table3": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+          "bundled": true,
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
@@ -21604,8 +21561,7 @@
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": false,
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "bundled": true,
           "requires": {
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0",
@@ -21614,13 +21570,11 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "bundled": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "bundled": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -21629,13 +21583,11 @@
         },
         "clone": {
           "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+          "bundled": true
         },
         "cmd-shim": {
           "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
+          "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "mkdirp": "~0.5.0"
@@ -21643,37 +21595,31 @@
         },
         "co": {
           "version": "4.6.0",
-          "resolved": false,
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "bundled": true
         },
         "color-convert": {
           "version": "1.9.1",
-          "resolved": false,
-          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+          "bundled": true,
           "requires": {
             "color-name": "^1.1.1"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "bundled": true
         },
         "colors": {
           "version": "1.3.3",
-          "resolved": false,
-          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+          "bundled": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": false,
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+          "bundled": true,
           "requires": {
             "strip-ansi": "^3.0.0",
             "wcwidth": "^1.0.0"
@@ -21681,21 +21627,18 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "bundled": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "bundled": true
         },
         "concat-stream": {
           "version": "1.6.2",
-          "resolved": false,
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "bundled": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -21705,8 +21648,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -21719,8 +21661,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -21729,8 +21670,7 @@
         },
         "config-chain": {
           "version": "1.1.12",
-          "resolved": false,
-          "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+          "bundled": true,
           "requires": {
             "ini": "^1.3.4",
             "proto-list": "~1.2.1"
@@ -21738,8 +21678,7 @@
         },
         "configstore": {
           "version": "3.1.2",
-          "resolved": false,
-          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+          "bundled": true,
           "requires": {
             "dot-prop": "^4.1.0",
             "graceful-fs": "^4.1.2",
@@ -21751,13 +21690,11 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "bundled": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+          "bundled": true,
           "requires": {
             "aproba": "^1.1.1",
             "fs-write-stream-atomic": "^1.0.8",
@@ -21769,33 +21706,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+              "bundled": true
             },
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+              "bundled": true
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+          "bundled": true
         },
         "create-error-class": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+          "bundled": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
           }
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": false,
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "bundled": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -21804,8 +21736,7 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.5",
-              "resolved": false,
-              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+              "bundled": true,
               "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -21813,104 +21744,87 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": false,
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+              "bundled": true
             }
           }
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+          "bundled": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "resolved": false,
-          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+          "bundled": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": false,
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "bundled": true,
           "requires": {
             "ms": "2.0.0"
           },
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "bundled": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+          "bundled": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+          "bundled": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": false,
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+          "bundled": true
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
+          "bundled": true
         },
         "defaults": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+          "bundled": true,
           "requires": {
             "clone": "^1.0.2"
           }
         },
         "define-properties": {
           "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "bundled": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+          "bundled": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "resolved": false,
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+          "bundled": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+          "bundled": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+          "bundled": true,
           "requires": {
             "asap": "^2.0.0",
             "wrappy": "1"
@@ -21918,26 +21832,22 @@
         },
         "dot-prop": {
           "version": "4.2.0",
-          "resolved": false,
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "bundled": true,
           "requires": {
             "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
           "version": "5.0.1",
-          "resolved": false,
-          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+          "bundled": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+          "bundled": true
         },
         "duplexify": {
           "version": "3.6.0",
-          "resolved": false,
-          "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+          "bundled": true,
           "requires": {
             "end-of-stream": "^1.0.0",
             "inherits": "^2.0.1",
@@ -21947,8 +21857,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -21961,8 +21870,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -21971,8 +21879,7 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "resolved": false,
-          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "jsbn": "~0.1.0",
@@ -21981,47 +21888,40 @@
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
+          "bundled": true
         },
         "encoding": {
           "version": "0.1.12",
-          "resolved": false,
-          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+          "bundled": true,
           "requires": {
             "iconv-lite": "~0.4.13"
           }
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "resolved": false,
-          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+          "bundled": true,
           "requires": {
             "once": "^1.4.0"
           }
         },
         "env-paths": {
           "version": "2.2.0",
-          "resolved": false,
-          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+          "bundled": true
         },
         "err-code": {
           "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+          "bundled": true
         },
         "errno": {
           "version": "0.1.7",
-          "resolved": false,
-          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+          "bundled": true,
           "requires": {
             "prr": "~1.0.1"
           }
         },
         "es-abstract": {
           "version": "1.12.0",
-          "resolved": false,
-          "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+          "bundled": true,
           "requires": {
             "es-to-primitive": "^1.1.1",
             "function-bind": "^1.1.1",
@@ -22032,8 +21932,7 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+          "bundled": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -22042,26 +21941,22 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "resolved": false,
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+          "bundled": true
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "resolved": false,
-          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+          "bundled": true,
           "requires": {
             "es6-promise": "^4.0.3"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "bundled": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": false,
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "bundled": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -22074,53 +21969,44 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+              "bundled": true
             }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+          "bundled": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+          "bundled": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+          "bundled": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+          "bundled": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "resolved": false,
-          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+          "bundled": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
+          "bundled": true
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "bundled": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+          "bundled": true,
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.4"
@@ -22128,8 +22014,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -22142,8 +22027,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -22152,13 +22036,11 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": false,
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+          "bundled": true
         },
         "form-data": {
           "version": "2.3.2",
-          "resolved": false,
-          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "bundled": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
@@ -22167,8 +22049,7 @@
         },
         "from2": {
           "version": "2.3.0",
-          "resolved": false,
-          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+          "bundled": true,
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
@@ -22176,8 +22057,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -22190,8 +22070,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -22200,16 +22079,14 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "resolved": false,
-          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "bundled": true,
           "requires": {
             "minipass": "^2.6.0"
           },
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": false,
-              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -22219,8 +22096,7 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "resolved": false,
-          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "path-is-inside": "^1.0.1",
@@ -22229,8 +22105,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "resolved": false,
-          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "iferr": "^0.1.5",
@@ -22240,13 +22115,11 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+              "bundled": true
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -22259,8 +22132,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -22269,18 +22141,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+          "bundled": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -22294,13 +22163,11 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+              "bundled": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -22311,13 +22178,11 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "resolved": false,
-          "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA=="
+          "bundled": true
         },
         "gentle-fs": {
           "version": "2.3.0",
-          "resolved": false,
-          "integrity": "sha512-3k2CgAmPxuz7S6nKK+AqFE2AdM1QuwqKLPKzIET3VRwK++3q96MsNFobScDjlCrq97ZJ8y5R725MOlm6ffUCjg==",
+          "bundled": true,
           "requires": {
             "aproba": "^1.1.2",
             "chownr": "^1.1.2",
@@ -22334,41 +22199,35 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+              "bundled": true
             },
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+              "bundled": true
             }
           }
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+          "bundled": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": false,
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "bundled": true,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": false,
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "glob": {
           "version": "7.1.4",
-          "resolved": false,
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -22380,16 +22239,14 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+          "bundled": true,
           "requires": {
             "ini": "^1.3.4"
           }
         },
         "got": {
           "version": "6.7.1",
-          "resolved": false,
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "bundled": true,
           "requires": {
             "create-error-class": "^3.0.0",
             "duplexer3": "^0.1.4",
@@ -22406,25 +22263,21 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+              "bundled": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.2.3",
-          "resolved": false,
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+          "bundled": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+          "bundled": true
         },
         "har-validator": {
           "version": "5.1.0",
-          "resolved": false,
-          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "bundled": true,
           "requires": {
             "ajv": "^5.3.0",
             "har-schema": "^2.0.0"
@@ -22432,41 +22285,34 @@
         },
         "has": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "bundled": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "bundled": true
         },
         "has-symbols": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+          "bundled": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+          "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.8.5",
-          "resolved": false,
-          "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+          "version": "2.8.6",
+          "bundled": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "resolved": false,
-          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+          "bundled": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+          "bundled": true,
           "requires": {
             "agent-base": "4",
             "debug": "3.1.0"
@@ -22474,8 +22320,7 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "bundled": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
@@ -22484,8 +22329,7 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "resolved": false,
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "bundled": true,
           "requires": {
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
@@ -22493,52 +22337,44 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+          "bundled": true,
           "requires": {
             "ms": "^2.0.0"
           }
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "resolved": false,
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "bundled": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "iferr": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg=="
+          "bundled": true
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+          "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "import-lazy": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+          "bundled": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+          "bundled": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
+          "bundled": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -22546,18 +22382,15 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+          "bundled": true
         },
         "init-package-json": {
           "version": "1.10.3",
-          "resolved": false,
-          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+          "bundled": true,
           "requires": {
             "glob": "^7.1.1",
             "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -22571,64 +22404,54 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+          "bundled": true
         },
         "ip": {
           "version": "1.1.5",
-          "resolved": false,
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+          "bundled": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+          "bundled": true
         },
         "is-callable": {
           "version": "1.1.4",
-          "resolved": false,
-          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+          "bundled": true
         },
         "is-ci": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+          "bundled": true,
           "requires": {
             "ci-info": "^1.0.0"
           },
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "resolved": false,
-              "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+              "bundled": true
             }
           }
         },
         "is-cidr": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
+          "bundled": true,
           "requires": {
             "cidr-regex": "^2.0.10"
           }
         },
         "is-date-object": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+          "bundled": true,
           "requires": {
             "global-dirs": "^0.1.0",
             "is-path-inside": "^1.0.0"
@@ -22636,108 +22459,89 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+          "bundled": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+          "bundled": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+          "bundled": true,
           "requires": {
             "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+          "bundled": true
         },
         "is-regex": {
           "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+          "bundled": true,
           "requires": {
             "has": "^1.0.1"
           }
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+          "bundled": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+          "bundled": true
         },
         "is-symbol": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+          "bundled": true,
           "requires": {
             "has-symbols": "^1.0.0"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+          "bundled": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "bundled": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": false,
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+          "bundled": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": false,
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+          "bundled": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": false,
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+          "bundled": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": false,
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+          "bundled": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+          "bundled": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": false,
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "bundled": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -22747,29 +22551,25 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+          "bundled": true,
           "requires": {
             "package-json": "^4.0.0"
           }
         },
         "lazy-property": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
+          "bundled": true
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "bundled": true,
           "requires": {
             "invert-kv": "^2.0.0"
           }
         },
         "libcipm": {
           "version": "4.0.7",
-          "resolved": false,
-          "integrity": "sha512-fTq33otU3PNXxxCTCYCYe7V96o59v/o7bvtspmbORXpgFk+wcWrGf5x6tBgui5gCed/45/wtPomBsZBYm5KbIw==",
+          "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
@@ -22790,8 +22590,7 @@
         },
         "libnpm": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
+          "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.3",
@@ -22817,8 +22616,7 @@
         },
         "libnpmaccess": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
+          "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "get-stream": "^4.0.0",
@@ -22828,8 +22626,7 @@
         },
         "libnpmconfig": {
           "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+          "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "find-up": "^3.0.0",
@@ -22838,16 +22635,14 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "bundled": true,
               "requires": {
                 "locate-path": "^3.0.0"
               }
             },
             "locate-path": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "bundled": true,
               "requires": {
                 "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
@@ -22855,31 +22650,27 @@
             },
             "p-limit": {
               "version": "2.2.0",
-              "resolved": false,
-              "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+              "bundled": true,
               "requires": {
                 "p-try": "^2.0.0"
               }
             },
             "p-locate": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "bundled": true,
               "requires": {
                 "p-limit": "^2.0.0"
               }
             },
             "p-try": {
               "version": "2.2.0",
-              "resolved": false,
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+              "bundled": true
             }
           }
         },
         "libnpmhook": {
           "version": "5.0.3",
-          "resolved": false,
-          "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
+          "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -22889,8 +22680,7 @@
         },
         "libnpmorg": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
+          "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -22900,8 +22690,7 @@
         },
         "libnpmpublish": {
           "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
+          "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.5.1",
@@ -22916,8 +22705,7 @@
         },
         "libnpmsearch": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
+          "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.0.0",
@@ -22926,8 +22714,7 @@
         },
         "libnpmteam": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
+          "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -22937,8 +22724,7 @@
         },
         "libnpx": {
           "version": "10.2.2",
-          "resolved": false,
-          "integrity": "sha512-ujaYToga1SAX5r7FU5ShMFi88CWpY75meNZtr6RtEyv4l2ZK3+Wgvxq2IqlwWBiDZOqhumdeiocPS1aKrCMe3A==",
+          "bundled": true,
           "requires": {
             "dotenv": "^5.0.1",
             "npm-package-arg": "^6.0.0",
@@ -22952,8 +22738,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "bundled": true,
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -22961,8 +22746,7 @@
         },
         "lock-verify": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
+          "bundled": true,
           "requires": {
             "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
@@ -22970,21 +22754,18 @@
         },
         "lockfile": {
           "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+          "bundled": true,
           "requires": {
             "signal-exit": "^3.0.2"
           }
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "resolved": false,
-          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
+          "bundled": true,
           "requires": {
             "lodash._createset": "~4.0.0",
             "lodash._root": "~3.0.0"
@@ -22992,87 +22773,72 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": false,
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+          "bundled": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "resolved": false,
-          "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
+          "bundled": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": false,
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+          "bundled": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "resolved": false,
-          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+          "bundled": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": false,
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "resolved": false,
-          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+          "bundled": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "resolved": false,
-          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+          "bundled": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "resolved": false,
-          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
+          "bundled": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+          "bundled": true
         },
         "lru-cache": {
           "version": "5.1.1",
-          "resolved": false,
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "bundled": true,
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "bundled": true,
           "requires": {
             "pify": "^3.0.0"
           }
         },
         "make-fetch-happen": {
           "version": "5.0.2",
-          "resolved": false,
-          "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
+          "bundled": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
             "cacache": "^12.0.0",
@@ -23089,21 +22855,18 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "resolved": false,
-          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+          "bundled": true,
           "requires": {
             "p-defer": "^1.0.0"
           }
         },
         "meant": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg=="
+          "bundled": true
         },
         "mem": {
           "version": "4.3.0",
-          "resolved": false,
-          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "bundled": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
             "mimic-fn": "^2.0.0",
@@ -23112,49 +22875,42 @@
           "dependencies": {
             "mimic-fn": {
               "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+              "bundled": true
             }
           }
         },
         "mime-db": {
           "version": "1.35.0",
-          "resolved": false,
-          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+          "bundled": true
         },
         "mime-types": {
           "version": "2.1.19",
-          "resolved": false,
-          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+          "bundled": true,
           "requires": {
             "mime-db": "~1.35.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "bundled": true
         },
         "minizlib": {
           "version": "1.3.3",
-          "resolved": false,
-          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "bundled": true,
           "requires": {
             "minipass": "^2.9.0"
           },
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": false,
-              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -23164,8 +22920,7 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+          "bundled": true,
           "requires": {
             "concat-stream": "^1.5.0",
             "duplexify": "^3.4.2",
@@ -23181,16 +22936,14 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+          "bundled": true,
           "requires": {
             "aproba": "^1.1.1",
             "copy-concurrently": "^1.0.0",
@@ -23202,30 +22955,25 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+              "bundled": true
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "bundled": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "resolved": false,
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+          "bundled": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+          "bundled": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+          "bundled": true,
           "requires": {
             "encoding": "^0.1.11",
             "json-parse-better-errors": "^1.0.0",
@@ -23234,8 +22982,7 @@
         },
         "node-gyp": {
           "version": "5.0.7",
-          "resolved": false,
-          "integrity": "sha512-K8aByl8OJD51V0VbUURTKsmdswkQQusIvlvmTyhHlIT1hBvaSxzdxpSle857XuXa7uc02UEZx9OR5aDxSWS5Qw==",
+          "bundled": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
@@ -23252,8 +22999,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -23261,8 +23007,7 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "resolved": false,
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "bundled": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
@@ -23272,8 +23017,7 @@
           "dependencies": {
             "resolve": {
               "version": "1.10.0",
-              "resolved": false,
-              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+              "bundled": true,
               "requires": {
                 "path-parse": "^1.0.6"
               }
@@ -23282,8 +23026,7 @@
         },
         "npm-audit-report": {
           "version": "1.3.2",
-          "resolved": false,
-          "integrity": "sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==",
+          "bundled": true,
           "requires": {
             "cli-table3": "^0.5.0",
             "console-control-strings": "^1.1.0"
@@ -23291,29 +23034,25 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+          "bundled": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
+          "bundled": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
+          "bundled": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
           "version": "3.1.4",
-          "resolved": false,
-          "integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
+          "bundled": true,
           "requires": {
             "byline": "^5.0.0",
             "graceful-fs": "^4.1.15",
@@ -23327,18 +23066,15 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg=="
+          "bundled": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+          "bundled": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "resolved": false,
-          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
+          "bundled": true,
           "requires": {
             "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
@@ -23347,18 +23083,17 @@
           }
         },
         "npm-packlist": {
-          "version": "1.4.7",
-          "resolved": false,
-          "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
+          "version": "1.4.8",
+          "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
+          "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
@@ -23367,8 +23102,7 @@
         },
         "npm-profile": {
           "version": "4.0.2",
-          "resolved": false,
-          "integrity": "sha512-VRsC04pvRH+9cF+PoVh2nTmJjiG21yu59IHpsBpkxk+jaGAV8lxx96G4SDc0jOHAkfWLXbc6kIph3dGAuRnotQ==",
+          "bundled": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
             "figgy-pudding": "^3.4.1",
@@ -23376,9 +23110,8 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.2",
-          "resolved": false,
-          "integrity": "sha512-Z0IFtPEozNdeZRPh3aHHxdG+ZRpzcbQaJLthsm3VhNf6DScicTFRHZzK82u8RsJUsUHkX+QH/zcB/5pmd20H4A==",
+          "version": "4.0.3",
+          "bundled": true,
           "requires": {
             "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
@@ -23391,28 +23124,24 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "resolved": false,
-              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+              "bundled": true
             }
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "requires": {
             "path-key": "^2.0.0"
           }
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
+          "bundled": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -23422,28 +23151,23 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "resolved": false,
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "bundled": true
         },
         "object-keys": {
           "version": "1.0.12",
-          "resolved": false,
-          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+          "bundled": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+          "bundled": true,
           "requires": {
             "define-properties": "^1.1.2",
             "es-abstract": "^1.5.1"
@@ -23451,26 +23175,22 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "opener": {
           "version": "1.5.1",
-          "resolved": false,
-          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
+          "bundled": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+          "bundled": true
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "bundled": true,
           "requires": {
             "execa": "^1.0.0",
             "lcid": "^2.0.0",
@@ -23479,8 +23199,7 @@
           "dependencies": {
             "cross-spawn": {
               "version": "6.0.5",
-              "resolved": false,
-              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+              "bundled": true,
               "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -23491,8 +23210,7 @@
             },
             "execa": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+              "bundled": true,
               "requires": {
                 "cross-spawn": "^6.0.0",
                 "get-stream": "^4.0.0",
@@ -23507,13 +23225,11 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -23521,44 +23237,37 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+          "bundled": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+          "bundled": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+          "bundled": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+          "bundled": true,
           "requires": {
             "p-try": "^1.0.0"
           }
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "bundled": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+          "bundled": true
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+          "bundled": true,
           "requires": {
             "got": "^6.7.1",
             "registry-auth-token": "^3.0.1",
@@ -23568,8 +23277,7 @@
         },
         "pacote": {
           "version": "9.5.12",
-          "resolved": false,
-          "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
+          "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",
             "cacache": "^12.0.2",
@@ -23605,8 +23313,7 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": false,
-              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -23616,8 +23323,7 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+          "bundled": true,
           "requires": {
             "cyclist": "~0.2.2",
             "inherits": "^2.0.3",
@@ -23626,8 +23332,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -23640,8 +23345,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -23650,58 +23354,47 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+          "bundled": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+          "bundled": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+          "bundled": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+          "bundled": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+          "bundled": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+          "bundled": true
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "bundled": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+          "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+          "bundled": true
         },
         "promise-retry": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+          "bundled": true,
           "requires": {
             "err-code": "^1.0.0",
             "retry": "^0.10.0"
@@ -23709,51 +23402,43 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "resolved": false,
-              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+              "bundled": true
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
-          "resolved": false,
-          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+          "bundled": true,
           "requires": {
             "read": "1"
           }
         },
         "proto-list": {
           "version": "1.2.4",
-          "resolved": false,
-          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+          "bundled": true
         },
         "protoduck": {
           "version": "5.0.1",
-          "resolved": false,
-          "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+          "bundled": true,
           "requires": {
             "genfun": "^5.0.0"
           }
         },
         "prr": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+          "bundled": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+          "bundled": true
         },
         "psl": {
           "version": "1.1.29",
-          "resolved": false,
-          "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+          "bundled": true
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "bundled": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -23761,8 +23446,7 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "resolved": false,
-          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+          "bundled": true,
           "requires": {
             "duplexify": "^3.6.0",
             "inherits": "^2.0.3",
@@ -23771,8 +23455,7 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+              "bundled": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -23782,23 +23465,19 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": false,
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "bundled": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "resolved": false,
-          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="
+          "bundled": true
         },
         "qs": {
           "version": "6.5.2",
-          "resolved": false,
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "bundled": true
         },
         "query-string": {
           "version": "6.8.2",
-          "resolved": false,
-          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
+          "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "split-on-first": "^1.0.0",
@@ -23807,13 +23486,11 @@
         },
         "qw": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ="
+          "bundled": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": false,
-          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+          "bundled": true,
           "requires": {
             "deep-extend": "^0.5.1",
             "ini": "~1.3.0",
@@ -23823,31 +23500,27 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "bundled": true
             }
           }
         },
         "read": {
           "version": "1.0.7",
-          "resolved": false,
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+          "bundled": true,
           "requires": {
             "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
           "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
+          "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": false,
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+          "bundled": true,
           "requires": {
             "debuglog": "^1.0.1",
             "graceful-fs": "^4.1.2",
@@ -23860,8 +23533,7 @@
         },
         "read-package-json": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
+          "bundled": true,
           "requires": {
             "glob": "^7.1.1",
             "graceful-fs": "^4.1.2",
@@ -23872,8 +23544,7 @@
         },
         "read-package-tree": {
           "version": "5.3.1",
-          "resolved": false,
-          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+          "bundled": true,
           "requires": {
             "read-package-json": "^2.0.0",
             "readdir-scoped-modules": "^1.0.0",
@@ -23881,9 +23552,8 @@
           }
         },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": false,
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "bundled": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -23892,8 +23562,7 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+          "bundled": true,
           "requires": {
             "debuglog": "^1.0.1",
             "dezalgo": "^1.0.0",
@@ -23903,8 +23572,7 @@
         },
         "registry-auth-token": {
           "version": "3.3.2",
-          "resolved": false,
-          "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+          "bundled": true,
           "requires": {
             "rc": "^1.1.6",
             "safe-buffer": "^5.0.1"
@@ -23912,16 +23580,14 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+          "bundled": true,
           "requires": {
             "rc": "^1.0.1"
           }
         },
         "request": {
           "version": "2.88.0",
-          "resolved": false,
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "bundled": true,
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -23947,115 +23613,96 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+          "bundled": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+          "bundled": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+          "bundled": true
         },
         "retry": {
           "version": "0.12.0",
-          "resolved": false,
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+          "bundled": true
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "bundled": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "run-queue": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+          "bundled": true,
           "requires": {
             "aproba": "^1.1.1"
           },
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+              "bundled": true
             }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+          "bundled": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": false,
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "bundled": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+          "bundled": true,
           "requires": {
             "semver": "^5.0.3"
           }
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+          "bundled": true
         },
         "sha": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
+          "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+          "bundled": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": false,
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+          "bundled": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "resolved": false,
-          "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+          "bundled": true
         },
         "socks": {
           "version": "2.3.3",
-          "resolved": false,
-          "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+          "bundled": true,
           "requires": {
             "ip": "1.1.5",
             "smart-buffer": "^4.1.0"
@@ -24063,8 +23710,7 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.2",
-          "resolved": false,
-          "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+          "bundled": true,
           "requires": {
             "agent-base": "~4.2.1",
             "socks": "~2.3.2"
@@ -24072,8 +23718,7 @@
           "dependencies": {
             "agent-base": {
               "version": "4.2.1",
-              "resolved": false,
-              "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+              "bundled": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
               }
@@ -24082,13 +23727,11 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
+          "bundled": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "resolved": false,
-          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
+          "bundled": true,
           "requires": {
             "from2": "^1.3.0",
             "stream-iterate": "^1.1.0"
@@ -24096,8 +23739,7 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "resolved": false,
-              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
+              "bundled": true,
               "requires": {
                 "inherits": "~2.0.1",
                 "readable-stream": "~1.1.10"
@@ -24105,13 +23747,11 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "resolved": false,
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+              "bundled": true
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": false,
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -24121,15 +23761,13 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": false,
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+              "bundled": true
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+          "bundled": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -24137,13 +23775,11 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+          "bundled": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "bundled": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -24151,18 +23787,15 @@
         },
         "spdx-license-ids": {
           "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
+          "bundled": true
         },
         "split-on-first": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+          "bundled": true
         },
         "sshpk": {
           "version": "1.14.2",
-          "resolved": false,
-          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+          "bundled": true,
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -24177,16 +23810,14 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": false,
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "bundled": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
           }
         },
         "stream-each": {
           "version": "1.2.2",
-          "resolved": false,
-          "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+          "bundled": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "stream-shift": "^1.0.0"
@@ -24194,8 +23825,7 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
+          "bundled": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "stream-shift": "^1.0.0"
@@ -24203,8 +23833,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -24217,8 +23846,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -24227,18 +23855,15 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+          "bundled": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+          "bundled": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "bundled": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -24246,18 +23871,15 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "bundled": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+              "bundled": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "bundled": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -24265,48 +23887,47 @@
           }
         },
         "string_decoder": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "version": "1.3.0",
+          "bundled": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true
+            }
           }
         },
         "stringify-package": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg=="
+          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+          "bundled": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "bundled": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "resolved": false,
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "bundled": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
         },
         "tar": {
           "version": "4.4.13",
-          "resolved": false,
-          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -24319,8 +23940,7 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": false,
-              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -24330,26 +23950,22 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+          "bundled": true,
           "requires": {
             "execa": "^0.7.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": false,
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+          "bundled": true
         },
         "through": {
           "version": "2.3.8",
-          "resolved": false,
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+          "bundled": true
         },
         "through2": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "bundled": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
@@ -24357,8 +23973,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -24371,8 +23986,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -24381,18 +23995,15 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+          "bundled": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A=="
+          "bundled": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": false,
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "bundled": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -24400,71 +24011,60 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": false,
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": false,
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "resolved": false,
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+          "bundled": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": false,
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+          "bundled": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
+          "bundled": true
         },
         "unique-filename": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+          "bundled": true,
           "requires": {
             "unique-slug": "^2.0.0"
           }
         },
         "unique-slug": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+          "bundled": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+          "bundled": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
           }
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+          "bundled": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+          "bundled": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": false,
-          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+          "bundled": true,
           "requires": {
             "boxen": "^1.2.1",
             "chalk": "^2.0.1",
@@ -24480,39 +24080,33 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "bundled": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "bundled": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
+          "bundled": true
         },
         "util-promisify": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
+          "bundled": true,
           "requires": {
             "object.getownpropertydescriptors": "^2.0.3"
           }
         },
         "uuid": {
           "version": "3.3.3",
-          "resolved": false,
-          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+          "bundled": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+          "bundled": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -24520,16 +24114,14 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+          "bundled": true,
           "requires": {
             "builtins": "^1.0.3"
           }
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": false,
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "bundled": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -24538,37 +24130,32 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+          "bundled": true,
           "requires": {
             "defaults": "^1.0.3"
           }
         },
         "which": {
           "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "bundled": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "requires": {
             "string-width": "^1.0.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -24579,24 +24166,21 @@
         },
         "widest-line": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+          "bundled": true,
           "requires": {
             "string-width": "^2.1.1"
           }
         },
         "worker-farm": {
           "version": "1.7.0",
-          "resolved": false,
-          "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+          "bundled": true,
           "requires": {
             "errno": "~0.1.7"
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1"
@@ -24604,8 +24188,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -24616,13 +24199,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "resolved": false,
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+          "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -24631,28 +24212,23 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+          "bundled": true
         },
         "xtend": {
           "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+          "bundled": true
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "bundled": true
         },
         "yargs": {
           "version": "11.1.1",
-          "resolved": false,
-          "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
+          "bundled": true,
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
@@ -24670,15 +24246,13 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "resolved": false,
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+              "bundled": true
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": false,
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "bundled": true,
           "requires": {
             "camelcase": "^4.1.0"
           }
@@ -26222,9 +25796,9 @@
           }
         },
         "hosted-git-info": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.3.tgz",
-          "integrity": "sha512-1ZStA49Bj7WGT+GF2ee50gWMkltL+04v+FgXs20OQbe/usWm9Vh6El9UViiGvD/CEYvsej3AMzABmKmd9DYwnw==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
+          "integrity": "sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==",
           "requires": {
             "lru-cache": "^5.1.1"
           }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@reactioncommerce/logger": "~1.1.2",
     "@reactioncommerce/nodemailer": "~5.0.5",
     "@reactioncommerce/plugin-authentication": "~1.0.0",
-    "@reactioncommerce/plugin-simple-authorization": "~1.0.1",
+    "@reactioncommerce/plugin-simple-authorization": "~1.0.2",
     "@reactioncommerce/plugin-system-information": "~1.0.0",
     "@reactioncommerce/random": "~1.0.2",
     "@reactioncommerce/reaction-error": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
   "main": "./src/index.js",
   "type": "module",


### PR DESCRIPTION
# v3.2.0

Reaction v3.2.0 introduces Federated Gateway capability for the API, moves the `simple-authorization` and `system-information` plugins into their own `npm` packages, and adds an `updateProductsVisibility` GraphQL mutation to the API.

## Features

- feat: add gateway capabilities to API ([#6100](https://github.com/reactioncommerce/reaction/pull/6100))
- feat: add updateProductsVisibility mutation ([#6104](https://github.com/reactioncommerce/reaction/pull/6104))

## Refactor

- refactor: move system information plugin to npm ([#6105](https://github.com/reactioncommerce/reaction/pull/6105))
- refactor: replace internal authentication plugin with NPM installed plugin-authentication ([#6108](https://github.com/reactioncommerce/reaction/pull/6108))

## Chores

- chore: update `plugin-simple-authorization` package ([#6110](https://github.com/reactioncommerce/reaction/pull/6110))