### PR TITLE
fix: write integration test for create shop

### DIFF
--- a/tests/integration/api/mutations/createShop/CreateShopMutation.graphql
+++ b/tests/integration/api/mutations/createShop/CreateShopMutation.graphql
@@ -6,7 +6,7 @@ mutation CreateShop($input: CreateShopInput!) {
       shopType
       timezone
       language
-      currency{
+      currency {
         code
       }
     }

--- a/tests/integration/api/mutations/createShop/CreateShopMutation.graphql
+++ b/tests/integration/api/mutations/createShop/CreateShopMutation.graphql
@@ -1,0 +1,14 @@
+mutation CreateShop($input: CreateShopInput!) {
+  createShop(input: $input) {
+    shop {
+      name
+      description
+      shopType
+      timezone
+      language
+      currency{
+        code
+      }
+    }
+  }
+}

--- a/tests/integration/api/mutations/createShop/createShop.test.js
+++ b/tests/integration/api/mutations/createShop/createShop.test.js
@@ -1,0 +1,157 @@
+import importAsString from "@reactioncommerce/api-utils/importAsString.js";
+import Factory from "/tests/util/factory.js";
+import { importPluginsJSONFile, ReactionTestAPICore } from "@reactioncommerce/api-core";
+
+const CreateShopMutation = importAsString("./CreateShopMutation.graphql");
+
+jest.setTimeout(300000);
+
+let testApp;
+let createShop;
+const shopId = null;// shop ID is null for account manager and system manager groups. Only these groups can create shop
+let mockAdminAccount;
+beforeAll(async () => {
+  testApp = new ReactionTestAPICore();
+  const plugins = await importPluginsJSONFile("../../../../../plugins.json", (pluginList) => {
+    // Remove the `files` plugin when testing. Avoids lots of errors.
+    delete pluginList.files;
+
+    return pluginList;
+  });
+  await testApp.reactionNodeApp.registerPlugins(plugins);
+  await testApp.start();
+
+  const adminGroup = Factory.Group.makeOne({
+    _id: "adminGroup",
+    createdBy: null,
+    name: "admin",
+    permissions: ["reaction:legacy:shops/create"],
+    slug: "admin",
+    shopId
+  });
+  await testApp.collections.Groups.insertOne(adminGroup);
+
+  mockAdminAccount = Factory.Account.makeOne({
+    groups: [adminGroup._id],
+    shopId: "123"
+  });
+  await testApp.createUserAndAccount(mockAdminAccount);
+
+  createShop = testApp.mutate(CreateShopMutation);
+
+  await testApp.setLoggedInUser(mockAdminAccount);
+});
+
+// There is no need to delete any test data from collections because
+// testApp.stop() will drop the entire test database. Each integration
+// test file gets its own test database.
+afterAll(() => testApp.stop());
+
+test("user with `reaction:legacy:shops/create` permission can create shop with name", async () => {
+  const mockShopSettings = {
+    name: "My Awesome Shop",
+    description: "A very awesome shop"
+  };
+
+  let result;
+  try {
+    result = await createShop({
+      input: {
+        ...mockShopSettings
+      }
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  const expectedShopSettings = {
+    name: "My Awesome Shop",
+    shopType: "primary",
+    description: "A very awesome shop",
+    timezone: "US/Pacific",
+    language: "en",
+    currency: {
+      code: "USD"
+    }
+  };
+  expect(result.createShop.shop).toEqual(expectedShopSettings);
+});
+
+test("user with `reaction:legacy:shops/create` permission cannot create 2nd primary shop type", async () => {
+  const mockShopSettings = {
+    name: "Primary shop",
+    type: "primary"
+  };
+
+  try {
+    await createShop({
+      input: {
+        ...mockShopSettings
+      }
+    });
+  } catch (error) {
+    expect(error).toBeDefined();
+    expect(error[0].message).toBe("There may be only one primary shop");
+    return;
+  }
+});
+
+test("user with `reaction:legacy:shops/create` permission can create multiple merchant shop", async () => {
+  let result;
+  const mockShopSettings1 = {
+    name: "Merchant shop 1",
+    type: "merchant"
+  };
+  const mockShopSettings2 = {
+    name: "Merchant shop 2",
+    type: "merchant",
+    defaultTimezone: "US/Eastern",
+    defaultLanguage: "es"
+  };
+
+  // create 1st merchant shop
+  try {
+    result = await createShop({
+      input: {
+        ...mockShopSettings1
+      }
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  const expectedShopSettings1 = {
+    name: "Merchant shop 1",
+    description: null,
+    shopType: "merchant",
+    timezone: "US/Pacific",
+    language: "en",
+    currency: {
+      code: "USD"
+    }
+  };
+  expect(result.createShop.shop).toEqual(expectedShopSettings1);
+
+  // create 2nd merchant shop
+  try {
+    result = await createShop({
+      input: {
+        ...mockShopSettings2
+      }
+    });
+  } catch (error) {
+    expect(error).toBeUndefined();
+    return;
+  }
+  const expectedShopSettings2 = {
+    name: "Merchant shop 2",
+    description: null,
+    shopType: "merchant",
+    timezone: "US/Eastern",
+    language: "es",
+    currency: {
+      code: "USD"
+    }
+  };
+  expect(result.createShop.shop).toEqual(expectedShopSettings2);
+});

--- a/tests/integration/api/mutations/createShop/createShop.test.js
+++ b/tests/integration/api/mutations/createShop/createShop.test.js
@@ -1,6 +1,6 @@
 import importAsString from "@reactioncommerce/api-utils/importAsString.js";
-import Factory from "/tests/util/factory.js";
 import { importPluginsJSONFile, ReactionTestAPICore } from "@reactioncommerce/api-core";
+import Factory from "/tests/util/factory.js";
 
 const CreateShopMutation = importAsString("./CreateShopMutation.graphql");
 


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #6147 
Impact: **minor**
Type: **test**

## Summary
The [fix](https://github.com/reactioncommerce/api-plugin-shops/pull/4) for this issue is already in place. Adding integration test for the Create Shop workflow.
