### PR TITLE
moved jest process env to a separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ yalc-packages
 
 # Build
 dist
+.idea

--- a/apps/reaction/tests/util/jestProcessEnv.json
+++ b/apps/reaction/tests/util/jestProcessEnv.json
@@ -1,0 +1,6 @@
+{
+  "MAIL_URL": "smtp://user:pass@email-smtp.us-west-2.amazonaws.com:465",
+  "REACTION_LOG_LEVEL": "ERROR",
+  "REACTION_WORKERS_ENABLED": false
+}
+

--- a/apps/reaction/tests/util/setupJestTests.js
+++ b/apps/reaction/tests/util/setupJestTests.js
@@ -1,11 +1,9 @@
 /* eslint-disable no-undef */
-
-require("../../src/checkNodeVersion.cjs");
-
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const jestProcessEnv = require("./jestProcessEnv.json");
 process.env = Object.assign(process.env, {
-  MAIL_URL: "smtp://user:pass@email-smtp.us-west-2.amazonaws.com:465",
-  REACTION_LOG_LEVEL: "ERROR",
-  REACTION_WORKERS_ENABLED: false
+  ...jestProcessEnv
 });
 
 process.on("unhandledRejection", (err) => {

--- a/apps/reaction/tests/util/setupJestTests.js
+++ b/apps/reaction/tests/util/setupJestTests.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-undef */
 import { createRequire } from "module";
+
 const require = createRequire(import.meta.url);
 const jestProcessEnv = require("./jestProcessEnv.json");
+
 process.env = Object.assign(process.env, {
   ...jestProcessEnv
 });


### PR DESCRIPTION
Signed-off-by: apadhi <aditya_padhi@intuit.com>

Resolves #none
Impact: **minor**
Type: **refactor**

## Issue

This is a minor change where the jest runtime values are moved to a separate json file so that it can be managed easily.
It can be used by other clis, like `reactioncommerce`.  This change will be helpful in fixing https://github.com/reactioncommerce/cli/issues/92

## Solution

I move the jest process env values to a separate json configuration file so that the json file can we easily maintained in node.js process as well

## Breaking changes

It is not a breaking change

## Testing

1. The test cases should execute as usual