### PR TITLE
fix: add check for org name/package name format

### DIFF
--- a/bin/package-link
+++ b/bin/package-link
@@ -19,6 +19,12 @@ yalc_packages_file_name="yalc-packages"
 container_id="$(docker-compose ps -q api)"
 container_copied_packages_path="/home/node/copied-packages"
 
+org_name='@reactioncommerce'
+if [[ $package_name != $org_name* ]]; then
+  echo "ERROR: The organization name does not match. Make sure the first argument is of the format '@reactioncommerce/<api-plugin-name>'"
+  exit 0
+fi
+
 if [[ -z "${package_name}" ]]; then
   if ! [[ -f "$yalc_packages_file_name" ]]; then
     echo "Yalc packages file doesn't exist. Creating..."

--- a/bin/package-link
+++ b/bin/package-link
@@ -10,7 +10,6 @@ set -o pipefail # don't ignore exit codes when piping output
 set -o posix    # more strict failures in subshells
 # set -x          # enable debugging
 
-IFS="$(printf "\n\t")"
 # ---- End unofficial bash strict mode boilerplate
 
 package_name=$1
@@ -19,11 +18,25 @@ yalc_packages_file_name="yalc-packages"
 container_id="$(docker-compose ps -q api)"
 container_copied_packages_path="/home/node/copied-packages"
 
-org_name='@reactioncommerce'
-if [[ $package_name != $org_name* ]]; then
-  echo "ERROR: The organization name does not match. Make sure the first argument is of the format '@reactioncommerce/<api-plugin-name>'"
+# validate input
+IFS='/'
+read -a pkgarr <<< "$1"
+org_name=${pkgarr[0]}
+package_name_without_org=${pkgarr[1]}
+if [ -z "$package_name_without_org" ] || [ -z "$org_name" ]; then
+  echo "ERROR: Incorrect input. Please check the format of the first argument. '@<org-name>/<api-plugin-name>'"
   exit 0
 fi
+
+#check if the package is valid by cross referencing with node_modules
+is_package=$(find node_modules/$org_name -type d -name $package_name_without_org)
+if [ -z "$is_package" ]; then
+  echo "$package_name does not exist"
+  exit 0
+fi
+
+
+IFS="$(printf "\n\t")"
 
 if [[ -z "${package_name}" ]]; then
   if ! [[ -f "$yalc_packages_file_name" ]]; then
@@ -65,7 +78,6 @@ else
   container_destination_path="${container_copied_packages_path}/${package_name}"
 
   if [[ -z "${package_path}" ]]; then
-    package_name_without_org="${package_name/#@reactioncommerce\/}"
     package_path="../api-plugins/${package_name_without_org}"
     full_package_path="$(cd ${package_path} && pwd)"
     echo "\nUsing local package path ${full_package_path}"

--- a/bin/package-unlink
+++ b/bin/package-unlink
@@ -15,6 +15,12 @@ IFS="$(printf "\n\t")"
 
 package_name=$1
 
+org_name='@reactioncommerce'
+if [[ $package_name != $org_name* ]]; then
+  echo "ERROR: The organization name does not match. Make sure the argument is of the format '@reactioncommerce/<api-plugin-name>'"
+  exit 0
+fi
+
 # Unlink the yalc dependency, remove the package drectory and npm install
 echo "Unlinking package from API..."
 docker-compose exec api sh -c "cd /usr/local/src/app && yalc remove ${package_name}"

--- a/bin/package-unlink
+++ b/bin/package-unlink
@@ -10,16 +10,29 @@ set -o pipefail # don't ignore exit codes when piping output
 set -o posix    # more strict failures in subshells
 # set -x          # enable debugging
 
-IFS="$(printf "\n\t")"
 # ---- End unofficial bash strict mode boilerplate
 
 package_name=$1
 
-org_name='@reactioncommerce'
-if [[ $package_name != $org_name* ]]; then
-  echo "ERROR: The organization name does not match. Make sure the argument is of the format '@reactioncommerce/<api-plugin-name>'"
+# validate input
+IFS='/'
+read -a pkgarr <<< "$1"
+org_name=${pkgarr[0]}
+package_name_without_org=${pkgarr[1]}
+if [ -z "$package_name_without_org" ] || [ -z "$org_name" ]; then
+  echo "ERROR: Incorrect input. Please check the format of the first argument. '@<org-name>/<api-plugin-name>'"
   exit 0
 fi
+
+#check if the package is valid by cross referencing with node_modules
+is_package=$(find node_modules/$org_name -type d -name $package_name_without_org)
+if [ -z "$is_package" ]; then
+  echo "$package_name does not exist"
+  exit 0
+fi
+
+
+IFS="$(printf "\n\t")"
 
 # Unlink the yalc dependency, remove the package drectory and npm install
 echo "Unlinking package from API..."


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #6377 
Impact: **minor**
Type: **bugfix**

## Issue

When linking a package without providing the account name (the @accountname/...) will end in an error when the API restarts.
the command does not provide a informative error message when this happens

## Solution

Validate the input format and check if package is valid.

## Testing

Test values:
Invalid - @reaXioncommerce/api-plugin-example
               @reactioncommerce/not-a-plugin
               @reactioncommerceapi-plugin-example
               @reactioncommerce/
               /api-plugin-example

Valid - @reactioncommerce/api-plugin-example
