### PR TITLE
fix: newly duplicated promotion should have created state

### DIFF
--- a/packages/api-plugin-promotions/src/mutations/duplicatePromotion.js
+++ b/packages/api-plugin-promotions/src/mutations/duplicatePromotion.js
@@ -17,6 +17,7 @@ export default async function duplicatePromotion(context, { shopId, promotionId 
   newPromotion._id = Random.id();
   newPromotion.createdAt = now;
   newPromotion.updatedAt = now;
+  newPromotion.state = "created";
   newPromotion.name = `Copy of ${existingPromotion.name}`;
   newPromotion.referenceId = await context.mutations.incrementSequence(context, newPromotion.shopId, "Promotions");
   PromotionSchema.validate(newPromotion);

--- a/packages/api-plugin-promotions/src/schemas/schema.graphql
+++ b/packages/api-plugin-promotions/src/schemas/schema.graphql
@@ -243,6 +243,9 @@ input PromotionUpdateInput {
 
   "Definition of how this promotion can be combined (none, per-type, or all)"
   stackability: StackabilityInput
+
+  "What is the current state of the promotion"
+  state: PromotionState
 }
 
 type PromotionUpdatedPayload {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4861,8 +4861,8 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: false
 
-  /@snyk/protect/1.1081.0:
-    resolution: {integrity: sha512-V+4DJPLorQph9j78PB3qpxOEREzXHJN/txg2Cxn2EGw+7IWOPPeLgUb4jO+tjVVmqMYmrvohMDQKErcjIxVqVg==}
+  /@snyk/protect/1.1071.0:
+    resolution: {integrity: sha512-/xoAhWLeMBEVW3mHufGPx6WrhJBy98qmJ+0jhTwdz3qerr93kk4e4dj3N6ZGI9zeBQ3+E1tPxKcC74CcmzQdhg==}
     engines: {node: '>=10'}
     hasBin: true
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
       '@reactioncommerce/file-collections-sa-gridfs': link:../../packages/file-collections-sa-gridfs
       '@reactioncommerce/logger': link:../../packages/logger
       '@reactioncommerce/random': link:../../packages/random
-      '@snyk/protect': 1.1081.0
+      '@snyk/protect': 1.1071.0
       graphql: 14.7.0
       nodemailer: 6.8.0
       semver: 6.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
       '@reactioncommerce/file-collections-sa-gridfs': link:../../packages/file-collections-sa-gridfs
       '@reactioncommerce/logger': link:../../packages/logger
       '@reactioncommerce/random': link:../../packages/random
-      '@snyk/protect': 1.1071.0
+      '@snyk/protect': 1.1081.0
       graphql: 14.7.0
       nodemailer: 6.8.0
       semver: 6.3.0
@@ -4861,8 +4861,8 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: false
 
-  /@snyk/protect/1.1071.0:
-    resolution: {integrity: sha512-/xoAhWLeMBEVW3mHufGPx6WrhJBy98qmJ+0jhTwdz3qerr93kk4e4dj3N6ZGI9zeBQ3+E1tPxKcC74CcmzQdhg==}
+  /@snyk/protect/1.1081.0:
+    resolution: {integrity: sha512-V+4DJPLorQph9j78PB3qpxOEREzXHJN/txg2Cxn2EGw+7IWOPPeLgUb4jO+tjVVmqMYmrvohMDQKErcjIxVqVg==}
     engines: {node: '>=10'}
     hasBin: true
     dev: false
@@ -11686,8 +11686,8 @@ packages:
     dependencies:
       bson: 4.7.0
       denque: 2.1.0
-      mongodb-connection-string-url: 2.5.3
-      socks: 2.7.0
+      mongodb-connection-string-url: 2.5.4
+      socks: 2.7.1
     optionalDependencies:
       saslprep: 1.0.3
     dev: false


### PR DESCRIPTION
Duplicated promotion should have `created` state
Related PR: https://github.com/reactioncommerce/kinetic/pull/152