### PR TITLE
feat: improve docker release flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,9 @@ jobs:
         command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
         ports:
           - "27017:27017"
+      - image: redis
+        ports:
+          - "6379:6379"
     steps:
       - checkout
       - restore_cache:
@@ -129,6 +132,9 @@ jobs:
         command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
         ports:
           - "27017:27017"
+      - image: redis
+        ports:
+          - "6379:6379"
     steps:
       - checkout
       - restore_cache:
@@ -167,8 +173,8 @@ jobs:
       - run:
           name: Check should build new image
           command: |
-            VERSION=$(cat ./apps/reaction/package.json | grep -m 1 version | sed 's/[^0-9.]//g')
-            if curl --silent -f --head -lL https://hub.docker.com/v2/repositories/${DOCKER_REPOSITORY}/tags/${VERSION}/ > /dev/null; then
+            head_commit=$(git log -1 --oneline | grep -m 1 releases)
+            if [[ $head_commit != *"/releases/docker-image"* ]]; then
               circleci-agent step halt
             fi
       - run:
@@ -189,6 +195,7 @@ jobs:
             echo "ROOT_URL=http://localhost:3000" >> .env
             echo "STORE_URL=http://localhost:4000" >> .env
             echo "STRIPE_API_KEY=YOUR_PRIVATE_STRIPE_API_KEY" >> .env
+            echo "REDIS_SERVER=redis://127.0.0.1:6379" >> .env
       - run:
           name: Create reaction.localhost network
           command: docker network create "reaction.localhost" || true
@@ -260,4 +267,9 @@ workflows:
               only:
                 - trunk
           requires:
-            - release
+            - dockerfile-lint
+            - eslint
+            - graphql-lint
+            - test-unit
+            - test-integration-query
+            - test-integration-mutation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,6 @@ jobs:
         command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
         ports:
           - "27017:27017"
-      - image: redis
-        ports:
-          - "6379:6379"
     steps:
       - checkout
       - restore_cache:
@@ -132,9 +129,6 @@ jobs:
         command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
         ports:
           - "27017:27017"
-      - image: redis
-        ports:
-          - "6379:6379"
     steps:
       - checkout
       - restore_cache:
@@ -195,7 +189,6 @@ jobs:
             echo "ROOT_URL=http://localhost:3000" >> .env
             echo "STORE_URL=http://localhost:4000" >> .env
             echo "STRIPE_API_KEY=YOUR_PRIVATE_STRIPE_API_KEY" >> .env
-            echo "REDIS_SERVER=redis://127.0.0.1:6379" >> .env
       - run:
           name: Create reaction.localhost network
           command: docker network create "reaction.localhost" || true

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -58,4 +58,3 @@ jobs:
           branch: "releases/docker-image-${{ steps.get-docker-version.outputs.NEW_DOCKER_IMAGE_VERSION }}"
           commit-message: "feat: update docker-compose file to ${{ steps.get-docker-version.outputs.NEW_DOCKER_IMAGE_VERSION }} [Docker Release]"
           signoff: true
-          committer: $(git --no-pager log --format=format:'%an' -n 1) <$(git --no-pager log --format=format:'%ae' -n 1)>

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,61 @@
+name: Docker release
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions: {}
+
+jobs:
+  create-docker-release-pr:
+    if: github.event.pull_request.merged == true && github.base_ref == 'trunk' && github.head_ref == 'changeset-release/trunk'
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get new docker version
+        id: get-docker-version
+        run: |
+          VERSION=$(cat ./apps/reaction/package.json | grep -m 1 version | sed 's/[^0-9.]//g')
+          echo "NEW_DOCKER_IMAGE_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "New release docker version is $VERSION"
+
+      - name: Check should build new image
+        id: should-build-new-image
+        run: |
+          if curl --silent -f --head -lL https://hub.docker.com/v2/repositories/reactioncommerce/reaction/tags/${{ steps.get-docker-version.outputs.NEW_DOCKER_IMAGE_VERSION }}/ > /dev/null; then
+            echo "RESULT=false" >> $GITHUB_OUTPUT
+          else
+            echo "RESULT=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set git user
+        if: steps.should-build-new-image.outputs.RESULT == 'true'
+        run: |
+          echo ${{ steps.should-build-new-image.outputs.RESULT }}
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+
+      - name: Update docker-compose file
+        if: steps.should-build-new-image.outputs.RESULT == 'true'
+        run: |
+          yes | cp -i docker-compose.circleci.yml docker-compose.yml
+          sed -i "s/REACTION_VERSION/${{ steps.get-docker-version.outputs.NEW_DOCKER_IMAGE_VERSION }}/g" ./docker-compose.yml
+
+      - name: Create Pull Request
+        if: steps.should-build-new-image.outputs.RESULT == 'true'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Docker image release  ${{ steps.get-docker-version.outputs.NEW_DOCKER_IMAGE_VERSION }}
+          body: "Release docker image ${{ steps.get-docker-version.outputs.NEW_DOCKER_IMAGE_VERSION }}"
+          branch: "releases/docker-image-${{ steps.get-docker-version.outputs.NEW_DOCKER_IMAGE_VERSION }}"
+          commit-message: "feat: update docker-compose file to ${{ steps.get-docker-version.outputs.NEW_DOCKER_IMAGE_VERSION }} [Docker Release]"
+          signoff: true
+          committer: $(git --no-pager log --format=format:'%an' -n 1) <$(git --no-pager log --format=format:'%ae' -n 1)>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,4 @@ jobs:
           committer_name: github-actions[bot]
           committer_email: 41898282+github-actions[bot]@users.noreply.github.com
           pathspec_error_handling: ignore
+          commit: --signoff


### PR DESCRIPTION
Resolves #6714
Impact: **major**
Type: **feature**

## Issue

To ensure that we have a docker image that starts properly we need to release packages before we release the docker image, so instead of our current 1 step process we would have a process like:

Current Step 1 that versions all packages and releases the app and publishes to npm and creates a PR for the docker release
A PR that when merged will release the docker file to Docker hub

## Solution

Create second step for Docker image release
