### PR TITLE
fix: unable to start with npm

### DIFF
--- a/.changeset/little-cameras-rest.md
+++ b/.changeset/little-cameras-rest.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-authentication": patch
+---
+
+feat: add graphql-tag for authentication plugin

--- a/packages/api-plugin-authentication/package.json
+++ b/packages/api-plugin-authentication/package.json
@@ -37,6 +37,7 @@
     "@reactioncommerce/logger": "^1.1.3",
     "@reactioncommerce/reaction-error": "^1.0.1",
     "envalid": "^6.0.2",
+    "graphql-tag": "^2.10.0",
     "jwt-decode": "^3.1.2",
     "mongoose": "^6.0.4",
     "node-fetch": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,7 @@ importers:
       '@reactioncommerce/logger': ^1.1.3
       '@reactioncommerce/reaction-error': ^1.0.1
       envalid: ^6.0.2
+      graphql-tag: ^2.10.0
       jwt-decode: ^3.1.2
       mongoose: ^6.0.4
       node-fetch: ^2.6.0
@@ -423,6 +424,7 @@ importers:
       '@reactioncommerce/logger': link:../logger
       '@reactioncommerce/reaction-error': link:../reaction-error
       envalid: 6.0.2
+      graphql-tag: 2.12.6_graphql@14.7.0
       jwt-decode: 3.1.2
       mongoose: 6.6.0
       node-fetch: 2.6.7


### PR DESCRIPTION
Impact: minor
Type: bugfix

## Issue

Unable to start project generated by CLI with error 
`Error: Cannot find module 'graphql-tag'`

```
- /home/brent/Projects/merchstack/cli-test-projects/sep-21-2022/myserver/node_modules/@reactioncommerce/api-plugin-authentication/node_modules/@accounts/graphql-api/lib/modules/accounts/schema/types.js
- /home/brent/Projects/merchstack/cli-test-projects/sep-21-2022/myserver/node_modules/@reactioncommerce/api-plugin-authentication/node_modules/@accounts/graphql-api/lib/modules/accounts/index.js
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
      at Function.Module._load (internal/modules/cjs/loader.js:746:27)
```

## Solution

Install `graphql-tag` for `api-plugin-authentication`
