### PR TITLE
fix: push to docker hub without v, get latest tag across all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
       - run:
           name: Build and push production Docker image
           command: |
-            VERSION=$(git describe --abbrev=0 --tags)
+            VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | cut -c2-100)
             docker build -t ${DOCKER_REPOSITORY}:${VERSION} .
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push ${DOCKER_REPOSITORY}:${VERSION}


### PR DESCRIPTION
Signed-off-by: Akarshit Wal <akarshitwal@gmail.com>

The problems were:
1. The image being pushed to dockerhub had an extra `v` in it. example `v3.12.0` instead of `3.12.0`
2. The `VERSION` variable in docker was always the old tag and not the current one. This was happening because we were using command that only got the latest version on current branch.