### PR TITLE
Product Index Optimizations

### DIFF
--- a/packages/api-plugin-products/src/index.js
+++ b/packages/api-plugin-products/src/index.js
@@ -33,8 +33,8 @@ export default async function register(app) {
           [{ hashtags: 1 }, { name: "c2_hashtags" }],
           [{ shopId: 1 }, { name: "c2_shopId" }],
           [{ "workflow.status": 1 }, { name: "c2_workflow.status" }],
-          [{ createdAt: 1, shopId: 1 }, { name: "c2_createdAt_shopId" }],
-          [{ updatedAt: 1, shopId: 1 }, { name: "c2_updatedAt_shopId" }],
+          [{ createdAt: 1, shopId: 1, ancestors: 1 }, { name: "c2_createdAt_shopId" }],
+          [{ updatedAt: 1, shopId: 1, ancestors: 1 }, { name: "c2_updatedAt_shopId" }],
           // Use _id as second sort to force full stability
           [{ updatedAt: 1, _id: 1 }]
         ]

--- a/packages/api-plugin-products/src/index.js
+++ b/packages/api-plugin-products/src/index.js
@@ -33,8 +33,8 @@ export default async function register(app) {
           [{ hashtags: 1 }, { name: "c2_hashtags" }],
           [{ shopId: 1 }, { name: "c2_shopId" }],
           [{ "workflow.status": 1 }, { name: "c2_workflow.status" }],
-          [{ createdAt: 1, shopId: 1, ancestors: 1 }, { name: "c2_createdAt_shopId" }],
-          [{ updatedAt: 1, shopId: 1, ancestors: 1 }, { name: "c2_updatedAt_shopId" }],
+          [{ createdAt: 1, shopId: 1, ancestors: 1 }, { name: "c2_createdAt_shopId_ancestors" }],
+          [{ updatedAt: 1, shopId: 1, ancestors: 1 }, { name: "c2_updatedAt_shopId_ancestors" }],
           // Use _id as second sort to force full stability
           [{ updatedAt: 1, _id: 1 }]
         ]

--- a/packages/api-plugin-products/src/utils/applyProductFilters.js
+++ b/packages/api-plugin-products/src/utils/applyProductFilters.js
@@ -103,7 +103,7 @@ export default function applyProductFilters(context, productFilters) {
 
   // Init default selector - Everyone can see products that fit this selector
   let selector = {
-    ancestors: [], // Lookup top-level products
+    ancestors: { $size: 0 }, // Lookup top-level products
     isDeleted: { $ne: true } // by default, we don't publish deleted products
   };
 


### PR DESCRIPTION
Resolves N/a
Impact: minor
Type: **performance**

## Issue

When dealing with a large number of products you may or may not observe a slowdown when querying via the products query. Digging a little deeper into this one the leading causes of this is that more often than not this query results in one or more sequential scans of the products collection.

This occurs because of a default filter being applied on Products.ancestors which is used to determine whether a product is top level or not. This default is causing the generated query plan to miss all available indexes in certain situations.
 
## Solution

In switching to an array size approach for determining whether a product has no ancestors, we are at least forcing a hit on the default index: https://github.com/reactioncommerce/reaction/blob/9d794208eeb37ad76a2ee109c6b58075284c0a6b/packages/api-plugin-products/src/index.js#L39

However this in and of itself does not guarantee that the correct index will be used without explicitly specifying ancestors as part of a compound index or providing the engine with an index hint; whether or not we get a partial index scan without doing so against the desired index very much depends on the sort criteria being specified.

