### PR TITLE
feat: add metafields as fact on get eligibleitems function

### DIFF
--- a/packages/api-plugin-carts/src/util/addCartItems.js
+++ b/packages/api-plugin-carts/src/util/addCartItems.js
@@ -110,7 +110,7 @@ export default async function addCartItems(context, currentItems, inputItems, op
       attributes,
       compareAtPrice: null,
       isTaxable: chosenVariant.isTaxable || false,
-      metafields,
+      metafields: metafields || catalogProduct.metafields,
       optionTitle: chosenVariant.optionTitle,
       parcel: chosenVariant.parcel,
       // This one will be kept updated by event handler watching for

--- a/packages/api-plugin-promotions-discounts/src/actions/discountAction.js
+++ b/packages/api-plugin-promotions-discounts/src/actions/discountAction.js
@@ -4,6 +4,7 @@ import Logger from "@reactioncommerce/logger";
 import applyItemDiscountToCart from "../discountTypes/item/applyItemDiscountToCart.js";
 import applyShippingDiscountToCart from "../discountTypes/shipping/applyShippingDiscountToCart.js";
 import applyOrderDiscountToCart from "../discountTypes/order/applyOrderDiscountToCart.js";
+import { DiscountActionCondition } from "../simpleSchemas.js";
 
 const require = createRequire(import.meta.url);
 
@@ -21,13 +22,6 @@ const functionMap = {
   shipping: applyShippingDiscountToCart,
   order: applyOrderDiscountToCart
 };
-
-export const Rules = new SimpleSchema({
-  conditions: {
-    type: Object,
-    blackbox: true
-  }
-});
 
 export const discountActionParameters = new SimpleSchema({
   discountType: {
@@ -50,10 +44,11 @@ export const discountActionParameters = new SimpleSchema({
     optional: true
   },
   inclusionRules: {
-    type: Rules
+    type: DiscountActionCondition,
+    optional: true
   },
   exclusionRules: {
-    type: Rules,
+    type: DiscountActionCondition,
     optional: true
   },
   neverStackWithOtherItemLevelDiscounts: {
@@ -100,7 +95,6 @@ export async function discountActionHandler(context, cart, params) {
   Logger.info({ params, cartId: cart._id, ...logCtx }, "applying discount to cart");
 
   const { cart: updatedCart, affected, reason } = await functionMap[discountType](context, params, cart);
-
 
   Logger.info({ ...logCtx, ...params.actionParameters, cartId: cart._id, cartDiscount: cart.discount }, "Completed applying Discount to Cart");
   return { updatedCart, affected, reason };

--- a/packages/api-plugin-promotions-discounts/src/discountTypes/item/applyItemDiscountToCart.test.js
+++ b/packages/api-plugin-promotions-discounts/src/discountTypes/item/applyItemDiscountToCart.test.js
@@ -125,6 +125,8 @@ test("should return cart with applied discount when parameters include rule", as
     test: jest.fn().mockReturnValue(10)
   };
 
+  mockContext.promotionOfferFacts = { test: jest.fn() };
+
   const result = await applyItemDiscountToCart.default(mockContext, parameters, cart);
 
   expect(result).toEqual({
@@ -184,6 +186,8 @@ test("should return affected is false with reason when have no items are discoun
   mockContext.discountCalculationMethods = {
     test: jest.fn().mockReturnValue(10)
   };
+
+  mockContext.promotionOfferFacts = { test: jest.fn() };
 
   const result = await applyItemDiscountToCart.default(mockContext, parameters, cart);
 

--- a/packages/api-plugin-promotions-discounts/src/facts/getKeyValueArray.js
+++ b/packages/api-plugin-promotions-discounts/src/facts/getKeyValueArray.js
@@ -1,0 +1,15 @@
+import _ from "lodash";
+
+/**
+ * @summary Get the get the custom field of the cart item
+ * @param {Object} context - The application context
+ * @param {Object} params - The parameters to pass to the fact
+ * @param {Object} almanac - The almanac to pass to the fact
+ * @returns {Promise<string>} - The total amount of a discount or promotion
+ */
+export default async function getKeyValueArray(context, params, almanac) {
+  const item = await almanac.factValue("item");
+  const { inputField = "key", inputValue = "name", outputField = "value", fieldName } = params.ruleParams || {};
+  const result = _.find(item[fieldName] || [], { [inputField]: inputValue });
+  return result && result[outputField] ? result[outputField] : "";
+}

--- a/packages/api-plugin-promotions-discounts/src/facts/index.js
+++ b/packages/api-plugin-promotions-discounts/src/facts/index.js
@@ -1,0 +1,5 @@
+import getKeyValueArray from "./getKeyValueArray.js";
+
+export default {
+  keyValueArray: getKeyValueArray
+};

--- a/packages/api-plugin-promotions-discounts/src/index.js
+++ b/packages/api-plugin-promotions-discounts/src/index.js
@@ -7,6 +7,7 @@ import addDiscountToOrderItem from "./utils/addDiscountToOrderItem.js";
 import preStartup from "./preStartup.js";
 import { discountCalculationMethods, registerDiscountCalculationMethod } from "./registration.js";
 import getTotalDiscountOnCart from "./utils/getTotalDiscountOnCart.js";
+import facts from "./facts/index.js";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
@@ -35,6 +36,7 @@ export default async function register(app) {
       actions,
       stackabilities
     },
-    discountCalculationMethods: methods
+    discountCalculationMethods: methods,
+    promotionOfferFacts: facts
   });
 }

--- a/packages/api-plugin-promotions-discounts/src/preStartup.js
+++ b/packages/api-plugin-promotions-discounts/src/preStartup.js
@@ -1,5 +1,5 @@
 import SimpleSchema from "simpl-schema";
-import { CartDiscount } from "./simpleSchemas.js";
+import { CartDiscount, ConditionRule } from "./simpleSchemas.js";
 
 const discountSchema = new SimpleSchema({
   // this is here for backwards compatibility with old discounts
@@ -180,4 +180,17 @@ async function extendOrderSchemas(context) {
 export default async function preStartupDiscounts(context) {
   await extendCartSchemas(context);
   await extendOrderSchemas(context);
+
+  const { promotionOfferFacts, promotions: { allowOperators } } = context;
+
+  const promotionFactKeys = Object.keys(promotionOfferFacts);
+
+  ConditionRule.extend({
+    fact: {
+      allowedValues: ConditionRule.getAllowedValuesForKey("fact").concat(promotionFactKeys)
+    },
+    operator: {
+      allowedValues: allowOperators
+    }
+  });
 }

--- a/packages/api-plugin-promotions-discounts/src/simpleSchemas.js
+++ b/packages/api-plugin-promotions-discounts/src/simpleSchemas.js
@@ -1,9 +1,64 @@
 import SimpleSchema from "simpl-schema";
 
-export const Rules = new SimpleSchema({
-  conditions: {
+const allowOperators = [
+  "equal",
+  "notEqual",
+  "lessThan",
+  "lessThanInclusive",
+  "greaterThan",
+  "greaterThanInclusive",
+  "in",
+  "notIn",
+  "contains",
+  "doesNotContain"
+];
+
+export const ConditionRule = new SimpleSchema({
+  "fact": {
+    type: String,
+    allowedValues: ["cart", "item"]
+  },
+  "operator": {
+    type: String,
+    allowedValues: allowOperators
+  },
+  "path": {
+    type: String,
+    optional: true
+  },
+  "value": {
+    type: SimpleSchema.oneOf(String, Number, Boolean, Array)
+  },
+  "value.$": {
+    type: SimpleSchema.oneOf(String, Number, Boolean)
+  },
+  "params": {
     type: Object,
-    blackbox: true
+    blackbox: true,
+    optional: true
+  }
+});
+
+export const RuleExpression = new SimpleSchema({
+  "all": {
+    type: Array,
+    optional: true
+  },
+  "all.$": {
+    type: ConditionRule
+  },
+  "any": {
+    type: Array,
+    optional: true
+  },
+  "any.$": {
+    type: ConditionRule
+  }
+});
+
+export const DiscountActionCondition = new SimpleSchema({
+  conditions: {
+    type: RuleExpression
   }
 });
 
@@ -40,10 +95,10 @@ export const Discount = new SimpleSchema({
     type: Number
   },
   inclusionRules: {
-    type: Rules
+    type: DiscountActionCondition
   },
   exclusionRules: {
-    type: Rules,
+    type: DiscountActionCondition,
     optional: true
   }
 });

--- a/packages/api-plugin-promotions-discounts/src/utils/engineHelpers.js
+++ b/packages/api-plugin-promotions-discounts/src/utils/engineHelpers.js
@@ -7,8 +7,17 @@ import { Engine } from "json-rules-engine";
  * @returns {Object} Engine - The engine with the operators added
  */
 export default function createEngine(context, rules) {
+  const { promotionOfferFacts, promotions: { operators } } = context;
+
   const engine = new Engine();
-  const { promotions: { operators } } = context;
+
+  Object.keys(promotionOfferFacts).forEach((factKey) => {
+    engine.addFact(factKey, (params, almanac) => {
+      const factParams = { ...rules, ruleParams: params };
+      return promotionOfferFacts[factKey](context, factParams, almanac);
+    });
+  });
+
   Object.keys(operators).forEach((operatorKey) => {
     engine.addOperator(operatorKey, operators[operatorKey]);
   });

--- a/packages/api-plugin-promotions-discounts/src/utils/getEligibleItems.test.js
+++ b/packages/api-plugin-promotions-discounts/src/utils/getEligibleItems.test.js
@@ -31,6 +31,7 @@ test("should return eligible items if inclusion rule is provided", async () => {
   mockContext.promotions = {
     operators: { test: jest.fn() }
   };
+  mockContext.promotionOfferFacts = { test: jest.fn() };
   const eligibleItems = await getEligibleItems(mockContext, items, parameters);
   expect(eligibleItems).toEqual([{ _id: "1", brand: "No1 Brand" }]);
 });
@@ -58,6 +59,8 @@ test("should remove ineligible items if exclusion rule is provided", async () =>
   mockContext.promotions = {
     operators: { test: jest.fn() }
   };
+  mockContext.promotionOfferFacts = { test: jest.fn() };
+
   const filteredItems = await getEligibleItems(mockContext, items, parameters);
   expect(filteredItems).toEqual([{ _id: "1", brand: "No1 Brand" }]);
 });

--- a/packages/api-plugin-promotions-offers/src/facts/getEligibleItems.test.js
+++ b/packages/api-plugin-promotions-offers/src/facts/getEligibleItems.test.js
@@ -39,6 +39,7 @@ test("should return eligible items if inclusion rule is provided", async () => {
   mockContext.promotions = {
     operators: { test: jest.fn() }
   };
+  mockContext.promotionOfferFacts = { test: jest.fn() };
   const eligibleItems = await getEligibleItems(mockContext, parameters, almanac);
   expect(eligibleItems).toEqual([{ _id: "1", brand: "No1 Brand" }]);
 });
@@ -70,6 +71,7 @@ test("should remove ineligible items if exclusion rule is provided", async () =>
   mockContext.promotions = {
     operators: { test: jest.fn() }
   };
+  mockContext.promotionOfferFacts = { test: jest.fn() };
   const eligibleItems = await getEligibleItems(mockContext, parameters, almanac);
   expect(eligibleItems).toEqual([{ _id: "1", brand: "No1 Brand" }]);
 });

--- a/packages/api-plugin-promotions-offers/src/facts/getKeyValueArray.js
+++ b/packages/api-plugin-promotions-offers/src/facts/getKeyValueArray.js
@@ -1,0 +1,15 @@
+import _ from "lodash";
+
+/**
+ * @summary Get the get the custom field of the cart item
+ * @param {Object} context - The application context
+ * @param {Object} params - The parameters to pass to the fact
+ * @param {Object} almanac - The almanac to pass to the fact
+ * @returns {Promise<string>} - The total amount of a discount or promotion
+ */
+export default async function getKeyValueArray(context, params, almanac) {
+  const item = await almanac.factValue("item");
+  const { inputField = "key", inputValue = "name", outputField = "value", fieldName } = params.ruleParams || {};
+  const result = _.find(item[fieldName] || [], { [inputField]: inputValue });
+  return result && result[outputField] ? result[outputField] : "";
+}

--- a/packages/api-plugin-promotions-offers/src/facts/index.js
+++ b/packages/api-plugin-promotions-offers/src/facts/index.js
@@ -1,9 +1,11 @@
 import totalItemAmount from "./totalItemAmount.js";
 import totalItemCount from "./totalItemCount.js";
 import getEligibleItems from "./getEligibleItems.js";
+import getKeyValueArray from "./getKeyValueArray.js";
 
 export default {
   totalItemAmount,
   totalItemCount,
-  getEligibleItems
+  eligibleItems: getEligibleItems,
+  keyValueArray: getKeyValueArray
 };

--- a/packages/api-plugin-promotions-offers/src/index.js
+++ b/packages/api-plugin-promotions-offers/src/index.js
@@ -3,6 +3,8 @@ import triggers from "./triggers/index.js";
 import enhancers from "./enhancers/index.js";
 import facts from "./facts/index.js";
 import { promotionOfferFacts, registerPromotionOfferFacts } from "./registration.js";
+import { ConditionRule } from "./simpleSchemas.js";
+import preStartupPromotionOffer from "./preStartup.js";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
@@ -18,6 +20,7 @@ export default async function register(app) {
     name: pkg.name,
     version: pkg.version,
     functionsByType: {
+      preStartup: [preStartupPromotionOffer],
       registerPluginHandler: [registerPromotionOfferFacts]
     },
     contextAdditions: {
@@ -27,6 +30,9 @@ export default async function register(app) {
       triggers,
       enhancers
     },
-    promotionOfferFacts: facts
+    promotionOfferFacts: facts,
+    simpleSchemas: {
+      ConditionRule
+    }
   });
 }

--- a/packages/api-plugin-promotions-offers/src/preStartup.js
+++ b/packages/api-plugin-promotions-offers/src/preStartup.js
@@ -1,0 +1,21 @@
+import { ConditionRule } from "./simpleSchemas.js";
+
+/**
+ * @summary Pre-startup function for api-plugin-promotions-offer
+ * @param {Object} context - Startup context
+ * @returns {Promise<void>} undefined
+ */
+export default async function preStartupPromotionOffer(context) {
+  const { promotionOfferFacts, promotions: { allowOperators } } = context;
+
+  const promotionFactKeys = Object.keys(promotionOfferFacts);
+
+  ConditionRule.extend({
+    fact: {
+      allowedValues: ConditionRule.getAllowedValuesForKey("fact").concat(promotionFactKeys)
+    },
+    operator: {
+      allowedValues: allowOperators
+    }
+  });
+}

--- a/packages/api-plugin-promotions-offers/src/simpleSchemas.js
+++ b/packages/api-plugin-promotions-offers/src/simpleSchemas.js
@@ -1,24 +1,78 @@
 import SimpleSchema from "simpl-schema";
 
-const Rules = new SimpleSchema({
-  conditions: {
+const allowOperators = [
+  "equal",
+  "notEqual",
+  "lessThan",
+  "lessThanInclusive",
+  "greaterThan",
+  "greaterThanInclusive",
+  "in",
+  "notIn",
+  "contains",
+  "doesNotContain"
+];
+
+export const ConditionRule = new SimpleSchema({
+  "fact": {
+    type: String,
+    allowedValues: ["cart", "item"]
+  },
+  "operator": {
+    type: String,
+    allowedValues: allowOperators
+  },
+  "path": {
+    type: String,
+    optional: true
+  },
+  "value": {
+    type: SimpleSchema.oneOf(String, Number, Boolean, Array)
+  },
+  "value.$": {
+    type: SimpleSchema.oneOf(String, Number, Boolean)
+  },
+  "params": {
     type: Object,
-    blackbox: true
+    blackbox: true,
+    optional: true
+  }
+});
+
+export const RuleExpression = new SimpleSchema({
+  "all": {
+    type: Array,
+    optional: true
+  },
+  "all.$": {
+    type: ConditionRule
+  },
+  "any": {
+    type: Array,
+    optional: true
+  },
+  "any.$": {
+    type: ConditionRule
+  }
+});
+
+export const OfferTriggerCondition = new SimpleSchema({
+  conditions: {
+    type: RuleExpression
   }
 });
 
 export const OfferTriggerParameters = new SimpleSchema({
   name: String,
   conditions: {
-    type: Object,
-    blackbox: true
+    type: RuleExpression
   },
   inclusionRules: {
-    type: Rules,
+    type: OfferTriggerCondition,
     optional: true
   },
   exclusionRules: {
-    type: Rules,
+    type: OfferTriggerCondition,
     optional: true
   }
 });

--- a/packages/api-plugin-promotions-offers/src/triggers/offerTriggerHandler.js
+++ b/packages/api-plugin-promotions-offers/src/triggers/offerTriggerHandler.js
@@ -14,12 +14,6 @@ const logCtx = {
   file: "offerTriggerHandler.js"
 };
 
-const defaultFacts = [
-  { fact: "eligibleItems", handlerName: "getEligibleItems" },
-  { fact: "totalItemAmount", handlerName: "totalItemAmount" },
-  { fact: "totalItemCount", handlerName: "totalItemCount" }
-];
-
 /**
  * @summary apply all offers to the cart
  * @param {String} context - The application context
@@ -30,18 +24,9 @@ const defaultFacts = [
  * @returns {Promise<boolean>} - The answer with offers applied
  */
 export async function offerTriggerHandler(context, enhancedCart, { triggerParameters }) {
-  const { promotionOfferFacts } = context;
-
   const engine = createEngine(context, triggerParameters);
 
   const facts = { cart: enhancedCart };
-
-  for (const { fact, handlerName, fromFact } of defaultFacts) {
-    engine.addFact(fact, (params, almanac) => {
-      const factParams = { ...triggerParameters, rulePrams: params, fromFact };
-      return promotionOfferFacts[handlerName](context, factParams, almanac);
-    });
-  }
 
   const results = await engine.run(facts);
   const { failureResults } = results;

--- a/packages/api-plugin-promotions-offers/src/triggers/offerTriggerHandler.test.js
+++ b/packages/api-plugin-promotions-offers/src/triggers/offerTriggerHandler.test.js
@@ -9,10 +9,6 @@ const pluginPromotion = {
   operators: {}
 };
 
-const promotionOfferFacts = {
-  testHandler: jest.fn().mockName("testFactHandler")
-};
-
 const triggerParameters = {
   name: "50% off your entire order when you spend more then $200",
   conditions: {
@@ -42,6 +38,7 @@ test("should return true when the cart qualified by promotion", async () => {
   const enhancedCart = merchandiseTotal(mockContext, cart);
 
   mockContext.promotions = pluginPromotion;
+  mockContext.promotionOfferFacts = { test: jest.fn() };
   expect(await offerTriggerHandler(mockContext, enhancedCart, { triggerParameters })).toBe(true);
 });
 
@@ -54,56 +51,4 @@ test("should return false when the cart isn't qualified by promotion", async () 
 
   mockContext.promotions = pluginPromotion;
   expect(await offerTriggerHandler(mockContext, enhancedCart, { triggerParameters })).toBe(false);
-});
-
-test("should add custom fact when facts provided on parameters", async () => {
-  const cart = {
-    _id: "cartId",
-    items: [{ _id: "product-1", price: { amount: 100 }, quantity: 2 }]
-  };
-  const enhancedCart = merchandiseTotal(mockContext, cart);
-
-  mockContext.promotions = pluginPromotion;
-  mockContext.promotionOfferFacts = promotionOfferFacts;
-  const parameters = {
-    ...triggerParameters,
-    facts: [
-      {
-        fact: "testFact",
-        handlerName: "testHandler"
-      }
-    ]
-  };
-  const mockAddFact = jest.fn().mockName("addFact");
-  createEngine.mockReturnValueOnce({
-    addFact: mockAddFact,
-    run: jest.fn().mockName("run").mockResolvedValue({ failureResults: [] })
-  });
-
-  await offerTriggerHandler(mockContext, enhancedCart, { triggerParameters: parameters });
-
-  expect(mockAddFact).toHaveBeenNthCalledWith(1, "eligibleItems", expect.any(Function));
-  expect(mockAddFact).toHaveBeenNthCalledWith(2, "totalItemAmount", expect.any(Function));
-  expect(mockAddFact).toHaveBeenNthCalledWith(3, "totalItemCount", expect.any(Function));
-});
-
-test("should not add custom fact when not provided on parameters", async () => {
-  const cart = {
-    _id: "cartId",
-    items: [{ _id: "product-1", price: { amount: 100 }, quantity: 2 }]
-  };
-  const enhancedCart = merchandiseTotal(mockContext, cart);
-
-  mockContext.promotions = pluginPromotion;
-  mockContext.promotionOfferFacts = promotionOfferFacts;
-  const mockAddFact = jest.fn().mockName("addFact");
-  createEngine.mockReturnValueOnce({
-    addFact: mockAddFact,
-    run: jest.fn().mockName("run").mockResolvedValue({ failureResults: [] })
-  });
-
-  await offerTriggerHandler(mockContext, enhancedCart, { triggerParameters });
-
-  expect(mockAddFact).toHaveBeenCalledWith("eligibleItems", expect.any(Function));
-  expect(mockAddFact).not.toHaveBeenCalledWith("testFact", expect.any(Function));
 });

--- a/packages/api-plugin-promotions-offers/src/utils/engineHelpers.js
+++ b/packages/api-plugin-promotions-offers/src/utils/engineHelpers.js
@@ -7,8 +7,17 @@ import { Engine } from "json-rules-engine";
  * @returns {Object} Engine - The engine with the operators added
  */
 export default function createEngine(context, rules) {
+  const { promotionOfferFacts, promotions: { operators } } = context;
+
   const engine = new Engine();
-  const { promotions: { operators } } = context;
+
+  Object.keys(promotionOfferFacts).forEach((factKey) => {
+    engine.addFact(factKey, (params, almanac) => {
+      const factParams = { ...rules, ruleParams: params };
+      return promotionOfferFacts[factKey](context, factParams, almanac);
+    });
+  });
+
   Object.keys(operators).forEach((operatorKey) => {
     engine.addOperator(operatorKey, operators[operatorKey]);
   });

--- a/packages/api-plugin-promotions/src/mutations/createPromotion.js
+++ b/packages/api-plugin-promotions/src/mutations/createPromotion.js
@@ -1,4 +1,5 @@
 import Random from "@reactioncommerce/random";
+import validateActionParams from "./validateActionParams.js";
 import validateTriggerParams from "./validateTriggerParams.js";
 
 /**
@@ -21,8 +22,11 @@ export default async function createPromotion(context, promotion) {
   promotion.createdAt = now;
   promotion.updatedAt = now;
   promotion.referenceId = await context.mutations.incrementSequence(context, promotion.shopId, "Promotions");
+
   PromotionSchema.validate(promotion);
   validateTriggerParams(context, promotion);
+  validateActionParams(context, promotion);
+
   const results = await Promotions.insertOne(promotion);
   const { insertedCount, insertedId } = results;
   promotion._id = insertedId;

--- a/packages/api-plugin-promotions/src/mutations/createPromotion.test.js
+++ b/packages/api-plugin-promotions/src/mutations/createPromotion.test.js
@@ -54,10 +54,56 @@ const offerTrigger = {
   type: "implicit"
 };
 
+const discountActionParameters = new SimpleSchema({
+  discountType: {
+    type: String,
+    allowedValues: ["item", "order", "shipping"]
+  },
+  discountCalculationType: {
+    type: String,
+    allowedValues: ["flat", "fixed", "percentage"]
+  },
+  discountValue: {
+    type: Number
+  },
+  discountMaxValue: {
+    type: Number,
+    optional: true
+  },
+  discountMaxUnits: {
+    type: Number,
+    optional: true
+  },
+  inclusionRules: {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
+  exclusionRules: {
+    type: Object,
+    blackbox: true,
+    optional: true
+  },
+  neverStackWithOtherItemLevelDiscounts: {
+    type: Boolean,
+    optional: true,
+    defaultValue: false
+  }
+});
+
+const discountAction = {
+  key: "discounts",
+  handler: () => {},
+  paramSchema: discountActionParameters
+};
+
 
 mockContext.promotions = {
   triggers: [
     offerTrigger
+  ],
+  actions: [
+    discountAction
   ]
 };
 

--- a/packages/api-plugin-promotions/src/mutations/fixtures/orderPromotion.js
+++ b/packages/api-plugin-promotions/src/mutations/fixtures/orderPromotion.js
@@ -28,8 +28,12 @@ export const CreateOrderPromotion = {
   ],
   actions: [
     {
-      actionKey: "noop",
-      actionParameters: {}
+      actionKey: "discounts",
+      actionParameters: {
+        discountType: "order",
+        discountCalculationType: "percentage",
+        discountValue: 5
+      }
     }
   ],
   startDate: now,

--- a/packages/api-plugin-promotions/src/mutations/validateActionParams.js
+++ b/packages/api-plugin-promotions/src/mutations/validateActionParams.js
@@ -1,0 +1,14 @@
+/**
+ * @summary validate the parameters of the particular action
+ * @param {Object} context - The application context
+ * @param {Object} promotion - The promotion to validate
+ * @returns {undefined} throws error if invalid
+ */
+export default function validateActionParams(context, promotion) {
+  const { promotions } = context;
+  for (const action of promotion.actions) {
+    const actionData = promotions.actions.find((ac) => ac.key === action.actionKey);
+    const { paramSchema } = actionData;
+    paramSchema.validate(action.actionParameters);
+  }
+}

--- a/packages/api-plugin-promotions/src/preStartup.js
+++ b/packages/api-plugin-promotions/src/preStartup.js
@@ -41,7 +41,7 @@ function extendCartSchema(context) {
 export default function preStartupPromotions(context) {
   extendSchemas(context);
   extendCartSchema(context);
-  const { actions: additionalActions, triggers: additionalTriggers, promotionTypes, stackabilities } = context.promotions;
+  const { actions: additionalActions, triggers: additionalTriggers, promotionTypes, stackabilities, allowOperators, operators } = context.promotions;
   const triggerKeys = _.map(additionalTriggers, "key");
   const actionKeys = _.map(additionalActions, "key");
   const promotionTypeKeys = Object.keys(promotionTypes);
@@ -69,4 +69,7 @@ export default function preStartupPromotions(context) {
       allowedValues: [...Stackability.getAllowedValuesForKey("key"), ...stackabilityKeys]
     }
   });
+
+  const newAddedOperatorKeys = Object.keys(operators);
+  allowOperators.push(...newAddedOperatorKeys);
 }

--- a/packages/api-plugin-promotions/src/registration.js
+++ b/packages/api-plugin-promotions/src/registration.js
@@ -56,7 +56,9 @@ const PromotionsDeclaration = new SimpleSchema({
   },
   "promotionTypes.$": {
     type: PromotionType
-  }
+  },
+  "allowOperators": Array,
+  "allowOperators.$": String
 });
 
 export const promotions = {
@@ -67,7 +69,19 @@ export const promotions = {
   operators: {}, // operators used for rule evaluations
   qualifiers: [],
   promotionTypes: [],
-  stackabilities: []
+  stackabilities: [],
+  allowOperators: [
+    "equal",
+    "notEqual",
+    "lessThan",
+    "lessThanInclusive",
+    "greaterThan",
+    "greaterThanInclusive",
+    "in",
+    "notIn",
+    "contains",
+    "doesNotContain"
+  ]
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: vanpho93 <vanpho02@gmail.com>
Resolves #6640
Impact: **major**
Type: **feature**

## Usage
Example metafields on the cart item:
```json
...
"metafields" : [
    {
        "key" : "name",
        "value" : "Test name",
        "description": "Test"
    }
]
...
```

Define the inclusion/exclusion rules:
```json
...
"inclusionRules" : {
    "conditions" : {
        "all" : [
            {
                "fact" : "keyValueArray",
                "operator" : "equal",
                "params": {
                    "fieldName": "metafields" => the metafields field in the cart item
                    "inputField": "key",
                    "inputValue": "value",
                    "outputField": "value"
                 },
                "value" : "Test name"
            }
        ]
    }
}
....
```
