### PR TITLE
fix: unable to start image due to sharp issue

### DIFF
--- a/.changeset/green-chefs-dance.md
+++ b/.changeset/green-chefs-dance.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-files": minor
+---
+
+feat: upgrade sharp 0.29 to 0.30

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,8 +190,13 @@ jobs:
           name: Create reaction.localhost network
           command: docker network create "reaction.localhost" || true
       - run:
+          name: Update docker-compose.circleci.yml with new reaction image version
+          command: |
+            VERSION=$(cat ./apps/reaction/package.json | grep -m 1 version | sed 's/[^0-9.]//g')
+            sed -i -e "s/REACTION_VERSION/$VERSION/g" ./docker-compose.circleci.yml
+      - run:
           name: Run image
-          command: docker-compose up -d
+          command: docker-compose -f ./docker-compose.circleci.yml up -d
       - run:
           name: Wait for image run completed
           command: sleep 30

--- a/docker-compose.circleci.yml
+++ b/docker-compose.circleci.yml
@@ -1,0 +1,43 @@
+# This docker-compose file is used to run the project's published image
+#
+# Usage: docker-compose up [-d]
+#
+# See comment in docker-compose.dev.yml if you want to run for development.
+
+version: "3.9"
+
+networks:
+  reaction:
+    name: reaction.localhost
+    external: true
+
+services:
+  api:
+    image: reactioncommerce/reaction:REACTION_VERSION
+    depends_on:
+      - mongo
+    env_file:
+      - ./.env
+    networks:
+      - default
+      - reaction
+    ports:
+      - "3000:3000"
+
+  mongo:
+    image: mongo:4.2.0
+    command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
+    networks:
+      - default
+      - reaction
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-db4:/data/db
+    healthcheck: # re-run rs.initiate() after startup if it failed.
+      test: test $$(echo "rs.status().ok || rs.initiate().ok" | mongo --quiet) -eq 1
+      interval: 10s
+      start_period: 30s
+
+volumes:
+  mongo-db4:


### PR DESCRIPTION
Resolves #issueNumber
Impact: **patch**
Type: **bugfix**

## Issue

- The new reaction image can't start after upgrade sharp 0.29 to 0.30
- The CI command use the wrong reaction image

## Solution

Add changesets to release new api-plugin-files
Update circleci config to test with the correct image

