### PR TITLE
fix: prevent applied coupon when is archived

### DIFF
--- a/packages/api-plugin-promotions-coupons/src/mutations/applyCouponToCart.js
+++ b/packages/api-plugin-promotions-coupons/src/mutations/applyCouponToCart.js
@@ -60,7 +60,8 @@ export default async function applyCouponToCart(context, input) {
     $or: [
       { expirationDate: { $gte: now } },
       { expirationDate: null }
-    ]
+    ],
+    isArchived: { $ne: true }
   }).toArray();
   if (coupons.length > 1) {
     throw new ReactionError("invalid-params", "The coupon have duplicate with other promotion. Please contact admin for more information");

--- a/packages/api-plugin-promotions-coupons/src/mutations/createStandardCoupon.js
+++ b/packages/api-plugin-promotions-coupons/src/mutations/createStandardCoupon.js
@@ -36,6 +36,10 @@ export default async function createStandardCoupon(context, input) {
   const promotion = await Promotions.findOne({ _id: promotionId, shopId });
   if (!promotion) throw new ReactionError("not-found", "Promotion not found");
 
+  if (promotion.triggerType !== "explicit") {
+    throw new ReactionError("invalid-params", "Coupon can only be created for explicit promotions");
+  }
+
   const existsCoupons = await Coupons.find({ code, shopId, isArchived: { $ne: true } }).toArray();
   if (existsCoupons.length > 0) {
     const promotionIds = _.map(existsCoupons, "promotionId");

--- a/packages/api-plugin-promotions-coupons/src/mutations/createStandardCoupon.test.js
+++ b/packages/api-plugin-promotions-coupons/src/mutations/createStandardCoupon.test.js
@@ -14,7 +14,7 @@ test("throws if validation check fails", async () => {
 test("throws error when coupon code already created", async () => {
   const input = { name: "test", code: "CODE", shopId: "123", promotionId: "123", canUseInStore: true };
   const coupon = { _id: "123", code: "CODE", promotionId: "promotionId" };
-  const promotion = { _id: "promotionId" };
+  const promotion = { _id: "promotionId", triggerType: "explicit" };
   mockContext.collections = {
     Promotions: {
       findOne: jest.fn().mockResolvedValueOnce(Promise.resolve(promotion)),
@@ -57,11 +57,30 @@ test("throws error when promotion does not exist", async () => {
   }
 });
 
+test("throws error when promotion is not explicit", async () => {
+  const input = { name: "test", code: "CODE", shopId: "123", promotionId: "123", canUseInStore: true };
+  const promotion = { _id: "123", triggerType: "automatic" };
+  mockContext.collections = {
+    Coupons: {
+      findOne: jest.fn().mockResolvedValueOnce(Promise.resolve(null))
+    },
+    Promotions: {
+      findOne: jest.fn().mockResolvedValueOnce(Promise.resolve(promotion))
+    }
+  };
+
+  try {
+    await createStandardCoupon(mockContext, input);
+  } catch (error) {
+    expect(error.message).toEqual("Coupon can only be created for explicit promotions");
+  }
+});
+
 test("throws error when coupon code already exists in promotion window", async () => {
   const now = new Date();
   const input = { name: "test", code: "CODE", shopId: "123", promotionId: "123", canUseInStore: true };
-  const promotion = { _id: "123", startDate: now, endDate: now };
-  const existsPromotion = { _id: "1234", startDate: now, endDate: now };
+  const promotion = { _id: "123", startDate: now, endDate: now, triggerType: "explicit" };
+  const existsPromotion = { _id: "1234", startDate: now, endDate: now, triggerType: "explicit" };
   const coupon = { _id: "123", code: "CODE", promotionId: "123" };
   mockContext.collections = {
     Coupons: {
@@ -88,7 +107,7 @@ test("throws error when coupon code already exists in promotion window", async (
 test("should insert a new coupon and return the created results", async () => {
   const now = new Date();
   const input = { name: "test", code: "CODE", shopId: "123", promotionId: "123", canUseInStore: true };
-  const promotion = { _id: "123", endDate: now };
+  const promotion = { _id: "123", endDate: now, triggerType: "explicit" };
 
   mockContext.collections = {
     Coupons: {


### PR DESCRIPTION
Resolves #issueNumber
Impact: **minor**
Type: **bugfix**

## Issue

Able to apply a coupon even it's archived.

## Solution

Exclude archived coupon from query