### PR TITLE
chore: update simple authorization plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,9 +1784,9 @@
       }
     },
     "@reactioncommerce/api-plugin-authorization-simple": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-plugin-authorization-simple/-/api-plugin-authorization-simple-1.2.1.tgz",
-      "integrity": "sha512-L9vOQlOn+RG7My+qyyFAHuv36OcNApsiwFK6PS8+BZqh0rFHfD9gDwuDio1y/aeZn6HDd8zImDBWL2L+gzwubw==",
+      "version": "1.3.0",
+      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@reactioncommerce/api-plugin-authorization-simple/-/api-plugin-authorization-simple-1.3.0.tgz",
+      "integrity": "sha1-JVGhesfbKLyewRsjjpl3IwQvx/s=",
       "requires": {
         "@reactioncommerce/api-utils": "^1.14.2",
         "@reactioncommerce/db-version-check": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@reactioncommerce/api-plugin-address-validation-test": "~1.0.0",
     "@reactioncommerce/api-plugin-address-validation": "~1.3.1",
     "@reactioncommerce/api-plugin-authentication": "~1.1.1",
-    "@reactioncommerce/api-plugin-authorization-simple": "~1.2.1",
+    "@reactioncommerce/api-plugin-authorization-simple": "~1.3.0",
     "@reactioncommerce/api-plugin-carts": "~1.2.1",
     "@reactioncommerce/api-plugin-catalogs": "~1.0.2",
     "@reactioncommerce/api-plugin-discounts-codes": "~1.1.1",


### PR DESCRIPTION
The Simple authorization plugin has been updated to version `1.3.0`.

This PR updates the installation so Reaction uses the latest.