### PR TITLE
Added shopId to payload for afterAddTagsToProducts & afterRemoveTagsFromProducts events

### DIFF
--- a/.changeset/moody-actors-flash.md
+++ b/.changeset/moody-actors-flash.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-products": minor
+---
+
+Added shopId to payload for afterAddTagsToProducts & afterRemoveTagsFromProducts events

--- a/packages/api-plugin-products/src/mutations/addTagsToProducts.js
+++ b/packages/api-plugin-products/src/mutations/addTagsToProducts.js
@@ -39,7 +39,7 @@ export default async function addTagsToProducts(context, input) {
 
   const results = await executeBulkOperation(Products, operations, totalProducts);
 
-  await Promise.all(tagIds.map((tagId) => appEvents.emit("afterAddTagsToProducts", { tagId, productIds })));
+  await Promise.all(tagIds.map((tagId) => appEvents.emit("afterAddTagsToProducts", { tagId, productIds, shopId })));
 
   return results;
 }

--- a/packages/api-plugin-products/src/mutations/removeTagsFromProducts.js
+++ b/packages/api-plugin-products/src/mutations/removeTagsFromProducts.js
@@ -40,7 +40,7 @@ export default async function removeTagsFromProducts(context, input) {
 
   const results = await executeBulkOperation(Products, operations, totalProducts);
 
-  await Promise.all(tagIds.map((tagId) => appEvents.emit("afterRemoveTagsFromProducts", { tagId, productIds })));
+  await Promise.all(tagIds.map((tagId) => appEvents.emit("afterRemoveTagsFromProducts", { tagId, productIds, shopId })));
 
   return results;
 }


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue

The afterAddTagsToProducts & afterRemoveTagsFromProducts events were recently added. The event payload doesn't have   shopId at the moment.

## Solution

This PR adds shopId to the event payload for afterAddTagsToProducts & afterRemoveTagsFromProducts events.