### PR TITLE
Updated CircleCI config to also tag image with latest.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,10 @@ jobs:
           name: Build and push production Docker image
           command: |
             VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | cut -c2-100)
-            docker build -t ${DOCKER_REPOSITORY}:${VERSION} .
+            docker build -t ${DOCKER_REPOSITORY}:${VERSION} -t ${DOCKER_REPOSITORY}:latest .
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push ${DOCKER_REPOSITORY}:${VERSION}
+            docker push ${DOCKER_REPOSITORY}:latest
 
 workflows:
   version: 2


### PR DESCRIPTION
Resolves #issueNumber
Impact: **minor**
Type: **feature**

## Issue

We are not currently adding the "latest" tag to newly built images.

## Solution

Updated the CircleCI config to also tag the docker image with "latest".
