### PR TITLE
fix: copy plugins.json into prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ RUN cd node_modules/sharp && (node install/libvips && node install/dll-copy && p
 
 # The base image copies /src but we need to copy additional folders in this project
 COPY --chown=node:node ./public ./public
+COPY --chown=node:node ./plugins.json ./plugins.json


### PR DESCRIPTION
Resolves #6243
Impact: **critical**
Type: **bugfix**

## Issue
The `reactioncommerce/reaction:3.7.0` tag of the API Docker image won't start because one new file wasn't copied into it when it was built.

## Solution
Update `Dockerfile` to copy `plugins.json` into the image.

## Breaking changes
None

## Testing
1. `docker-compose down`
2. Delete `docker-compose.override.yml` in this project if there is one.
3. Check out this branch
4. `docker-compose up -d`
5. `docker-compose logs -f api` and see the error from the bug report
6. `docker-compose down`
7. `docker build -t reactioncommerce/reaction:3.7.0 .` (there's a period at the end of this command)
8. `docker-compose up -d`
9. `docker-compose logs -f api` and verify the API started without error
10. `docker-compose down`