### PR TITLE
fix: fix for botched rename

### DIFF
--- a/packages/api-plugin-sequences/src/registration.js
+++ b/packages/api-plugin-sequences/src/registration.js
@@ -5,7 +5,7 @@ export const sequenceConfigs = [];
  * @param {Object} pluginPromotions - Extensions passed in via child plugins
  * @returns {undefined} undefined
  */
-export function registerPluginHandlerForSequences({ Sequences: sequences }) {
+export function registerPluginHandlerForSequences({ sequenceConfigs: sequences }) {
   if (sequences) {
     sequenceConfigs.push(...sequences);
   }


### PR DESCRIPTION
Fixes bug found by @vannguyenn where sequences weren't working because of a botched rename during code review.