### PR TITLE
release v3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v3.9.0
+
+Reaction v3.9.0 adds minor features and performance enhancements, and contains no breaking changes since v3.8.0
+
+## Chores
+
+chore: update simple authorization plugin ([#6274](https://github.com/reactioncommerce/reaction/pull/6274))
+chore: Update accounts package ([#6269](https://github.com/reactioncommerce/reaction/pull/6269))
+chore: use yalc for package link and unlink ([#6266](https://github.com/reactioncommerce/reaction/pull/6266))
+chore: updated api plugins ([#6265](https://github.com/reactioncommerce/reaction/pull/6265))
+chore: fix package link script issues ([#6251](https://github.com/reactioncommerce/reaction/pull/6251))
+
+## Contributors
+
+Thanks to @loan-laux for contributing to this release! 🎉
+
 # v3.8.0
 
 Reaction v3.8.0 adds minor features and performance enhancements, and contains no breaking changes since v3.7.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   api:
-    image: reactioncommerce/reaction:3.8.0
+    image: reactioncommerce/reaction:3.9.0
     depends_on:
       - mongo
     env_file:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1744,9 +1744,9 @@
       }
     },
     "@reactioncommerce/api-plugin-authentication": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-plugin-authentication/-/api-plugin-authentication-1.1.1.tgz",
-      "integrity": "sha512-qSfkKw2Am/KBOz/NtEdHsgs6tRFrGyd1GQHC/WT7amjSvGcVOm3Ke5bmVdOirvSLD+yryztd8Z1ZkGhOoEnnsg==",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@reactioncommerce/api-plugin-authentication/-/api-plugin-authentication-1.2.0.tgz",
+      "integrity": "sha1-7QbGLz8IXChRnJnDxTPFozW+lJo=",
       "requires": {
         "@reactioncommerce/api-utils": "^1.14.2",
         "@reactioncommerce/logger": "^1.1.3",
@@ -1758,8 +1758,8 @@
       "dependencies": {
         "chalk": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1767,8 +1767,8 @@
         },
         "envalid": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/envalid/-/envalid-6.0.2.tgz",
-          "integrity": "sha512-ChJb9a5rjwZ/NkcXfBrzEl5cFZaGLg38N7MlWJkv5qsmSypX2WJe28LkoAWcklC60nKZXYKRlBbsjuJSjYw0Xg==",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/envalid/-/envalid-6.0.2.tgz",
+          "integrity": "sha1-cTl3DgiazJRcDke1B11ykV2Gg+g=",
           "requires": {
             "chalk": "^3.0.0",
             "dotenv": "^8.2.0",
@@ -1778,8 +1778,8 @@
         },
         "validator": {
           "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-13.1.1.tgz",
-          "integrity": "sha512-8GfPiwzzRoWTg7OV1zva1KvrSemuMkv07MA9TTl91hfhe+wKrsrgVN4H2QSFd/U/FhiU3iWPYVgvbsOGwhyFWw=="
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/validator/-/validator-13.1.1.tgz",
+          "integrity": "sha1-+IETaEc9IXOp2GEVcrWMV4PyI78="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@reactioncommerce/api-plugin-accounts": "~1.4.4",
     "@reactioncommerce/api-plugin-address-validation-test": "~1.0.0",
     "@reactioncommerce/api-plugin-address-validation": "~1.3.1",
-    "@reactioncommerce/api-plugin-authentication": "~1.1.1",
+    "@reactioncommerce/api-plugin-authentication": "~1.2.0",
     "@reactioncommerce/api-plugin-authorization-simple": "~1.3.0",
     "@reactioncommerce/api-plugin-carts": "~1.2.1",
     "@reactioncommerce/api-plugin-catalogs": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
   "main": "./src/index.js",
   "type": "module",


### PR DESCRIPTION
# v3.9.0

Reaction v3.9.0 adds minor features and performance enhancements, and contains no breaking changes since v3.8.0

## Chores

chore: update simple authorization plugin ([#6274](https://github.com/reactioncommerce/reaction/pull/6274))
chore: Update accounts package ([#6269](https://github.com/reactioncommerce/reaction/pull/6269))
chore: use yalc for package link and unlink ([#6266](https://github.com/reactioncommerce/reaction/pull/6266))
chore: updated api plugins ([#6265](https://github.com/reactioncommerce/reaction/pull/6265))
chore: fix package link script issues ([#6251](https://github.com/reactioncommerce/reaction/pull/6251))

## Contributors

Thanks to @loan-laux for contributing to this release! 🎉