### PR TITLE
release v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Fixed issues causing image upload to fail.
 
 - chore: Update @reactioncommerce dependencies ([#6296](https://github.com/reactioncommerce/reaction/pull/6296))
 - chore: Update api-plugin-shops ([#6295](https://github.com/reactioncommerce/reaction/pull/6295))
+- chore: update api-plugin-accounts package ([6312](https://github.com/reactioncommerce/reaction/pull/6312))
 
 ## Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# v3.11.0
+
+Reaction v3.11.0 adds minor enhancements, fixes bugs and contains no breaking changes since v3.10.0.
+
+## Notable changes
+
+### Fixed image uploads
+
+Fixed issues causing image upload to fail.
+
+## Fixes
+
+- fix: Get product image uploads working again ([#6309](https://github.com/reactioncommerce/reaction/pull/6309))
+
+## Refactors
+
+- refactor:  preserve symlinks in docker debug npm scripts ([#6302](https://github.com/reactioncommerce/reaction/pull/6302))
+
+## Chores
+
+- chore: Update @reactioncommerce dependencies ([#6296](https://github.com/reactioncommerce/reaction/pull/6296))
+- chore: Update api-plugin-shops ([#6295](https://github.com/reactioncommerce/reaction/pull/6295))
+
+## Contributors
+
+Thanks to @loan-laux and @balibebas for contributing to this release! 🎉
+
 # v3.10.0
 
 Reaction v3.10.0 adds minor features and performance enhancements, and contains no breaking changes since v3.9.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   api:
-    image: reactioncommerce/reaction:3.10.0
+    image: reactioncommerce/reaction:3.11.0
     depends_on:
       - mongo
     env_file:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4127,6 +4127,16 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
@@ -4634,6 +4644,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -6341,6 +6352,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-api",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Reaction is a modern reactive, real-time event driven ecommerce platform.",
   "main": "./src/index.js",
   "type": "module",


### PR DESCRIPTION
# v3.11.0

Reaction v3.11.0 adds minor enhancements, fixes bugs and contains no breaking changes since v3.10.0.

## Notable changes

### Fixed image uploads

Fixed issues causing image upload to fail.

## Fixes

- fix: Get product image uploads working again ([#6309](https://github.com/reactioncommerce/reaction/pull/6309))

## Refactors

- refactor:  preserve symlinks in docker debug npm scripts ([#6302](https://github.com/reactioncommerce/reaction/pull/6302))

## Chores

- chore: Update @reactioncommerce dependencies ([#6296](https://github.com/reactioncommerce/reaction/pull/6296))
- chore: Update api-plugin-shops ([#6295](https://github.com/reactioncommerce/reaction/pull/6295))

## Contributors

Thanks to @loan-laux and @balibebas for contributing to this release! 🎉