### PR TITLE
Set default ff-type for shop to be used in CreateProduct

### DIFF
--- a/apps/reaction/plugins.json
+++ b/apps/reaction/plugins.json
@@ -39,5 +39,6 @@
   "fulfillmentMethodShippingFlatRate": "../../packages/api-plugin-fulfillment-method-shipping-flat-rate/index.js",
   "fulfillmentMethodShippingUPS": "../../packages/api-plugin-fulfillment-method-shipping-ups/index.js",
   "fulfillmentTypePickup": "../../packages/api-plugin-fulfillment-type-pickup/index.js",
-  "fulfillmentMethodPickupStore": "../../packages/api-plugin-fulfillment-method-pickup-store/index.js"
+  "fulfillmentMethodPickupStore": "../../packages/api-plugin-fulfillment-method-pickup-store/index.js",
+  "sampleData": "../../packages/api-plugin-sample-data/index.js"
 }

--- a/apps/reaction/plugins.json
+++ b/apps/reaction/plugins.json
@@ -39,6 +39,5 @@
   "fulfillmentMethodShippingFlatRate": "../../packages/api-plugin-fulfillment-method-shipping-flat-rate/index.js",
   "fulfillmentMethodShippingUPS": "../../packages/api-plugin-fulfillment-method-shipping-ups/index.js",
   "fulfillmentTypePickup": "../../packages/api-plugin-fulfillment-type-pickup/index.js",
-  "fulfillmentMethodPickupStore": "../../packages/api-plugin-fulfillment-method-pickup-store/index.js",
-  "sampleData": "../../packages/api-plugin-sample-data/index.js"
+  "fulfillmentMethodPickupStore": "../../packages/api-plugin-fulfillment-method-pickup-store/index.js"
 }

--- a/packages/api-plugin-authorization-simple/src/util/defaultRoles.js
+++ b/packages/api-plugin-authorization-simple/src/util/defaultRoles.js
@@ -60,6 +60,7 @@ export const defaultShopManagerRoles = [
   "reaction:legacy:products/update:prices",
   "reaction:legacy:products/update",
   "reaction:legacy:shipping-rates/update:settings",
+  "reaction:legacy:fulfillmentTypes/update:settings",
   "reaction:legacy:fulfillmentTypes/create",
   "reaction:legacy:fulfillmentTypes/delete",
   "reaction:legacy:fulfillmentTypes/read",

--- a/packages/api-plugin-fulfillment/src/index.js
+++ b/packages/api-plugin-fulfillment/src/index.js
@@ -56,17 +56,16 @@ export default async function register(app) {
       MethodEmptyData
     },
     shopSettingsConfig: {
-      defaultFulfillmentTypesForShop: {
+      baseFulfillmentTypesForShop: {
         permissionsThatCanEdit: ["reaction:legacy:fulfillmentTypes/update:settings"],
         simpleSchema: {
           type: {
-            "defaultFulfillmentTypesForShop": {
+            "baseFulfillmentTypesForShop": {
               type: Array,
               optional: true
             },
-            "defaultFulfillmentTypesForShop.$": {
-              type: String,
-              optional: true
+            "baseFulfillmentTypesForShop.$": {
+              type: String
             }
           }
         }

--- a/packages/api-plugin-fulfillment/src/index.js
+++ b/packages/api-plugin-fulfillment/src/index.js
@@ -54,6 +54,23 @@ export default async function register(app) {
     },
     simpleSchemas: {
       MethodEmptyData
+    },
+    shopSettingsConfig: {
+      defaultFulfillmentTypesForShop: {
+        permissionsThatCanEdit: ["reaction:legacy:fulfillmentTypes/update:settings"],
+        simpleSchema: {
+          type: {
+            "defaultFulfillmentTypesForShop": {
+              type: Array,
+              optional: true
+            },
+            "defaultFulfillmentTypesForShop.$": {
+              type: String,
+              optional: true
+            }
+          }
+        }
+      }
     }
   });
 }

--- a/packages/api-plugin-fulfillment/src/schemas/schema.graphql
+++ b/packages/api-plugin-fulfillment/src/schemas/schema.graphql
@@ -2,14 +2,14 @@ extend type ShopSettings {
   """
   List of fulfillment types that will be added to each new product by default
   """
-  defaultFulfillmentTypesForShop: [FulfillmentType]
+  baseFulfillmentTypesForShop: [FulfillmentType]
 }
 
 extend input ShopSettingsUpdates {
   """
   The input for default fulfillment type for shop should be one of the installed fulfillment type plugin
   """
-  defaultFulfillmentTypesForShop: [FulfillmentType]
+  baseFulfillmentTypesForShop: [FulfillmentType]
 }
 
 "Allowed fulfillment types, extended by fulfillment-type plugins"

--- a/packages/api-plugin-fulfillment/src/schemas/schema.graphql
+++ b/packages/api-plugin-fulfillment/src/schemas/schema.graphql
@@ -1,3 +1,17 @@
+extend type ShopSettings {
+  """
+  List of fulfillment types that will be added to each new product by default
+  """
+  defaultFulfillmentTypesForShop: [FulfillmentType]
+}
+
+extend input ShopSettingsUpdates {
+  """
+  The input for default fulfillment type for shop should be one of the installed fulfillment type plugin
+  """
+  defaultFulfillmentTypesForShop: [FulfillmentType]
+}
+
 "Allowed fulfillment types, extended by fulfillment-type plugins"
 enum FulfillmentType {
   "Default fulfillment type when none is decided by user"

--- a/packages/api-plugin-products/src/mutations/createProduct.js
+++ b/packages/api-plugin-products/src/mutations/createProduct.js
@@ -49,10 +49,12 @@ export default async function createProduct(context, input) {
     throw new ReactionError("invalid-param", "Creating a deleted product is not allowed");
   }
 
-  const { defaultFulfillmentTypesForShop } = await context.queries.appSettings(context, shopId);
+  // Include the base/shop-level fulfillment types for all products
+  // if user has provided additional fulfillment types, include them also
+  const { baseFulfillmentTypesForShop } = await context.queries.appSettings(context, shopId);
   const { supportedFulfillmentTypes } = initialProductData;
   let combinedSupportedFulfillmentTypes = [];
-  if (defaultFulfillmentTypesForShop) combinedSupportedFulfillmentTypes = [...defaultFulfillmentTypesForShop];
+  if (baseFulfillmentTypesForShop) combinedSupportedFulfillmentTypes = [...baseFulfillmentTypesForShop];
   if (supportedFulfillmentTypes) combinedSupportedFulfillmentTypes = [...combinedSupportedFulfillmentTypes, ...supportedFulfillmentTypes];
   combinedSupportedFulfillmentTypes = [...new Set(combinedSupportedFulfillmentTypes)];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
       '@reactioncommerce/logger': link:../../packages/logger
       '@reactioncommerce/nodemailer': 5.0.5
       '@reactioncommerce/random': link:../../packages/random
-      '@snyk/protect': 1.1017.0
+      '@snyk/protect': 1.1020.0
       graphql: 14.7.0
       semver: 6.3.0
       sharp: 0.29.3
@@ -4747,8 +4747,8 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: false
 
-  /@snyk/protect/1.1017.0:
-    resolution: {integrity: sha512-6WHVyRUBba7Q/e6BAbn3+J3SSvBQU0Ps9YItg9Z/B7w91JusSCq6P4KTNt66AZxHwQ1X2iUbIWrkNEIpKuXePQ==}
+  /@snyk/protect/1.1020.0:
+    resolution: {integrity: sha512-Uncxecj9mtEVlaEFVojpNOu6wZ3Om4cpvDDB25FcyOd0o+buru57GKNCMT89G2UC35dKpz6FOYyn1/gXNQZqIQ==}
     engines: {node: '>=10'}
     hasBin: true
     dev: false


### PR DESCRIPTION
Signed-off-by: Sujith <mail.sujithvn@gmail.com>

Resolves #6474 
Impact: **major**
Type: **feature**

## Issue

Admin should be able to define what available fulfillment types should be added by default to new products(#6474)
User should be able to check a box in the admin on any/all/none of the fulfillment types and those would automatically be added to new products as they are created. THIS SHOULD NOT AFFECT EXISTING PRODUCTS AT ALL

## Solution

Current available FF-types can be retrieved using the query `getFulfillmentTypes` and presented to user. User can select one/all/none of the ff-types and use the `updateShopSettings` mutation to update the same.

While creating a new Product, the `supportedFulfillmentTypes` in the input (if provided) will be added to the default ff-types from the shop settings and used for creating new product.

## Breaking changes
None. If there are no ff-types added then no entries are added to product.  User input will be retained as it is.

## Testing
1. use the `updateShopSettings` mutation to update the default ff-types for shop.
2. new products created will include the default ff-type from shop settings 
3. use the `updateShopSettings` mutation to remove any of the default ff-types for shop.
4. new products created will contain only user input ff-types
