### PR TITLE
fix: validate org name only

### DIFF
--- a/bin/package-link
+++ b/bin/package-link
@@ -28,10 +28,10 @@ if [ -z "$package_name_without_org" ] || [ -z "$org_name" ]; then
   exit 0
 fi
 
-#check if the package is valid by cross referencing with node_modules
-is_package=$(find node_modules/$org_name -type d -name $package_name_without_org)
+#check if the organization name is valid by cross referencing with node_modules
+is_package=$(find node_modules -type d -name $org_name)
 if [ -z "$is_package" ]; then
-  echo "$package_name does not exist"
+  echo "$org_name does not exist"
   exit 0
 fi
 

--- a/bin/package-unlink
+++ b/bin/package-unlink
@@ -24,10 +24,10 @@ if [ -z "$package_name_without_org" ] || [ -z "$org_name" ]; then
   exit 0
 fi
 
-#check if the package is valid by cross referencing with node_modules
-is_package=$(find node_modules/$org_name -type d -name $package_name_without_org)
+#check if the organization name is valid by cross referencing with node_modules
+is_package=$(find node_modules -type d -name $org_name)
 if [ -z "$is_package" ]; then
-  echo "$package_name does not exist"
+  echo "$org_name does not exist"
   exit 0
 fi
 


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #6379 
Impact: **minor**
Type: **bugfix**

## Issue

Newly created plugin does not link. Throws error since it is not available in node_modules and validation fails.

## Solution

Validate for just org name. Package name is validated while copying package contents.
