### PR TITLE
docs: Fix typo for node version manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To start working with your own project built on Mailchimp Open Commerce you can 
 the quickest and easiest way to develop on Open Commerce. It allows you to create and work with API, Admin, and Storefront projects all via the command line.
 
 ## What you need
-- We recommend installing [nmv](https://github.com/nvm-sh/nvm)
+- We recommend installing [nvm](https://github.com/nvm-sh/nvm)
 - [14.18.1 ≤ Node version < 16](https://nodejs.org/ja/blog/release/v14.18.1/)
 - [Git](https://git-scm.com/)
 - [Docker](https://www.docker.com/get-started/)


### PR DESCRIPTION
Fixing typo of `nvm` in Readme

Resolves #none
Impact: **minor**
Type: **docs**

## Issue

There is a typo in the short form of node version manager in the readme. It should be `nvm` instead of `nmv`.

## Solution

Fixed the typo.

## Breaking changes

None

## Testing

1. List the steps needed for testing your change in this section.
2. Assume that testers already know how to start the app, and do the basic setup tasks.
3. Be detailed enough that someone can work through it without being too granular

More detail for what each of these sections should include are available in our [Contributing Docs](CONTRIBUTING.md). This project uses [semantic-release](https://semantic-release.gitbook.io/semantic-release/), please use their [commit message format.](https://semantic-release.gitbook.io/semantic-release/#commit-message-format).
