### PR TITLE
Feat/promotions add promotion type

### DIFF
--- a/packages/api-plugin-promotions-coupons/src/triggers/couponsTriggerHandler.js
+++ b/packages/api-plugin-promotions-coupons/src/triggers/couponsTriggerHandler.js
@@ -16,5 +16,6 @@ export async function couponTriggerHandler(context, enhancedCart, { triggerParam
 export default {
   key: "coupons",
   handler: couponTriggerHandler,
-  paramSchema: CouponTriggerParameters
+  paramSchema: CouponTriggerParameters,
+  triggerType: "explicit"
 };

--- a/packages/api-plugin-promotions-coupons/src/triggers/couponsTriggerHandler.js
+++ b/packages/api-plugin-promotions-coupons/src/triggers/couponsTriggerHandler.js
@@ -17,5 +17,5 @@ export default {
   key: "coupons",
   handler: couponTriggerHandler,
   paramSchema: CouponTriggerParameters,
-  triggerType: "explicit"
+  type: "explicit"
 };

--- a/packages/api-plugin-promotions-offers/src/triggers/offerTriggerHandler.js
+++ b/packages/api-plugin-promotions-offers/src/triggers/offerTriggerHandler.js
@@ -49,5 +49,6 @@ export async function offerTriggerHandler(context, enhancedCart, { triggerParame
 export default {
   key: "offers",
   handler: offerTriggerHandler,
-  paramSchema: OfferTriggerParameters
+  paramSchema: OfferTriggerParameters,
+  triggerType: "implicit"
 };

--- a/packages/api-plugin-promotions-offers/src/triggers/offerTriggerHandler.js
+++ b/packages/api-plugin-promotions-offers/src/triggers/offerTriggerHandler.js
@@ -50,5 +50,5 @@ export default {
   key: "offers",
   handler: offerTriggerHandler,
   paramSchema: OfferTriggerParameters,
-  triggerType: "implicit"
+  type: "implicit"
 };

--- a/packages/api-plugin-promotions/src/handlers/applyPromotions.js
+++ b/packages/api-plugin-promotions/src/handlers/applyPromotions.js
@@ -28,7 +28,7 @@ async function getImplicitPromotions(context, shopId) {
   const promotions = await Promotions.find({
     shopId,
     enabled: true,
-    type: "implicit",
+    triggerType: "implicit",
     startDate: { $lt: now },
     endDate: { $gt: now }
   }).toArray();

--- a/packages/api-plugin-promotions/src/index.js
+++ b/packages/api-plugin-promotions/src/index.js
@@ -6,6 +6,7 @@ import preStartupPromotions from "./preStartup.js";
 import { Promotion } from "./simpleSchemas.js";
 import actions from "./actions/index.js";
 import qualifiers from "./qualifiers/index.js";
+import promotionTypes from "./promotionTypes/index.js";
 import schemas from "./schemas/index.js";
 import queries from "./queries/index.js";
 import resolvers from "./resolvers/index.js";
@@ -52,7 +53,8 @@ export default async function register(app) {
     },
     promotions: {
       actions,
-      qualifiers
+      qualifiers,
+      promotionTypes
     },
     mutations,
     queries

--- a/packages/api-plugin-promotions/src/mutations/createPromotion.js
+++ b/packages/api-plugin-promotions/src/mutations/createPromotion.js
@@ -8,8 +8,14 @@ import validateTriggerParams from "./validateTriggerParams.js";
  * @return {Promise<Object>} - The created promotion
  */
 export default async function createPromotion(context, promotion) {
-  const { collections: { Promotions }, simpleSchemas: { Promotion: PromotionSchema } } = context;
+  const { collections: { Promotions }, simpleSchemas: { Promotion: PromotionSchema }, promotions } = context;
   promotion._id = Random.id();
+  const now = new Date();
+  const { triggerKey } = promotions.triggers[0];
+  const trigger = promotions.triggers.find((tr) => tr.triggerKey === triggerKey);
+  promotion.triggerType = trigger.triggerType;
+  promotion.createdAt = now;
+  promotion.updatedAt = now;
   PromotionSchema.validate(promotion);
   validateTriggerParams(context, promotion);
   const results = await Promotions.insertOne(promotion);

--- a/packages/api-plugin-promotions/src/mutations/createPromotion.js
+++ b/packages/api-plugin-promotions/src/mutations/createPromotion.js
@@ -13,7 +13,7 @@ export default async function createPromotion(context, promotion) {
   const now = new Date();
   const { triggerKey } = promotions.triggers[0];
   const trigger = promotions.triggers.find((tr) => tr.triggerKey === triggerKey);
-  promotion.triggerType = trigger.triggerType;
+  promotion.triggerType = trigger.type;
   promotion.createdAt = now;
   promotion.updatedAt = now;
   PromotionSchema.validate(promotion);

--- a/packages/api-plugin-promotions/src/mutations/createPromotion.test.js
+++ b/packages/api-plugin-promotions/src/mutations/createPromotion.test.js
@@ -2,14 +2,21 @@ import mockCollection from "@reactioncommerce/api-utils/tests/mockCollection.js"
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import _ from "lodash";
 import SimpleSchema from "simpl-schema";
-import { Promotion, Trigger } from "../simpleSchemas.js";
+import { Promotion as PromotionSchema, Promotion, Trigger } from "../simpleSchemas.js";
 import createPromotion from "./createPromotion.js";
 
 const triggerKeys = ["offers"];
+const promotionTypes = ["coupon"];
 
 Trigger.extend({
   triggerKey: {
     allowedValues: [...Trigger.getAllowedValuesForKey("triggerKey"), ...triggerKeys]
+  }
+});
+
+PromotionSchema.extend({
+  promotionType: {
+    allowedValues: [...PromotionSchema.getAllowedValuesForKey("promotionType"), ...promotionTypes]
   }
 });
 
@@ -26,7 +33,7 @@ const now = new Date();
 const OrderPromotion = {
   _id: "orderPromotion",
   shopId: "testShop",
-  type: "implicit",
+  promotionType: "coupon",
   label: "5 percent off your entire order when you spend more then $200",
   description: "5 percent off your entire order when you spend more then $200",
   enabled: true,
@@ -74,7 +81,8 @@ export const OfferTriggerParameters = new SimpleSchema({
 const offerTrigger = {
   key: "offers",
   handler: () => {},
-  paramSchema: OfferTriggerParameters
+  paramSchema: OfferTriggerParameters,
+  triggerType: "implicit"
 };
 
 

--- a/packages/api-plugin-promotions/src/mutations/createPromotion.test.js
+++ b/packages/api-plugin-promotions/src/mutations/createPromotion.test.js
@@ -82,7 +82,7 @@ const offerTrigger = {
   key: "offers",
   handler: () => {},
   paramSchema: OfferTriggerParameters,
-  triggerType: "implicit"
+  type: "implicit"
 };
 
 

--- a/packages/api-plugin-promotions/src/mutations/updatePromotion.js
+++ b/packages/api-plugin-promotions/src/mutations/updatePromotion.js
@@ -9,6 +9,8 @@ import validateTriggerParams from "./validateTriggerParams.js";
  */
 export default async function updatePromotion(context, { shopId, promotion }) {
   const { collections: { Promotions }, simpleSchemas: { Promotion: PromotionSchema } } = context;
+  const now = new Date();
+  promotion.updatedAt = now;
   PromotionSchema.validate(promotion);
   validateTriggerParams(context, promotion);
   const { _id } = promotion;

--- a/packages/api-plugin-promotions/src/mutations/updatePromotion.test.js
+++ b/packages/api-plugin-promotions/src/mutations/updatePromotion.test.js
@@ -87,7 +87,7 @@ const offerTrigger = {
   key: "offers",
   handler: () => {},
   paramSchema: OfferTriggerParameters,
-  triggerType: "explicit"
+  type: "explicit"
 };
 
 

--- a/packages/api-plugin-promotions/src/mutations/updatePromotion.test.js
+++ b/packages/api-plugin-promotions/src/mutations/updatePromotion.test.js
@@ -2,14 +2,24 @@ import mockCollection from "@reactioncommerce/api-utils/tests/mockCollection.js"
 import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import _ from "lodash";
 import SimpleSchema from "simpl-schema";
-import { Promotion, Trigger } from "../simpleSchemas.js";
+import { Promotion as PromotionSchema, Promotion, Trigger } from "../simpleSchemas.js";
 import updatePromotion from "./updatePromotion.js";
 
+const now = new Date();
+
 const triggerKeys = ["offers"];
+const promotionTypes = ["coupon"];
 
 Trigger.extend({
   triggerKey: {
     allowedValues: [...Trigger.getAllowedValuesForKey("triggerKey"), ...triggerKeys]
+  }
+});
+
+
+PromotionSchema.extend({
+  promotionType: {
+    allowedValues: [...PromotionSchema.getAllowedValuesForKey("promotionType"), ...promotionTypes]
   }
 });
 
@@ -21,12 +31,12 @@ const insertResults = {
 };
 mockContext.collections.Promotions.insertOne = () => insertResults;
 
-const now = new Date();
 
 const OrderPromotion = {
   _id: "orderPromotion",
   shopId: "testShop",
-  type: "implicit",
+  promotionType: "coupon",
+  triggerType: "explicit",
   label: "5 percent off your entire order when you spend more then $200",
   description: "5 percent off your entire order when you spend more then $200",
   enabled: true,
@@ -56,7 +66,9 @@ const OrderPromotion = {
   ],
   startDate: now,
   endDate: new Date(now.getTime() + 1000 * 60 * 60 * 24 * 7),
-  stackAbility: "none"
+  stackAbility: "none",
+  createdAt: now,
+  updatedAt: now
 };
 
 mockContext.simpleSchemas = {
@@ -74,7 +86,8 @@ export const OfferTriggerParameters = new SimpleSchema({
 const offerTrigger = {
   key: "offers",
   handler: () => {},
-  paramSchema: OfferTriggerParameters
+  paramSchema: OfferTriggerParameters,
+  triggerType: "explicit"
 };
 
 

--- a/packages/api-plugin-promotions/src/preStartup.js
+++ b/packages/api-plugin-promotions/src/preStartup.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { Action, Trigger } from "./simpleSchemas.js";
+import { Action, Trigger, Promotion as PromotionSchema } from "./simpleSchemas.js";
 
 /**
  * @summary apply all schema extensions to the Promotions schema
@@ -41,10 +41,10 @@ function extendCartSchema(context) {
 export default function preStartupPromotions(context) {
   extendSchemas(context);
   extendCartSchema(context);
-
-  const { actions: additionalActions, triggers: additionalTriggers } = context.promotions;
+  const { actions: additionalActions, triggers: additionalTriggers, promotionTypes } = context.promotions;
   const triggerKeys = _.map(additionalTriggers, "key");
   const actionKeys = _.map(additionalActions, "key");
+  const promotionTypeKeys = Object.keys(promotionTypes);
   Action.extend({
     actionKey: {
       allowedValues: [...Action.getAllowedValuesForKey("actionKey"), ...actionKeys]
@@ -54,6 +54,12 @@ export default function preStartupPromotions(context) {
   Trigger.extend({
     triggerKey: {
       allowedValues: [...Trigger.getAllowedValuesForKey("triggerKey"), ...triggerKeys]
+    }
+  });
+
+  PromotionSchema.extend({
+    promotionType: {
+      allowedValues: [...PromotionSchema.getAllowedValuesForKey("promotionType"), ...promotionTypeKeys]
     }
   });
 }

--- a/packages/api-plugin-promotions/src/promotionTypes/index.js
+++ b/packages/api-plugin-promotions/src/promotionTypes/index.js
@@ -1,0 +1,31 @@
+const OrderDiscount = {
+  name: "order-discount",
+  action: {
+    actionKey: "discount",
+    actionParameters: {
+      discountType: "order"
+    }
+  }
+};
+
+const ItemDiscount = {
+  name: "item-discount",
+  action: {
+    actionKey: "discount",
+    actionParameters: {
+      discountType: "item"
+    }
+  }
+};
+
+const ShippingDiscount = {
+  name: "shipping-discount",
+  action: {
+    actionKey: "discount",
+    actionParameters: {
+      discountType: "shipping"
+    }
+  }
+};
+
+export default [OrderDiscount, ItemDiscount, ShippingDiscount];

--- a/packages/api-plugin-promotions/src/registration.js
+++ b/packages/api-plugin-promotions/src/registration.js
@@ -1,5 +1,6 @@
 import SimpleSchema from "simpl-schema";
 import _ from "lodash";
+import { PromotionType } from "./simpleSchemas.js";
 
 const PromotionsDeclaration = new SimpleSchema({
   "triggers": {
@@ -41,6 +42,12 @@ const PromotionsDeclaration = new SimpleSchema({
   },
   "qualifiers.$": {
     type: Function
+  },
+  "promotionTypes": {
+    type: Array
+  },
+  "promotionTypes.$": {
+    type: PromotionType
   }
 });
 
@@ -50,7 +57,8 @@ export const promotions = {
   enhancers: [], // enhancers for promotion data,
   schemaExtensions: [],
   operators: {}, // operators used for rule evaluations
-  qualifiers: []
+  qualifiers: [],
+  promotionTypes: []
 };
 
 /**
@@ -60,7 +68,7 @@ export const promotions = {
  */
 export function registerPluginHandlerForPromotions({ promotions: pluginPromotions }) {
   if (pluginPromotions) {
-    const { triggers, actions, enhancers, schemaExtensions, operators, qualifiers } = pluginPromotions;
+    const { triggers, actions, enhancers, schemaExtensions, operators, qualifiers, promotionTypes } = pluginPromotions;
     if (triggers) {
       promotions.triggers = _.uniqBy(promotions.triggers.concat(triggers), "key");
     }
@@ -78,6 +86,9 @@ export function registerPluginHandlerForPromotions({ promotions: pluginPromotion
     }
     if (qualifiers) {
       promotions.qualifiers = promotions.qualifiers.concat(qualifiers);
+    }
+    if (promotionTypes) {
+      promotions.promotionTypes = promotions.promotionTypes.concat(promotionTypes);
     }
   }
   PromotionsDeclaration.validate(promotions);

--- a/packages/api-plugin-promotions/src/schemas/schema.graphql
+++ b/packages/api-plugin-promotions/src/schemas/schema.graphql
@@ -34,15 +34,15 @@ input ActionInput {
   actionParameters: JSONObject
 }
 
-enum PromotionType {
-  implicit
-  explicit
-}
-
 enum Stackability {
   all
   none
   type
+}
+
+enum TriggerType {
+  implicit
+  explicit
 }
 
 "A record representing a particular promotion"
@@ -50,8 +50,11 @@ type Promotion {
   "The unique ID of the promotion"
   _id: String!
 
-  "Whether the promotion is implicit or explicit"
-  type: PromotionType!
+  "What type of promotion is this"
+  promotionType: String!
+
+  "What type of trigger this promotion uses"
+  triggerType: TriggerType!
 
   "The id of the shop that this promotion resides"
   shopId: String!
@@ -79,6 +82,12 @@ type Promotion {
 
   "Definition of how this promotion can be combined (none, per-type, or all)"
   stackAbility: Stackability
+
+  "When was this record created"
+  createdAt: Date!
+
+  "When was this record last updated"
+  updatedAt: Date!
 }
 
 "A connection edge in which each node is a `Promotion` object"
@@ -116,11 +125,12 @@ input PromotionFilter {
 }
 
 input PromotionCreateInput {
-  "Whether the promotion is implicit or explicit"
-  type: PromotionType!
 
   "The id of the shop that this promotion resides"
   shopId: String!
+
+  "What type of promotion this is for stackability purposes"
+  promotionType: String!
 
   "The short description of the promotion"
   label: String!
@@ -152,11 +162,14 @@ input PromotionUpdateInput {
   "The unique ID of the promotion"
   _id: String!
 
-  "Whether the promotion is implicit or explicit"
-  type: PromotionType!
-
   "The id of the shop that this promotion resides"
   shopId: String!
+
+  "What type of trigger this uses"
+  triggerType: TriggerType!
+
+  "What type of promotion this is for stackability purposes"
+  promotionType: String!
 
   "The short description of the promotion"
   label: String!

--- a/packages/api-plugin-promotions/src/simpleSchemas.js
+++ b/packages/api-plugin-promotions/src/simpleSchemas.js
@@ -1,9 +1,12 @@
 import SimpleSchema from "simpl-schema";
+import promotionTypes from "./promotionTypes/index.js";
+
+const promotionTypeKeys = promotionTypes.map((pt) => pt.name);
 
 export const Action = new SimpleSchema({
   actionKey: {
     type: String,
-    allowedValues: ["noop"]
+    allowedValues: ["noop", "discount"]
   },
   actionParameters: {
     type: Object,
@@ -22,6 +25,21 @@ export const Trigger = new SimpleSchema({
   }
 });
 
+export const PromotionType = new SimpleSchema({
+  name: {
+    type: String
+  },
+  action: {
+    type: Action,
+    optional: true
+  },
+  trigger: {
+    type: Trigger,
+    optional: true
+  }
+});
+
+
 /**
  * @name Promotion
  * @memberof Schemas
@@ -32,9 +50,13 @@ export const Promotion = new SimpleSchema({
   "_id": {
     type: String
   },
-  "type": {
+  "triggerType": {
     type: String,
     allowedValues: ["implicit", "explicit"]
+  },
+  "promotionType": {
+    type: String, // this is the key to the promotion type object
+    allowedValues: promotionTypeKeys
   },
   "shopId": {
     type: String
@@ -73,5 +95,11 @@ export const Promotion = new SimpleSchema({
     // defines what other offers it can be defined as
     type: String,
     allowedValues: ["none", "per-type", "all"]
+  },
+  "createdAt": {
+    type: Date
+  },
+  "updatedAt": {
+    type: Date
   }
 });

--- a/packages/api-plugin-sample-data/src/loaders/loadPromotions.js
+++ b/packages/api-plugin-sample-data/src/loaders/loadPromotions.js
@@ -2,7 +2,8 @@ const now = new Date();
 
 const OrderPromotion = {
   _id: "orderPromotion",
-  type: "implicit",
+  triggerType: "implicit",
+  promotionType: "order-discount",
   label: "5 percent off your entire order when you spend more then $200",
   description: "5 percent off your entire order when you spend more then $200",
   enabled: true,
@@ -37,7 +38,8 @@ const OrderPromotion = {
 
 const CouponPromotion = {
   _id: "couponPromotion",
-  type: "explicit",
+  triggerType: "implicit",
+  promotionType: "order-discount",
   label: "Specific coupon code",
   description: "Specific coupon code",
   enabled: true,


### PR DESCRIPTION
Resolves [#6641](https://github.com/reactioncommerce/reaction/issues/6641)
Impact: **minor**
Type: **feature**

## Issue

For stackability purposes and for quick creation purposes we need to have "promotionTypes"

## Solution

We define promotion types and allow plugin authors to add their own promotionTypes which can indicate any combination for triggers and actions for creation purposes

## Breaking changes

None