### PR TITLE
Add AccountsJS configurations as env vars

### DIFF
--- a/.changeset/smooth-jokes-attend.md
+++ b/.changeset/smooth-jokes-attend.md
@@ -1,0 +1,5 @@
+---
+"@reactioncommerce/api-plugin-authentication": minor
+---
+
+Add accounts js env var configuration (jwt expiration time comfig, returnTokensAfterResetPassword config)

--- a/packages/api-plugin-authentication/src/config.js
+++ b/packages/api-plugin-authentication/src/config.js
@@ -1,10 +1,13 @@
 import envalid from "envalid";
 
-const { str } = envalid;
+const { str, bool } = envalid;
 
 export default envalid.cleanEnv(
   process.env,
   {
+    ACCOUNTS_JS_RETURN_TOKENS_AFTER_RESET_PASSWORD: bool({ default: false }),
+    ACCOUNTS_JS_ACCESS_TOKEN_EXPIRES_IN: str({ default: "90m" }),
+    ACCOUNTS_JS_REFRESH_TOKEN_EXPIRES_IN: str({ default: "30d" }),
     PASSWORD_RESET_PATH_FRAGMENT: str({ default: "?resetToken=" }),
     STORE_URL: str({ devDefault: "http://localhost:4000" }),
     TOKEN_SECRET: str({ default: "UPDATE_THIS_SECRET" })

--- a/packages/api-plugin-authentication/src/util/accountServer.js
+++ b/packages/api-plugin-authentication/src/util/accountServer.js
@@ -14,7 +14,15 @@ export default async (app) => {
   if (accountsServer && accountsGraphQL) {
     return { accountsServer, accountsGraphQL };
   }
-  const { MONGO_URL, PASSWORD_RESET_PATH_FRAGMENT, STORE_URL, TOKEN_SECRET } = config;
+  const {
+    ACCOUNTS_JS_RETURN_TOKENS_AFTER_RESET_PASSWORD,
+    ACCOUNTS_JS_ACCESS_TOKEN_EXPIRES_IN,
+    ACCOUNTS_JS_REFRESH_TOKEN_EXPIRES_IN,
+    MONGO_URL,
+    PASSWORD_RESET_PATH_FRAGMENT,
+    STORE_URL,
+    TOKEN_SECRET
+  } = config;
   const { context } = app;
 
   const client = await mongoConnectWithRetry(MONGO_URL);
@@ -26,12 +34,22 @@ export default async (app) => {
     idProvider: () => mongoose.Types.ObjectId().toString()
   });
 
-  const password = new AccountsPassword();
+  const password = new AccountsPassword({
+    returnTokensAfterResetPassword: ACCOUNTS_JS_RETURN_TOKENS_AFTER_RESET_PASSWORD
+  });
 
   accountsServer = new AccountsServer(
     {
       siteUrl: STORE_URL,
       tokenSecret: TOKEN_SECRET,
+      tokenConfigs: {
+        accessToken: {
+          expiresIn: ACCOUNTS_JS_ACCESS_TOKEN_EXPIRES_IN
+        },
+        refreshToken: {
+          expiresIn: ACCOUNTS_JS_REFRESH_TOKEN_EXPIRES_IN
+        }
+      },
       db: accountsMongo,
       enableAutologin: true,
       ambiguousErrorMessages: false,


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue

Developers can't customize the JWT access and refresh tokens' expiration date. Also, there is no way to configure whether the reset password mutation returns new auth tokens or not.

## Solution

This PR adds environmental variables that allow to configure the aforementioned accounts js server properties, i.e. the jwt access and refresh token expiration time and the password reset mutation return type.

## Breaking changes

None. The default values of the env vars are identical to the accounts js library default values.

## Testing

### Testing the password reset returned tokens:
1. Set the `ACCOUNTS_JS_RETURN_TOKENS_AFTER_RESET_PASSWORD` env var to `true`.
2. Run the password reset workflow and run the `resetPassword` mutation with the `tokens` in the return body like so:
```graphql
mutation resetPassword($token: String!, $newPassword: String!) {
  resetPassword(token: $token, newPassword: $newPassword) {
    tokens {
      accessToken
      refreshToken
    }
  }
}
```
If the env var is set to true, you should see the newly generated access and refresh tokens in the response
If the env var is set to false, you should see `null` in the response

### Testing the jwt token expiration time:
1. Set the `ACCOUNTS_JS_ACCESS_TOKEN_EXPIRES_IN` to `7d` for example
2. Authenitcate with the `authenticate` mutation or with the Kinetic Admin
3. Overserve the generated jwt token expiration date after you decoded it:
<img width="1202" alt="Screenshot 2023-05-19 at 11 51 16" src="https://github.com/reactioncommerce/reaction/assets/32718995/7739a806-e188-4dbe-b839-bc41900eca45">
<img width="540" alt="Screenshot 2023-05-19 at 11 51 26" src="https://github.com/reactioncommerce/reaction/assets/32718995/194fcf1e-d53a-493a-a95c-bf6cda9a1527">
