### PR TITLE
ci: create GitHub releases on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:
-          publish: pnpm release
+          publish: pnpm release && npx changeset tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
       '@reactioncommerce/logger': link:../../packages/logger
       '@reactioncommerce/nodemailer': 5.0.5
       '@reactioncommerce/random': link:../../packages/random
-      '@snyk/protect': 1.1012.0
+      '@snyk/protect': 1.1020.0
       graphql: 14.7.0
       semver: 6.3.0
       sharp: 0.29.3
@@ -4666,8 +4666,8 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: false
 
-  /@snyk/protect/1.1012.0:
-    resolution: {integrity: sha512-FetJA4igmHDYLcxq0dvSolgCWBAWvut1lhY8aDbwZDw+dMd7sXkjb4Dl1F7XzRDqUt3wjfyb73OJjSAn1ADZHg==}
+  /@snyk/protect/1.1020.0:
+    resolution: {integrity: sha512-Uncxecj9mtEVlaEFVojpNOu6wZ3Om4cpvDDB25FcyOd0o+buru57GKNCMT89G2UC35dKpz6FOYyn1/gXNQZqIQ==}
     engines: {node: '>=10'}
     hasBin: true
     dev: false


### PR DESCRIPTION
Resolves #6540
Impact: **minor**
Type: **chore**

When a `Release` action is triggered, the job will publish all modified packages and then will commit github tags and github releases with the plugin changelogs.