### PR TITLE
release v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,6 @@ Fixes a bug which was causing cart and checkout to fail if an item was hidden af
 
 - chore: update graphql-schema-linter ([#6192](https://github.com/reactioncommerce/reaction/pull/6192))
 
-## Contributors
-
-Thanks to @timgates42 for contributing to this release! 🎉
-
 # v3.5.0
 
 Reaction v3.5.0 adds minor features and performance enhancements, fixes bugs, and contains no breaking changes since v3.4.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+# v3.6.0
+
+Reaction v3.6.0 adds minor features and performance enhancements, fixes bugs, and contains no breaking changes since v3.5.0.
+
+## Notable changes
+
+### Addresses hidden items in cart and checkout
+
+Fixes a bug which was causing cart and checkout to fail if an item was hidden after it was added to cart
+
+### Moves eight plugins into their own npm packages
+
+`accounts`, `address-validation`, `address-validation-test` `catalogs`, `i18n` `settings`, `simple-schema` and `shops` plugins have been moved from internal plugins, to npm install packages.
+
+## Refactors
+
+- refactor: use npm package for settings plugin ([#6203](https://github.com/reactioncommerce/reaction/pull/6203))
+- refactor: move `simple-schema` plugin to npm ([#6202](https://github.com/reactioncommerce/reaction/pull/6202))
+- refactor: use npm package for shops plugin ([#6201](https://github.com/reactioncommerce/reaction/pull/6201))
+- refactor: move catalogs plugin to npm ([#6196](https://github.com/reactioncommerce/reaction/pull/6196))
+- refactor: move i18n service to npm ([#6193](https://github.com/reactioncommerce/reaction/pull/6193))
+- refactor: move address-validation service and address-validation-test plugin to npm ([#6186](https://github.com/reactioncommerce/reaction/pull/6186))
+- refactor: move accounts plugin to npm ([#6189](https://github.com/reactioncommerce/reaction/pull/6189))
+
+## Fixes
+
+- fix: find catalog product regardless of visibility ([#6089](https://github.com/reactioncommerce/reaction/pull/6089))
+
+## Chores
+
+- chore: update graphql-schema-linter ([#6192](https://github.com/reactioncommerce/reaction/pull/6192))
+
+## Contributors
+
+Thanks to @timgates42 for contributing to this release! 🎉
+
 # v3.5.0
 
 Reaction v3.5.0 adds minor features and performance enhancements, fixes bugs, and contains no breaking changes since v3.4.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Fixes a bug which was causing cart and checkout to fail if an item was hidden af
 
 ### Moves eight plugins into their own npm packages
 
-`accounts`, `address-validation`, `address-validation-test` `catalogs`, `i18n` `settings`, `simple-schema` and `shops` plugins have been moved from internal plugins, to npm install packages.
+`accounts`, `address-validation`, `address-validation-test`, `catalogs`, `i18n`, `settings`, `simple-schema` and `shops` plugins have been moved from internal plugins, to npm install packages.
 
 ## Refactors
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Signed-off-by: Jane Doe <jane.doe@example.com>
 
 You can sign-off your commit automatically with Git by using `git commit -s` if you have your `user.name` and `user.email` set as part of your Git configuration.
 
-We ask that you use your real full name (please no anonymous contributions or pseudonyms) and a real email address. By signing-off your commit you are certifying that you have the right to submit it under the [GNU GPLv3 Licensed](./LICENSE.md).
+We ask that you use your real full name (please no anonymous contributions or pseudonyms) and a real email address. By signing-off your commit you are certifying that you have the right to submit it under the [GNU GPLv3 License](./LICENSE.md).
 
 We use the [Probot DCO GitHub app](https://github.com/apps/dco) to check for DCO sign-offs of every commit.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   api:
-    image: reactioncommerce/reaction:3.5.0
+    image: reactioncommerce/reaction:3.6.0
     depends_on:
       - mongo
     env_file:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
   "main": "./src/index.js",
   "type": "module",


### PR DESCRIPTION
# v3.6.0

Reaction v3.6.0 adds minor features and performance enhancements, fixes bugs, and contains no breaking changes since v3.5.0.

## Notable changes

### Addresses hidden items in cart and checkout

Fixes a bug which was causing cart and checkout to fail if an item was hidden after it was added to cart

### Moves eight plugins into their own npm packages

`accounts`, `address-validation`, `address-validation-test`, `catalogs`, `i18n`, `settings`, `simple-schema` and `shops` plugins have been moved from internal plugins, to npm install packages.

## Refactors

- refactor: use npm package for settings plugin ([#6203](https://github.com/reactioncommerce/reaction/pull/6203))
- refactor: move `simple-schema` plugin to npm ([#6202](https://github.com/reactioncommerce/reaction/pull/6202))
- refactor: use npm package for shops plugin ([#6201](https://github.com/reactioncommerce/reaction/pull/6201))
- refactor: move catalogs plugin to npm ([#6196](https://github.com/reactioncommerce/reaction/pull/6196))
- refactor: move i18n service to npm ([#6193](https://github.com/reactioncommerce/reaction/pull/6193))
- refactor: move address-validation service and address-validation-test plugin to npm ([#6186](https://github.com/reactioncommerce/reaction/pull/6186))
- refactor: move accounts plugin to npm ([#6189](https://github.com/reactioncommerce/reaction/pull/6189))

## Fixes

- fix: find catalog product regardless of visibility ([#6089](https://github.com/reactioncommerce/reaction/pull/6089))

## Chores

- chore: update graphql-schema-linter ([#6192](https://github.com/reactioncommerce/reaction/pull/6192))