### PR TITLE
fix: should query un-archived coupon in promotion

### DIFF
--- a/packages/api-plugin-promotions-coupons/src/resolvers/Promotion/getPreviewPromotionCoupon.js
+++ b/packages/api-plugin-promotions-coupons/src/resolvers/Promotion/getPreviewPromotionCoupon.js
@@ -8,6 +8,6 @@
  */
 export default async function getPreviewPromotionCoupon(promotion, args, context) {
   const { collections: { Coupons } } = context;
-  const coupon = await Coupons.findOne({ promotionId: promotion._id });
+  const coupon = await Coupons.findOne({ promotionId: promotion._id, isArchived: { $ne: true } });
   return coupon;
 }

--- a/packages/api-plugin-promotions-coupons/src/resolvers/Promotion/getPromotionCoupon.js
+++ b/packages/api-plugin-promotions-coupons/src/resolvers/Promotion/getPromotionCoupon.js
@@ -8,6 +8,6 @@
  */
 export default async function getPromotionCoupon(promotion, args, context) {
   const { collections: { Coupons } } = context;
-  const coupon = await Coupons.findOne({ promotionId: promotion._id });
+  const coupon = await Coupons.findOne({ promotionId: promotion._id, isArchived: { $ne: true } });
   return coupon;
 }


### PR DESCRIPTION
When retrieving the coupon for a promotion, we should filter out the archived coupon.