### PR TITLE
chore: fix package link script issues

### DIFF
--- a/bin/package-link
+++ b/bin/package-link
@@ -20,12 +20,16 @@ container_copied_packages_path="/home/node/copied-packages"
 container_destination_path="${container_copied_packages_path}/${package_name}"
 
 if [[ -z "${package_path}" ]]; then
-  package_path="../api-plugins/${package_name}"
+  package_name_without_org="${package_name/#@reactioncommerce\/}"
+  package_path="../api-plugins/${package_name_without_org}"
+  full_package_path="$(cd ${package_path} && pwd)"
+  echo "\nUsing local package path ${full_package_path}"
+  echo "If this is not correct, specify the correct path as the second argument.\n"
 fi
 
 echo "Copying ${package_name} package code into container..."
-docker-compose exec api sh -c "mkdir -p ${container_copied_packages_path}"
-docker cp "${package_path}" "${container_id}:${container_destination_path}"
+docker-compose exec api sh -c "mkdir -p ${container_destination_path}"
+docker cp "${package_path}/." "${container_id}:${container_destination_path}"
 
 # Then npm link into this project
 echo "Linking package into API..."
@@ -33,4 +37,5 @@ docker-compose exec api sh -c "npm config set prefix /home/node/npm && cd /usr/l
 
 # Fool nodemon into thinking something has changed so that it restarts.
 # Touch first file found in /src with .js extension
+echo "Restarting API..."
 docker-compose exec api sh -c "touch -c $(ls ./src/*.js | head -n1)"

--- a/bin/package-unlink
+++ b/bin/package-unlink
@@ -14,11 +14,28 @@ IFS="$(printf "\n\t")"
 # ---- End unofficial bash strict mode boilerplate
 
 package_name=$1
+package_path_in_container="./node_modules/${package_name}"
+container_copied_packages_path="/home/node/copied-packages"
+container_destination_path="${container_copied_packages_path}/${package_name}"
 
-# Then npm link into this project
-echo "Unlinking package from API..."
-docker-compose exec api sh -c "cd /usr/local/src/app && npm unlink "${package_name}""
+# We start by attempting to confirm that a package with the given name is actually
+# symlinked in ./node_modules in the container. If not, we don't want to run the
+# `npm unlink` command with an erroneous package name because that has odd behavior
+# where it actually removed all symlinks or might even uninstall a necessary package.
+# I think this is because `npm unlink` is actually just an alias for `npm uninstall`.
+check_command="if [ -L "${package_path_in_container}" -a -d "${package_path_in_container}" ]; then echo -n '1'; fi"
+symlink_found="$(docker-compose exec api sh -c "${check_command}")"
 
-# Fool nodemon into thinking something has changed so that it restarts.
-# Touch first file found in /src with .js extension
-docker-compose exec api sh -c "touch -c $(ls ./src/*.js | head -n1)"
+if [[ "${symlink_found}" == "1" ]]; then
+  # Then npm link into this project
+  echo "Unlinking package from API..."
+  docker-compose exec api sh -c "cd /usr/local/src/app && npm unlink ${container_destination_path}"
+
+  # Fool nodemon into thinking something has changed so that it restarts.
+  # Touch first file found in /src with .js extension
+  echo "Restarting API..."
+  docker-compose exec api sh -c "touch -c $(ls ./src/*.js | head -n1)"
+else
+  echo "${package_name} does not appear to be linked"
+fi
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Resolves #6250
Impact: **minor**
Type: **chore**

- npm install official packages after unlink
- don't unlink unless it is truly linked
- require package namespace for both commands

## Breaking changes
The `package-link` and `package-unlink` commands now need the full package name, including `@reactioncommerce/` org prefix.

## Testing
Try it