### PR TITLE
Fix typo: corrected promotion removal message #6811

### DIFF
--- a/packages/api-plugin-promotions/src/handlers/applyPromotions.js
+++ b/packages/api-plugin-promotions/src/handlers/applyPromotions.js
@@ -135,9 +135,10 @@ export default async function applyPromotions(context, cart, options = { skipTem
     if (!promotion.enabled) {
       if (canAddToCartMessages(cart, promotion)) {
         enhancedCart.messages.push(createCartMessage({
-          title: "The promotion no longer available",
+          title: "Promotion is no longer available",
           subject: "promotion",
           severity: "warning",
+          requiresReadAcknowledgement: true,
           metaFields: {
             promotionId: promotion._id
           }

--- a/packages/api-plugin-promotions/src/handlers/applyPromotions.test.js
+++ b/packages/api-plugin-promotions/src/handlers/applyPromotions.test.js
@@ -159,7 +159,7 @@ describe("cart message", () => {
 
     await applyPromotions(mockContext, cart);
 
-    expect(cart.messages[0].title).toEqual("The promotion no longer available");
+    expect(cart.messages[0].title).toEqual("Promotion is no longer available");
   });
 
   test("should have promotion is not eligible message when explicit promotion is not eligible", async () => {


### PR DESCRIPTION
Resolves #6811
Impact: minor
Type: bugfix

## Issue

Message says "The promotion no longer available", should say "Promotion is no longer available". Also not sure that requiresReadAcknowledgement should be set to true on this.

## Solution

1. Changed the message from "The promotion no longer available" to "Promotion is no longer available" in packages/api-plugin-promotions/src/handlers/applyPromotions.js and packages/api-plugin-promotions/src/handlers/applyPromotions.test.js.
2. Added requiresReadAcknowledgement: true to this message in packages/api-plugin-promotions/src/handlers/applyPromotions.js

## Breaking changes

None

## Testing

1. Changed expect(cart.messages[0].title).toEqual("The promotion no longer available"); to     expect(cart.messages[0].title).toEqual("Promotion is no longer available");
2. Can add expect(cart.messages[0].requiresReadAcknowledgement).toEqual(true); in packages/api-plugin-promotions/src/handlers/applyPromotions.test.js to test whether requiresReadAcknowledgement is set to true or not.
