### PR TITLE
fix: update surcharge mutation will send the whole item

### DIFF
--- a/.changeset/updateSurcharge-return-full-item.md
+++ b/.changeset/updateSurcharge-return-full-item.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-surcharges": patch
+---
+
+Fixed Update surcharge mutation to return the whole item from db

--- a/apps/reaction/tests/integration/api/mutations/surcharges/updateSurcharge.test.js
+++ b/apps/reaction/tests/integration/api/mutations/surcharges/updateSurcharge.test.js
@@ -106,6 +106,7 @@ test("an authorized user can update a surcharge", async () => {
         shopId: opaqueShopId,
         surchargeId: createdSurchargeOpaqueId,
         surcharge: {
+          createdAt: new Date(),
           amount: 29.99,
           messagesByLanguage: [surchargeMessagesByLanguage[0]],
           type: "surcharge",
@@ -119,8 +120,8 @@ test("an authorized user can update a surcharge", async () => {
     expect(error).toBeUndefined();
   }
 
-  Logger.trace({result }, "Printing result");
-  expect(result.updatedSurcharge.updateSurcharge.surcharge.shopId).toEqual(opaqueShopId);
+  Logger.trace({ result }, "Printing result");
+  expect(result.updateSurcharge.surcharge.shopId).toEqual(opaqueShopId);
   expect(result.updateSurcharge.surcharge.amount.amount).toEqual(29.99);
   expect(result.updateSurcharge.surcharge.messagesByLanguage).toEqual([surchargeMessagesByLanguage[0]]);
   expect(result.updateSurcharge.surcharge.attributes).toEqual([surchargeAttributes[1]]);

--- a/apps/reaction/tests/integration/api/mutations/surcharges/updateSurcharge.test.js
+++ b/apps/reaction/tests/integration/api/mutations/surcharges/updateSurcharge.test.js
@@ -2,6 +2,7 @@ import importAsString from "@reactioncommerce/api-utils/importAsString.js";
 import insertPrimaryShop from "@reactioncommerce/api-utils/tests/insertPrimaryShop.js";
 import Factory from "/tests/util/factory.js";
 import { importPluginsJSONFile, ReactionTestAPICore } from "@reactioncommerce/api-core";
+import Logger from "@reactioncommerce/logger";
 
 const CreateSurchargeMutation = importAsString("./CreateSurchargeMutation.graphql");
 const UpdateSurchargeMutation = importAsString("./UpdateSurchargeMutation.graphql");
@@ -114,10 +115,12 @@ test("an authorized user can update a surcharge", async () => {
       }
     });
   } catch (error) {
+    Logger.error(error);
     expect(error).toBeUndefined();
   }
 
-  expect(result.updateSurcharge.surcharge.shopId).toEqual(opaqueShopId);
+  Logger.trace({result }, "Printing result");
+  expect(result.updatedSurcharge.updateSurcharge.surcharge.shopId).toEqual(opaqueShopId);
   expect(result.updateSurcharge.surcharge.amount.amount).toEqual(29.99);
   expect(result.updateSurcharge.surcharge.messagesByLanguage).toEqual([surchargeMessagesByLanguage[0]]);
   expect(result.updateSurcharge.surcharge.attributes).toEqual([surchargeAttributes[1]]);

--- a/apps/reaction/tests/integration/api/mutations/surcharges/updateSurcharge.test.js
+++ b/apps/reaction/tests/integration/api/mutations/surcharges/updateSurcharge.test.js
@@ -2,7 +2,6 @@ import importAsString from "@reactioncommerce/api-utils/importAsString.js";
 import insertPrimaryShop from "@reactioncommerce/api-utils/tests/insertPrimaryShop.js";
 import Factory from "/tests/util/factory.js";
 import { importPluginsJSONFile, ReactionTestAPICore } from "@reactioncommerce/api-core";
-import Logger from "@reactioncommerce/logger";
 
 const CreateSurchargeMutation = importAsString("./CreateSurchargeMutation.graphql");
 const UpdateSurchargeMutation = importAsString("./UpdateSurchargeMutation.graphql");
@@ -115,11 +114,9 @@ test("an authorized user can update a surcharge", async () => {
       }
     });
   } catch (error) {
-    Logger.error(error);
     expect(error).toBeUndefined();
   }
 
-  Logger.trace({ result }, "Printing result");
   expect(result.updateSurcharge.surcharge.shopId).toEqual(opaqueShopId);
   expect(result.updateSurcharge.surcharge.amount.amount).toEqual(29.99);
   expect(result.updateSurcharge.surcharge.messagesByLanguage).toEqual([surchargeMessagesByLanguage[0]]);

--- a/apps/reaction/tests/integration/api/mutations/surcharges/updateSurcharge.test.js
+++ b/apps/reaction/tests/integration/api/mutations/surcharges/updateSurcharge.test.js
@@ -106,7 +106,6 @@ test("an authorized user can update a surcharge", async () => {
         shopId: opaqueShopId,
         surchargeId: createdSurchargeOpaqueId,
         surcharge: {
-          createdAt: new Date(),
           amount: 29.99,
           messagesByLanguage: [surchargeMessagesByLanguage[0]],
           type: "surcharge",

--- a/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
+++ b/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
@@ -37,13 +37,13 @@ export default async function updateSurchargeMutation(context, input) {
 
   Surcharge.validate(modifier, { modifier: true });
 
-  const { matchedCount } = await Surcharges.updateOne({
+  const { modifiedCount, value: updatedSurcharge } = await Surcharges.findOneAndUpdate({
     _id: surchargeId,
     shopId
-  }, modifier);
-  surcharge._id = surchargeId;
-  surcharge.shopId = shopId;
-  if (matchedCount === 0) throw new ReactionError("not-found", "Not found");
+  }, modifier, {
+    returnOriginal: false
+  });
+  if (modifiedCount === 0 || !updatedSurcharge) throw new ReactionError("not-found", "Unable to update surcharge");
 
-  return { surcharge };
+  return { updatedSurcharge };
 }

--- a/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
+++ b/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
@@ -37,12 +37,12 @@ export default async function updateSurchargeMutation(context, input) {
 
   Surcharge.validate(modifier, { modifier: true });
 
-  const { matchedCount } = await Surcharges.updateOne({
-    _id: surchargeId, shopId
-  }, modifier);
-  if (matchedCount === 0) throw new ReactionError("not-found", "Unable to update surcharge");
+  const { matchedCount, value: updatedSurcharge } = await Surcharges.findOneAndUpdate(
+    { _id: surchargeId, shopId },
+    modifier,
+    { returnOriginal: false }
+  );
+  if (matchedCount === 0) throw new ReactionError("not-found", "Not found");
 
-  const updatedSurcharge = await Surcharges.findOne({ _id: surchargeId, shopId });
-
-  return updatedSurcharge;
+  return { surcharge: updatedSurcharge };
 }

--- a/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
+++ b/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
@@ -1,6 +1,5 @@
 import SimpleSchema from "simpl-schema";
 import ReactionError from "@reactioncommerce/reaction-error";
-import Logger from "@reactioncommerce/logger";
 import { Surcharge } from "../simpleSchemas.js";
 
 const inputSchema = new SimpleSchema({
@@ -27,10 +26,6 @@ export default async function updateSurchargeMutation(context, input) {
   const { collections } = context;
   const { Surcharges } = collections;
 
-  Logger.trace({ surcharge }, "Print surchage");
-  Logger.trace({ surchargeId }, "Print surchageId");
-  Logger.trace({ shopId }, "Print shopId");
-
   await context.validatePermissions(`reaction:legacy:surcharges:${surchargeId}`, "update", { shopId });
 
   const modifier = {
@@ -45,14 +40,9 @@ export default async function updateSurchargeMutation(context, input) {
   const { matchedCount } = await Surcharges.updateOne({
     _id: surchargeId, shopId
   }, modifier);
-
-  Logger.trace({ matchedCount }, "Print updated count");
-
   if (matchedCount === 0) throw new ReactionError("not-found", "Unable to update surcharge");
 
   const updatedSurcharge = await Surcharges.findOne({ _id: surchargeId, shopId });
-
-  Logger.trace({ updatedSurcharge }, "Print updated surcharge");
 
   return updatedSurcharge;
 }

--- a/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
+++ b/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
@@ -1,5 +1,6 @@
 import SimpleSchema from "simpl-schema";
 import ReactionError from "@reactioncommerce/reaction-error";
+import Logger from "@reactioncommerce/logger";
 import { Surcharge } from "../simpleSchemas.js";
 
 const inputSchema = new SimpleSchema({
@@ -26,6 +27,10 @@ export default async function updateSurchargeMutation(context, input) {
   const { collections } = context;
   const { Surcharges } = collections;
 
+  Logger.trace({ surcharge }, "Print surchage");
+  Logger.trace({ surchargeId }, "Print surchageId");
+  Logger.trace({ shopId }, "Print shopId");
+
   await context.validatePermissions(`reaction:legacy:surcharges:${surchargeId}`, "update", { shopId });
 
   const modifier = {
@@ -40,9 +45,14 @@ export default async function updateSurchargeMutation(context, input) {
   const { matchedCount } = await Surcharges.updateOne({
     _id: surchargeId, shopId
   }, modifier);
+
+  Logger.trace({ matchedCount }, "Print updated count");
+
   if (matchedCount === 0) throw new ReactionError("not-found", "Unable to update surcharge");
 
   const updatedSurcharge = await Surcharges.findOne({ _id: surchargeId, shopId });
+
+  Logger.trace({ updatedSurcharge }, "Print updated surcharge");
 
   return updatedSurcharge;
 }

--- a/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
+++ b/packages/api-plugin-surcharges/src/mutations/updateSurcharge.js
@@ -37,13 +37,12 @@ export default async function updateSurchargeMutation(context, input) {
 
   Surcharge.validate(modifier, { modifier: true });
 
-  const { modifiedCount, value: updatedSurcharge } = await Surcharges.findOneAndUpdate({
-    _id: surchargeId,
-    shopId
-  }, modifier, {
-    returnOriginal: false
-  });
-  if (modifiedCount === 0 || !updatedSurcharge) throw new ReactionError("not-found", "Unable to update surcharge");
+  const { matchedCount } = await Surcharges.updateOne({
+    _id: surchargeId, shopId
+  }, modifier);
+  if (matchedCount === 0) throw new ReactionError("not-found", "Unable to update surcharge");
 
-  return { updatedSurcharge };
+  const updatedSurcharge = await Surcharges.findOne({ _id: surchargeId, shopId });
+
+  return updatedSurcharge;
 }

--- a/packages/api-plugin-surcharges/src/mutations/updateSurcharge.test.js
+++ b/packages/api-plugin-surcharges/src/mutations/updateSurcharge.test.js
@@ -30,7 +30,7 @@ const updatedSurcharge = {
   ]
 };
 
-const newSubcharge = {
+const newSurcharge = {
   type: "surcharge",
   attributes: [
     { property: "vendor", value: "john", propertyType: "string", operator: "eq" },
@@ -51,14 +51,16 @@ const newSubcharge = {
 };
 
 test("update a surcharge", async () => {
-  mockContext.collections.Surcharges.findOneAndUpdate.mockReturnValueOnce(Promise.resolve({
-    modifiedCount: 1,
-    value: updatedSurcharge
+  mockContext.collections.Surcharges.updateOne.mockReturnValueOnce(Promise.resolve({
+    matchedCount: 1
+  }));
+  mockContext.collections.Surcharges.findOne.mockReturnValueOnce(Promise.resolve({
+    updatedSurcharge
   }));
 
   const result = await updateSurchargeMutation(mockContext, {
     surchargeId: "surcharge123",
-    surcharge: newSubcharge,
+    surcharge: newSurcharge,
     shopId: "shop123"
   });
 

--- a/packages/api-plugin-surcharges/src/mutations/updateSurcharge.test.js
+++ b/packages/api-plugin-surcharges/src/mutations/updateSurcharge.test.js
@@ -51,11 +51,9 @@ const newSurcharge = {
 };
 
 test("update a surcharge", async () => {
-  mockContext.collections.Surcharges.updateOne.mockReturnValueOnce(Promise.resolve({
-    matchedCount: 1
-  }));
-  mockContext.collections.Surcharges.findOne.mockReturnValueOnce(Promise.resolve({
-    updatedSurcharge
+  mockContext.collections.Surcharges.findOneAndUpdate.mockReturnValueOnce(Promise.resolve({
+    matchedCount: 1,
+    value: updatedSurcharge
   }));
 
   const result = await updateSurchargeMutation(mockContext, {
@@ -64,5 +62,5 @@ test("update a surcharge", async () => {
     shopId: "shop123"
   });
 
-  expect(result.updatedSurcharge).toEqual(updatedSurcharge);
+  expect(result.surcharge).toEqual(updatedSurcharge);
 });

--- a/packages/api-plugin-surcharges/src/mutations/updateSurcharge.test.js
+++ b/packages/api-plugin-surcharges/src/mutations/updateSurcharge.test.js
@@ -9,27 +9,8 @@ mockContext.validatePermissions.mockReturnValueOnce(Promise.resolve(null));
 
 const createdAt = new Date();
 
-const surcharge = {
-  type: "surcharge",
-  attributes: [
-    { property: "vendor", value: "reaction", propertyType: "string", operator: "eq" },
-    { property: "productType", value: "knife", propertyType: "string", operator: "eq" }
-  ],
-  createdAt,
-  destination: { region: ["CO", "NY"] },
-  amount: 5.99,
-  messagesByLanguage: [
-    {
-      content: "Original Message English",
-      language: "en"
-    }, {
-      content: "Original Message Spanish",
-      language: "es"
-    }
-  ]
-};
-
 const updatedSurcharge = {
+  updatedAt: jasmine.any(Date),
   type: "surcharge",
   attributes: [
     { property: "vendor", value: "john", propertyType: "string", operator: "eq" },
@@ -37,10 +18,27 @@ const updatedSurcharge = {
   ],
   createdAt,
   destination: { region: ["NJ", "WY"] },
-  amount: {
-    amount: 17.99,
-    currencyCode: "USD"
-  },
+  amount: 17.99,
+  messagesByLanguage: [
+    {
+      content: "Updated Message English",
+      language: "en"
+    }, {
+      content: "Updated Message Spanish",
+      language: "es"
+    }
+  ]
+};
+
+const newSubcharge = {
+  type: "surcharge",
+  attributes: [
+    { property: "vendor", value: "john", propertyType: "string", operator: "eq" },
+    { property: "productType", value: "gun", propertyType: "string", operator: "eq" }
+  ],
+  createdAt,
+  destination: { region: ["NJ", "WY"] },
+  amount: 17.99,
   messagesByLanguage: [
     {
       content: "Updated Message English",
@@ -53,38 +51,16 @@ const updatedSurcharge = {
 };
 
 test("update a surcharge", async () => {
-  mockContext.collections.Surcharges.updateOne.mockReturnValueOnce(Promise.resolve({
-    ok: 1,
-    updatedSurcharge
+  mockContext.collections.Surcharges.findOneAndUpdate.mockReturnValueOnce(Promise.resolve({
+    modifiedCount: 1,
+    value: updatedSurcharge
   }));
 
   const result = await updateSurchargeMutation(mockContext, {
-    surcharge,
     surchargeId: "surcharge123",
+    surcharge: newSubcharge,
     shopId: "shop123"
   });
 
-  expect(result).toEqual({
-    surcharge: {
-      _id: "surcharge123",
-      shopId: "shop123",
-      type: "surcharge",
-      attributes: [
-        { property: "vendor", value: "reaction", propertyType: "string", operator: "eq" },
-        { property: "productType", value: "knife", propertyType: "string", operator: "eq" }
-      ],
-      createdAt,
-      destination: { region: ["CO", "NY"] },
-      amount: 5.99,
-      messagesByLanguage: [
-        {
-          content: "Original Message English",
-          language: "en"
-        }, {
-          content: "Original Message Spanish",
-          language: "es"
-        }
-      ]
-    }
-  });
+  expect(result.updatedSurcharge).toEqual(updatedSurcharge);
 });


### PR DESCRIPTION
Signed-off-by: Sushmitha Malae [malaesushmitha@gmail.com](mailto:malaesushmitha@gmail.com)

Resolves #6508 
Impact: **minor**
Type: **bugfix**

## Issue

The updateSurcharge Mutation will only return the updated fields instead of returning the full item from db

## Solution

Returning the updated full document instead of the partially updated fields.


## Breaking changes

None

## Testing

Modified the existing utc, to test the change.

More detail for what each of these sections should include are available in our [Contributing Docs](CONTRIBUTING.md). This project uses [semantic-release](https://semantic-release.gitbook.io/semantic-release/), please use their [commit message format.](https://semantic-release.gitbook.io/semantic-release/#commit-message-format).
