### PR TITLE
Support Dynamic Password Reset URL

### DIFF
--- a/.changeset/hip-owls-hug.md
+++ b/.changeset/hip-owls-hug.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-authentication": minor
+---
+
+Allow dynamic password reset URL in the email

--- a/packages/api-plugin-authentication/src/config.js
+++ b/packages/api-plugin-authentication/src/config.js
@@ -5,6 +5,7 @@ const { str } = envalid;
 export default envalid.cleanEnv(
   process.env,
   {
+    PASSWORD_RESET_PATH_FRAGMENT: str({ default: "?resetToken=" }),
     STORE_URL: str({ devDefault: "http://localhost:4000" }),
     TOKEN_SECRET: str({ default: "UPDATE_THIS_SECRET" })
   },

--- a/packages/api-plugin-authentication/src/util/accountServer.js
+++ b/packages/api-plugin-authentication/src/util/accountServer.js
@@ -14,7 +14,7 @@ export default async (app) => {
   if (accountsServer && accountsGraphQL) {
     return { accountsServer, accountsGraphQL };
   }
-  const { MONGO_URL, STORE_URL, TOKEN_SECRET } = config;
+  const { MONGO_URL, PASSWORD_RESET_PATH_FRAGMENT, STORE_URL, TOKEN_SECRET } = config;
   const { context } = app;
 
   const client = await mongoConnectWithRetry(MONGO_URL);
@@ -38,7 +38,7 @@ export default async (app) => {
       sendMail: async ({ to, text }) => {
         const query = text.split("/");
         const token = query[query.length - 1];
-        const url = `${STORE_URL}/?resetToken=${token}`;
+        const url = `${STORE_URL}/${PASSWORD_RESET_PATH_FRAGMENT}${token}`;
         await context.mutations.sendResetAccountPasswordEmail(context, {
           email: to,
           url


### PR DESCRIPTION
Resolves #6838
Impact: **minor**
Type: **feature**

## Issue

The authentication plugin generates a password reset email with a hardcoded URL.

## Solution

Instead of hardcoding the URL, we can parametrize it by introducing a password reset path fragment environmental variable like PASSWORD_RESET_PATH_FRAGMENT and turn the password reset URL into:

```
${STORE_URL}/${PASSWORD_RESET_PATH_FRAGMENT}${token}
```

If we provide the default value of this env var to be ?resetToken=, it will support backward compatibility.

Technically we can set the STORE_URL to a more specific route like http://localhost:4000/password-reset that will evaluate to an URL, but the name of the variable doesn't imply that it will be only used in the password reset scenario. That's why I think it's a better idea to add additional configurable fragment to provide flexibility.

## Breaking changes

None. The default value of the newly proposed environmental variable provides backward compatibility.

## Testing

1. Set up Opencommerce with a working email client.
2. Set up the `PASSWORD_RESET_PATH_FRAGMENT` to a desired path
3. Call the `sendResetAccountPasswordEmail` for an existing account.
4. Validate that the password reset URL in the received email matches the desired format.