### PR TITLE
Added validatePermissions for Surcharges query endpoints

### DIFF
--- a/.changeset/spotty-turkeys-exercise.md
+++ b/.changeset/spotty-turkeys-exercise.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-surcharges": patch
+---
+
+Added validatePermissions for the query endpoints

--- a/apps/reaction/tests/integration/api/queries/surchargeById/surchargeById.test.js
+++ b/apps/reaction/tests/integration/api/queries/surchargeById/surchargeById.test.js
@@ -15,6 +15,7 @@ const opaqueSurchargeId = encodeOpaqueId("reaction/surcharge", internalSurcharge
 const shopName = "Test Shop";
 let testApp;
 let surchargeById;
+let mockAdminAccount;
 
 const mockSurcharge = Factory.Surcharge.makeOne({
   _id: internalSurchargeId,
@@ -35,6 +36,23 @@ beforeAll(async () => {
 
   await insertPrimaryShop(testApp.context, { _id: internalShopId, name: shopName });
   await testApp.collections.Surcharges.insertOne(mockSurcharge);
+
+  const adminGroup = Factory.Group.makeOne({
+    _id: "adminGroup",
+    createdBy: null,
+    name: "admin",
+    permissions: ["reaction:legacy:surcharges/read"],
+    slug: "admin",
+    shopId: internalShopId
+  });
+  await testApp.collections.Groups.insertOne(adminGroup);
+
+  mockAdminAccount = Factory.Account.makeOne({
+    groups: [adminGroup._id]
+  });
+  await testApp.createUserAndAccount(mockAdminAccount);
+  await testApp.setLoggedInUser(mockAdminAccount);
+
   surchargeById = testApp.query(SurchargeByIdQuery);
 });
 

--- a/apps/reaction/tests/integration/api/queries/surcharges/surcharges.test.js
+++ b/apps/reaction/tests/integration/api/queries/surcharges/surcharges.test.js
@@ -14,6 +14,7 @@ const shopName = "Test Shop";
 let testApp;
 let surcharges;
 let mockSurcharges;
+let mockAdminAccount;
 
 beforeAll(async () => {
   testApp = new ReactionTestAPICore();
@@ -32,6 +33,22 @@ beforeAll(async () => {
     amount: 10
   });
   await testApp.collections.Surcharges.insertMany(mockSurcharges);
+
+  const adminGroup = Factory.Group.makeOne({
+    _id: "adminGroup",
+    createdBy: null,
+    name: "admin",
+    permissions: ["reaction:legacy:surcharges/read"],
+    slug: "admin",
+    shopId: internalShopId
+  });
+  await testApp.collections.Groups.insertOne(adminGroup);
+
+  mockAdminAccount = Factory.Account.makeOne({
+    groups: [adminGroup._id]
+  });
+  await testApp.createUserAndAccount(mockAdminAccount);
+  await testApp.setLoggedInUser(mockAdminAccount);
   surcharges = testApp.query(SurchargesQuery);
 });
 

--- a/packages/api-plugin-surcharges/src/queries/surchargeById.js
+++ b/packages/api-plugin-surcharges/src/queries/surchargeById.js
@@ -14,6 +14,8 @@ export default async function surchargeById(context, { surchargeId, shopId } = {
   const { collections } = context;
   const { Surcharges } = collections;
 
+  await context.validatePermissions("reaction:legacy:surcharges", "read", { shopId });
+
   const surcharge = await Surcharges.findOne({
     _id: surchargeId,
     shopId

--- a/packages/api-plugin-surcharges/src/queries/surchargeById.test.js
+++ b/packages/api-plugin-surcharges/src/queries/surchargeById.test.js
@@ -1,0 +1,39 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import mockCollection from "@reactioncommerce/api-utils/tests/mockCollection.js";
+import ReactionError from "@reactioncommerce/reaction-error";
+import surchargeByIdQuery from "./surchargeById.js";
+
+const fakeShopId = "FAKE_SHOP_ID";
+const fakeSurchargeId = "FAKE_SURCHARGE_ID";
+const mockSurcharge = { _id: fakeSurchargeId };
+mockContext.validatePermissions = jest.fn("validatePermissions");
+mockContext.collections.Surcharges = mockCollection("Surcharges");
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test("returns the surcharge if validatePermission returns true", async () => {
+  mockContext.collections.Surcharges.findOne.mockReturnValueOnce(Promise.resolve(mockSurcharge));
+  mockContext.validatePermissions.mockReturnValueOnce(Promise.resolve(undefined));
+  const result = await surchargeByIdQuery(mockContext, { surchargeId: fakeSurchargeId, shopId: fakeShopId });
+
+  expect(mockContext.validatePermissions).toHaveBeenCalledWith(
+    "reaction:legacy:surcharges",
+    "read",
+    { shopId: fakeShopId }
+  );
+  expect(mockContext.collections.Surcharges.findOne).toHaveBeenCalledWith({ _id: fakeSurchargeId, shopId: fakeShopId });
+  await expect(result).toBe(mockSurcharge);
+});
+
+
+test("throws access-denied if not allowed", async () => {
+  mockContext.validatePermissions.mockImplementation(() => {
+    throw new ReactionError("access-denied", "Access Denied");
+  });
+  mockContext.collections.Accounts.findOne.mockReturnValueOnce(undefined);
+  const result = surchargeByIdQuery(mockContext, { surchargeId: fakeSurchargeId, shopId: fakeShopId });
+  const expectedResult = new ReactionError("access-denied", "Access Denied");
+  await expect(result).rejects.toThrow(expectedResult);
+});

--- a/packages/api-plugin-surcharges/src/queries/surcharges.js
+++ b/packages/api-plugin-surcharges/src/queries/surcharges.js
@@ -12,6 +12,8 @@ export default async function surcharges(context, { shopId } = {}) {
   const { collections } = context;
   const { Surcharges } = collections;
 
+  await context.validatePermissions("reaction:legacy:surcharges", "read", { shopId });
+
   return Surcharges.find({
     shopId
   });

--- a/packages/api-plugin-surcharges/src/queries/surcharges.test.js
+++ b/packages/api-plugin-surcharges/src/queries/surcharges.test.js
@@ -1,0 +1,37 @@
+import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
+import mockCollection from "@reactioncommerce/api-utils/tests/mockCollection.js";
+import ReactionError from "@reactioncommerce/reaction-error";
+import surchargesQuery from "./surcharges.js";
+
+const fakeShopId = "FAKE_SHOP_ID";
+mockContext.validatePermissions = jest.fn("validatePermissions");
+mockContext.collections.Surcharges = mockCollection("Surcharges");
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test("returns the surcharges cursor if validatePermission returns true", async () => {
+  mockContext.collections.Surcharges.find.mockReturnValueOnce(Promise.resolve("CURSOR"));
+  mockContext.validatePermissions.mockReturnValueOnce(Promise.resolve(undefined));
+  const result = await surchargesQuery(mockContext, { shopId: fakeShopId });
+
+  expect(mockContext.collections.Surcharges.find).toHaveBeenCalledWith({ shopId: fakeShopId });
+  expect(mockContext.validatePermissions).toHaveBeenCalledWith(
+    "reaction:legacy:surcharges",
+    "read",
+    { shopId: fakeShopId }
+  );
+  await expect(result).toBe("CURSOR");
+});
+
+
+test("throws access-denied if not allowed", async () => {
+  mockContext.validatePermissions.mockImplementation(() => {
+    throw new ReactionError("access-denied", "Access Denied");
+  });
+  mockContext.collections.Accounts.findOne.mockReturnValueOnce(undefined);
+  const result = surchargesQuery(mockContext, { shopId: fakeShopId });
+  const expectedResult = new ReactionError("access-denied", "Access Denied");
+  await expect(result).rejects.toThrow(expectedResult);
+});


### PR DESCRIPTION
Signed-off-by: Sujith <mail.sujithvn@gmail.com>

Resolves #6634 
Impact: **minor**
Type: **bugfix**

## Issue

As reported in issue #6634, Surcharges query endpoints were missing permission validation

## Solution

Added validatePermissions call for both the queries [surcharges & surchargeById]

## Breaking changes
If any user expected to have this permissions is not added to the required groups which has permission, will no longer be able to get results from these 2 queries unless added to the required groups.

## Testing
Test caes added