### PR TITLE
release 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v3.7.1
+
+Reaction v3.7.1 adds a bug fix and contains no breaking changes since v3.7.0
+
+## Notable changes
+
+### Fix API Docker image
+
+Updates `Dockerfile` to copy new `plugins.json` into the Docker image.
+
+## Fixes
+
+- fix: copy plugins.json into prod image ([#6244](https://github.com/reactioncommerce/reaction/pull/6244))
+
 # v3.7.0
 
 Reaction v3.7.0 adds minor features and performance enhancements, and contains no breaking changes since v3.6.0.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   api:
-    image: reactioncommerce/reaction:3.7.0
+    image: reactioncommerce/reaction:3.7.1
     depends_on:
       - mongo
     env_file:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
   "main": "./src/index.js",
   "type": "module",


### PR DESCRIPTION
# v3.7.1

Reaction v3.7.1 adds a bug fix and contains no breaking changes since v3.7.0

## Notable changes

### Fix API Docker image

Updates `Dockerfile` to copy new `plugins.json` into the Docker image.

## Fixes

- fix: copy plugins.json into prod image ([#6244](https://github.com/reactioncommerce/reaction/pull/6244))