### PR TITLE
feat: add promotion date before/after filter

### DIFF
--- a/packages/api-plugin-promotions/src/queries/promotions.js
+++ b/packages/api-plugin-promotions/src/queries/promotions.js
@@ -6,9 +6,7 @@
  * @return {Promise<Promotions>} - A list of promotions
  */
 export default async function promotions(context, shopId, filter) {
-  const {
-    collections: { Promotions }
-  } = context;
+  const { collections: { Promotions } } = context;
 
   const selector = { shopId };
 

--- a/packages/api-plugin-promotions/src/queries/promotions.js
+++ b/packages/api-plugin-promotions/src/queries/promotions.js
@@ -6,14 +6,40 @@
  * @return {Promise<Promotions>} - A list of promotions
  */
 export default async function promotions(context, shopId, filter) {
-  const { enabled } = filter;
-  const { collections: { Promotions } } = context;
+  const {
+    collections: { Promotions }
+  } = context;
 
+  const selector = { shopId };
 
-  // because enabled could be false we need to check for undefined
-  if (typeof enabled !== "undefined") {
-    filter.enabled = enabled;
+  if (filter) {
+    const { enabled, startDate, endDate } = filter;
+    // because enabled could be false we need to check for undefined
+    if (typeof enabled !== "undefined") {
+      selector.enabled = enabled;
+    }
+    if (startDate && startDate.eq) {
+      selector.startDate = { $eq: startDate.eq };
+    }
+
+    if (startDate && startDate.before) {
+      selector.startDate = { ...selector.startDate, $lt: startDate.before };
+    }
+    if (startDate && startDate.after) {
+      selector.startDate = { ...selector.startDate, $gt: startDate.after };
+    }
+
+    if (endDate && endDate.eq) {
+      selector.endDate = { $eq: endDate.eq };
+    }
+
+    if (endDate && endDate.before) {
+      selector.endDate = { ...selector.endDate, $lt: endDate.before };
+    }
+    if (endDate && endDate.after) {
+      selector.endDate = { ...selector.endDate, $gt: endDate.after };
+    }
   }
-  filter.shopId = shopId;
-  return Promotions.find(filter);
+
+  return Promotions.find(selector);
 }

--- a/packages/api-plugin-promotions/src/schemas/schema.graphql
+++ b/packages/api-plugin-promotions/src/schemas/schema.graphql
@@ -123,7 +123,7 @@ input PromotionDateOperators {
   "The value must be equal to the given value"
   eq: Date
 
-  "The value must be greater than the given value"
+  "The value must be less than the given value"
   before: Date
 
   "The value must be greater than or equal to the given value"
@@ -235,17 +235,23 @@ input PromotionQueryInput {
 }
 
 extend type Mutation {
-  createPromotion(input: PromotionCreateInput): PromotionUpdateCreatePayload
+  createPromotion(
+    input: PromotionCreateInput
+  ): PromotionUpdateCreatePayload
 
   duplicatePromotion(
     input: PromotionDuplicateInput
   ): PromotionUpdateCreatePayload
 
-  updatePromotion(input: PromotionUpdateInput): PromotionUpdateCreatePayload
+  updatePromotion(
+    input: PromotionUpdateInput
+  ): PromotionUpdateCreatePayload
 }
 
 extend type Query {
-  promotion(input: PromotionQueryInput): Promotion
+  promotion(
+    input: PromotionQueryInput
+  ): Promotion
 }
 
 extend type Query {

--- a/packages/api-plugin-promotions/src/schemas/schema.graphql
+++ b/packages/api-plugin-promotions/src/schemas/schema.graphql
@@ -102,7 +102,6 @@ type PromotionEdge {
   node: Promotion
 }
 
-
 type PromotionConnection {
   "The list of nodes that match the query, wrapped in an edge to provide a cursor string for each"
   edges: [PromotionEdge]
@@ -120,15 +119,24 @@ type PromotionConnection {
   totalCount: Int!
 }
 
+input PromotionDateOperators {
+  "The value must be equal to the given value"
+  eq: Date
+
+  "The value must be greater than the given value"
+  before: Date
+
+  "The value must be greater than or equal to the given value"
+  after: Date
+}
+
 input PromotionFilter {
-  shopId: String!
   enabled: Boolean
-  startDate: Date
-  endDate: Date
+  startDate: PromotionDateOperators
+  endDate: PromotionDateOperators
 }
 
 input PromotionCreateInput {
-
   "The id of the shop that this promotion resides in"
   shopId: String!
 
@@ -218,7 +226,6 @@ type PromotionUpdateCreatePayload {
   promotion: Promotion
 }
 
-
 input PromotionQueryInput {
   "The unique ID of the promotion"
   _id: String!
@@ -228,26 +235,18 @@ input PromotionQueryInput {
 }
 
 extend type Mutation {
-  createPromotion(
-    input: PromotionCreateInput
-  ): PromotionUpdateCreatePayload
+  createPromotion(input: PromotionCreateInput): PromotionUpdateCreatePayload
 
   duplicatePromotion(
     input: PromotionDuplicateInput
   ): PromotionUpdateCreatePayload
 
-  updatePromotion(
-    input: PromotionUpdateInput
-  ): PromotionUpdateCreatePayload
+  updatePromotion(input: PromotionUpdateInput): PromotionUpdateCreatePayload
 }
 
 extend type Query {
-  promotion(
-    input: PromotionQueryInput
-  ): Promotion
+  promotion(input: PromotionQueryInput): Promotion
 }
-
-
 
 extend type Query {
   promotions(
@@ -255,25 +254,24 @@ extend type Query {
     shopId: ID!
 
     "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
-    after: ConnectionCursor,
+    after: ConnectionCursor
 
     "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
-    before: ConnectionCursor,
+    before: ConnectionCursor
 
     "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
-    first: ConnectionLimitInt,
+    first: ConnectionLimitInt
 
     "Return at most this many results. This parameter may be used with the `before` parameter."
-    last: ConnectionLimitInt,
+    last: ConnectionLimitInt
 
     "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
-    offset: Int,
+    offset: Int
 
     filter: PromotionFilter
 
     sortBy: String
 
     sortOrder: String
-
   ): PromotionConnection!
 }


### PR DESCRIPTION
## Issue
Add support filtering promotions startDate and endDate with a before/after day. This is helpful when we want to know active/upcoming/past Promotions.
