### PR TITLE
feat: promotion preview

### DIFF
--- a/packages/api-plugin-authorization-simple/src/util/defaultRoles.js
+++ b/packages/api-plugin-authorization-simple/src/util/defaultRoles.js
@@ -87,7 +87,8 @@ export const defaultShopManagerRoles = [
   "reaction:legacy:taxRates/update",
   "reaction:legacy:promotions/create",
   "reaction:legacy:promotions/read",
-  "reaction:legacy:promotions/update"
+  "reaction:legacy:promotions/update",
+  "reaction:legacy:promotions/review"
 ];
 
 export const defaultShopOwnerRoles = [

--- a/packages/api-plugin-authorization-simple/src/util/defaultRoles.js
+++ b/packages/api-plugin-authorization-simple/src/util/defaultRoles.js
@@ -88,7 +88,7 @@ export const defaultShopManagerRoles = [
   "reaction:legacy:promotions/create",
   "reaction:legacy:promotions/read",
   "reaction:legacy:promotions/update",
-  "reaction:legacy:promotions/review"
+  "reaction:legacy:promotions/preview"
 ];
 
 export const defaultShopOwnerRoles = [

--- a/packages/api-plugin-promotions/src/handlers/applyPromotions.js
+++ b/packages/api-plugin-promotions/src/handlers/applyPromotions.js
@@ -82,7 +82,7 @@ export async function getCurrentTime(context, shopId) {
   const customCurrentTime = getCustomCurrentTime(context);
 
   if (!customCurrentTime) return now;
-  if (!(await context.userHasPermission("reaction:legacy:promotions", "review", { shopId }))) return now;
+  if (!(await context.userHasPermission("reaction:legacy:promotions", "preview", { shopId }))) return now;
 
   const currentTime = new Date(customCurrentTime);
   if (currentTime.toString() === "Invalid Date") {

--- a/packages/api-plugin-promotions/src/handlers/applyPromotions.test.js
+++ b/packages/api-plugin-promotions/src/handlers/applyPromotions.test.js
@@ -281,7 +281,7 @@ test("should not have promotion message when the promotion already message added
   expect(cart.messages.length).toEqual(1);
 });
 
-test("getCurrentTime should return system time when user doesn't have review permission", async () => {
+test("getCurrentTime should return system time when user doesn't have preview permission", async () => {
   const shopId = "shopId";
   const date = new Date();
 
@@ -292,7 +292,7 @@ test("getCurrentTime should return system time when user doesn't have review per
   expect(time).toEqual(date);
 });
 
-test("getCurrentTime should return custom time when user has review permission", async () => {
+test("getCurrentTime should return custom time when user has preview permission", async () => {
   const shopId = "shopId";
   const customTime = "2023-01-01T00:00:00.000Z";
 

--- a/packages/api-plugin-promotions/src/index.js
+++ b/packages/api-plugin-promotions/src/index.js
@@ -35,11 +35,11 @@ export default async function register(app) {
       Promotions: {
         name: "Promotions",
         indexes: [
-          [{ shopId: 1, type: 1, enabled: 1, startDate: 1, endDate: 1 }, { name: "shopId__type__enabled__startDate_endDate" }],
+          [{ shopId: 1, triggerType: 1, enabled: 1, state: 1, startDate: 1 }, { name: "shopId__triggerType__enabled__state__startDate" }],
           [{ shopId: 1, referenceId: 1 }, { unique: true }],
           [
-            { "shopId": 1, "type": 1, "enabled": 1, "triggers.triggerKey": 1, "triggers.triggerParameters.couponCode": 1, "startDate": 1 },
-            { name: "shopId__type__enabled__triggerKey__couponCode__startDate" }
+            { "shopId": 1, "triggerType": 1, "enabled": 1, "triggers.triggerKey": 1, "triggers.triggerParameters.couponCode": 1, "startDate": 1 },
+            { name: "shopId__triggerType__enabled__triggerKey__couponCode__startDate" }
           ]
         ]
       }

--- a/packages/api-plugin-promotions/src/utils/getCurrentShopTime.test.js
+++ b/packages/api-plugin-promotions/src/utils/getCurrentShopTime.test.js
@@ -21,5 +21,5 @@ test("returns time for local timezone for all shops", async () => {
   const dt2 = currentShopTime.shop2;
   let diff = (dt1.getTime() - dt2.getTime()) / 1000;
   diff /= (60 * 60);
-  expect(diff).toEqual(-3);
+  expect(Number(diff.toFixed(3))).toEqual(-3);
 });


### PR DESCRIPTION
Resolves #6668
Impact: **minor**
Type: **feature**

## Solution
Allows operators with role `reaction:legacy:promotions/review` to override on current date by using header `"x-custom-current-promotion-time"`.