### PR TITLE
feat: use timezone in shop settings for time calculations not server time

### DIFF
--- a/.changeset/smooth-bags-sleep.md
+++ b/.changeset/smooth-bags-sleep.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-utils": patch
+---
+
+feat: using real shop timezone on insetPrimaryShop

--- a/apps/reaction/tests/integration/api/mutations/checkout/promotionCheckout.test.js
+++ b/apps/reaction/tests/integration/api/mutations/checkout/promotionCheckout.test.js
@@ -55,6 +55,46 @@ beforeAll(async () => {
     groups: ["adminGroup"],
     shopId: internalShopId
   });
+
+  const shop = await testApp.collections.Shops.findOne({ _id: decodeOpaqueIdForNamespace("reaction/shop")(opaqueShopId) });
+
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: shop.timezone }));
+
+  mockPromotion = Factory.Promotion.makeOne({
+    actions: [
+      {
+        actionKey: "discounts",
+        actionParameters: {
+          discountType: "order",
+          discountCalculationType: "percentage",
+          discountValue: 50
+        }
+      }
+    ],
+    triggers: [
+      {
+        triggerKey: "offers",
+        triggerParameters: {
+          name: "50 percent off your entire order when you spend more then $100",
+          conditions: {
+            all: [
+              {
+                fact: "totalItemAmount",
+                operator: "greaterThanInclusive",
+                value: 100
+              }
+            ]
+          }
+        }
+      }
+    ],
+    triggerType: "implicit",
+    promotionType: "order-discount",
+    startDate: now,
+    endDate: new Date(now.getTime() + 1000 * 60 * 60 * 24 * 7),
+    enabled: true,
+    shopId: decodeOpaqueIdForNamespace("reaction/shop")(opaqueShopId)
+  });
   await testApp.createUserAndAccount(mockAdminAccount);
 
   await testApp.collections.Sequences.insertOne({

--- a/packages/api-plugin-promotions/src/handlers/applyPromotions.test.js
+++ b/packages/api-plugin-promotions/src/handlers/applyPromotions.test.js
@@ -2,10 +2,12 @@ import mockContext from "@reactioncommerce/api-utils/tests/mockContext.js";
 import Random from "@reactioncommerce/random";
 import canBeApplied from "../utils/canBeApplied.js";
 import isPromotionExpired from "../utils/isPromotionExpired.js";
+import getCurrentShopTime from "../utils/getCurrentShopTime.js";
 import applyPromotions, { createCartMessage, getCurrentTime } from "./applyPromotions.js";
 
 jest.mock("../utils/canBeApplied.js", () => jest.fn());
 jest.mock("../utils/isPromotionExpired.js", () => jest.fn());
+jest.mock("../utils/getCurrentShopTime.js", () => jest.fn().mockReturnValue(Promise.resolve({ shopId: new Date() })));
 
 const testTrigger = jest.fn().mockReturnValue(Promise.resolve(true));
 const testAction = jest.fn();
@@ -319,6 +321,8 @@ describe("cart message", () => {
 test("getCurrentTime should return system time when user doesn't have preview permission", async () => {
   const shopId = "shopId";
   const date = new Date();
+
+  getCurrentShopTime.mockReturnValue(Promise.resolve({ shopId: date }));
 
   mockContext.userHasPermission.mockReturnValue(false);
 

--- a/packages/api-plugin-promotions/src/utils/isPromotionExpired.js
+++ b/packages/api-plugin-promotions/src/utils/isPromotionExpired.js
@@ -1,10 +1,10 @@
 /**
  * @summary check if promotion is expired
+ * @param {Date} currentTime - The current time
  * @param {Object} promotion - The promotion to check
  * @returns {Boolean} - Whether the promotion is expired
  */
-export default function isPromotionExpired(promotion) {
+export default function isPromotionExpired(currentTime, promotion) {
   const { endDate } = promotion;
-  const now = Date.now();
-  return endDate && endDate < now;
+  return endDate && endDate < currentTime;
 }

--- a/packages/api-plugin-promotions/src/utils/isPromotionExpired.test.js
+++ b/packages/api-plugin-promotions/src/utils/isPromotionExpired.test.js
@@ -5,15 +5,17 @@ beforeAll(() => {
 });
 
 test("returns true if promotion is expired", () => {
+  const currentTime = new Date(2018, 1, 1);
   const promotion = {
     endDate: new Date("2018-01-01")
   };
-  expect(isPromotionExpired(promotion)).toBe(true);
+  expect(isPromotionExpired(currentTime, promotion)).toBe(true);
 });
 
 test("returns false if promotion is not expired", () => {
+  const currentTime = new Date(2018, 1, 1);
   const promotion = {
     endDate: new Date("2022-02-01")
   };
-  expect(isPromotionExpired(promotion)).toBe(false);
+  expect(isPromotionExpired(currentTime, promotion)).toBe(false);
 });

--- a/packages/api-utils/lib/tests/insertPrimaryShop.js
+++ b/packages/api-utils/lib/tests/insertPrimaryShop.js
@@ -47,7 +47,7 @@ const mockShop = {
   language: "en",
   languages: [{ label: "mockLabel", i18n: "mockI18n", enabled: false }],
   public: "mockPublic",
-  timezone: "mockTimezone",
+  timezone: "US/Pacific",
   baseUOL: "mockBaseUOL",
   unitsOfLength: [
     {

--- a/packages/api-utils/lib/tests/insertPrimaryShop.test.js
+++ b/packages/api-utils/lib/tests/insertPrimaryShop.test.js
@@ -48,7 +48,7 @@ const expectedShopBase = {
   language: "en",
   languages: [{ label: "mockLabel", i18n: "mockI18n", enabled: false }],
   public: "mockPublic",
-  timezone: "mockTimezone",
+  timezone: "US/Pacific",
   baseUOL: "mockBaseUOL",
   unitsOfLength: [
     {


### PR DESCRIPTION
Signed-off-by: vanpho93 <vanpho02@gmail.com>

Resolves #6603
Impact: **major**
Type: **feature**

## Issue

Currently we using server time for promotion calculation

## Solution

Change to timezone in shop settings