### PR TITLE
Run rs.initiate() to start replication on clean mongo boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "27017:27017"
     volumes:
       - mongo-db4:/data/db
-    healthcheck: # This is hack to run the rs.initiate() after startup.
+    healthcheck: # re-run rs.initiate() after startup if it failed.
       test: test $$(echo "rs.status().ok || rs.initiate().ok" | mongo --quiet) -eq 1
       interval: 10s
       start_period: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,10 @@ services:
       - "27017:27017"
     volumes:
       - mongo-db4:/data/db
+    healthcheck: # This is hack to run the rs.initiate() after startup.
+      test: test $$(echo "rs.status().ok || rs.initiate().ok" | mongo --quiet) -eq 1
+      interval: 10s
+      start_period: 30s
 
 volumes:
   mongo-db4:


### PR DESCRIPTION
Resolves reactioncommerce/reaction-development-platform#165
Impact: **major**
Type: **bugfix**

## Issue
On the initial load of the mongod if started in replica, `rs.initiate()` has to be run on one of the instance to start the replication. This was missing from our configuration files.

## Solution
Using `healthcheck` option of the docker-compose to hack docker running the rs.initiate() command. Used this for reference: https://zgadzaj.com/development/docker/docker-compose/turning-standalone-mongodb-server-into-a-replica-set-with-docker-compose

## Breaking changes
None expected.


## Testing
1. `make clean`
2. `make init-dev`

Would love to have a couple of eyes on this one and discuss if there could be a better solution on this one. Most of the resources day that `rs.initiate()` should be run manually based on need, but in our use case, we are using replication more for oplog than for actual replication.