### PR TITLE
Filter for Promotions

### DIFF
--- a/.changeset/funny-scissors-share.md
+++ b/.changeset/funny-scissors-share.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-promotions": minor
+---
+
+filter feature for promotions

--- a/packages/api-plugin-promotions/package.json
+++ b/packages/api-plugin-promotions/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@reactioncommerce/api-utils": "^1.16.9",
+    "@reactioncommerce/api-utils": "~1.17.1",
     "@reactioncommerce/logger": "^1.1.3",
     "@reactioncommerce/random": "^1.0.2",
     "@reactioncommerce/reaction-error": "^1.0.1",

--- a/packages/api-plugin-promotions/src/queries/filterPromotions.js
+++ b/packages/api-plugin-promotions/src/queries/filterPromotions.js
@@ -1,0 +1,24 @@
+import generateFilterQuery from "@reactioncommerce/api-utils/generateFilterQuery.js";
+
+/**
+ * @name filterPromotions
+ * @method
+ * @memberof GraphQL/Promotions
+ * @summary Query the Promotions collection for a list of promotions
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} conditions - object containing the filter conditions
+ * @param {String} shopId - shopID to filter by
+ * @returns {Promise<Object>} Promotions object Promise
+ */
+export default async function filterPromotions(context, conditions, shopId) {
+  const { collections: { Promotions } } = context;
+
+  if (!shopId) {
+    throw new Error("shopId is required");
+  }
+  await context.validatePermissions("reaction:legacy:promotions", "read", { shopId });
+
+  const { filterQuery } = generateFilterQuery(context, "Promotion", conditions, shopId);
+
+  return Promotions.find(filterQuery);
+}

--- a/packages/api-plugin-promotions/src/queries/index.js
+++ b/packages/api-plugin-promotions/src/queries/index.js
@@ -1,7 +1,9 @@
 import promotions from "./promotions.js";
 import promotion from "./promotion.js";
+import filterPromotions from "./filterPromotions.js";
 
 export default {
+  filterPromotions,
   promotions,
   promotion
 };

--- a/packages/api-plugin-promotions/src/resolvers/Query/filterPromotions.js
+++ b/packages/api-plugin-promotions/src/resolvers/Query/filterPromotions.js
@@ -1,0 +1,31 @@
+import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
+import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
+
+/**
+ * @name Query/promotions
+ * @method
+ * @memberof Promotions/Query
+ * @summary Query for a list of promotions
+ * @param {Object} _ - unused
+ * @param {Object} args - an object of all arguments that were sent by the client
+ * @param {String} args.shopId - id of shop to query
+ * @param {Object} args.conditions - object containing the filter conditions
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} info Info about the GraphQL request
+ * @returns {Promise<Object>} Promotions
+ */
+export default async function filterPromotions(_, args, context, info) {
+  const {
+    shopId,
+    conditions,
+    ...connectionArgs
+  } = args;
+
+  const query = await context.queries.filterPromotions(context, conditions, shopId);
+
+  return getPaginatedResponse(query, connectionArgs, {
+    includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
+    includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
+    includeTotalCount: wasFieldRequested("totalCount", info)
+  });
+}

--- a/packages/api-plugin-promotions/src/resolvers/Query/index.js
+++ b/packages/api-plugin-promotions/src/resolvers/Query/index.js
@@ -1,7 +1,9 @@
 import promotions from "./promotions.js";
 import promotion from "./promotion.js";
+import filterPromotions from "./filterPromotions.js";
 
 export default {
+  filterPromotions,
   promotion,
   promotions
 };

--- a/packages/api-plugin-promotions/src/schemas/schema.graphql
+++ b/packages/api-plugin-promotions/src/schemas/schema.graphql
@@ -62,6 +62,30 @@ enum PromotionState {
   archived
 }
 
+"The fields by which you are allowed to sort any query that returns an `PromotionConnection`"
+enum PromotionSortByField {
+  "Promotion ID"
+  _id
+
+  "What type of promotion is this"
+  PromotionType
+
+  "What type of trigger this promotion uses"
+  TriggerType
+
+  "Date and time at which this Promotion was created"
+  createdAt
+
+  "The short description of the promotion"
+  label
+
+  "Whether the promotion is current active"
+  enabled
+
+  "Date and time at which this Promotion was last updated"
+  updatedAt
+}
+
 "A record representing a particular promotion"
 type Promotion {
   "The unique ID of the promotion"
@@ -315,4 +339,34 @@ extend type Query {
 
     sortOrder: String
   ): PromotionConnection!
+
+    "Query to get a filtered list of Accounts"
+  filterPromotions(
+    "Shop ID"
+    shopId: ID!,
+
+    "Input Conditions for fliter (use either 'any' or 'all' not both)"
+    conditions: FilterConditionsInput,
+
+    "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
+    after: ConnectionCursor,
+
+    "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
+    before: ConnectionCursor,
+
+    "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
+    first: ConnectionLimitInt,
+
+    "Return at most this many results. This parameter may be used with the `before` parameter."
+    last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int
+
+    "Return results sorted in this order"
+    sortOrder: SortOrder = desc,
+
+    "By default, accounts are sorted by createdAt. Set this to sort by one of the other allowed fields"
+    sortBy: PromotionSortByField = createdAt
+  ): PromotionConnection
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1038,7 +1038,7 @@ importers:
 
   packages/api-plugin-promotions:
     specifiers:
-      '@reactioncommerce/api-utils': ^1.16.9
+      '@reactioncommerce/api-utils': ~1.17.1
       '@reactioncommerce/logger': ^1.1.3
       '@reactioncommerce/random': ^1.0.2
       '@reactioncommerce/reaction-error': ^1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11686,8 +11686,8 @@ packages:
     dependencies:
       bson: 4.7.0
       denque: 2.1.0
-      mongodb-connection-string-url: 2.5.3
-      socks: 2.7.0
+      mongodb-connection-string-url: 2.5.4
+      socks: 2.7.1
     optionalDependencies:
       saslprep: 1.0.3
     dev: false


### PR DESCRIPTION
Signed-off-by: Sujith <mail.sujithvn@gmail.com>

Resolves #6689 
Impact: **minor**
Type: **feature**

## Issue

Add filtering for Promotions collection like was done for Customer/Orders (Ticket #6689)

## Solution

Added new query endpoint `filterPromotions` which will provide the requested feature.
To get a list of available fields and their type, the UI could use the new query end-point `introspectSchema` (currently in PR status).

## Breaking changes

None.
But for passing the validate permissions, we need an entry ["reaction:legacy:promotions", "read"] which is handled in the PR #6732 

## Testing

Unit test for the common query function is already included in the Filter PR (6684). This PR is only adding the new end-point in the same format
