### PR TITLE
Product/Tag Date Filtering

### DIFF
--- a/.changeset/chilly-geckos-deliver.md
+++ b/.changeset/chilly-geckos-deliver.md
@@ -1,0 +1,6 @@
+---
+"@reactioncommerce/api-plugin-products": minor
+"@reactioncommerce/api-plugin-tags": minor
+---
+
+Added ability to filter by createdAt/updatedAt on products and tags query

--- a/packages/api-plugin-products/src/index.js
+++ b/packages/api-plugin-products/src/index.js
@@ -33,6 +33,8 @@ export default async function register(app) {
           [{ hashtags: 1 }, { name: "c2_hashtags" }],
           [{ shopId: 1 }, { name: "c2_shopId" }],
           [{ "workflow.status": 1 }, { name: "c2_workflow.status" }],
+          [{ createdAt: 1, shopId: 1 }, { name: "c2_createdAt_shopId" }],
+          [{ updatedAt: 1, shopId: 1 }, { name: "c2_updatedAt_shopId" }],
           // Use _id as second sort to force full stability
           [{ updatedAt: 1, _id: 1 }]
         ]

--- a/packages/api-plugin-products/src/resolvers/Query/products.js
+++ b/packages/api-plugin-products/src/resolvers/Query/products.js
@@ -16,6 +16,8 @@ import { decodeProductOpaqueId, decodeShopOpaqueId, decodeTagOpaqueId } from "..
  */
 export default async function products(_, args, context, info) {
   const {
+    createdAt,
+    updatedAt,
     productIds: opaqueProductIds,
     shopIds: opaqueShopIds,
     tagIds: opaqueTagIds,
@@ -35,6 +37,8 @@ export default async function products(_, args, context, info) {
   const tagIds = opaqueTagIds && opaqueTagIds.map(decodeTagOpaqueId);
 
   const query = await context.queries.products(context, {
+    createdAt,
+    updatedAt,
     productIds,
     shopIds,
     tagIds,

--- a/packages/api-plugin-products/src/schemas/product.graphql
+++ b/packages/api-plugin-products/src/schemas/product.graphql
@@ -544,6 +544,30 @@ enum ProductSortByField {
   updatedAt
 }
 
+"Range operator for DateTime fields"
+input ProductDateRange {
+  "The start of the date range"
+  start: DateTime!
+
+  "The end of the date range"
+  end: DateTime!
+}
+
+"Operators for filtering on a DateTime field"
+input ProductDateOperators {
+  "The value must be equal to the given value"
+  eq: DateTime
+
+  "The value must be greater than the given value"
+  before: DateTime
+
+  "The value must be greater than or equal to the given value"
+  after: DateTime
+
+  "The value must be between the given values"
+  between: ProductDateRange
+}
+
 extend type Mutation {
   "Archive products"
   archiveProducts(
@@ -613,6 +637,12 @@ extend type Query {
 
   "Query for a list of Products"
   products(
+    "Filter by created timestamp"
+    createdAt: ProductDateOperators
+
+    "Filter by updated at timestamp"
+    updatedAt: ProductDateOperators
+
     "Filter by archived"
     isArchived: Boolean
 

--- a/packages/api-plugin-products/src/utils/applyProductFilters.js
+++ b/packages/api-plugin-products/src/utils/applyProductFilters.js
@@ -1,6 +1,44 @@
 import SimpleSchema from "simpl-schema";
 
+const dateRangeFilter = new SimpleSchema({
+  start: {
+    type: Date,
+    optional: false
+  },
+  end: {
+    type: Date,
+    optional: false
+  }
+});
+
+const dateFilter = new SimpleSchema({
+  eq: {
+    type: Date,
+    optional: true
+  },
+  before: {
+    type: Date,
+    optional: true
+  },
+  after: {
+    type: Date,
+    optional: true
+  },
+  between: {
+    type: dateRangeFilter,
+    optional: true
+  }
+});
+
 const filters = new SimpleSchema({
+  "createdAt": {
+    type: dateFilter,
+    optional: true
+  },
+  "updatedAt": {
+    type: dateFilter,
+    optional: true
+  },
   "productIds": {
     type: Array,
     optional: true
@@ -70,6 +108,78 @@ export default function applyProductFilters(context, productFilters) {
   };
 
   if (productFilters) {
+    // Filter by createdAt
+    if (productFilters.createdAt) {
+      const createdAtSelectors = [];
+      if (productFilters.createdAt.eq) {
+        createdAtSelectors.push({
+          createdAt: productFilters.createdAt.eq
+        });
+      }
+      if (productFilters.createdAt.before) {
+        createdAtSelectors.push({
+          createdAt: {
+            $lt: productFilters.createdAt.before
+          }
+        });
+      }
+      if (productFilters.createdAt.after) {
+        createdAtSelectors.push({
+          createdAt: {
+            $gt: productFilters.createdAt.after
+          }
+        });
+      }
+      if (productFilters.createdAt.between) {
+        const { start, end } = productFilters.createdAt.between;
+        createdAtSelectors.push({
+          createdAt: {
+            $gte: start,
+            $lte: end
+          }
+        });
+      }
+      if (createdAtSelectors.length) {
+        selector.$and = [...(selector.$and || []), ...createdAtSelectors];
+      }
+    }
+
+    // Filter by updatedAt
+    if (productFilters.updatedAt) {
+      const updatedAtSelectors = [];
+      if (productFilters.updatedAt.eq) {
+        updatedAtSelectors.push({
+          updatedAt: productFilters.updatedAt.eq
+        });
+      }
+      if (productFilters.updatedAt.before) {
+        updatedAtSelectors.push({
+          updatedAt: {
+            $lt: productFilters.updatedAt.before
+          }
+        });
+      }
+      if (productFilters.updatedAt.after) {
+        updatedAtSelectors.push({
+          updatedAt: {
+            $gt: productFilters.updatedAt.after
+          }
+        });
+      }
+      if (productFilters.updatedAt.between) {
+        const { start, end } = productFilters.updatedAt.between;
+        updatedAtSelectors.push({
+          updatedAt: {
+            $gte: start,
+            $lte: end
+          }
+        });
+      }
+      if (updatedAtSelectors.length) {
+        selector.$and = [...(selector.$and || []), ...updatedAtSelectors];
+      }
+    }
+
     // filter by productIds
     if (productFilters.productIds) {
       selector = {

--- a/packages/api-plugin-products/src/utils/applyProductFilters.test.js
+++ b/packages/api-plugin-products/src/utils/applyProductFilters.test.js
@@ -4,6 +4,8 @@ import applyProductFilters from "./applyProductFilters";
 
 describe("Test metafields search methods", () => {
   const mockProductFilters = {
+    createdAt: undefined,
+    updatedAt: undefined,
     productIds: undefined,
     shopIds: ["mockShopId"],
     tagIds: undefined,

--- a/packages/api-plugin-tags/src/index.js
+++ b/packages/api-plugin-tags/src/index.js
@@ -31,6 +31,8 @@ export default async function register(app) {
           [{ name: 1 }, { name: "c2_name" }],
           [{ relatedTagIds: 1 }, { name: "c2_relatedTagIds" }],
           [{ shopId: 1 }, { name: "c2_shopId" }],
+          [{ createdAt: 1, shopId: 1 }, { name: "c2_createdAt_shopId" }],
+          [{ updatedAt: 1, shopId: 1 }, { name: "c2_updatedAt_shopId" }],
           [{ slug: 1, shopId: 1 }, { unique: true }]
         ]
       }

--- a/packages/api-plugin-tags/src/queries/tags.js
+++ b/packages/api-plugin-tags/src/queries/tags.js
@@ -19,6 +19,8 @@ export default async function tags(
   context,
   shopId,
   {
+    createdAt,
+    updatedAt,
     filter,
     shouldIncludeDeleted = false,
     isTopLevel,
@@ -38,6 +40,78 @@ export default async function tags(
   });
 
   if (isTopLevel === false || isTopLevel === true) query.isTopLevel = isTopLevel;
+
+  // Filter by createdAt
+  if (createdAt) {
+    const createdAtPredicates = [];
+    if (createdAt.eq) {
+      createdAtPredicates.push({
+        createdAt: createdAt.eq
+      });
+    }
+    if (createdAt.before) {
+      createdAtPredicates.push({
+        createdAt: {
+          $lt: createdAt.before
+        }
+      });
+    }
+    if (createdAt.after) {
+      createdAtPredicates.push({
+        createdAt: {
+          $gt: createdAt.after
+        }
+      });
+    }
+    if (createdAt.between) {
+      const { start, end } = createdAt.between;
+      createdAtPredicates.push({
+        createdAt: {
+          $gte: start,
+          $lte: end
+        }
+      });
+    }
+    if (createdAtPredicates.length) {
+      query.$and = [...(query.$and || []), ...createdAtPredicates];
+    }
+  }
+
+  // Filter by updatedAt
+  if (updatedAt) {
+    const updatedAtPredicates = [];
+    if (updatedAt.eq) {
+      updatedAtPredicates.push({
+        updatedAt: updatedAt.eq
+      });
+    }
+    if (updatedAt.before) {
+      updatedAtPredicates.push({
+        updatedAt: {
+          $lt: updatedAt.before
+        }
+      });
+    }
+    if (updatedAt.after) {
+      updatedAtPredicates.push({
+        updatedAt: {
+          $gt: updatedAt.after
+        }
+      });
+    }
+    if (updatedAt.between) {
+      const { start, end } = updatedAt.between;
+      updatedAtPredicates.push({
+        updatedAt: {
+          $gte: start,
+          $lte: end
+        }
+      });
+    }
+    if (updatedAtPredicates.length) {
+      query.$and = [...(query.$and || []), ...updatedAtPredicates];
+    }
+  }
 
   // Use `filter` to filter out results on the server
   if (filter) {

--- a/packages/api-plugin-tags/src/schemas/tags.graphql
+++ b/packages/api-plugin-tags/src/schemas/tags.graphql
@@ -103,6 +103,31 @@ enum TagSortByField {
   updatedAt
 }
 
+
+"Range operator for DateTime fields"
+input TagDateRange {
+  "The start of the date range"
+  start: DateTime!
+
+  "The end of the date range"
+  end: DateTime!
+}
+
+"Operators for filtering on a DateTime field"
+input TagDateOperators {
+  "The value must be equal to the given value"
+  eq: DateTime
+
+  "The value must be greater than the given value"
+  before: DateTime
+
+  "The value must be greater than or equal to the given value"
+  after: DateTime
+
+  "The value must be between the given values"
+  between: ProductDateRange
+}
+
 "A connection edge in which each node is a `Tag` object"
 type TagEdge implements NodeEdge {
   "The cursor that represents this node in the paginated results"
@@ -140,6 +165,12 @@ type TagConnection {
 extend type Query {
   "Returns a paged list of tags for a shop. You must include a shopId when querying."
   tags(
+    "Filter by created timestamp"
+    createdAt: TagDateOperators
+
+    "Filter by updated at timestamp"
+    updatedAt: TagDateOperators
+
     "Only tags associated with this shop will be returned"
     shopId: ID!,
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
       '@reactioncommerce/logger': link:../../packages/logger
       '@reactioncommerce/nodemailer': 5.0.5
       '@reactioncommerce/random': link:../../packages/random
-      '@snyk/protect': 1.1012.0
+      '@snyk/protect': 1.1025.0
       graphql: 14.7.0
       semver: 6.3.0
       sharp: 0.29.3
@@ -4637,7 +4637,7 @@ packages:
     dependencies:
       eslint: 8.23.1
       eslint-plugin-import: 2.25.4_eslint@8.23.1
-      eslint-plugin-jest: 26.9.0_eslint@8.23.1
+      eslint-plugin-jest: 26.9.0_2ex7m26yair3ztqnyc2u7licva
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.23.1
       eslint-plugin-node: 11.1.0_eslint@8.23.1
       eslint-plugin-promise: 6.0.1_eslint@8.23.1
@@ -4666,8 +4666,8 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: false
 
-  /@snyk/protect/1.1012.0:
-    resolution: {integrity: sha512-FetJA4igmHDYLcxq0dvSolgCWBAWvut1lhY8aDbwZDw+dMd7sXkjb4Dl1F7XzRDqUt3wjfyb73OJjSAn1ADZHg==}
+  /@snyk/protect/1.1025.0:
+    resolution: {integrity: sha512-RK9tY2Aqujv5l9e/5nE4yiTilk8vxyB99VtJJ/6p9TZYhddCVQUUv+PNenhVVO3jkSD8/3gLWbPakIvQsFKynA==}
     engines: {node: '>=10'}
     hasBin: true
     dev: false
@@ -4962,26 +4962,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.37.0:
-    resolution: {integrity: sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.37.0
-      '@typescript-eslint/visitor-keys': 5.37.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.7
-      tsutils: 3.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/5.37.0_typescript@2.9.2:
     resolution: {integrity: sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5003,7 +4983,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.37.0_eslint@8.23.1:
+  /@typescript-eslint/utils/5.37.0_2ex7m26yair3ztqnyc2u7licva:
     resolution: {integrity: sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5012,7 +4992,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.37.0
       '@typescript-eslint/types': 5.37.0
-      '@typescript-eslint/typescript-estree': 5.37.0
+      '@typescript-eslint/typescript-estree': 5.37.0_typescript@2.9.2
       eslint: 8.23.1
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.23.1
@@ -7786,7 +7766,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest/26.9.0_eslint@8.23.1:
+  /eslint-plugin-jest/26.9.0_2ex7m26yair3ztqnyc2u7licva:
     resolution: {integrity: sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7799,7 +7779,7 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.37.0_eslint@8.23.1
+      '@typescript-eslint/utils': 5.37.0_2ex7m26yair3ztqnyc2u7licva
       eslint: 8.23.1
     transitivePeerDependencies:
       - supports-color
@@ -13861,15 +13841,6 @@ packages:
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-
-  /tsutils/3.21.0:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-    dev: true
 
   /tsutils/3.21.0_typescript@2.9.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue

This PR adds basic date filtering to products and tags via several different operands eg. after, before, between.

At the moment this is light touch, only servicing products and tags and could be improved upon by constraining these date filter types with graphql interfaces, however I wasn't sure whether that's an existing pattern, nor where they would live.

I wasn't aware of #6527 when I began this, so this wasn't specifically drafted with that in mind, but rather precipitated by our own internal requirements.

Copied from: #6534 