### PR TITLE
chore: update docker dev image to 14.18

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ version: '3.4'
 
 services:
   api:
-    image: reactioncommerce/node-dev:14.15.0-v1
+    image: reactioncommerce/node-dev:14.18.1-v1
     ports:
       - "3000:3000"
       - "9229:9229"


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

Same change @delagroove made [here](https://github.com/reactioncommerce/reaction/pull/6405) but without the package updates which seem to be breaking tests

Impact: **minor**
Type: **chore**

## Issue
Current node-dev image doesn't match node version minimum


## Solution

Update to the new 14.18 image


## Breaking changes

None

