### PR TITLE
fix: duplicatePromotion endpoint issue

### DIFF
--- a/packages/api-plugin-promotions/src/mutations/duplicatePromotion.js
+++ b/packages/api-plugin-promotions/src/mutations/duplicatePromotion.js
@@ -24,8 +24,8 @@ export default async function duplicatePromotion(context, { shopId, promotionId 
   PromotionSchema.validate(newPromotion);
   validateTriggerParams(context, newPromotion);
   const results = await Promotions.insertOne(newPromotion);
-  const { insertedCount } = results;
-  if (!insertedCount) {
+  const { insertedId } = results;
+  if (!insertedId) {
     return {
       success: false,
       errors: [{


### PR DESCRIPTION
- Use `insertedId` instead of `insertedCount` for success check
- The response from `insertOne` doesn't include the `insertedCount` property