### PR TITLE
fix: changed "Twitter" to "𝕏 (Twitter)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h4 align="center">
   <a href="https://mailchimp.com/developer/open-commerce/">Open Commerce Website</a> |
-  <a href="https://twitter.com/getreaction">Twitter</a> |
+  <a href="https://twitter.com/getreaction">𝕏 (Twitter)</a> |
   <a href="https://mailchimp.com/developer/open-commerce/">Documentation</a> |
   <a href="https://discord.gg/Bwm63tBcQY">Discord</a> |
   <a href="https://github.com/reactioncommerce/reaction/discussions">Discussions</a>


### PR DESCRIPTION
changed "Twitter" to "𝕏 (Twitter)"

Resolves https://github.com/reactioncommerce/reaction/issues/6863
Impact: **minor**
Type: **docs**

## Issue

Twitter is now known as 𝕏 but in README.md it is still old name.

## Solution

Change the name in README.md

