### PR TITLE
chore: update api-plugin-accounts package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1869,9 +1869,9 @@
       }
     },
     "@reactioncommerce/api-plugin-accounts": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-plugin-accounts/-/api-plugin-accounts-1.5.0.tgz",
-      "integrity": "sha512-qmcl0XPgGjPJQx3qCER7N8lYPGF6TJikyu5M0gWFVJlo8NUzy7p1X2q9XRJV1DnYJKZFbH0WaRUK20O/6L1mxQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-plugin-accounts/-/api-plugin-accounts-1.6.0.tgz",
+      "integrity": "sha512-EuGi5oxYXaoLag2GchP/uo7zE5hv53zUtWPe9t3UgLOIR91Aii8FVTbB+qy1J8RjQa1lRnEBWKelr8leFDB1cA==",
       "requires": {
         "@reactioncommerce/api-utils": "^1.14.3",
         "@reactioncommerce/db-version-check": "^1.0.0",
@@ -4127,6 +4127,16 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
@@ -4634,6 +4644,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -6341,6 +6352,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@reactioncommerce/api-core": "~1.4.2",
-    "@reactioncommerce/api-plugin-accounts": "~1.5.0",
+    "@reactioncommerce/api-plugin-accounts": "~1.6.0",
     "@reactioncommerce/api-plugin-address-validation": "~1.3.1",
     "@reactioncommerce/api-plugin-address-validation-test": "~1.0.0",
     "@reactioncommerce/api-plugin-authentication": "~1.2.0",


### PR DESCRIPTION
Resolves n/a
Impact: **minor**
Type: **chore**

## Issue

Migrations were broken due to an old version of the `api-plugin-accounts` package

## Solution

Update account package

## Breaking changes

none

## Testing
1. Migrations should run
2. ...and the app should run!

