### PR TITLE
feat: add price type for product

### DIFF
--- a/packages/api-plugin-pricing-simple/src/index.js
+++ b/packages/api-plugin-pricing-simple/src/index.js
@@ -11,6 +11,7 @@ import getMinPriceSortByFieldPath from "./util/getMinPriceSortByFieldPath.js";
 import mutateNewProductBeforeCreate from "./util/mutateNewProductBeforeCreate.js";
 import mutateNewVariantBeforeCreate from "./util/mutateNewVariantBeforeCreate.js";
 import publishProductToCatalog from "./util/publishProductToCatalog.js";
+import addPriceTypeToCartItems from "./util/addPriceTypeToCartItems.js";
 import { PriceRange } from "./simpleSchemas.js";
 
 /**
@@ -45,6 +46,15 @@ export default async function register(app) {
     },
     simpleSchemas: {
       PriceRange
+    },
+    cart: {
+      transforms: [
+        {
+          name: "addPriceTypeToCartItems",
+          fn: addPriceTypeToCartItems,
+          priority: 10
+        }
+      ]
     }
   });
 }

--- a/packages/api-plugin-pricing-simple/src/mutations/updateProductVariantPrices.js
+++ b/packages/api-plugin-pricing-simple/src/mutations/updateProductVariantPrices.js
@@ -9,6 +9,11 @@ const pricesInput = new SimpleSchema({
   price: {
     type: Number,
     optional: true
+  },
+  priceType: {
+    type: String,
+    optional: true,
+    allowedValues: ["full", "clearance", "sale"]
   }
 });
 

--- a/packages/api-plugin-pricing-simple/src/schemas/schema.graphql
+++ b/packages/api-plugin-pricing-simple/src/schemas/schema.graphql
@@ -80,6 +80,17 @@ type ProductPriceRange {
   range: String
 }
 
+enum PriceType {
+  "The full price of the product"
+  full
+
+  "The price that was permanently marked down to move"
+  clearance
+
+  "Temporarily on sale (e.g. Black Friday or Mother's Day sale) but return to full price"
+  sale
+}
+
 extend type CatalogProduct {
   "Price and related information, per currency"
   pricing: [ProductPricingInfo]!
@@ -88,6 +99,9 @@ extend type CatalogProduct {
 extend type CatalogProductVariant {
   "Price and related information, per currency"
   pricing: [ProductPricingInfo]!
+
+  "The type of price for this variant"
+  priceType: PriceType
 }
 
 extend type Product {
@@ -107,6 +121,14 @@ extend type ProductVariant {
 
   "Pricing information"
   pricing: ProductPricingInfo!
+
+  "The type of price for this variant"
+  priceType: PriceType
+}
+
+extend type CartItem {
+  "The price type of the product"
+  priceType: PriceType
 }
 
 extend input ProductVariantInput {
@@ -117,12 +139,18 @@ extend input ProductVariantInput {
   "Variant price. DEPRECATED. Use the `updateProductVariantPrices` mutation to set product variant prices."
   # @deprecated isn't allowed on input fields yet. See See https://github.com/graphql/graphql-spec/pull/525
   price: Float
+
+  "The type of price for product variant"
+  priceType: PriceType
 }
 
 "Input for the `updateProductVariantField` mutation"
 input UpdateProductVariantPricesInput  {
   "Prices to update"
   prices: ProductVariantPricesInput!
+
+  "The type of price for product variant"
+  priceType: PriceType
 
   "ID of shop that owns the variant to update"
   shopId: ID!

--- a/packages/api-plugin-pricing-simple/src/simpleSchemas.js
+++ b/packages/api-plugin-pricing-simple/src/simpleSchemas.js
@@ -42,6 +42,7 @@ export function extendSimplePricingSchemas(schemas) {
     CatalogProduct,
     CatalogProductOption,
     CatalogProductVariant,
+    CartItem,
     Product,
     ProductVariant
   } = schemas;
@@ -67,6 +68,21 @@ export function extendSimplePricingSchemas(schemas) {
       defaultValue: 0.00,
       min: 0,
       optional: true
+    },
+    priceType: {
+      type: String,
+      optional: true,
+      allowedValues: ["full", "clearance", "sale"],
+      defaultValue: "full"
+    }
+  });
+
+  CartItem.extend({
+    priceType: {
+      type: String,
+      optional: true,
+      allowedValues: ["full", "clearance", "sale"],
+      defaultValue: "full"
     }
   });
 

--- a/packages/api-plugin-pricing-simple/src/util/addPriceTypeToCartItems.js
+++ b/packages/api-plugin-pricing-simple/src/util/addPriceTypeToCartItems.js
@@ -1,0 +1,17 @@
+/**
+ * @summary Add price type to cart items
+ * @param {Object} context - The application context
+ * @param {Object} cart - The cart
+ * @returns {undefined}
+ */
+export default async function addPriceTypeToCartItems(context, cart) {
+  for (const cartItem of cart.items) {
+    // eslint-disable-next-line no-await-in-loop
+    const { variant } = await context.queries.findProductAndVariant(
+      context,
+      cartItem.productId,
+      cartItem.variantId
+    );
+    cartItem.priceType = variant.priceType || "full";
+  }
+}

--- a/packages/api-plugin-pricing-simple/src/util/mutateNewVariantBeforeCreate.js
+++ b/packages/api-plugin-pricing-simple/src/util/mutateNewVariantBeforeCreate.js
@@ -5,4 +5,5 @@
  */
 export default function mutateNewVariantBeforeCreateForSimplePricing(variant) {
   if (!variant.price) variant.price = 0;
+  if (!variant.priceType) variant.priceType = "full";
 }

--- a/packages/api-plugin-pricing-simple/src/util/publishProductToCatalog.js
+++ b/packages/api-plugin-pricing-simple/src/util/publishProductToCatalog.js
@@ -13,7 +13,8 @@ function getPricingObject(doc, priceInfo) {
     displayPrice: priceInfo.range,
     maxPrice: priceInfo.max,
     minPrice: priceInfo.min,
-    price: typeof doc.price === "number" ? doc.price : null
+    price: typeof doc.price === "number" ? doc.price : null,
+    priceType: doc.priceType
   };
 }
 


### PR DESCRIPTION
Resolves #6638
Impact: **major**
Type: **feature**

Basically this is used to include or exclude items that are on sale or on clearance.

Stock price types are:

full - (not MSRP, but not discounted)
clearance - Permanently marked down to move
sale - Temporarily on sale (e.g. Black Friday or Mother's Day sale) but return to full price