### PR TITLE
Initial i18n for Fulfillment

### DIFF
--- a/packages/api-plugin-fulfillment-method-pickup-store/src/i18n/en.json
+++ b/packages/api-plugin-fulfillment-method-pickup-store/src/i18n/en.json
@@ -9,7 +9,7 @@
           "methodLabel": "Store",
           "rateSaved": "Fulfillment method saved",
           "rateFailed": "Fulfillment method update failed",
-          "noUPSRatesFound": "No Store pickup fulfillment methods found"
+          "noRatesFound": "No Store pickup fulfillment methods found"
         },
         "pickupGrid": {
           "name": "Name",

--- a/packages/api-plugin-fulfillment-method-pickup-store/src/i18n/en.json
+++ b/packages/api-plugin-fulfillment-method-pickup-store/src/i18n/en.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "en",
+  "ns": "reaction-pickup-store",
+  "translation": {
+    "reaction-pickup-store": {
+      "admin": {
+        "pickupSettings": {
+          "header": "Pickup",
+          "methodLabel": "Store",
+          "rateSaved": "Fulfillment method saved",
+          "rateFailed": "Fulfillment method update failed",
+          "noUPSRatesFound": "No Store pickup fulfillment methods found"
+        },
+        "pickupGrid": {
+          "name": "Name",
+          "group": "Group",
+          "rate": "Rate",
+          "label": "Label"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-pickup-store/src/i18n/index.js
+++ b/packages/api-plugin-fulfillment-method-pickup-store/src/i18n/index.js
@@ -1,0 +1,12 @@
+import en from "./en.json";
+
+//
+// we want all the files in individual
+// imports for easier handling by
+// automated translation software
+//
+export default {
+  translations: [
+    ...en
+  ]
+};

--- a/packages/api-plugin-fulfillment-method-pickup-store/src/index.js
+++ b/packages/api-plugin-fulfillment-method-pickup-store/src/index.js
@@ -1,4 +1,5 @@
 import { createRequire } from "module";
+import i18n from "./i18n/index.js";
 import fulfillmentMethodPickupStorePreStartup from "./preStartup.js";
 import fulfillmentMethodPickupStoreStartup from "./startup.js";
 import { MethodStoreData } from "./simpleSchemas.js";
@@ -19,6 +20,7 @@ export default async function register(app) {
     label: "Fulfillment Method Pickup Store",
     name: "fulfillment-method-pickup-store",
     version: pkg.version,
+    i18n,
     graphQL: {
       schemas
     },

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/ar.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/ar.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "ar",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "معدل",
+          "confirmRateDelete": "حذف معدل؟",
+          "rateSaved": "معدل ثابت حفظها.",
+          "rateFailed": "فشل تحديث معدل ثابت.",
+          "noRatesFound": "لم يتم العثور على أسعار الفائدة."
+        },
+        "shippingGrid": {
+          "name": "اسم",
+          "group": "مجموعة",
+          "rate": "معدل",
+          "label": "ملصق"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/bg.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/bg.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "bg",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Единна ставка",
+          "confirmRateDelete": "ставка Изтриване?",
+          "rateSaved": "Единна ставка спасен.",
+          "rateFailed": "актуализация Единна ставка провали.",
+          "noRatesFound": "Няма намерени проценти."
+        },
+        "shippingGrid": {
+          "name": "Име",
+          "group": "група",
+          "rate": "скорост",
+          "label": "Етикет"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/cs.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/cs.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "cs",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "jednotná sazba",
+          "confirmRateDelete": "Smazat míru?",
+          "rateSaved": "Paušální částka uložena.",
+          "rateFailed": "Byt rychlost aktualizace nezdařila.",
+          "noRatesFound": "Nebyly nalezeny žádné ceny."
+        },
+        "shippingGrid": {
+          "name": "Název",
+          "group": "Skupina",
+          "rate": "Rychlost",
+          "label": "Označení"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/de.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/de.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "de",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Flatrate",
+          "confirmRateDelete": "Löschen Rate?",
+          "rateSaved": "Flatrate gespeichert.",
+          "rateFailed": "Flatrate-Update ist fehlgeschlagen.",
+          "noRatesFound": "Keine Preise gefunden."
+        },
+        "shippingGrid": {
+          "name": "Name",
+          "group": "Gruppe",
+          "rate": "Preis",
+          "label": "Etikette"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/el.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/el.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "el",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Flat Rate",
+          "confirmRateDelete": "Διαγραφή ποσοστό;",
+          "rateSaved": "Κατ 'αποκοπή ποσό σωθεί.",
+          "rateFailed": "ενημέρωση κατ 'αποκοπή απέτυχε.",
+          "noRatesFound": "Δεν βρέθηκαν τιμές."
+        },
+        "shippingGrid": {
+          "name": "Όνομα",
+          "group": "Ομάδα",
+          "rate": "Τιμή",
+          "label": "Επιγραφή"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/en.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/en.json
@@ -1,0 +1,24 @@
+[{
+  "i18n": "en",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "header": "Shipping",
+          "flatRateLabel": "Flat Rate",
+          "confirmRateDelete": "Delete this fulfillment method?",
+          "rateSaved": "Fulfillment method saved",
+          "rateFailed": "Fulfillment method update failed",
+          "noRatesFound": "No flat rate fulfillment methods found"
+        },
+        "shippingGrid": {
+          "name": "Name",
+          "group": "Group",
+          "rate": "Rate",
+          "label": "Label"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/es.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/es.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "es",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Tarifa plana",
+          "confirmRateDelete": "Eliminar tasa?",
+          "rateSaved": "La tarifa plana de guarda.",
+          "rateFailed": "actualización de tarifa plana falló.",
+          "noRatesFound": "No se encontraron tasas."
+        },
+        "shippingGrid": {
+          "name": "Nombre",
+          "group": "Grupo",
+          "rate": "Tarifa",
+          "label": "Etiqueta"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/fr.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/fr.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "fr",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Forfait",
+          "confirmRateDelete": "Supprimer le tarif ?",
+          "rateSaved": "Tarif forfaitaire sauvegardé.",
+          "rateFailed": "La mise à jour du tarif forfaitaire a échouée.",
+          "noRatesFound": "Pas de prix trouvés."
+        },
+        "shippingGrid": {
+          "name": "Nom",
+          "group": "Groupe",
+          "rate": "Tarif",
+          "label": "Étiquette"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/he.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/he.json
@@ -1,0 +1,5 @@
+[{
+  "i18n": "he",
+  "ns": "reaction-shipping-rates",
+  "translation": { }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/hr.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/hr.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "hr",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "flat rate",
+          "confirmRateDelete": "Brisanje stopa?",
+          "rateSaved": "Stan stopa spasio.",
+          "rateFailed": "Flat rate ažuriranje nije uspjelo.",
+          "noRatesFound": "Nisu pronađene stope."
+        },
+        "shippingGrid": {
+          "name": "Ime",
+          "group": "Skupina",
+          "rate": "Stopa",
+          "label": "Označiti"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/hu.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/hu.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "hu",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Átalánydíj",
+          "confirmRateDelete": "Törlés arány?",
+          "rateSaved": "Átalánydíjas mentve.",
+          "rateFailed": "Átalánydíjas sikertelen volt.",
+          "noRatesFound": "Nem talált árak."
+        },
+        "shippingGrid": {
+          "name": "Név",
+          "group": "Csoport",
+          "rate": "Arány",
+          "label": "Címke"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/index.js
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/index.js
@@ -1,0 +1,58 @@
+import ar from "./ar.json";
+import bg from "./bg.json";
+import cs from "./cs.json";
+import de from "./de.json";
+import el from "./el.json";
+import en from "./en.json";
+import es from "./es.json";
+import fr from "./fr.json";
+import he from "./he.json";
+import hr from "./hr.json";
+import hu from "./hu.json";
+import it from "./it.json";
+import my from "./my.json";
+import nb from "./nb.json";
+import nl from "./nl.json";
+import pl from "./pl.json";
+import pt from "./pt.json";
+import ro from "./ro.json";
+import ru from "./ru.json";
+import sl from "./sl.json";
+import sv from "./sv.json";
+import tr from "./tr.json";
+import vi from "./vi.json";
+import zh from "./zh.json";
+
+//
+// we want all the files in individual
+// imports for easier handling by
+// automated translation software
+//
+export default {
+  translations: [
+    ...ar,
+    ...bg,
+    ...cs,
+    ...de,
+    ...el,
+    ...en,
+    ...es,
+    ...fr,
+    ...he,
+    ...hr,
+    ...hu,
+    ...it,
+    ...my,
+    ...nb,
+    ...nl,
+    ...pl,
+    ...pt,
+    ...ro,
+    ...ru,
+    ...sl,
+    ...sv,
+    ...tr,
+    ...vi,
+    ...zh
+  ]
+};

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/it.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/it.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "it",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Tasso fisso",
+          "confirmRateDelete": "Eliminare tasso?",
+          "rateSaved": "Tariffa unica salvato.",
+          "rateFailed": "aggiornamento tasso di piatto non è riuscito.",
+          "noRatesFound": "Prezzi non trovato."
+        },
+        "shippingGrid": {
+          "name": "Nome",
+          "group": "Gruppo",
+          "rate": "Tasso",
+          "label": "Etichetta"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/my.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/my.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "my",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "စျေးနှုန်းတစ်သတ်မှတ်တည်းဖြစ်သော",
+          "confirmRateDelete": "မှုနှုန်းကိုဖျက်ရမလား?",
+          "rateSaved": "ပြားချပ်ချပ်နှုန်းသည်ကယ်တင်ခြင်းသို့ရောက်ရ၏။",
+          "rateFailed": "ပြားချပ်ချပ်နှုန်းကို update ကိုပျက်ကွက်ခဲ့သည်။",
+          "noRatesFound": "အဘယ်သူမျှမနှုန်းထားများတွေ့ရှိခဲ့ပါတယ်။"
+        },
+        "shippingGrid": {
+          "name": "နာမကိုအမှီ",
+          "group": "Group က",
+          "rate": "rate",
+          "label": "တံဆိပ်"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/nb.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/nb.json
@@ -1,0 +1,5 @@
+[{
+  "i18n": "nb",
+  "ns": "reaction-shipping-rates",
+  "translation": { }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/nl.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/nl.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "nl",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Vast bedrag",
+          "confirmRateDelete": "rate verwijderen?",
+          "rateSaved": "Flat rate opgeslagen.",
+          "rateFailed": "Flat rate update is mislukt.",
+          "noRatesFound": "Geen prijzen gevonden."
+        },
+        "shippingGrid": {
+          "name": "Naam",
+          "group": "Groep",
+          "rate": "Snelheid",
+          "label": "Etiket"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/pl.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/pl.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "pl",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Jednolita stawka",
+          "confirmRateDelete": "Usuń stopę?",
+          "rateSaved": "Ryczałt zapisane.",
+          "rateFailed": "Aktualizacja ryczałtowa nie powiodło się.",
+          "noRatesFound": "Nie znaleziono stopy."
+        },
+        "shippingGrid": {
+          "name": "Nazwa",
+          "group": "Grupa",
+          "rate": "Oceniać",
+          "label": "Etykieta"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/pt.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/pt.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "pt",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Taxa fixa",
+          "confirmRateDelete": "Excluir taxa?",
+          "rateSaved": "Taxa fixa salvo.",
+          "rateFailed": "atualização de taxa fixa falhou.",
+          "noRatesFound": "Sem preço encontrado."
+        },
+        "shippingGrid": {
+          "name": "Nome",
+          "group": "Grupo",
+          "rate": "Taxa",
+          "label": "Etiqueta"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/ro.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/ro.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "ro",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Preţ global",
+          "confirmRateDelete": "Rata șterge?",
+          "rateSaved": "Rata de plat salvat.",
+          "rateFailed": "actualizare rată fixă ​​a eșuat.",
+          "noRatesFound": "Nu există tarife găsite."
+        },
+        "shippingGrid": {
+          "name": "Nume",
+          "group": "grup",
+          "rate": "Rată",
+          "label": "Eticheta"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/ru.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/ru.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "ru",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Квартирная плата",
+          "confirmRateDelete": "Удалить ставку?",
+          "rateSaved": "Фиксированная ставка сохранена.",
+          "rateFailed": "обновление фиксированная ставка не удалось.",
+          "noRatesFound": "Нет ставок не найдено."
+        },
+        "shippingGrid": {
+          "name": "Имя",
+          "group": "Группа",
+          "rate": "Ставка",
+          "label": "Этикетка"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/sl.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/sl.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "sl",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Flat Rate",
+          "confirmRateDelete": "Brisanje hitrost?",
+          "rateSaved": "Pavšalno shranjene.",
+          "rateFailed": "Stanovanje posodobitev stopnja ni uspela.",
+          "noRatesFound": "Ni mere."
+        },
+        "shippingGrid": {
+          "name": "Name",
+          "group": "skupina",
+          "rate": "Oceniti",
+          "label": "Label"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/sv.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/sv.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "sv",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "ENHETSTAXA",
+          "confirmRateDelete": "Radera frekvens?",
+          "rateSaved": "Schablonbelopp sparas.",
+          "rateFailed": "Platt uppdateringsfrekvens misslyckades.",
+          "noRatesFound": "Det finns inga priser hittades."
+        },
+        "shippingGrid": {
+          "name": "Namn",
+          "group": "Grupp",
+          "rate": "Betygsätt",
+          "label": "Etikett"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/tr.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/tr.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "tr",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "Sabit fiyat",
+          "confirmRateDelete": "oranı silinsin mi?",
+          "rateSaved": "Sabit ücret kaydedildi.",
+          "rateFailed": "Sabit ücret güncellemesi başarısız oldu.",
+          "noRatesFound": "Hiçbir oranlar bulunamadı."
+        },
+        "shippingGrid": {
+          "name": "Isim",
+          "group": "grup",
+          "rate": "Oran",
+          "label": "Etiket"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/vi.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/vi.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "vi",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "giá thấp nhứt",
+          "confirmRateDelete": "Xóa tỷ lệ?",
+          "rateSaved": "tỷ lệ căn hộ lưu.",
+          "rateFailed": "cập nhật tỷ lệ căn hộ thất bại.",
+          "noRatesFound": "Không tìm thấy giá."
+        },
+        "shippingGrid": {
+          "name": "Tên",
+          "group": "Nhóm",
+          "rate": "Tỷ lệ",
+          "label": "Nhãn"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/zh.json
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/i18n/zh.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "zh",
+  "ns": "reaction-shipping-rates",
+  "translation": {
+    "reaction-shipping-rates": {
+      "admin": {
+        "shippingSettings": {
+          "flatRateLabel": "扁平率",
+          "confirmRateDelete": "删除率是多少？",
+          "rateSaved": "扁平率保存。",
+          "rateFailed": "统一费率更新失败。",
+          "noRatesFound": "没有发现率。"
+        },
+        "shippingGrid": {
+          "name": "名字",
+          "group": "组",
+          "rate": "率",
+          "label": "标签"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/index.js
+++ b/packages/api-plugin-fulfillment-method-shipping-flat-rate/src/index.js
@@ -1,6 +1,7 @@
 import { createRequire } from "module";
 import getFulfillmentMethodsWithQuotesShippingFlatRate from "./getFulfillmentMethodsWithQuotesShippingFlatRate.js";
 import validateOrderMethodsflatRate from "./util/validateOrderMethodsflatrate.js";
+import i18n from "./i18n/index.js";
 import resolvers from "./resolvers/index.js";
 import mutations from "./mutations/index.js";
 import policies from "./policies.json";
@@ -29,6 +30,7 @@ export default async function register(app) {
     label: "Fulfillment Method Shipping Flat Rate",
     name: "fulfillment-method-shipping-flat-rate",
     version: pkg.version,
+    i18n,
     graphQL: {
       resolvers,
       schemas

--- a/packages/api-plugin-fulfillment-method-shipping-ups/src/i18n/en.json
+++ b/packages/api-plugin-fulfillment-method-shipping-ups/src/i18n/en.json
@@ -1,15 +1,15 @@
 [{
   "i18n": "en",
-  "ns": "reaction-shipping-ups",
+  "ns": "reaction-shipping-dynamic-rate",
   "translation": {
-    "reaction-shipping-ups": {
+    "reaction-shipping-dynamic-rate": {
       "admin": {
         "shippingSettings": {
           "header": "Shipping",
-          "methodLabel": "UPS",
+          "methodLabel": "Dynamic Rate",
           "rateSaved": "Fulfillment method saved",
           "rateFailed": "Fulfillment method update failed",
-          "noUPSRatesFound": "No UPS fulfillment methods found"
+          "noRatesFound": "No dynamic rate fulfillment methods found"
         },
         "shippingGrid": {
           "name": "Name",

--- a/packages/api-plugin-fulfillment-method-shipping-ups/src/i18n/en.json
+++ b/packages/api-plugin-fulfillment-method-shipping-ups/src/i18n/en.json
@@ -1,0 +1,23 @@
+[{
+  "i18n": "en",
+  "ns": "reaction-shipping-ups",
+  "translation": {
+    "reaction-shipping-ups": {
+      "admin": {
+        "shippingSettings": {
+          "header": "Shipping",
+          "methodLabel": "UPS",
+          "rateSaved": "Fulfillment method saved",
+          "rateFailed": "Fulfillment method update failed",
+          "noUPSRatesFound": "No UPS fulfillment methods found"
+        },
+        "shippingGrid": {
+          "name": "Name",
+          "group": "Group",
+          "rate": "Rate",
+          "label": "Label"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-method-shipping-ups/src/i18n/index.js
+++ b/packages/api-plugin-fulfillment-method-shipping-ups/src/i18n/index.js
@@ -1,0 +1,12 @@
+import en from "./en.json";
+
+//
+// we want all the files in individual
+// imports for easier handling by
+// automated translation software
+//
+export default {
+  translations: [
+    ...en
+  ]
+};

--- a/packages/api-plugin-fulfillment-method-shipping-ups/src/index.js
+++ b/packages/api-plugin-fulfillment-method-shipping-ups/src/index.js
@@ -1,5 +1,6 @@
 import { createRequire } from "module";
 import { MethodUPSData } from "./simpleSchemas.js";
+import i18n from "./i18n/index.js";
 import preStartup from "./preStartup.js";
 import startup from "./startup.js";
 import schemas from "./schemas/index.js";
@@ -19,6 +20,7 @@ export default async function register(app) {
     label: "Fulfillment Method Shipping UPS",
     name: "fulfillment-method-shipping-ups",
     version: pkg.version,
+    i18n,
     graphQL: {
       schemas
     },

--- a/packages/api-plugin-fulfillment-type-pickup/src/i18n/en.json
+++ b/packages/api-plugin-fulfillment-type-pickup/src/i18n/en.json
@@ -1,0 +1,58 @@
+[{
+  "i18n": "en",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "pickupLabel": "Pickup",
+          "pickupTitle": "Pickup",
+          "pickupDescription": "Manage Pickup"
+        },
+        "settings": {
+          "pickupLabel": "Pickup"
+        }
+      },
+      "checkoutPickup": {
+        "selectPickupOption": "Select pickup option",
+        "noPickupMethods": "No pickup methods are configured.",
+        "contactAdmin": "Please contact the store administrator.",
+        "configureNow": "Configure now.",
+        "pickup": "Pickup"
+      },
+      "pickup": {
+        "editPickupProvider": "Edit pickup provider",
+        "editPickupMethod": "Edit pickup method",
+        "noSettingsForThisView": "No settings for this view",
+        "noPickupMethods": "No pickup methods are configured.",
+        "pickupProviderSaved": "Pickup provider saved.",
+        "pickupProviderUpdated": "Pickup provider data updated.",
+        "pickupMethodRateAdded": "Pickup method rate added.",
+        "pickupMethodRateUpdated": "Pickup method rate updated.",
+        "name": "Name",
+        "label": "Label",
+        "group": "Group",
+        "cost": "Cost",
+        "handling": "Handling",
+        "rate": "Rate",
+        "enabled": "Enabled",
+        "disabled": "Disabled",
+        "updateRate": "Update {{name}} rate",
+        "provider": {
+          "name": "Service Code",
+          "label": "Public Label",
+          "enabled": "Enabled"
+        }
+      },
+      "pickupMethod": {
+        "name": "Method Name",
+        "label": "Public Label",
+        "group": "Group",
+        "cost": "Cost",
+        "handling": "Handling",
+        "rate": "Rate",
+        "enabled": "Enabled"
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-pickup/src/i18n/index.js
+++ b/packages/api-plugin-fulfillment-type-pickup/src/i18n/index.js
@@ -1,0 +1,12 @@
+import en from "./en.json";
+
+//
+// we want all the files in individual
+// imports for easier handling by
+// automated translation software
+//
+export default {
+  translations: [
+    ...en
+  ]
+};

--- a/packages/api-plugin-fulfillment-type-pickup/src/index.js
+++ b/packages/api-plugin-fulfillment-type-pickup/src/index.js
@@ -1,4 +1,5 @@
 import { createRequire } from "module";
+import i18n from "./i18n/index.js";
 import schemas from "./schemas/index.js";
 import startup from "./startup.js";
 
@@ -15,6 +16,7 @@ export default async function register(app) {
     label: "Fulfillment Type Pickup",
     name: "fulfillment-type-pickup",
     version: pkg.version,
+    i18n,
     graphQL: {
       schemas
     },

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/ar.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/ar.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "ar",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "الشحن",
+          "shippingTitle": "الشحن",
+          "shippingDescription": "توفير معدلات الشحن"
+        },
+        "settings": {
+          "shippingLabel": "الشحن"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "حدد خيار الشحن",
+        "noShippingMethods": "يتم تكوين أي وسائل النقل البحري.",
+        "contactAdmin": "يرجى الاتصال بمسؤول المتجر.",
+        "configureNow": "تكوين الآن.",
+        "shipping": "الشحن"
+      },
+      "shipping": {
+        "addShippingProvider": "إضافة مزود الشحن",
+        "editShippingProvider": "تحرير مزود الشحن",
+        "addShippingMethod": "إضافة وسيلة النقل البحري",
+        "editShippingMethod": "تعديل طريقة الشحن",
+        "deleteShippingMethod": "حذف طريقة الشحن",
+        "noSettingsForThisView": "أي إعدادات لهذا الرأي",
+        "noShippingMethods": "يتم تكوين أي وسائل النقل البحري.",
+        "removeShippingMethodConfirm": "هل أنت متأكد أنك تريد حذف {{method}}؟",
+        "removeShippingMethodTitle": "إزالة طريقة شحن",
+        "shippingMethodDeleted": "لقد تم حذف هذه طريقة الشحن.",
+        "removeShippingProvider": "إزالة الشحن موفر",
+        "removeShippingProviderConfirm": "هل أنت متأكد أنك تريد حذف {{provider}}؟",
+        "shippingProviderSaved": "مزود الشحن حفظها.",
+        "shippingProviderUpdated": "تجديد البيانات مزود الشحن.",
+        "shippingMethodRateAdded": "وأضاف معدل طريقة الشحن.",
+        "shippingMethodRateUpdated": "الشحن معدل طريقة تحديثها.",
+        "name": "اسم",
+        "label": "ملصق",
+        "group": "مجموعة",
+        "cost": "كلفة",
+        "handling": "معالجة",
+        "rate": "معدل",
+        "enabled": "تمكين",
+        "disabled": "تعطيل",
+        "addRate": "إضافة معدل",
+        "updateRate": "تحديث معدل {{name}}",
+        "addNewCondition": "إضافة حالة جديدة",
+        "deleteCondition": "حذف شرط",
+        "provider": {
+          "name": "رمز الخدمة",
+          "label": "تسمية العامة",
+          "enabled": "تمكين"
+        }
+      },
+      "shippingMethod": {
+        "name": "اسم الطريقة",
+        "label": "تسمية العامة",
+        "group": "مجموعة",
+        "cost": "كلفة",
+        "handling": "معالجة",
+        "rate": "معدل",
+        "enabled": "تمكين",
+        "matchingCartRanges": "مطابقة نطاقات العربة",
+        "validRanges": {
+          "begin": "ابدأ",
+          "end": "النهاية"
+        },
+        "matchingLocales": "مطابقة لغات",
+        "validLocales": {
+          "origination": "من عند",
+          "destination": "إلى",
+          "deliveryBegin": "مؤسسة النقل البحري.",
+          "deliveryEnd": "مؤسسة التسليم."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/bg.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/bg.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "bg",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Доставка",
+          "shippingTitle": "Доставка",
+          "shippingDescription": "Осигуряване на тарифите за доставка"
+        },
+        "settings": {
+          "shippingLabel": "Доставка"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Изберете опция за доставка",
+        "noShippingMethods": "Не са методи на доставка са конфигурирани.",
+        "contactAdmin": "Моля, свържете се с администратора на магазина.",
+        "configureNow": "Конфигуриране на предприятието.",
+        "shipping": "Доставка"
+      },
+      "shipping": {
+        "addShippingProvider": "Добави доставчик корабоплаването",
+        "editShippingProvider": "Edit доставчик корабоплаването",
+        "addShippingMethod": "Добави начин за доставка",
+        "editShippingMethod": "метод Edit корабоплаването",
+        "deleteShippingMethod": "Изтриване на начин за доставка",
+        "noSettingsForThisView": "Не настройки за тази гледка",
+        "noShippingMethods": "Не са методи на доставка са конфигурирани.",
+        "removeShippingMethodConfirm": "Сигурни ли сте, че искате да изтриете {{method}}?",
+        "removeShippingMethodTitle": "Премахване Начин на доставка",
+        "shippingMethodDeleted": "Този метод на пратката е била изтрита.",
+        "removeShippingProvider": "Премахване Provider Доставка",
+        "removeShippingProviderConfirm": "Сигурни ли сте, че искате да изтриете {{provider}}?",
+        "shippingProviderSaved": "доставчик Доставка спасен.",
+        "shippingProviderUpdated": "актуализирани данни на доставчика за доставка.",
+        "shippingMethodRateAdded": "прибавя процент Доставка метод.",
+        "shippingMethodRateUpdated": "ставка метод за доставка се обновява.",
+        "name": "Име",
+        "label": "Етикет",
+        "group": "група",
+        "cost": "цена",
+        "handling": "боравене",
+        "rate": "скорост",
+        "enabled": "Enabled",
+        "disabled": "хора с увреждания",
+        "addRate": "Добави скорост",
+        "updateRate": "Актуализация {{name}} скорост",
+        "addNewCondition": "Добавяне на нов състояние",
+        "deleteCondition": "Изтриване състояние",
+        "provider": {
+          "name": "Service Code",
+          "label": "Public Label",
+          "enabled": "Enabled"
+        }
+      },
+      "shippingMethod": {
+        "name": "Име на метода",
+        "label": "Public Label",
+        "group": "група",
+        "cost": "цена",
+        "handling": "боравене",
+        "rate": "скорост",
+        "enabled": "Enabled",
+        "matchingCartRanges": "Съвпадение Количка диапазоните",
+        "validRanges": {
+          "begin": "започвам",
+          "end": "Край"
+        },
+        "matchingLocales": "съвпадение Локалите",
+        "validLocales": {
+          "origination": "от",
+          "destination": "Да се",
+          "deliveryBegin": "Доставка Est.",
+          "deliveryEnd": "Доставка Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/cs.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/cs.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "cs",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "lodní",
+          "shippingTitle": "lodní",
+          "shippingDescription": "Poskytnout sazby za dopravu"
+        },
+        "settings": {
+          "shippingLabel": "lodní"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Vyberte možnost lodní",
+        "noShippingMethods": "Žádné způsoby dopravy jsou konfigurovány.",
+        "contactAdmin": "Obraťte se na správce obchodu.",
+        "configureNow": "Nakofigurujte.",
+        "shipping": "lodní"
+      },
+      "shipping": {
+        "addShippingProvider": "Přidat provozovatele přepravní",
+        "editShippingProvider": "Editovat poskytovatel lodní",
+        "addShippingMethod": "Přidat způsob dopravy",
+        "editShippingMethod": "Upravit způsob dopravy",
+        "deleteShippingMethod": "Smazat způsob dopravy",
+        "noSettingsForThisView": "Žádná nastavení pro tento názor",
+        "noShippingMethods": "Žádné způsoby dopravy jsou konfigurovány.",
+        "removeShippingMethodConfirm": "Jste si jisti, že chcete smazat {{method}}?",
+        "removeShippingMethodTitle": "Odstraňte Způsob dopravy",
+        "shippingMethodDeleted": "Tento způsob dopravy byla smazána.",
+        "removeShippingProvider": "Odstraňte Shipping Provider",
+        "removeShippingProviderConfirm": "Jste si jisti, že chcete smazat {{provider}}?",
+        "shippingProviderSaved": "Poskytovatel vodní doprava uložen.",
+        "shippingProviderUpdated": "Data Provider vodní doprava aktualizována.",
+        "shippingMethodRateAdded": "Způsob dopravy rychlost přidán.",
+        "shippingMethodRateUpdated": "Způsob dopravy rychlost aktualizován.",
+        "name": "Název",
+        "label": "Označení",
+        "group": "Skupina",
+        "cost": "Náklady",
+        "handling": "Zacházení",
+        "rate": "Rychlost",
+        "enabled": "Povoleno",
+        "disabled": "invalidní",
+        "addRate": "Přidejte míru",
+        "updateRate": "Aktualizace {{name}} rychlost",
+        "addNewCondition": "Přidat novou podmínku",
+        "deleteCondition": "smazat podmínku",
+        "provider": {
+          "name": "Service Code",
+          "label": "veřejné Label",
+          "enabled": "Povoleno"
+        }
+      },
+      "shippingMethod": {
+        "name": "Jméno metoda",
+        "label": "veřejné Label",
+        "group": "Skupina",
+        "cost": "Náklady",
+        "handling": "Zacházení",
+        "rate": "Rychlost",
+        "enabled": "Povoleno",
+        "matchingCartRanges": "Odpovídající košík rozsahy",
+        "validRanges": {
+          "begin": "Začít",
+          "end": "Konec"
+        },
+        "matchingLocales": "odpovídající místního prostredí",
+        "validLocales": {
+          "origination": "Od",
+          "destination": "Na",
+          "deliveryBegin": "Vodní doprava Est.",
+          "deliveryEnd": "Dodávka Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/de.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/de.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "de",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Versand",
+          "shippingTitle": "Versand",
+          "shippingDescription": "Geben Sie Versandkosten"
+        },
+        "settings": {
+          "shippingLabel": "Versand"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Wählen Versandoption",
+        "noShippingMethods": "Keine Versandmethoden konfiguriert sind.",
+        "contactAdmin": "Bitte wenden Sie sich an den Ladenverwalter.",
+        "configureNow": "Jetzt konfigurieren.",
+        "shipping": "Versand"
+      },
+      "shipping": {
+        "addShippingProvider": "Versandkosten Anbieter",
+        "editShippingProvider": "Bearbeiten Versandanbieter",
+        "addShippingMethod": "In Verfahren Versand",
+        "editShippingMethod": "Bearbeiten Versandart",
+        "deleteShippingMethod": "Löschen Versandart",
+        "noSettingsForThisView": "Keine Einstellungen für diese Ansicht",
+        "noShippingMethods": "Keine Versandmethoden konfiguriert sind.",
+        "removeShippingMethodConfirm": "Sind Sie sicher, dass Sie {{method}} löschen?",
+        "removeShippingMethodTitle": "Entfernen Sie Versandart",
+        "shippingMethodDeleted": "Diese Versandart wurde gelöscht.",
+        "removeShippingProvider": "Entfernen Sie Liefer-Provider",
+        "removeShippingProviderConfirm": "Sind Sie sicher, dass Sie {{provider}} löschen?",
+        "shippingProviderSaved": "Versandanbieters gespeichert.",
+        "shippingProviderUpdated": "Versand-Provider-Daten aktualisiert.",
+        "shippingMethodRateAdded": "Versandart Rate hinzugefügt.",
+        "shippingMethodRateUpdated": "Versandart Rate aktualisiert.",
+        "name": "Name",
+        "label": "Etikette",
+        "group": "Gruppe",
+        "cost": "Kosten",
+        "handling": "Handhabung",
+        "rate": "Preis",
+        "enabled": "Aktiviert",
+        "disabled": "Behindert",
+        "addRate": "In Rate",
+        "updateRate": "Update-Rate {{name}}",
+        "addNewCondition": "Hinzufügen neuer Zustand",
+        "deleteCondition": "Bedingung löschen",
+        "provider": {
+          "name": "Servicecode",
+          "label": "Öffentliche Etikett",
+          "enabled": "Aktiviert"
+        }
+      },
+      "shippingMethod": {
+        "name": "Methodenname",
+        "label": "Öffentliche Etikett",
+        "group": "Gruppe",
+        "cost": "Kosten",
+        "handling": "Handhabung",
+        "rate": "Preis",
+        "enabled": "Aktiviert",
+        "matchingCartRanges": "Passende Wagen Ranges",
+        "validRanges": {
+          "begin": "Start",
+          "end": "Ende"
+        },
+        "matchingLocales": "Passende Locales",
+        "validLocales": {
+          "origination": "Von",
+          "destination": "Bis",
+          "deliveryBegin": "Versand Est.",
+          "deliveryEnd": "Lieferung Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/el.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/el.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "el",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Αποστολή",
+          "shippingTitle": "Αποστολή",
+          "shippingDescription": "Παρέχουν τα έξοδα αποστολής"
+        },
+        "settings": {
+          "shippingLabel": "Αποστολή"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Επιλέξτε την επιλογή αποστολής",
+        "noShippingMethods": "Δεν μέθοδοι ναυτιλίας ρυθμιστεί.",
+        "contactAdmin": "Επικοινωνήστε με τον διαχειριστή του καταστήματος.",
+        "configureNow": "Διαμορφώστε τώρα.",
+        "shipping": "Αποστολή"
+      },
+      "shipping": {
+        "addShippingProvider": "Προσθέστε την υπηρεσία αποστολής",
+        "editShippingProvider": "Επεξεργασία υπηρεσία αποστολής",
+        "addShippingMethod": "Προσθήκη μέθοδο αποστολής",
+        "editShippingMethod": "Επεξεργασία μεθόδου αποστολής",
+        "deleteShippingMethod": "Διαγραφή μέθοδο αποστολής",
+        "noSettingsForThisView": "Δεν υπάρχουν ρυθμίσεις για αυτό το σκοπό",
+        "noShippingMethods": "Δεν μέθοδοι ναυτιλίας ρυθμιστεί.",
+        "removeShippingMethodConfirm": "Είστε σίγουροι ότι θέλετε να διαγράψετε {{method}};",
+        "removeShippingMethodTitle": "Κατάργηση Μέθοδος ναυτιλίας",
+        "shippingMethodDeleted": "Αυτή η μέθοδος ναυτιλίας έχει διαγραφεί.",
+        "removeShippingProvider": "Κατάργηση Provider Ναυτιλίας",
+        "removeShippingProviderConfirm": "Είστε σίγουροι ότι θέλετε να διαγράψετε {{provider}};",
+        "shippingProviderSaved": "Ο πάροχος υπηρεσιών αποστολής σωθεί.",
+        "shippingProviderUpdated": "ενημερωμένα δεδομένα παρόχου ναυτιλία.",
+        "shippingMethodRateAdded": "ρυθμός μέθοδο αποστολής πρόσθεσε.",
+        "shippingMethodRateUpdated": "ρυθμός μέθοδο αποστολής ενημερωθεί.",
+        "name": "Όνομα",
+        "label": "Επιγραφή",
+        "group": "Ομάδα",
+        "cost": "Κόστος",
+        "handling": "Χειριζόμενος",
+        "rate": "Τιμή",
+        "enabled": "Ενεργοποιήθηκε",
+        "disabled": "Ανάπηρος",
+        "addRate": "Προσθέστε ποσοστό",
+        "updateRate": "ρυθμό ανανέωσης {{name}}",
+        "addNewCondition": "Προσθήκη νέου κατάσταση",
+        "deleteCondition": "Διαγραφή κατάσταση",
+        "provider": {
+          "name": "Κωδικός υπηρεσίας",
+          "label": "δημόσια Label",
+          "enabled": "Ενεργοποιήθηκε"
+        }
+      },
+      "shippingMethod": {
+        "name": "Όνομα μέθοδο",
+        "label": "δημόσια Label",
+        "group": "Ομάδα",
+        "cost": "Κόστος",
+        "handling": "Χειριζόμενος",
+        "rate": "Τιμή",
+        "enabled": "Ενεργοποιήθηκε",
+        "matchingCartRanges": "Ταιριάζουν καλαθιού Σειρές",
+        "validRanges": {
+          "begin": "Αρχίζουν",
+          "end": "Τέλος"
+        },
+        "matchingLocales": "ταιριάζουν Τοπικές",
+        "validLocales": {
+          "origination": "Από",
+          "destination": "Να",
+          "deliveryBegin": "Αποστολές Est.",
+          "deliveryEnd": "Παράδοση Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/en.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/en.json
@@ -1,0 +1,84 @@
+[{
+  "i18n": "en",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Shipping",
+          "shippingTitle": "Shipping",
+          "shippingDescription": "Provide shipping rates"
+        },
+        "settings": {
+          "shippingLabel": "Shipping"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Select shipping option",
+        "noShippingMethods": "No shipping methods are configured.",
+        "contactAdmin": "Please contact the store administrator.",
+        "configureNow": "Configure now.",
+        "shipping": "Shipping"
+      },
+      "shipping": {
+        "addShippingProvider": "Add shipping provider",
+        "editShippingProvider": "Edit shipping provider",
+        "addShippingMethod": "Add shipping method",
+        "editShippingMethod": "Edit shipping method",
+        "deleteShippingMethod": "Delete shipping method",
+        "noSettingsForThisView": "No settings for this view",
+        "noShippingMethods": "No shipping methods are configured.",
+        "removeShippingMethodConfirm": "Are you sure you want to delete {{method}}?",
+        "removeShippingMethodTitle": "Remove Shipping Method",
+        "shippingMethodDeleted": "This shipping method has been deleted.",
+        "removeShippingProvider": "Remove Shipping Provider",
+        "removeShippingProviderConfirm": "Are you sure you want to delete {{provider}}?",
+        "shippingProviderSaved": "Shipping provider saved.",
+        "shippingProviderUpdated": "Shipping provider data updated.",
+        "shippingMethodRateAdded": "Shipping method rate added.",
+        "shippingMethodRateUpdated": "Shipping method rate updated.",
+        "name": "Name",
+        "label": "Label",
+        "group": "Group",
+        "cost": "Cost",
+        "handling": "Handling",
+        "rate": "Rate",
+        "enabled": "Enabled",
+        "disabled": "Disabled",
+        "addRate": "Add rate",
+        "updateRate": "Update {{name}} rate",
+        "addNewCondition": "Add new condition",
+        "deleteCondition": "Delete condition",
+        "provider": {
+          "name": "Service Code",
+          "label": "Public Label",
+          "enabled": "Enabled"
+        }
+      },
+      "shippingMethod": {
+        "name": "Method Name",
+        "label": "Public Label",
+        "group": "Group",
+        "cost": "Cost",
+        "handling": "Handling",
+        "rate": "Rate",
+        "enabled": "Enabled",
+        "matchingCartRanges": "Matching Cart Ranges",
+        "validRanges": {
+          "begin": "Begin",
+          "end": "End"
+        },
+        "matchingLocales": "Matching Locales",
+        "validLocales": {
+          "origination": "From",
+          "destination": "To",
+          "deliveryBegin": "Shipping Est.",
+          "deliveryEnd": "Delivery Est."
+        }
+      },
+      "defaultParcelSize": {
+        "label": "Default Parcel Size"
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/es.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/es.json
@@ -1,0 +1,87 @@
+[{
+  "i18n": "es",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Envío",
+          "shippingTitle": "Envío",
+          "shippingDescription": "Indicar gastos de envío"
+        },
+        "settings": {
+          "shippingLabel": "Envío"
+        },
+        "shippingSettings": {
+          "header": "Envío"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Seleccione la opción de envío",
+        "noShippingMethods": "No hay métodos de envío están configurados.",
+        "contactAdmin": "Póngase en contacto con el administrador de la tienda.",
+        "configureNow": "Configurar ahora.",
+        "shipping": "Envío"
+      },
+      "shipping": {
+        "addShippingProvider": "Añadir la empresa de transportes",
+        "editShippingProvider": "Editar proveedor de envío",
+        "addShippingMethod": "Añadir método de envío",
+        "editShippingMethod": "Editar método de envío",
+        "deleteShippingMethod": "Eliminar método de envío",
+        "noSettingsForThisView": "No hay parámetros para este punto de vista",
+        "noShippingMethods": "No hay métodos de envío están configurados.",
+        "removeShippingMethodConfirm": "¿Está seguro de que quiere eliminar {{method}}?",
+        "removeShippingMethodTitle": "Retire Método de envío",
+        "shippingMethodDeleted": "Este método de envío que se ha suprimido.",
+        "removeShippingProvider": "Retire Proveedor de envío",
+        "removeShippingProviderConfirm": "¿Está seguro de que quiere eliminar {{provider}}?",
+        "shippingProviderSaved": "Formas de envío salvó.",
+        "shippingProviderUpdated": "Formas de envío de datos actualizados.",
+        "shippingMethodRateAdded": "tasa método de envío añadió.",
+        "shippingMethodRateUpdated": "tasa de actualización del método de envío.",
+        "name": "Nombre",
+        "label": "Etiqueta",
+        "group": "Grupo",
+        "cost": "Costo",
+        "handling": "Manejo",
+        "rate": "Tarifa",
+        "enabled": "Activado",
+        "disabled": "Discapacitados",
+        "addRate": "Añadir tasa",
+        "updateRate": "Velocidad de actualización {{name}}",
+        "addNewCondition": "Añadir nueva condición",
+        "deleteCondition": "eliminar condición",
+        "provider": {
+          "name": "Código de servicio",
+          "label": "Etiqueta pública",
+          "enabled": "Activado"
+        }
+      },
+      "shippingMethod": {
+        "name": "Nombre del método",
+        "label": "Etiqueta pública",
+        "group": "Grupo",
+        "cost": "Costo",
+        "handling": "Manejo",
+        "rate": "Tarifa",
+        "enabled": "Activado",
+        "matchingCartRanges": "Coincidencia Cesta Gamas",
+        "validRanges": {
+          "begin": "Empezar",
+          "end": "Fin"
+        },
+        "matchingLocales": "Locales a juego",
+        "validLocales": {
+          "origination": "De",
+          "destination": "A",
+          "deliveryBegin": "Este envío.",
+          "deliveryEnd": "Entrega Est."
+        }
+      },
+      "defaultParcelSize": {
+        "label": "Tamaño por defecto del paquete"
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/fr.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/fr.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "fr",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Livraison",
+          "shippingTitle": "Livraison",
+          "shippingDescription": "Gérer les frais de port"
+        },
+        "settings": {
+          "shippingLabel": "Livraison"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Sélectionnez une option d'expédition",
+        "noShippingMethods": "Aucune méthode d'expédition n'est configurée.",
+        "contactAdmin": "Veuillez contacter l'administrateur de la boutique.",
+        "configureNow": "Configurer maintenant.",
+        "shipping": "Livraison"
+      },
+      "shipping": {
+        "addShippingProvider": "Ajouter un transporteur",
+        "editShippingProvider": "Modifier le transporteur",
+        "addShippingMethod": "Ajouter un mode de livraison",
+        "editShippingMethod": "Modifier le mode de livraison",
+        "deleteShippingMethod": "Supprimer le mode de livraison",
+        "noSettingsForThisView": "Pas de paramètres pour cette vue",
+        "noShippingMethods": "Aucune méthode d'expédition n'est configurée.",
+        "removeShippingMethodConfirm": "Êtes-vous sûr de vouloir supprimer {{method}} ?",
+        "removeShippingMethodTitle": "Supprimer le mode de livraison",
+        "shippingMethodDeleted": "Ce mode de livraison a été supprimé.",
+        "removeShippingProvider": "Supprimer le transporteur",
+        "removeShippingProviderConfirm": "Êtes-vous sûr de vouloir supprimer {{provider}}?",
+        "shippingProviderSaved": "Mode de livraison sauvegardé.",
+        "shippingProviderUpdated": "Données du fournisseur de livraison mises à jour.",
+        "shippingMethodRateAdded": "Tarif de livraison ajouté.",
+        "shippingMethodRateUpdated": "Tarif de livraison mis à jour.",
+        "name": "Nom",
+        "label": "Étiquette",
+        "group": "Groupe",
+        "cost": "Coût",
+        "handling": "Prise en charge",
+        "rate": "Taux",
+        "enabled": "Activé",
+        "disabled": "Désactivé",
+        "addRate": "Ajouter tarif",
+        "updateRate": "Mettre à jour le tarif {{name}}",
+        "addNewCondition": "Ajouter un nouvel état",
+        "deleteCondition": "Supprimer l'état",
+        "provider": {
+          "name": "Référence interne",
+          "label": "Nom public",
+          "enabled": "Activé"
+        }
+      },
+      "shippingMethod": {
+        "name": "Référence interne",
+        "label": "Nom public",
+        "group": "Groupe",
+        "cost": "Coût",
+        "handling": "Prise en charge",
+        "rate": "Taux",
+        "enabled": "Activé",
+        "matchingCartRanges": "Fourchette de panier correspondante",
+        "validRanges": {
+          "begin": "Début",
+          "end": "Fin"
+        },
+        "matchingLocales": "Localités correspondantes",
+        "validLocales": {
+          "origination": "Au départ de",
+          "destination": "Vers",
+          "deliveryBegin": "Estimation des frais de port",
+          "deliveryEnd": "Livraison estimée"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/he.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/he.json
@@ -1,0 +1,5 @@
+[{
+  "i18n": "he",
+  "ns": "reaction-shipping",
+  "translation": { }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/hr.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/hr.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "hr",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "dostava",
+          "shippingTitle": "dostava",
+          "shippingDescription": "Osigurati cijene dostave"
+        },
+        "settings": {
+          "shippingLabel": "dostava"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Odaberite opciju dostave",
+        "noShippingMethods": "Nema načina dostave konfigurirane.",
+        "contactAdmin": "Obratite se administratoru trgovine.",
+        "configureNow": "Konfiguracija sada.",
+        "shipping": "dostava"
+      },
+      "shipping": {
+        "addShippingProvider": "Dodaj dostave davatelja",
+        "editShippingProvider": "Uredi ponuđač dostave",
+        "addShippingMethod": "Dodaj način dostave",
+        "editShippingMethod": "Uredite način dostave",
+        "deleteShippingMethod": "Brisanje način dostave",
+        "noSettingsForThisView": "Nema postavki za ovu pogled",
+        "noShippingMethods": "Nema načina dostave konfigurirane.",
+        "removeShippingMethodConfirm": "Jeste li sigurni da želite obrisati {{method}}?",
+        "removeShippingMethodTitle": "Ukloni Način dostave",
+        "shippingMethodDeleted": "Ova metoda dostave je obrisan.",
+        "removeShippingProvider": "Ukloni Dostava Provider",
+        "removeShippingProviderConfirm": "Jeste li sigurni da želite obrisati {{provider}}?",
+        "shippingProviderSaved": "Dostava davatelj spasio.",
+        "shippingProviderUpdated": "Dostava davatelja podataka ažurirati.",
+        "shippingMethodRateAdded": "Dostava stopa metoda dodan.",
+        "shippingMethodRateUpdated": "Dostava stopa metoda ažuriran.",
+        "name": "Ime",
+        "label": "Označiti",
+        "group": "Skupina",
+        "cost": "cijena",
+        "handling": "Rukovanje",
+        "rate": "Stopa",
+        "enabled": "Omogućeno",
+        "disabled": "onesposobljen",
+        "addRate": "Dodaj stopu",
+        "updateRate": "Ažuriranje {{name}} stopa",
+        "addNewCondition": "Dodaj novo stanje",
+        "deleteCondition": "Brisanje stanje",
+        "provider": {
+          "name": "kod usluga",
+          "label": "Javni Label",
+          "enabled": "Omogućeno"
+        }
+      },
+      "shippingMethod": {
+        "name": "Naziv metoda",
+        "label": "Javni Label",
+        "group": "Skupina",
+        "cost": "cijena",
+        "handling": "Rukovanje",
+        "rate": "Stopa",
+        "enabled": "Omogućeno",
+        "matchingCartRanges": "Odgovarajući košarice rasponi",
+        "validRanges": {
+          "begin": "Početi",
+          "end": "Kraj"
+        },
+        "matchingLocales": "odgovarajući locales",
+        "validLocales": {
+          "origination": "Iz",
+          "destination": "Do",
+          "deliveryBegin": "Dostava Est.",
+          "deliveryEnd": "Isporuka Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/hu.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/hu.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "hu",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Szállítás",
+          "shippingTitle": "Szállítás",
+          "shippingDescription": "Adjon szállítási díjak"
+        },
+        "settings": {
+          "shippingLabel": "Szállítás"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Válassza ki a szállítási opciót",
+        "noShippingMethods": "Nincs szállítási módszerek vannak beállítva.",
+        "contactAdmin": "Kérjük, forduljon a bolt rendszergazda.",
+        "configureNow": "Konfigurálása most.",
+        "shipping": "Szállítás"
+      },
+      "shipping": {
+        "addShippingProvider": "Add szállítási szolgáltató",
+        "editShippingProvider": "Szállítás szerkesztése szolgáltató",
+        "addShippingMethod": "Add szállítási mód",
+        "editShippingMethod": "Szállítási mód szerkesztése",
+        "deleteShippingMethod": "Törlés szállítási mód",
+        "noSettingsForThisView": "Nincs beállítás ehhez a nézethez",
+        "noShippingMethods": "Nincs szállítási módszerek vannak beállítva.",
+        "removeShippingMethodConfirm": "Biztosan törölni szeretné {{method}}?",
+        "removeShippingMethodTitle": "Távolítsuk Szállítás módja",
+        "shippingMethodDeleted": "Ez a szállítási mód törölték.",
+        "removeShippingProvider": "Távolítsuk el a Szállítási Szolgáltató",
+        "removeShippingProviderConfirm": "Biztosan törölni szeretné {{provider}}?",
+        "shippingProviderSaved": "Szállítási szolgáltató mentve.",
+        "shippingProviderUpdated": "Szállítási szolgáltató adatai módosítva.",
+        "shippingMethodRateAdded": "Szállítási mód arány hozzá.",
+        "shippingMethodRateUpdated": "Szállítási mód sebesség frissíteni.",
+        "name": "Név",
+        "label": "Címke",
+        "group": "Csoport",
+        "cost": "Költség",
+        "handling": "Kezelése",
+        "rate": "Arány",
+        "enabled": "Engedélyezett",
+        "disabled": "Tiltva",
+        "addRate": "Add ráta",
+        "updateRate": "Frissítés {{name}} ráta",
+        "addNewCondition": "Új állapot",
+        "deleteCondition": "Törlés állapotban",
+        "provider": {
+          "name": "Service Code",
+          "label": "Public Label",
+          "enabled": "Engedélyezett"
+        }
+      },
+      "shippingMethod": {
+        "name": "módszer neve",
+        "label": "Public Label",
+        "group": "Csoport",
+        "cost": "Költség",
+        "handling": "Kezelése",
+        "rate": "Arány",
+        "enabled": "Engedélyezett",
+        "matchingCartRanges": "Matching Cart tartományok",
+        "validRanges": {
+          "begin": "Kezdődik",
+          "end": "vég"
+        },
+        "matchingLocales": "Matching Nyelv",
+        "validLocales": {
+          "origination": "Ból ből",
+          "destination": "Nak nek",
+          "deliveryBegin": "Szállítási Est.",
+          "deliveryEnd": "Szállítási Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/index.js
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/index.js
@@ -1,0 +1,54 @@
+import ar from "./ar.json";
+import bg from "./bg.json";
+import de from "./de.json";
+import el from "./el.json";
+import en from "./en.json";
+import es from "./es.json";
+import fr from "./fr.json";
+import he from "./he.json";
+import hr from "./hr.json";
+import it from "./it.json";
+import my from "./my.json";
+import nb from "./nb.json";
+import nl from "./nl.json";
+import pl from "./pl.json";
+import pt from "./pt.json";
+import ro from "./ro.json";
+import ru from "./ru.json";
+import sl from "./sl.json";
+import sv from "./sv.json";
+import tr from "./tr.json";
+import vi from "./vi.json";
+import zh from "./zh.json";
+
+//
+// we want all the files in individual
+// imports for easier handling by
+// automated translation software
+//
+export default {
+  translations: [
+    ...ar,
+    ...bg,
+    ...de,
+    ...el,
+    ...en,
+    ...es,
+    ...fr,
+    ...he,
+    ...hr,
+    ...it,
+    ...my,
+    ...nb,
+    ...nl,
+    ...pl,
+    ...pt,
+    ...ro,
+    ...ru,
+    ...sl,
+    ...sv,
+    ...tr,
+    ...vi,
+    ...zh
+  ]
+};

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/it.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/it.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "it",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "spedizione",
+          "shippingTitle": "spedizione",
+          "shippingDescription": "Fornire le tariffe di spedizione"
+        },
+        "settings": {
+          "shippingLabel": "spedizione"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Selezionare l'opzione di spedizione",
+        "noShippingMethods": "No Metodi di spedizione sono configurati.",
+        "contactAdmin": "Contattare l'amministratore del negozio.",
+        "configureNow": "Configurare ora.",
+        "shipping": "spedizione"
+      },
+      "shipping": {
+        "addShippingProvider": "Aggiungere corriere",
+        "editShippingProvider": "Fornitore di trasporto Modifica",
+        "addShippingMethod": "Aggiungere il metodo di spedizione",
+        "editShippingMethod": "Modifica metodo di spedizione",
+        "deleteShippingMethod": "Elimina metodo di spedizione",
+        "noSettingsForThisView": "Nessuna impostazione per questo punto di vista",
+        "noShippingMethods": "No Metodi di spedizione sono configurati.",
+        "removeShippingMethodConfirm": "Sei sicuro di voler eliminare {{method}}?",
+        "removeShippingMethodTitle": "Rimuovere Metodo di Spedizione",
+        "shippingMethodDeleted": "Questo metodo di trasporto è stato eliminato.",
+        "removeShippingProvider": "Rimuovere Spedizione Provider",
+        "removeShippingProviderConfirm": "Sei sicuro di voler eliminare {{provider}}?",
+        "shippingProviderSaved": "Fornitore di trasporto salvato.",
+        "shippingProviderUpdated": "i dati del provider Spedizione aggiornati.",
+        "shippingMethodRateAdded": "tasso Metodo di trasporto aggiunto.",
+        "shippingMethodRateUpdated": "tasso Metodo di trasporto aggiornato.",
+        "name": "Nome",
+        "label": "Etichetta",
+        "group": "Gruppo",
+        "cost": "Costo",
+        "handling": "maneggio",
+        "rate": "Tasso",
+        "enabled": "Abilitato",
+        "disabled": "Disabilitato",
+        "addRate": "Aggiungere tasso",
+        "updateRate": "Velocità di aggiornamento {{name}}",
+        "addNewCondition": "Aggiungi nuova condizione",
+        "deleteCondition": "Eliminare condizioni",
+        "provider": {
+          "name": "Codice servizio",
+          "label": "pubblico Label",
+          "enabled": "Abilitato"
+        }
+      },
+      "shippingMethod": {
+        "name": "Nome metodo",
+        "label": "pubblico Label",
+        "group": "Gruppo",
+        "cost": "Costo",
+        "handling": "maneggio",
+        "rate": "Tasso",
+        "enabled": "Abilitato",
+        "matchingCartRanges": "Abbinamento Carrello Ranges",
+        "validRanges": {
+          "begin": "Inizio",
+          "end": "Fine"
+        },
+        "matchingLocales": "Impostazioni internazionali di corrispondenza",
+        "validLocales": {
+          "origination": "Da",
+          "destination": "A",
+          "deliveryBegin": "Spedizione Est.",
+          "deliveryEnd": "Consegna Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/my.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/my.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "my",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "သင်္ဘောဖြင့်ကုန်ပစ္စည်းပို့ခြင်း",
+          "shippingTitle": "သင်္ဘောဖြင့်ကုန်ပစ္စည်းပို့ခြင်း",
+          "shippingDescription": "ရေကြောင်းနှုန်းထားများပေး"
+        },
+        "settings": {
+          "shippingLabel": "သင်္ဘောဖြင့်ကုန်ပစ္စည်းပို့ခြင်း"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "ရေကြောင်း option ကို Select လုပ်ပါ",
+        "noShippingMethods": "အဘယ်သူမျှမရေကြောင်းနည်းလမ်းများ configured ကြသည်။",
+        "contactAdmin": "စတိုးဆိုင်စီမံခန့်ခွဲသူကိုဆက်သွယ်ပါ။",
+        "configureNow": "ယခု configure ။",
+        "shipping": "သင်္ဘောဖြင့်ကုန်ပစ္စည်းပို့ခြင်း"
+      },
+      "shipping": {
+        "addShippingProvider": "ရေကြောင်းပံ့ပိုးပေး Add",
+        "editShippingProvider": "Edit ကိုရေကြောင်းပံ့ပိုးပေး",
+        "addShippingMethod": "ရေကြောင်းနည်းလမ်း Add",
+        "editShippingMethod": "Edit ကိုရေကြောင်းနည်းလမ်း",
+        "deleteShippingMethod": "ရေကြောင်းနည်းလမ်းဖျက်ပစ်ပါ",
+        "noSettingsForThisView": "ဒီအမြင်အဘို့အဘယ်သူမျှမကအပြင်အဆင်များ",
+        "noShippingMethods": "အဘယ်သူမျှမရေကြောင်းနည်းလမ်းများ configured ကြသည်။",
+        "removeShippingMethodConfirm": "သငျသညျ {{method}} သင်ဖျက်လိုသည်မှာသေချာပါသလား",
+        "removeShippingMethodTitle": "သဘောင်္တင်ခ Method ကို Remove",
+        "shippingMethodDeleted": "ဒီသင်္ဘောနည်းလမ်းဖျက်ထားသည်။",
+        "removeShippingProvider": "သဘောင်္တင်ခပေးသူ Remove",
+        "removeShippingProviderConfirm": "သငျသညျ {{provider}} သင်ဖျက်လိုသည်မှာသေချာပါသလား",
+        "shippingProviderSaved": "သဘောင်္တင်ပံ့ပိုးပေးသူကယ်လွှတ်တော်မူ၏။",
+        "shippingProviderUpdated": "သဘောင်္တင်ပံ့ပိုးပေးသူဒေတာ updated ။",
+        "shippingMethodRateAdded": "သဘောင်္တင်ခနည်းလမ်းမှုနှုန်းကဆက်ပြောသည်။",
+        "shippingMethodRateUpdated": "updated သဘောင်္တင်နည်းလမ်းနှုန်းသည်။",
+        "name": "နာမကိုအမှီ",
+        "label": "တံဆိပ်",
+        "group": "Group က",
+        "cost": "ပေးရ",
+        "handling": "ကိုင်တွယ်",
+        "rate": "rate",
+        "enabled": "enabled",
+        "disabled": "မသန်စွမ်း",
+        "addRate": "နှုန်းမှာ Add",
+        "updateRate": "Update ကို {{name}} မှုနှုန်း",
+        "addNewCondition": "အသစ်အခွအေနေ Add",
+        "deleteCondition": "အခွအေနေဖျက်ပစ်ပါ",
+        "provider": {
+          "name": "Service ကို Code ကို",
+          "label": "ပြည်သူ့တံဆိပ်",
+          "enabled": "enabled"
+        }
+      },
+      "shippingMethod": {
+        "name": "method ကိုအမည်",
+        "label": "ပြည်သူ့တံဆိပ်",
+        "group": "Group က",
+        "cost": "ပေးရ",
+        "handling": "ကိုင်တွယ်",
+        "rate": "rate",
+        "enabled": "enabled",
+        "matchingCartRanges": "ကိုက်ညီတဲ့လှည်းတောင်တန်း",
+        "validRanges": {
+          "begin": "အစ",
+          "end": "အဆုံး"
+        },
+        "matchingLocales": "ကိုက်ညီတဲ့ဒေသခံ",
+        "validLocales": {
+          "origination": "မှ",
+          "destination": "သို့",
+          "deliveryBegin": "သဘောင်္တင်ခ Est ။",
+          "deliveryEnd": "Delivery Est ။"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/nb.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/nb.json
@@ -1,0 +1,5 @@
+[{
+  "i18n": "nb",
+  "ns": "reaction-shipping",
+  "translation": { }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/nl.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/nl.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "nl",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Verzenden",
+          "shippingTitle": "Verzenden",
+          "shippingDescription": "Bieden verzendkosten"
+        },
+        "settings": {
+          "shippingLabel": "Verzenden"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Kies verzendoptie",
+        "noShippingMethods": "Geen verzendkosten methoden worden geconfigureerd.",
+        "contactAdmin": "Neem contact op met de winkelbeheerder.",
+        "configureNow": "Configureren nu.",
+        "shipping": "Verzenden"
+      },
+      "shipping": {
+        "addShippingProvider": "Voeg scheepvaart provider",
+        "editShippingProvider": "Bewerken scheepvaart provider",
+        "addShippingMethod": "Voeg verzendmethode",
+        "editShippingMethod": "Bewerken verzendmethode",
+        "deleteShippingMethod": "Verwijder verzendmethode",
+        "noSettingsForThisView": "Geen instellingen voor dit standpunt",
+        "noShippingMethods": "Geen verzendkosten methoden worden geconfigureerd.",
+        "removeShippingMethodConfirm": "Bent u zeker dat u wilt {{method}} verwijderen?",
+        "removeShippingMethodTitle": "Verwijder Verzendmethode",
+        "shippingMethodDeleted": "Deze verzendmethode is verwijderd.",
+        "removeShippingProvider": "Verwijder Shipping Provider",
+        "removeShippingProviderConfirm": "Bent u zeker dat u wilt {{provider}} verwijderen?",
+        "shippingProviderSaved": "Shipping provider opgeslagen.",
+        "shippingProviderUpdated": "Verzending provider gegevens bijgewerkt.",
+        "shippingMethodRateAdded": "Verzendmethode snelheid toegevoegd.",
+        "shippingMethodRateUpdated": "Verzendmethode rate bijgewerkt.",
+        "name": "Naam",
+        "label": "Etiket",
+        "group": "Groep",
+        "cost": "Kosten",
+        "handling": "behandeling",
+        "rate": "Snelheid",
+        "enabled": "Ingeschakeld",
+        "disabled": "Gehandicapte",
+        "addRate": "tarief toe te voegen",
+        "updateRate": "Update {{name}} rate",
+        "addNewCondition": "Voeg een nieuwe voorwaarde",
+        "deleteCondition": "Verwijder conditie",
+        "provider": {
+          "name": "service Code",
+          "label": "openbare Label",
+          "enabled": "Ingeschakeld"
+        }
+      },
+      "shippingMethod": {
+        "name": "methode Naam",
+        "label": "openbare Label",
+        "group": "Groep",
+        "cost": "Kosten",
+        "handling": "behandeling",
+        "rate": "Snelheid",
+        "enabled": "Ingeschakeld",
+        "matchingCartRanges": "Matching winkelwagen Ranges",
+        "validRanges": {
+          "begin": "Beginnen",
+          "end": "Einde"
+        },
+        "matchingLocales": "matching Locales",
+        "validLocales": {
+          "origination": "Van",
+          "destination": "Naar",
+          "deliveryBegin": "Shipping Est.",
+          "deliveryEnd": "Levering Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/pl.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/pl.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "pl",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Wysyłka",
+          "shippingTitle": "Wysyłka",
+          "shippingDescription": "Zapewnić koszty wysyłki"
+        },
+        "settings": {
+          "shippingLabel": "Wysyłka"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Wybierz opcję wysyłki",
+        "noShippingMethods": "są skonfigurowane żadne metody wysyłki.",
+        "contactAdmin": "Skontaktuj się z administratorem sklepu.",
+        "configureNow": "Skonfiguruj teraz.",
+        "shipping": "Wysyłka"
+      },
+      "shipping": {
+        "addShippingProvider": "Dodaj dostawcę przesyłki",
+        "editShippingProvider": "Edycja kurierska",
+        "addShippingMethod": "Dodaj metodę wysyłki",
+        "editShippingMethod": "Zmień sposób wysyłki",
+        "deleteShippingMethod": "Usuń metodę wysyłki",
+        "noSettingsForThisView": "Brak ustawienia dla tego widoku",
+        "noShippingMethods": "są skonfigurowane żadne metody wysyłki.",
+        "removeShippingMethodConfirm": "Czy na pewno chcesz usunąć {{method}}?",
+        "removeShippingMethodTitle": "Usuń metody wysyłki",
+        "shippingMethodDeleted": "Ta metoda wysyłki została usunięta.",
+        "removeShippingProvider": "Usuń kurierska",
+        "removeShippingProviderConfirm": "Czy na pewno chcesz usunąć {{provider}}?",
+        "shippingProviderSaved": "dostawcą Dostawa zapisane.",
+        "shippingProviderUpdated": "zaktualizowane dane kurierska.",
+        "shippingMethodRateAdded": "Dostawa stopa metoda dodaje.",
+        "shippingMethodRateUpdated": "Dostawa stopa metoda aktualizowana.",
+        "name": "Nazwa",
+        "label": "Etykieta",
+        "group": "Grupa",
+        "cost": "Koszt",
+        "handling": "Obsługa",
+        "rate": "Oceniać",
+        "enabled": "Włączone",
+        "disabled": "Niepełnosprawny",
+        "addRate": "Dodaj stopę",
+        "updateRate": "Częstotliwość odświeżania {{name}}",
+        "addNewCondition": "Dodaj nowy warunek",
+        "deleteCondition": "Usuń warunek",
+        "provider": {
+          "name": "service Code",
+          "label": "Etykieta publiczny",
+          "enabled": "Włączone"
+        }
+      },
+      "shippingMethod": {
+        "name": "Nazwa metody",
+        "label": "Etykieta publiczny",
+        "group": "Grupa",
+        "cost": "Koszt",
+        "handling": "Obsługa",
+        "rate": "Oceniać",
+        "enabled": "Włączone",
+        "matchingCartRanges": "Dopasowane Koszyk Zakresy",
+        "validRanges": {
+          "begin": "Zaczynać",
+          "end": "Koniec"
+        },
+        "matchingLocales": "Dopasowane Locales",
+        "validLocales": {
+          "origination": "Od",
+          "destination": "Do",
+          "deliveryBegin": "Dostawa Est.",
+          "deliveryEnd": "Dostawa Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/pt.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/pt.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "pt",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Remessa",
+          "shippingTitle": "Remessa",
+          "shippingDescription": "Fornecer taxas de envio"
+        },
+        "settings": {
+          "shippingLabel": "Remessa"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Selecione a opção de envio",
+        "noShippingMethods": "Não há métodos de envio estão configurados.",
+        "contactAdmin": "Entre em contato com o administrador da loja.",
+        "configureNow": "Configurar agora.",
+        "shipping": "Remessa"
+      },
+      "shipping": {
+        "addShippingProvider": "Adicionar provedor de transporte",
+        "editShippingProvider": "Editar provedor de transporte",
+        "addShippingMethod": "Adicionar método de envio",
+        "editShippingMethod": "Editar método de envio",
+        "deleteShippingMethod": "Excluir método de envio",
+        "noSettingsForThisView": "Não há definições para este ponto de vista",
+        "noShippingMethods": "Não há métodos de envio estão configurados.",
+        "removeShippingMethodConfirm": "Tem certeza de que deseja excluir {{method}}?",
+        "removeShippingMethodTitle": "Remover Método de Envio",
+        "shippingMethodDeleted": "Este método de envio foi excluída.",
+        "removeShippingProvider": "Remover fornecedor de Frete",
+        "removeShippingProviderConfirm": "Tem certeza de que deseja excluir {{provider}}?",
+        "shippingProviderSaved": "provedor de envio salvo.",
+        "shippingProviderUpdated": "dados do provedor envio atualizado.",
+        "shippingMethodRateAdded": "Envio da tarifa método acrescentou.",
+        "shippingMethodRateUpdated": "taxa de método de envio atualizado.",
+        "name": "Nome",
+        "label": "Etiqueta",
+        "group": "Grupo",
+        "cost": "Custo",
+        "handling": "Manipulação",
+        "rate": "Taxa",
+        "enabled": "Ativado",
+        "disabled": "Desativado",
+        "addRate": "Adicionar taxa de",
+        "updateRate": "Taxa de Atualização {{name}}",
+        "addNewCondition": "Adicionar nova condição",
+        "deleteCondition": "excluir condição",
+        "provider": {
+          "name": "Código de serviço",
+          "label": "Etiqueta pública",
+          "enabled": "Ativado"
+        }
+      },
+      "shippingMethod": {
+        "name": "Nome do método",
+        "label": "Etiqueta pública",
+        "group": "Grupo",
+        "cost": "Custo",
+        "handling": "Manipulação",
+        "rate": "Taxa",
+        "enabled": "Ativado",
+        "matchingCartRanges": "Combinando Carrinho Ranges",
+        "validRanges": {
+          "begin": "Início",
+          "end": "Fim"
+        },
+        "matchingLocales": "Localidades combinando",
+        "validLocales": {
+          "origination": "A partir da",
+          "destination": "Para",
+          "deliveryBegin": "O envio Est.",
+          "deliveryEnd": "Entrega Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/ro.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/ro.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "ro",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "livrare",
+          "shippingTitle": "livrare",
+          "shippingDescription": "Oferi tarife de transport maritim"
+        },
+        "settings": {
+          "shippingLabel": "livrare"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Selectați opțiunea de transport maritim",
+        "noShippingMethods": "Nu există metode de expediere sunt configurate.",
+        "contactAdmin": "Contactați administratorul magazinului.",
+        "configureNow": "Configurati.",
+        "shipping": "livrare"
+      },
+      "shipping": {
+        "addShippingProvider": "Adăugați un furnizor de transport maritim",
+        "editShippingProvider": "Editare furnizori de transport maritim",
+        "addShippingMethod": "Adăugați o metodă de transport maritim",
+        "editShippingMethod": "Edita metodă de expediere",
+        "deleteShippingMethod": "Șterge metodă de expediere",
+        "noSettingsForThisView": "Nu există setări pentru această vizualizare",
+        "noShippingMethods": "Nu există metode de expediere sunt configurate.",
+        "removeShippingMethodConfirm": "Sunteți sigur că doriți să ștergeți {{method}}?",
+        "removeShippingMethodTitle": "Eliminați Metodă de expediere",
+        "shippingMethodDeleted": "Această metodă de transport maritim a fost șters.",
+        "removeShippingProvider": "Furnizorul de transport elimina",
+        "removeShippingProviderConfirm": "Sunteți sigur că doriți să ștergeți {{provider}}?",
+        "shippingProviderSaved": "Furnizor de transport maritim salvat.",
+        "shippingProviderUpdated": "Date de furnizor de transport maritim actualizat.",
+        "shippingMethodRateAdded": "Rata metodă de expediere adăugată.",
+        "shippingMethodRateUpdated": "Rata metodă de expediere actualizată.",
+        "name": "Nume",
+        "label": "Eticheta",
+        "group": "grup",
+        "cost": "A costat",
+        "handling": "manipularea",
+        "rate": "Rată",
+        "enabled": "Activat",
+        "disabled": "Pentru persoane cu handicap",
+        "addRate": "adauga o rată",
+        "updateRate": "Rata de actualizare {{name}}",
+        "addNewCondition": "Adăugați o condiție nouă",
+        "deleteCondition": "şterge condiție",
+        "provider": {
+          "name": "Codul de service",
+          "label": "Etichetă publică",
+          "enabled": "Activat"
+        }
+      },
+      "shippingMethod": {
+        "name": "Nume metoda",
+        "label": "Etichetă publică",
+        "group": "grup",
+        "cost": "A costat",
+        "handling": "manipularea",
+        "rate": "Rată",
+        "enabled": "Activat",
+        "matchingCartRanges": "Potrivire Ranges Coș",
+        "validRanges": {
+          "begin": "ÎNCEPE",
+          "end": "Sfârşit"
+        },
+        "matchingLocales": "potrivire Localizările",
+        "validLocales": {
+          "origination": "Din",
+          "destination": "La",
+          "deliveryBegin": "De transport maritim Est.",
+          "deliveryEnd": "Livrare Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/ru.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/ru.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "ru",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Перевозка",
+          "shippingTitle": "Перевозка",
+          "shippingDescription": "Обеспечить стоимость доставки"
+        },
+        "settings": {
+          "shippingLabel": "Перевозка"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Выберите вариант доставки",
+        "noShippingMethods": "Нет способов доставки не настроены.",
+        "contactAdmin": "Обратитесь к администратору магазина.",
+        "configureNow": "Настроить сейчас.",
+        "shipping": "Перевозка"
+      },
+      "shipping": {
+        "addShippingProvider": "Добавить поставщика доставки",
+        "editShippingProvider": "Редактировать поставщик доставка",
+        "addShippingMethod": "Добавить способ доставки",
+        "editShippingMethod": "Способ редактирования отправка",
+        "deleteShippingMethod": "Удалить способ доставки",
+        "noSettingsForThisView": "Нет настроек для этой точки зрения",
+        "noShippingMethods": "Нет способов доставки не настроены.",
+        "removeShippingMethodConfirm": "Вы уверены, что хотите удалить {{method}}?",
+        "removeShippingMethodTitle": "Удалить Способ доставки",
+        "shippingMethodDeleted": "Этот способ доставки был удален.",
+        "removeShippingProvider": "Удалить поставщика доставки",
+        "removeShippingProviderConfirm": "Вы уверены, что хотите удалить {{provider}}?",
+        "shippingProviderSaved": "поставщик Доставка сохранен.",
+        "shippingProviderUpdated": "Поставщик услуг Доставка обновляется.",
+        "shippingMethodRateAdded": "добавлен скорость Способ доставки.",
+        "shippingMethodRateUpdated": "Скорость Способ доставки обновлен.",
+        "name": "Имя",
+        "label": "Этикетка",
+        "group": "Группа",
+        "cost": "Стоимость",
+        "handling": "обращение",
+        "rate": "Ставка",
+        "enabled": "Включено",
+        "disabled": "Отключено",
+        "addRate": "Добавить скорость",
+        "updateRate": "Обновление {{name}} скорости",
+        "addNewCondition": "Добавить новое условие",
+        "deleteCondition": "Удалить условие",
+        "provider": {
+          "name": "Сервисный код",
+          "label": "Общественный Этикетка",
+          "enabled": "Включено"
+        }
+      },
+      "shippingMethod": {
+        "name": "Имя метода",
+        "label": "Общественный Этикетка",
+        "group": "Группа",
+        "cost": "Стоимость",
+        "handling": "обращение",
+        "rate": "Ставка",
+        "enabled": "Включено",
+        "matchingCartRanges": "Matching Корзина Ranges",
+        "validRanges": {
+          "begin": "Начать",
+          "end": "Конец"
+        },
+        "matchingLocales": "Соответствие Локали",
+        "validLocales": {
+          "origination": "Из",
+          "destination": "Для",
+          "deliveryBegin": "Доставка Est.",
+          "deliveryEnd": "Доставка Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/sl.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/sl.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "sl",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Dostava",
+          "shippingTitle": "Dostava",
+          "shippingDescription": "Navedite stroške pošiljanja"
+        },
+        "settings": {
+          "shippingLabel": "Dostava"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Izberite možnost ladijskega prometa",
+        "noShippingMethods": "Ni metode pošiljanja so nastavljeni.",
+        "contactAdmin": "Obrnite se na skrbnika trgovine.",
+        "configureNow": "Konfiguracija zdaj.",
+        "shipping": "Dostava"
+      },
+      "shipping": {
+        "addShippingProvider": "Dodaj ponudnika ladijskega",
+        "editShippingProvider": "Uredi ponudnik ladijski promet",
+        "addShippingMethod": "Dodaj način pošiljanja",
+        "editShippingMethod": "Uredite način pošiljanja",
+        "deleteShippingMethod": "Brisanje način pošiljanja",
+        "noSettingsForThisView": "Ni nastavitev za to mnenje",
+        "noShippingMethods": "Ni metode pošiljanja so nastavljeni.",
+        "removeShippingMethodConfirm": "Ali ste prepričani, da želite izbrisati {{method}}?",
+        "removeShippingMethodTitle": "Odstrani Shipping Method",
+        "shippingMethodDeleted": "Ta način pošiljanja je bil izbrisan.",
+        "removeShippingProvider": "Odstrani ponudnika dostave",
+        "removeShippingProviderConfirm": "Ali ste prepričani, da želite izbrisati {{provider}}?",
+        "shippingProviderSaved": "Ponudnik prevoz shranjene.",
+        "shippingProviderUpdated": "Podatki ponudnika prevoz posodabljajo.",
+        "shippingMethodRateAdded": "Dostava stopnja metoda dodal.",
+        "shippingMethodRateUpdated": "Dostava stopnja način posodobljena.",
+        "name": "Name",
+        "label": "Label",
+        "group": "skupina",
+        "cost": "strošek",
+        "handling": "Ravnanje",
+        "rate": "Oceniti",
+        "enabled": "omogočeno",
+        "disabled": "Onemogočeno",
+        "addRate": "Dodaj stopnjo",
+        "updateRate": "Update {{name}} stopnja",
+        "addNewCondition": "Dodaj nov pogoj",
+        "deleteCondition": "Brisanje stanje",
+        "provider": {
+          "name": "Koda Service",
+          "label": "javni Label",
+          "enabled": "omogočeno"
+        }
+      },
+      "shippingMethod": {
+        "name": "Ime metoda",
+        "label": "javni Label",
+        "group": "skupina",
+        "cost": "strošek",
+        "handling": "Ravnanje",
+        "rate": "Oceniti",
+        "enabled": "omogočeno",
+        "matchingCartRanges": "Ujemanje košarice Območja",
+        "validRanges": {
+          "begin": "Začeti",
+          "end": "End"
+        },
+        "matchingLocales": "ujemanje Locales",
+        "validLocales": {
+          "origination": "iz",
+          "destination": "Za",
+          "deliveryBegin": "Dostava Est.",
+          "deliveryEnd": "Dostava Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/sv.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/sv.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "sv",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Frakt",
+          "shippingTitle": "Frakt",
+          "shippingDescription": "Tillhandahålla fraktkostnader"
+        },
+        "settings": {
+          "shippingLabel": "Frakt"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Välj leveransalternativ",
+        "noShippingMethods": "Inga transportsätt konfigureras.",
+        "contactAdmin": "Kontakta butikshanteraren.",
+        "configureNow": "Konfigurera nu.",
+        "shipping": "Frakt"
+      },
+      "shipping": {
+        "addShippingProvider": "Fogar sändnings provider",
+        "editShippingProvider": "Redigera leverans provider",
+        "addShippingMethod": "Lägg fraktsätt",
+        "editShippingMethod": "Redigera leveranssätt",
+        "deleteShippingMethod": "Radera fraktsätt",
+        "noSettingsForThisView": "Inga inställningar för denna uppfattning",
+        "noShippingMethods": "Inga transportsätt konfigureras.",
+        "removeShippingMethodConfirm": "Är du säker på att du vill radera {{method}}?",
+        "removeShippingMethodTitle": "Ta Sändningsmetod",
+        "shippingMethodDeleted": "Denna leveransmetod har tagits bort.",
+        "removeShippingProvider": "Avlägsna Shipping Provider",
+        "removeShippingProviderConfirm": "Är du säker på att du vill radera {{provider}}?",
+        "shippingProviderSaved": "Speditör sparas.",
+        "shippingProviderUpdated": "Fraktoperatörsdata uppdateras.",
+        "shippingMethodRateAdded": "Fraktsätt hastigheten tillsätts.",
+        "shippingMethodRateUpdated": "Fraktsätt hastighet uppdateras.",
+        "name": "Namn",
+        "label": "Etikett",
+        "group": "Grupp",
+        "cost": "Kosta",
+        "handling": "Hantering",
+        "rate": "Betygsätt",
+        "enabled": "Aktiverad",
+        "disabled": "Funktionshindrade",
+        "addRate": "Lägg hastighet",
+        "updateRate": "Uppdatering {{name}} hastighet",
+        "addNewCondition": "Lägg till nyskick",
+        "deleteCondition": "radera Förhållande",
+        "provider": {
+          "name": "service-kod",
+          "label": "offentliga Label",
+          "enabled": "Aktiverad"
+        }
+      },
+      "shippingMethod": {
+        "name": "metod Namn",
+        "label": "offentliga Label",
+        "group": "Grupp",
+        "cost": "Kosta",
+        "handling": "Hantering",
+        "rate": "Betygsätt",
+        "enabled": "Aktiverad",
+        "matchingCartRanges": "Matchning Vagn Ranges",
+        "validRanges": {
+          "begin": "Börja",
+          "end": "Slut"
+        },
+        "matchingLocales": "matchning språkversioner",
+        "validLocales": {
+          "origination": "Från",
+          "destination": "Till",
+          "deliveryBegin": "Shipping Est.",
+          "deliveryEnd": "Leverans Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/tr.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/tr.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "tr",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Nakliye",
+          "shippingTitle": "Nakliye",
+          "shippingDescription": "nakliye fiyatları sağlamamıza"
+        },
+        "settings": {
+          "shippingLabel": "Nakliye"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Seç nakliye seçeneği",
+        "noShippingMethods": "Hiçbir nakliye yöntemleri yapılandırılır.",
+        "contactAdmin": "Lütfen mağaza yöneticisine başvurun.",
+        "configureNow": "Şimdi yapılandırın.",
+        "shipping": "Nakliye"
+      },
+      "shipping": {
+        "addShippingProvider": "nakliye sağlayıcı ekle",
+        "editShippingProvider": "Düzenleme nakliye sağlayıcı",
+        "addShippingMethod": "nakliye yöntemi ekleyin",
+        "editShippingMethod": "Düzenleme gönderim yöntemi",
+        "deleteShippingMethod": "nakliye yöntemini sil",
+        "noSettingsForThisView": "Bu görünüm için ayar yok",
+        "noShippingMethods": "Hiçbir nakliye yöntemleri yapılandırılır.",
+        "removeShippingMethodConfirm": "Eğer {{method}} silmek istediğinizden emin misiniz?",
+        "removeShippingMethodTitle": "Nakliye Yöntemi kaldır",
+        "shippingMethodDeleted": "Bu nakliye yöntemi silindi.",
+        "removeShippingProvider": "Nakliye Sağlayıcı kaldır",
+        "removeShippingProviderConfirm": "Eğer {{provider}} silmek istediğinizden emin misiniz?",
+        "shippingProviderSaved": "Kargo sağlayıcı kaydedildi.",
+        "shippingProviderUpdated": "Kargo sağlayıcı verileri güncellendi.",
+        "shippingMethodRateAdded": "Nakliye yöntemi oranı eklendi.",
+        "shippingMethodRateUpdated": "Nakliye yöntemi oranı güncellendi.",
+        "name": "Isim",
+        "label": "Etiket",
+        "group": "grup",
+        "cost": "Maliyet",
+        "handling": "kullanma",
+        "rate": "Oran",
+        "enabled": "Etkin",
+        "disabled": "engelli",
+        "addRate": "oranı ekle",
+        "updateRate": "Güncelleme {{name}} oranı",
+        "addNewCondition": "Yeni koşul ekle",
+        "deleteCondition": "koşulu sil",
+        "provider": {
+          "name": "servis Kodu",
+          "label": "kamu Etiket",
+          "enabled": "Etkin"
+        }
+      },
+      "shippingMethod": {
+        "name": "yöntem Adı",
+        "label": "kamu Etiket",
+        "group": "grup",
+        "cost": "Maliyet",
+        "handling": "kullanma",
+        "rate": "Oran",
+        "enabled": "Etkin",
+        "matchingCartRanges": "Sepet aralıkları Eşleştirme",
+        "validRanges": {
+          "begin": "Başla",
+          "end": "Son"
+        },
+        "matchingLocales": "Yerel eşleştirme",
+        "validLocales": {
+          "origination": "Itibaren",
+          "destination": "Için",
+          "deliveryBegin": "Nakliye Est.",
+          "deliveryEnd": "Teslim Tahmini."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/vi.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/vi.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "vi",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "Đang chuyển hàng",
+          "shippingTitle": "Đang chuyển hàng",
+          "shippingDescription": "Cung cấp mức giá vận chuyển"
+        },
+        "settings": {
+          "shippingLabel": "Đang chuyển hàng"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "Chọn tùy chọn vận chuyển",
+        "noShippingMethods": "Không có phương pháp vận chuyển được cấu hình.",
+        "contactAdmin": "Vui lòng liên hệ với quản trị viên kho.",
+        "configureNow": "Cấu hình hiện nay.",
+        "shipping": "Đang chuyển hàng"
+      },
+      "shipping": {
+        "addShippingProvider": "Thêm nhà cung cấp vận chuyển",
+        "editShippingProvider": "Sửa nhà cung cấp vận chuyển",
+        "addShippingMethod": "Thêm phương thức vận chuyển",
+        "editShippingMethod": "Chỉnh sửa phương thức vận chuyển",
+        "deleteShippingMethod": "Xóa phương thức vận chuyển",
+        "noSettingsForThisView": "Không có thiết lập cho quan điểm này",
+        "noShippingMethods": "Không có phương pháp vận chuyển được cấu hình.",
+        "removeShippingMethodConfirm": "Bạn có chắc chắn muốn xóa {{method}}?",
+        "removeShippingMethodTitle": "Di Shipping Method",
+        "shippingMethodDeleted": "Phương pháp vận chuyển này đã bị xóa.",
+        "removeShippingProvider": "Di Vận Chuyển Nhà cung cấp",
+        "removeShippingProviderConfirm": "Bạn có chắc chắn muốn xóa {{provider}}?",
+        "shippingProviderSaved": "cung cấp dịch vụ vận chuyển lưu.",
+        "shippingProviderUpdated": "cung cấp dữ liệu vận chuyển được cập nhật.",
+        "shippingMethodRateAdded": "tỷ lệ phương pháp vận chuyển thêm.",
+        "shippingMethodRateUpdated": "phương pháp tỷ lệ vận chuyển được cập nhật.",
+        "name": "Tên",
+        "label": "Nhãn",
+        "group": "Nhóm",
+        "cost": "Giá cả",
+        "handling": "xử lý",
+        "rate": "Tỷ lệ",
+        "enabled": "Bật",
+        "disabled": "Tàn tật",
+        "addRate": "Thêm tỷ lệ",
+        "updateRate": "tốc độ cập nhật {{name}}",
+        "addNewCondition": "Thêm điều kiện mới",
+        "deleteCondition": "xóa điều kiện",
+        "provider": {
+          "name": "Mã dịch vụ",
+          "label": "Nhãn Công",
+          "enabled": "Bật"
+        }
+      },
+      "shippingMethod": {
+        "name": "Tên phương pháp",
+        "label": "Nhãn Công",
+        "group": "Nhóm",
+        "cost": "Giá cả",
+        "handling": "xử lý",
+        "rate": "Tỷ lệ",
+        "enabled": "Bật",
+        "matchingCartRanges": "Phù hợp với Ranges Giỏ hàng",
+        "validRanges": {
+          "begin": "bắt đầu",
+          "end": "Kết thúc"
+        },
+        "matchingLocales": "phù hợp với miền địa phương",
+        "validLocales": {
+          "origination": "Từ",
+          "destination": "Đến",
+          "deliveryBegin": "Vận Chuyển Est.",
+          "deliveryEnd": "Giao hàng Est."
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/i18n/zh.json
+++ b/packages/api-plugin-fulfillment-type-shipping/src/i18n/zh.json
@@ -1,0 +1,81 @@
+[{
+  "i18n": "zh",
+  "ns": "reaction-shipping",
+  "translation": {
+    "reaction-shipping": {
+      "admin": {
+        "dashboard": {
+          "shippingLabel": "运输",
+          "shippingTitle": "运输",
+          "shippingDescription": "提供运费"
+        },
+        "settings": {
+          "shippingLabel": "运输"
+        }
+      },
+      "checkoutShipping": {
+        "selectShippingOption": "选择送货方式",
+        "noShippingMethods": "没有送货方式配置。",
+        "contactAdmin": "请联系店主管理员。",
+        "configureNow": "现在配置。",
+        "shipping": "运输"
+      },
+      "shipping": {
+        "addShippingProvider": "添加航运商",
+        "editShippingProvider": "编辑航运商",
+        "addShippingMethod": "添加送货方式",
+        "editShippingMethod": "编辑送货方式",
+        "deleteShippingMethod": "删除运输方式",
+        "noSettingsForThisView": "对于这种观点没有设置",
+        "noShippingMethods": "没有送货方式配置。",
+        "removeShippingMethodConfirm": "你确定要删除{{method}}？",
+        "removeShippingMethodTitle": "除去运输方式",
+        "shippingMethodDeleted": "这种运输方式已被删除。",
+        "removeShippingProvider": "除去运输提供商",
+        "removeShippingProviderConfirm": "你确定要删除{{provider}}？",
+        "shippingProviderSaved": "航运提供商保存。",
+        "shippingProviderUpdated": "航运商的数据更新。",
+        "shippingMethodRateAdded": "送货方式加入速度。",
+        "shippingMethodRateUpdated": "更新送货方法率。",
+        "name": "名字",
+        "label": "标签",
+        "group": "组",
+        "cost": "费用",
+        "handling": "处理",
+        "rate": "率",
+        "enabled": "启用",
+        "disabled": "残疾人",
+        "addRate": "添加率",
+        "updateRate": "更新{{name}}率",
+        "addNewCondition": "新增条件",
+        "deleteCondition": "删除条件",
+        "provider": {
+          "name": "服务代码",
+          "label": "公共标签",
+          "enabled": "启用"
+        }
+      },
+      "shippingMethod": {
+        "name": "方法名称",
+        "label": "公共标签",
+        "group": "组",
+        "cost": "费用",
+        "handling": "处理",
+        "rate": "率",
+        "enabled": "启用",
+        "matchingCartRanges": "匹配车范围",
+        "validRanges": {
+          "begin": "开始",
+          "end": "结束"
+        },
+        "matchingLocales": "匹配的语言环境",
+        "validLocales": {
+          "origination": "从",
+          "destination": "至",
+          "deliveryBegin": "航运预估。",
+          "deliveryEnd": "交货预估。"
+        }
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment-type-shipping/src/index.js
+++ b/packages/api-plugin-fulfillment-type-shipping/src/index.js
@@ -1,4 +1,5 @@
 import { createRequire } from "module";
+import i18n from "./i18n/index.js";
 import schemas from "./schemas/index.js";
 import startup from "./startup.js";
 
@@ -22,6 +23,7 @@ export default async function register(app) {
     label: "Fulfillment Type Shipping",
     name: "fulfillment-type-shipping",
     version: pkg.version,
+    i18n,
     graphQL: {
       schemas
     },

--- a/packages/api-plugin-fulfillment/src/i18n/en.json
+++ b/packages/api-plugin-fulfillment/src/i18n/en.json
@@ -1,0 +1,37 @@
+[{
+  "i18n": "en",
+  "ns": "reaction-fulfillment",
+  "translation": {
+    "reaction-fulfillment": {
+      "admin": {
+        "dashboard": {
+          "fulfillmentLabel": "Fulfillment",
+          "fulfillmentTitle": "Fulfillment",
+          "fulfillmentDescription": "Manage Fulfillment"
+        },
+        "settings": {
+          "fulfillmentLabel": "Fulfillment",
+          "editFulfillmentType": "Edit Fulfillment Type",
+          "editFulfillmentMethod": "Edit Fulfillment Method"
+        }
+      },
+      "checkoutShipping": {
+        "selectFulfillmentType": "Select fulfillment type for the item",
+        "noFulfillmentTypes": "No fulfillment types are configured.",
+        "noFulfillmentMethods": "No fulfillment methods are configured.",
+        "addiionalDetails": "Additional details required for the selected fulfillment method",
+        "contactAdmin": "Please contact the store administrator.",
+        "configureNow": "Configure now.",
+        "fulfillment": "Fulfillment"
+      },
+      "fulfillment": {
+        "editFulfillmentProvider": "Edit fulfillment provider",
+        "editFulfillmentMethod": "Edit fulfillment method",
+        "noSettingsForThisView": "No settings for this view",
+        "noFulfillmentMethods": "No fulfillment methods are configured.",
+        "fulfillmentProviderUpdated": "Fulfillment provider data updated.",
+        "fulfillmentMethodUpdated": "Fulfillment method updated."
+      }
+    }
+  }
+}]

--- a/packages/api-plugin-fulfillment/src/i18n/index.js
+++ b/packages/api-plugin-fulfillment/src/i18n/index.js
@@ -1,0 +1,12 @@
+import en from "./en.json";
+
+//
+// we want all the files in individual
+// imports for easier handling by
+// automated translation software
+//
+export default {
+  translations: [
+    ...en
+  ]
+};

--- a/packages/api-plugin-fulfillment/src/index.js
+++ b/packages/api-plugin-fulfillment/src/index.js
@@ -1,4 +1,5 @@
 import { createRequire } from "module";
+import i18n from "./i18n/index.js";
 import mutations from "./mutations/index.js";
 import queries from "./queries/index.js";
 import resolvers from "./resolvers/index.js";
@@ -21,6 +22,7 @@ export default async function register(app) {
     label: "Fulfillment",
     name: "fulfillment",
     version: pkg.version,
+    i18n,
     collections: {
       FulfillmentRestrictions: {
         name: "FulfillmentRestrictions",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
       '@reactioncommerce/logger': link:../../packages/logger
       '@reactioncommerce/nodemailer': 5.0.5
       '@reactioncommerce/random': link:../../packages/random
-      '@snyk/protect': 1.1017.0
+      '@snyk/protect': 1.1021.0
       graphql: 14.7.0
       semver: 6.3.0
       sharp: 0.29.3
@@ -4747,8 +4747,8 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: false
 
-  /@snyk/protect/1.1017.0:
-    resolution: {integrity: sha512-6WHVyRUBba7Q/e6BAbn3+J3SSvBQU0Ps9YItg9Z/B7w91JusSCq6P4KTNt66AZxHwQ1X2iUbIWrkNEIpKuXePQ==}
+  /@snyk/protect/1.1021.0:
+    resolution: {integrity: sha512-d301HqyFvhvXa6SOIL5OSDYECOooMs4ARZdBlg7pY5SOW7jXksPBP95imaIRrS7qos9CZ5f7h8orkM9J2B3EOQ==}
     engines: {node: '>=10'}
     hasBin: true
     dev: false


### PR DESCRIPTION
Signed-off-by: Sujith <mail.sujithvn@gmail.com>

Resolves #6473 
Impact: **minor**
Type: **feature**

## Issue

There are no localised versions of customer or admin facing messages.

## Solution

Created i18n config files for the newly introduced plugins. 

The required files for two of the below mentioned plugins were completely copied over from old plugin. 
`api-plugin-fulfillment-type-shipping` (copied over from `api-plugin-shipments`)
`api-plugin-fulfillment-method-shipping-flat-rate` (copied over from `api-plugin-shipments-flat-rate`)

Added new config files for remaining 4 plugins below
`api-plugin-fulfillment`
`api-plugin-fulfillment-type-pickup`
`api-plugin-fulfillment-method-pickup-store`
`api-plugin-fulfillment-method-shipping-ups`

## Breaking changes
None

## Testing
Need to co-ordinate with the Front-end team to understand if there are any additional entries required in the config-files for the new plugins.