### PR TITLE
feat: add coverage thresholds to jest config

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -233,6 +233,14 @@ const jestConfig = {
 
   // Whether to use watchman for file crawling
   // watchman: true,
+
+  collectCoverage: true,
+  coverageThreshold: {
+    global: 50,
+    functions: 50,
+    lines: 50,
+    statements: 50
+  }
 };
 
 module.exports = jestConfig;


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

Resolves #issueNumber
Impact: **minor**
Type: **test**

## Issue

Currently no coverage minimum are defined

## Solution

Jest allows you to set a minimum percentage of test coverage for your test sweet so that you can establish a baseline of how much coverage you require. This PR is a test with establishing a baseline coverage percentage of 50

