### PR TITLE
feat: allow for second parameter on getSlug function for allowed char…

### DIFF
--- a/.changeset/three-lamps-carry.md
+++ b/.changeset/three-lamps-carry.md
@@ -1,0 +1,6 @@
+---
+"@reactioncommerce/api-plugin-tags": patch
+"@reactioncommerce/api-utils": patch
+---
+
+Allow getSlug to take a second parameter of allowedChars

--- a/packages/api-plugin-tags/src/mutations/addTag.js
+++ b/packages/api-plugin-tags/src/mutations/addTag.js
@@ -24,13 +24,14 @@ export default async function addTag(context, input) {
     slug = slugInput;
   }
 
+  const allowedCharacters = "a-zA-Z0-9-/";
   const now = new Date();
   const tag = {
     _id: Random.id(),
     isDeleted: false,
     isTopLevel: false,
     isVisible,
-    slug: getSlug(slug),
+    slug: getSlug(slug, allowedCharacters),
     metafields,
     name,
     displayTitle,

--- a/packages/api-plugin-tags/src/mutations/updateTag.js
+++ b/packages/api-plugin-tags/src/mutations/updateTag.js
@@ -41,6 +41,7 @@ export default async function updateTag(context, input) {
   await context.validatePermissions(`reaction:legacy:tags:${tagId}`, "update", { shopId });
 
   const metafields = [];
+  const allowedCharacters = "a-zA-Z0-9-/";
 
   // Filter out blank meta fields
   Array.isArray(input.metafields) && input.metafields.forEach((field) => {
@@ -55,7 +56,7 @@ export default async function updateTag(context, input) {
   }
 
   const params = {
-    slug: getSlug(slug),
+    slug: getSlug(slug, allowedCharacters),
     name: input.name,
     displayTitle: input.displayTitle,
     isVisible: input.isVisible,

--- a/packages/api-utils/lib/getSlug.js
+++ b/packages/api-utils/lib/getSlug.js
@@ -10,8 +10,9 @@ const { slugify } = require("transliteration");
  * @see https://www.npmjs.com/package/transliteration
  * @memberof Utils
  * @param {String} slugString - string to slugify
+ * @param {String|Boolean} allowedChars - specify extra characters that are not removed by slugify
  * @returns {String} slugified string
  */
-export default function getSlug(slugString) {
-  return (typeof slugString === "string" && slugify(slugString, { allowedChars: "a-zA-Z0-9-/" })) || "";
+export default function getSlug(slugString, allowedChars = false) {
+  return (typeof slugString === "string" && slugify(slugString, { allowedChars })) || "";
 }

--- a/packages/api-utils/lib/getSlug.js
+++ b/packages/api-utils/lib/getSlug.js
@@ -4,7 +4,7 @@ const require = createRequire(import.meta.url);
 
 const { slugify } = require("transliteration");
 
-const standardSlug = "a-zA-Z0-9-";
+const standardSlug = "a-zA-Z0-9-_.~'";
 
 /**
  * @name getSlug
@@ -12,7 +12,7 @@ const standardSlug = "a-zA-Z0-9-";
  * @see https://www.npmjs.com/package/transliteration
  * @memberof Utils
  * @param {String} slugString - string to slugify
- * @param {String|Boolean} allowedChars - specify extra characters that are not removed by slugify
+ * @param {String} [allowedChars=a-zA-Z0-9-_.~'] - specify extra characters that are not removed by slugify
  * @returns {String} slugified string
  */
 export default function getSlug(slugString, allowedChars = standardSlug) {

--- a/packages/api-utils/lib/getSlug.js
+++ b/packages/api-utils/lib/getSlug.js
@@ -4,6 +4,8 @@ const require = createRequire(import.meta.url);
 
 const { slugify } = require("transliteration");
 
+const standardSlug = "a-zA-Z0-9-";
+
 /**
  * @name getSlug
  * @summary Return a slugified string using "slugify" from transliteration
@@ -13,6 +15,6 @@ const { slugify } = require("transliteration");
  * @param {String|Boolean} allowedChars - specify extra characters that are not removed by slugify
  * @returns {String} slugified string
  */
-export default function getSlug(slugString, allowedChars = false) {
+export default function getSlug(slugString, allowedChars = standardSlug) {
   return (typeof slugString === "string" && slugify(slugString, { allowedChars })) || "";
 }

--- a/packages/api-utils/lib/getSlug.test.js
+++ b/packages/api-utils/lib/getSlug.test.js
@@ -1,5 +1,7 @@
 import getSlug from "./getSlug.js";
 
+const allowedCharacters = "a-zA-Z0-9-/";
+
 it("should slugify a latin text", () => {
   const text = "This is a title";
   const slugified = getSlug(text);
@@ -8,6 +10,6 @@ it("should slugify a latin text", () => {
 
 it("should slugify a latin text with / (backslash)", () => {
   const text = "men/jacket";
-  const slugified = getSlug(text);
+  const slugified = getSlug(text, allowedCharacters);
   expect(slugified).toEqual("men/jacket");
 });

--- a/packages/api-utils/lib/getSlug.test.js
+++ b/packages/api-utils/lib/getSlug.test.js
@@ -13,3 +13,9 @@ it("should slugify a latin text with / (backslash)", () => {
   const slugified = getSlug(text, allowedCharacters);
   expect(slugified).toEqual("men/jacket");
 });
+
+it("should slugify with a mix of slash and others", () => {
+  const text = "extremely tall men/jacket";
+  const slugified = getSlug(text, allowedCharacters);
+  expect(slugified).toEqual("extremely-tall-men/jacket");
+});


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

Impact: **minor**
Type: **bugfix**

## Issue

getSlug in Tags needs to incorporate slashes however we should not change the global behavior which affects many other items

## Solution

Provide a second parameter which allows you to specify allowedChar

## Breaking changes

None

## Testing
You should be able to create a tag with a slash in the name and have it retain the slash
