### PR TITLE
FIX Surchages query missing permission validation

### DIFF
--- a/packages/api-plugin-surcharges/src/queries/surcharges.js
+++ b/packages/api-plugin-surcharges/src/queries/surcharges.js
@@ -1,3 +1,5 @@
+import { checkPermission } from 'your-permissions-library'; // Replace with your actual permissions library
+
 /**
  * @name surcharges
  * @method
@@ -9,10 +11,19 @@
  * @returns {Promise<Object>|undefined} - Surcharge documents, if found
  */
 export default async function surcharges(context, { shopId } = {}) {
-  const { collections } = context;
+  const { collections, user } = context;
   const { Surcharges } = collections;
 
+  // Check if the user has the read permission for surcharges (adjust this logic to your permission system)
+  const hasReadPermission = checkPermission(user, 'surcharges:read');
+
+  if (!hasReadPermission) {
+    // User does not have the required permission, return an error or handle as needed
+    throw new Error('Permission denied: You do not have permission to read surcharges.');
+  }
+
+  // Query the Surcharges collection
   return Surcharges.find({
-    shopId
+    shopId,
   });
 }


### PR DESCRIPTION
Resolves #6634
Impact: **breaking|critical|major|minor**
Type: **feature|bugfix|performance|test|style|refactor|docs|chore**

## Issue

Description of the issue this PR is solving, why it's happening, and how to reproduce it. This may differ from the original ticket as you now have more information at your disposal.

## Solution



## Breaking changes
![1](https://github.com/reactioncommerce/reaction/assets/44186372/3f9cec1c-c664-4d96-a03d-200f20dcf970)


If you have a breaking changes, list them here, otherwise list none.
**Yes Following

We import the checkPermission function from your permissions library. You should replace 'your-permissions-library' with the actual name of your permissions library.
We check if the user has the necessary read permission for surcharges using checkPermission(user, 'surcharges:read'). You should replace 'surcharges:read' with the specific permission string or identifier used in your 

If you're solving a UIX related issue, please attach screen-caps or gifs showing how your solution differs from the issue.

Examples of breaking changes include changing file names, moving files, deleting files, renaming functions or exports, or changes to code which might cause previous versions of Reaction or third-party code not to work as expected.

Note any work that you did to mitigate the effect of any breaking changes such as creating migrations, deprecation warnings, etc.

## Testing

1. List the steps needed for testing your change in this section.
2. Assume that testers already know how to start the app, and do the basic setup tasks.
3. Be detailed enough that someone can work through it without being too granular

More detail for what each of these sections should include are available in our [Contributing Docs](CONTRIBUTING.md).
