### PR TITLE
fix: unable to connect mongodb on circleci test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,10 +182,13 @@ jobs:
             VERSION=$(cat ./apps/reaction/package.json | grep -m 1 version | sed 's/[^0-9.]//g')
             docker build --no-cache -t ${DOCKER_REPOSITORY}:${VERSION} -t ${DOCKER_REPOSITORY}:latest -f ./apps/reaction/Dockerfile .
       - run:
-          name: Copy env file
+          name: Create .env file
           command: |
-            cp ./apps/reaction/.env.example ./.env
+            touch .env
+            echo "MONGO_URL=mongodb://mongo.reaction.localhost:27017/reaction?&replicaSet=rs0" >> .env
+            echo "ROOT_URL=http://localhost:3000" >> .env
             echo "STORE_URL=http://localhost:4000" >> .env
+            echo "STRIPE_API_KEY=YOUR_PRIVATE_STRIPE_API_KEY" >> .env
       - run:
           name: Create reaction.localhost network
           command: docker network create "reaction.localhost" || true


### PR DESCRIPTION
Signed-off-by: vanpho93 <vanpho02@gmail.com>

Resolves #issueNumber
Impact: **minor**
Type: **bugfix**

## Issue

Unable to connect to mongodb from docker compose in circleci because of error "MongoError: Not master"

## Solution

Change MONGO_URL from `mongodb://mongo.reaction.localhost:27017/reaction` to `MONGO_URL=mongodb://mongo.reaction.localhost:27017/reaction?&replicaSet=rs0`