### PR TITLE
Support backslash in getSlug util

### DIFF
--- a/.changeset/happy-snails-study.md
+++ b/.changeset/happy-snails-study.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-utils": patch
+---
+
+Support `/` in the getSlug utility function

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 #
 # See comment in docker-compose.dev.yml if you want to run for development.
 
-version: "3.4"
+version: "3.9"
 
 networks:
   reaction:

--- a/packages/api-utils/lib/getSlug.js
+++ b/packages/api-utils/lib/getSlug.js
@@ -13,5 +13,5 @@ const { slugify } = require("transliteration");
  * @returns {String} slugified string
  */
 export default function getSlug(slugString) {
-  return (typeof slugString === "string" && slugify(slugString)) || "";
+  return (typeof slugString === "string" && slugify(slugString, { allowedChars: "a-zA-Z0-9-/" })) || "";
 }

--- a/packages/api-utils/lib/getSlug.test.js
+++ b/packages/api-utils/lib/getSlug.test.js
@@ -1,0 +1,13 @@
+import getSlug from "./getSlug.js";
+
+it("should slugify a latin text", () => {
+  const text = "This is a title";
+  const slugified = getSlug(text);
+  expect(slugified).toEqual("this-is-a-title");
+});
+
+it("should slugify a latin text with / (backslash)", () => {
+  const text = "men/jacket";
+  const slugified = getSlug(text);
+  expect(slugified).toEqual("men/jacket");
+});


### PR DESCRIPTION
Signed-off-by: tedraykov <tedraykov@gmail.com>

Impact: **minor**
Type: **bugfix**

## Issue

When we save a slug that contains a `/`, the API automatically converts it to `-`.
For example, the tag slug `men/jacket` turns into `men-jacket`

## Solution

Extend the slugify function to support `/` charecter.

## Breaking changes

None

## Testing

- Create a new tag with a slug, that contains a `/`
- Validate that the saved result contains the `/`