### PR TITLE
fix: prevent release without version pr

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,8 @@
   "baseBranch": "trunk",
   "updateInternalDependencies": "patch",
   "ignore": [
-  ]
+  ],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.github/workflows/tagging-and-release.yml
+++ b/.github/workflows/tagging-and-release.yml
@@ -1,10 +1,16 @@
 name: Tagging And Release
 on:
-  push:
-    branches:
-      - trunk
+  pull_request:
+    types:
+      - closed
+
+permissions: {}
+
 jobs:
   tagging-and-release:
+    if: github.event.pull_request.merged == true && github.base_ref == 'trunk' && github.head_ref == 'changeset-release/trunk'
+    permissions:
+      contents: write # to create release (changesets/action)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Impact: minor
Type: bugfix

## Issue

* Create version PR on every new merge to trunk (should only create version PR when run release action)
* Increase version when peer dependencies are still in range

## Solution

* Only run `Tagging And Release` when Version PR merged
* Add flag onlyUpdatePeerDependentsWhenOutOfRange: true