### PR TITLE
fix: allow restrictions on nested properties

### DIFF
--- a/.changeset/modern-poems-smash.md
+++ b/.changeset/modern-poems-smash.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-shipments-flat-rate": patch
+---
+
+allow nested properties to be accessible for shipment restrictions.

--- a/packages/api-plugin-shipments-flat-rate/package.json
+++ b/packages/api-plugin-shipments-flat-rate/package.json
@@ -30,7 +30,8 @@
     "@reactioncommerce/logger": "^1.1.3",
     "@reactioncommerce/random": "^1.0.2",
     "@reactioncommerce/reaction-error": "^1.0.1",
-    "simpl-schema": "^1.12.0"
+    "simpl-schema": "^1.12.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/packages/api-plugin-shipments-flat-rate/src/util/attributeDenyCheck.js
+++ b/packages/api-plugin-shipments-flat-rate/src/util/attributeDenyCheck.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import operators from "@reactioncommerce/api-utils/operators.js";
 import propertyTypes from "@reactioncommerce/api-utils/propertyTypes.js";
 import isDestinationRestricted from "./isDestinationRestricted.js";
@@ -25,12 +26,13 @@ export async function attributeDenyCheck(methodRestrictions, method, hydratedOrd
 
       // Item must meet all attributes to be restricted
       return attributes.every((attribute) => {
-        let attributeFound = operators[attribute.operator](item[attribute.property], propertyTypes[attribute.propertyType](attribute.value));
+        const attributePropertyValue = _.get(item, attribute.property);
+        let attributeFound = operators[attribute.operator](attributePropertyValue, propertyTypes[attribute.propertyType](attribute.value));
 
         // If attribute is an array on the item, use `includes` instead of checking for ===
         // This works for tags, tagIds, and any future attribute that might be an array
-        if (Array.isArray(item[attribute.property])) {
-          attributeFound = item[attribute.property].includes(attribute.value);
+        if (Array.isArray(attributePropertyValue)) {
+          attributeFound = attributePropertyValue.includes(attribute.value);
         }
 
         if (attributeFound) {

--- a/packages/api-plugin-shipments-flat-rate/src/util/filterShippingMethods.test.js
+++ b/packages/api-plugin-shipments-flat-rate/src/util/filterShippingMethods.test.js
@@ -52,7 +52,17 @@ const mockHydratedOrderItems = {
   variantId: "tMkp5QwZog5ihYTfG",
   weight: 50,
   width: 10,
-  tags: [Array]
+  tags: [Array],
+  subtotal: {
+    amount: 12.99,
+    currencyCode: "USD"
+  },
+  parcel: {
+    height: 10,
+    weight: 50,
+    width: 10,
+    length: 10
+  }
 };
 
 const mockHydratedOrder = {
@@ -813,4 +823,83 @@ test("deny method - multiple attributes - item value is less than $100 AND item 
   const allowedMethods = await filterShippingMethods(mockContext, mockShippingMethod, mockHydratedOrder);
 
   expect(allowedMethods).toEqual([]);
+});
+
+/*
+* Tests with nested item/attribute restrictions
+*/
+test("deny method - nested attribute - subtotal.amount is less than $100, item restricted", async () => {
+  const mockMethodRestrictions = [
+    {
+      _id: "allow001",
+      methodIds: [
+        "stviZaLdqRvTKW6J5"
+      ],
+      type: "allow",
+      destination: {
+        country: [
+          "US"
+        ]
+      }
+    },
+    {
+      _id: "deny001",
+      methodIds: [
+        "stviZaLdqRvTKW6J5"
+      ],
+      type: "deny",
+      attributes: [
+        {
+          property: "subtotal.amount",
+          value: 100,
+          propertyType: "int",
+          operator: "lt"
+        }
+      ]
+    }
+  ];
+
+  mockContext.collections.FlatRateFulfillmentRestrictions.toArray.mockReturnValue(Promise.resolve(mockMethodRestrictions));
+
+  const allowedMethods = await filterShippingMethods(mockContext, mockShippingMethod, mockHydratedOrder);
+
+  expect(allowedMethods).toEqual([]);
+});
+
+test("deny method - nested attributes - parcel.weight is greater than 50, no item restrictions", async () => {
+  const mockMethodRestrictions = [
+    {
+      _id: "allow001",
+      methodIds: [
+        "stviZaLdqRvTKW6J5"
+      ],
+      type: "allow",
+      destination: {
+        country: [
+          "US"
+        ]
+      }
+    },
+    {
+      _id: "deny001",
+      methodIds: [
+        "stviZaLdqRvTKW6J5"
+      ],
+      type: "deny",
+      attributes: [
+        {
+          property: "parcel.weight",
+          value: 50,
+          propertyType: "int",
+          operator: "gt"
+        }
+      ]
+    }
+  ];
+
+  mockContext.collections.FlatRateFulfillmentRestrictions.toArray.mockReturnValue(Promise.resolve(mockMethodRestrictions));
+
+  const allowedMethods = await filterShippingMethods(mockContext, mockShippingMethod, mockHydratedOrder);
+
+  expect(allowedMethods).toEqual(mockShippingMethod);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
       '@reactioncommerce/logger': link:../../packages/logger
       '@reactioncommerce/nodemailer': 5.0.5
       '@reactioncommerce/random': link:../../packages/random
-      '@snyk/protect': 1.1032.0
+      '@snyk/protect': 1.1035.0
       graphql: 14.7.0
       semver: 6.3.0
       sharp: 0.29.3
@@ -1087,12 +1087,14 @@ importers:
       babel-plugin-rewire-exports: ^2.0.0
       babel-plugin-transform-es2015-modules-commonjs: ^6.26.2
       babel-plugin-transform-import-meta: ~1.0.0
+      lodash: ^4.17.15
       simpl-schema: ^1.12.0
     dependencies:
       '@reactioncommerce/api-utils': link:../api-utils
       '@reactioncommerce/logger': link:../logger
       '@reactioncommerce/random': link:../random
       '@reactioncommerce/reaction-error': link:../reaction-error
+      lodash: 4.17.21
       simpl-schema: 1.12.3
     devDependencies:
       '@babel/core': 7.19.0
@@ -4666,8 +4668,8 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: false
 
-  /@snyk/protect/1.1032.0:
-    resolution: {integrity: sha512-C6EvuhDycvmyMCmhjC/KAV1z3aykVGKrYhGRI5u5Buzz27HgjHhB4DSC3MDpyljpahtAkCS/E7pAwo9zP3m4bA==}
+  /@snyk/protect/1.1035.0:
+    resolution: {integrity: sha512-8s1HygVBFDmNn7HdDTslb8LyLBKdtexexl8lsbR4W1o0/JgXDxOSEztTRakVdONFOnlRNbS3DtEBvVRdHiYFVg==}
     engines: {node: '>=10'}
     hasBin: true
     dev: false


### PR DESCRIPTION
Resolves https://github.com/reactioncommerce/reaction/issues/6501
Impact: **minor**
Type: **bugfix**

## Issue
The checks for shipping restrictions based on an item's properties only work top for level properties in the item. It doesn't work for nested properties such as `price.amount` or `subtotal.amount`.

Steps to reproduce:

1. Create a product, create a variant with the price attribute set.
2. Create a shipping method.
4.  Create a "deny" shipping restriction with the attribute `price.amount` which would exclude the shipping method for the product if it was applied.
5. See that the shipping method is available for the cart in checkout process even when it shouldn't be (based on restriction `price` value).

## Solution

Can be solved by using lodash `_.get()` for getting the nested property from the item, instead of using the default javascript getter. This would make sure the restrictions work with both nested and non-nested attributes.

## Testing

1. Create a product, create a variant with the weight and price attribute set.
2. Create a shipping method.
3. Create "deny" shipping restriction with the attribute `weight` which would exclude the shipping method for the product if it was applied.
4.  Create another "deny" shipping restriction with the attribute `price.amount` which would exclude the shipping method for the product if it was applied.
5. See that the shipping method is available/unavailable for the cart in checkout process (based on the restrictions).
