### PR TITLE
fix: add wait time before release Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,14 @@ defaults: &defaults
 install_pnpm: &install_pnpm
   - run:
       name: Install pnpm package manager
-      command: sudo npm i -g pnpm@7
+      command: sudo npm i -g pnpm@7.11.0
   - run:
       name: Check pnpm version
       command: pnpm -v
+
+delay_job: &delay_job
+  - run: Wait for packages to be propagated
+    command: sleep 350
 
 jobs:
   install-dependencies:
@@ -154,10 +158,9 @@ jobs:
     steps:
       - checkout
       - <<: *install_pnpm
-      - restore_cache:
-          keys:
-            - reaction-v6-node-modules-{{ checksum "package.json" }}-{{ checksum "pnpm-lock.yaml" }}
-            - reaction-v6-node-modules-{{ .Branch }}
+      - run:
+          name: Install PNPM dependencies
+          command: pnpm install -r
       - run:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
@@ -175,7 +178,7 @@ jobs:
           name: Build and push production Docker image
           command: |
             VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | cut -c2-100)
-            docker build -t ${DOCKER_REPOSITORY}:${VERSION} -t ${DOCKER_REPOSITORY}:latest -f ./app/reaction/Dockerfile .
+            docker build -t ${DOCKER_REPOSITORY}:${VERSION} -t ${DOCKER_REPOSITORY}:latest -f ./apps/reaction/Dockerfile .
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push ${DOCKER_REPOSITORY}:${VERSION}
             docker push ${DOCKER_REPOSITORY}:latest

--- a/apps/reaction/Dockerfile
+++ b/apps/reaction/Dockerfile
@@ -12,7 +12,7 @@ COPY ./apps/reaction ./apps/reaction
 COPY .npmrc .nvmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 RUN npm i -g pnpm@7.11.0
-RUN pnpm --filter=@reactioncommerce/reaction-api --prod deploy deps --ignore-scripts
+RUN pnpm --filter=@reactioncommerce/reaction-api --prod deploy deps --ignore-scripts --prefer-online
 
 
 FROM node:14.18.1-alpine


### PR DESCRIPTION
Impact: minor
Type: bugfix

## Issue
After new packages published to npm registry, it needs time to propagate. If we run install immediately, we can end up using old version or fail to install. 

## Solution
Add 350 seconds wait time before release image. We can consider a better approach later.