### PR TITLE
feat: add replaceOne to mockCollection

### DIFF
--- a/.changeset/shaggy-feet-look.md
+++ b/.changeset/shaggy-feet-look.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-utils": patch
+---
+
+feat: add replaceOne to mockCollection

--- a/.changeset/shaggy-feet-look.md
+++ b/.changeset/shaggy-feet-look.md
@@ -1,5 +1,5 @@
 ---
-"@reactioncommerce/api-utils": patch
+"@reactioncommerce/api-utils": minor
 ---
 
 feat: add replaceOne to mockCollection

--- a/.changeset/shaggy-feet-look.md
+++ b/.changeset/shaggy-feet-look.md
@@ -2,4 +2,4 @@
 "@reactioncommerce/api-utils": minor
 ---
 
-feat: add replaceOne to mockCollection
+feat: add replaceOne mock function to mockCollection in the api-untils plugin

--- a/packages/api-utils/lib/tests/mockCollection.js
+++ b/packages/api-utils/lib/tests/mockCollection.js
@@ -40,6 +40,7 @@ export default function mockCollection(collectionName) {
       matchedCount: 1,
       modifiedCount: 1
     })),
-    updateMany: jest.fn().mockName(`${collectionName}.updateMany`)
+    updateMany: jest.fn().mockName(`${collectionName}.updateMany`),
+    replaceOne: jest.fn().mockName(`${collectionName}.replaceOne`)
   };
 }


### PR DESCRIPTION
Signed-off-by: tuanvu0995 <tuanvu0995@gmail.com>

Resolves #6510
Impact: **minor**
Type: **feature**

## Issue
The replaceOne function that's been available since 3.2 but is not available on Mock collections

## Solution

Add the replaceOne mock function to the mockCollection on the `api-utils` package.

## Breaking changes
None

## Testing
None
