### PR TITLE
feat: prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,7 +10,7 @@ on:
 permissions: {}
 jobs:
   version:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/prerelease'
     permissions:
       contents: write # to create release (changesets/action)
       pull-requests: write # to create pull request (changesets/action)
@@ -42,7 +42,7 @@ jobs:
 
       - name: Enter prerelease mode
         run: pnpm changeset pre enter next || true
-      
+
       - name: Check should create release
         id: should-create-release
         run: |
@@ -51,7 +51,6 @@ jobs:
           else
             echo "RESULT=false" >> $GITHUB_OUTPUT
           fi
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         if: steps.should-create-release.outputs.RESULT == 'true'
@@ -72,16 +71,14 @@ jobs:
           else
             echo "IS_CHANGED=false" >> $GITHUB_OUTPUT
           fi
-
       - name: Commit pnpm-lock.yaml
         if: steps.update-lock-file.outputs.IS_CHANGED == 'true'
         run: |
           git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
           git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
           git add pnpm-lock.yaml
-          git commit -m "chore: update pnpm-lock.yaml"
+          git commit -m "chore: update pnpm-lock.yaml" -s
           git push -u origin changeset-release/prerelease
-
   release:
     if: github.event.pull_request.merged == true && github.base_ref == 'prerelease' && github.head_ref == 'changeset-release/prerelease'
     permissions:
@@ -115,7 +112,6 @@ jobs:
           else
             echo "RESULT=false" >> $GITHUB_OUTPUT
           fi
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         if: steps.should-create-release.outputs.RESULT == 'true'
@@ -125,3 +121,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Exit prerelease mode
+        id: exit-prerelease-mode
+        run: |
+          rm ./.changeset/pre.json
+          if [[ $(git status --porcelain | grep -m 1 pre.json | sed 's/[^a-z]\-//g') == *"pre.json"* ]]; then
+            echo "IS_CHANGED=true" >> $GITHUB_OUTPUT
+          else
+            echo "IS_CHANGED=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit pre.json
+        if: steps.exit-prerelease-mode.outputs.IS_CHANGED == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .changeset/pre.json
+          git commit -m "chore: exit prerelease mode" -s
+          git push origin prerelease

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,127 @@
+name: PRERELEASE
+on:
+  workflow_dispatch:
+    branches:
+      - prerelease
+  pull_request:
+    types:
+      - closed
+
+permissions: {}
+jobs:
+  version:
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write # to create release (changesets/action)
+      pull-requests: write # to create pull request (changesets/action)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          key: reaction-v6-node-modules-${{ hashFiles('package.json') }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: "**/node_modules"
+
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install pnpm
+        run: npm i -g pnpm@latest
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+
+      - name: Enter prerelease mode
+        run: pnpm changeset pre enter next || true
+      
+      - name: Check should create release
+        id: should-create-release
+        run: |
+          if [[ $(cat ./.changeset/pre.json | grep -m 1 mode | sed 's/[^a-z]//g') == *"pre"* ]]; then
+            echo "RESULT=true" >> $GITHUB_OUTPUT
+          else
+            echo "RESULT=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        if: steps.should-create-release.outputs.RESULT == 'true'
+        uses: changesets/action@v1
+        with:
+          publish: pnpm changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Update pnpm-lock.yaml
+        id: update-lock-file
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          pnpm install --ignore-scripts --lockfile-only
+          if [[ $(git status --porcelain | grep -m 1 pnpm-lock.yaml | sed 's/[^a-z]\-//g') == *"pnpm-lock.yaml"* ]]; then
+            echo "IS_CHANGED=true" >> $GITHUB_OUTPUT
+          else
+            echo "IS_CHANGED=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit pnpm-lock.yaml
+        if: steps.update-lock-file.outputs.IS_CHANGED == 'true'
+        run: |
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+          git add pnpm-lock.yaml
+          git commit -m "chore: update pnpm-lock.yaml"
+          git push -u origin changeset-release/prerelease
+
+  release:
+    if: github.event.pull_request.merged == true && github.base_ref == 'prerelease' && github.head_ref == 'changeset-release/prerelease'
+    permissions:
+      contents: write # to create release (changesets/action)
+      pull-requests: write # to create pull request (changesets/action)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install pnpm
+        run: npm i -g pnpm@latest
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+
+      - name: Enter prerelease mode
+        run: pnpm changeset pre enter next || true
+
+      - name: Check should create release
+        id: should-create-release
+        run: |
+          if [[ $(cat ./.changeset/pre.json | grep -m 1 mode | sed 's/[^a-z]//g') == *"pre"* ]]; then
+            echo "RESULT=true" >> $GITHUB_OUTPUT
+          else
+            echo "RESULT=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        if: steps.should-create-release.outputs.RESULT == 'true'
+        uses: changesets/action@v1
+        with:
+          publish: pnpm changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,4 @@ jobs:
           committer_name: github-actions[bot]
           committer_email: 41898282+github-actions[bot]@users.noreply.github.com
           pathspec_error_handling: ignore
+          commit: --signoff

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ engine-strict=true
 auto-install-peers=true
 strict-peer-dependencies=false
 publish-branch=trunk
+prefer-workspace-packages=true

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ pnpm run start:dev
 ## Prerelease flows
 1. All PRs will be merged into `prerelease` branch before triggering `PRERELEASE` action.
 2. Before merging PRs into `prerelease` branch, please make sure that all the changesets are added.
-3. Manually trigger `PRERELEASE` action to create `Version Packages (next)` PR. This PR will remove all changeset files, bump up packages versions as `1.0.0-next.{number}`, update CHANGELOG files.
+3. Manually trigger `PRERELEASE` action to create `Version Packages (next)` PR. After merged, the changeset/action will bump up packages versions as `{next-version}-next.{number}`, update CHANGELOG files.
 4. Merge `Version Packages (next)` PR into `prerelease` branch, action will publish all the packages into npm.
 
 # Get involved

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ pnpm run start:dev
 1. Run `release` action to create `Version PR`. This PR will remove all changeset files, bump up packages versions, update CHANGELOG files.
 2. Merge `Version PR` into trunk, CircleCI will publish all the packages into npm.
 
+## Prerelease flows
+1. All PRs will be merged into `prerelease` branch before triggering `PRERELEASE` action.
+2. Before merging PRs into `prerelease` branch, please make sure that all the changesets are added.
+3. Manually trigger `PRERELEASE` action to create `Version Packages (next)` PR. This PR will remove all changeset files, bump up packages versions as `1.0.0-next.{number}`, update CHANGELOG files.
+4. Merge `Version Packages (next)` PR into `prerelease` branch, action will publish all the packages into npm.
+
 # Get involved
 ## Contribute
 


### PR DESCRIPTION
Signed-off-by: vanpho93 <vanpho02@gmail.com>

Resolves #6746
Impact: **major**
Type: **feature**

## Issue

To unblock people from trying packages that have been waiting for release.

## Solution

Using [changeset prerelease](https://github.com/changesets/changesets/blob/main/docs/prereleases.md), create version PR on a prerelease branch. When we merge that PR, it will release packages under https://github.com/next on npm.